### PR TITLE
Fix CI test failure and deprecation warnings

### DIFF
--- a/tests/unit/test_retry_queue.py
+++ b/tests/unit/test_retry_queue.py
@@ -779,6 +779,8 @@ class TestRetryQueueConfig:
         from work_buddy.config import load_config
         cfg = load_config()
         rq = cfg.get("sidecar", {}).get("retry_queue", {})
+        if not rq:
+            pytest.skip("config.yaml not present (CI environment)")
         assert rq.get("enabled") is True
         assert isinstance(rq.get("max_retries"), int)
         assert rq.get("default_backoff") in ("adaptive", "fixed_10s", "exponential")

--- a/work_buddy/dashboard/frontend/script_main.py
+++ b/work_buddy/dashboard/frontend/script_main.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 
 def _script() -> str:
-    return """
+    return r"""
 // ---- Tab switching ----
 const staticLoaders = {
     overview: () => loadOverview(),

--- a/work_buddy/dashboard/frontend/script_workflows.py
+++ b/work_buddy/dashboard/frontend/script_workflows.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 
 def _workflow_views_script() -> str:
-    return """
+    return r"""
 // ---- Workflow view polling ----
 const _knownViews = new Set();
 const _viewRenderers = {};  // viewType → function(container, viewId, payload)


### PR DESCRIPTION
## Summary

Follow-up to #6 — the PyTorch source fix got CI running, but two issues remained:

- **`test_config_loads` fails in CI** because `config.yaml` is gitignored and not present. Added `pytest.skip()` when the config section is empty.
- **DeprecationWarning: invalid escape sequence `\/`** in `script_main.py` and `script_workflows.py` — JS code containing `/` (division, URL paths) inside Python triple-quoted strings. Fixed by using raw strings (`r"""`).

## Test plan

- [ ] CI passes (all tests green, no deprecation warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)