### PR TITLE
Add Codecov token to CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,5 +58,6 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           fail_ci_if_error: false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that adds an explicit secret token to the Codecov upload action; main impact is on coverage upload behavior/permissions.
> 
> **Overview**
> Ensures Codecov uploads from the `main` branch CI run authenticate by passing `secrets.CODECOV_TOKEN` to `codecov/codecov-action@v5` in the `Upload coverage to Codecov` step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6798b03f47c2e8079aee3cb7e7b9ccb402a69ca7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->