### PR TITLE
Fix dashboard JS syntax errors, broken Unicode glyphs, and sidecar error reporting

### DIFF
--- a/work_buddy/dashboard/frontend/script_main.py
+++ b/work_buddy/dashboard/frontend/script_main.py
@@ -49,7 +49,7 @@ updateClock();
 
 
 // ---- Helpers ----
-function statusBadge(status) {
+function statusBadge(status, tooltip) {
     const map = {
         healthy: 'badge-green', running: 'badge-green', active: 'badge-green', ok: 'badge-green',
         unhealthy: 'badge-yellow', stalled: 'badge-yellow', waiting: 'badge-yellow', degraded: 'badge-yellow',
@@ -59,7 +59,8 @@ function statusBadge(status) {
         inbox: 'badge-purple', someday: 'badge-muted',
         consent_required: 'badge-yellow',
     };
-    return `<span class="badge ${map[status] || 'badge-muted'}">${status}</span>`;
+    const tip = tooltip ? ` title="${escapeHtml(tooltip)}" style="cursor:help"` : '';
+    return `<span class="badge ${map[status] || 'badge-muted'}"${tip}>${status}</span>`;
 }
 
 function _healthDotClass(status) {
@@ -81,7 +82,7 @@ function _healthChips(c) {
 }
 
 function _reprobeBtn(c) {
-    return `<button class="health-reprobe-btn" onclick="event.stopPropagation(); reprobeComponent('${c.id}', this)" title="Refresh status">\\u21BB</button>`;
+    return `<button class="health-reprobe-btn" onclick="event.stopPropagation(); reprobeComponent('${c.id}', this)" title="Refresh status">\u21BB</button>`;
 }
 
 function _diagBtn(c) {
@@ -155,7 +156,7 @@ function _renderDiagPanel(diag) {
     if (diag.steps_run && diag.steps_run.length > 0) {
         html += '<div class="health-diag-steps">';
         for (const step of diag.steps_run) {
-            const icon = step.ok ? '\\u2713' : '\\u2717';
+            const icon = step.ok ? '\u2713' : '\u2717';
             const cls = step.ok ? '' : ' fail';
             html += `<div class="health-diag-step${cls}">
                 <span class="step-icon">${icon}</span>
@@ -374,7 +375,7 @@ function renderHealthTree(health) {
                 <div class="health-item collapsed" data-component="${c.id}">
                     <div class="health-row${issueCls}" onclick="toggleHealthItem(this)">
                         <div class="health-row-main">
-                            <span class="health-chevron">\\u25BE</span>
+                            <span class="health-chevron">\u25BE</span>
                             <span class="status-dot ${_healthDotClass(c.status)}"></span>
                             <span class="health-name">${c.display_name}</span>
                             ${statusBadge(c.status)}
@@ -493,7 +494,7 @@ async function loadOverview() {
         <tr>
             <td>${j.name}</td>
             <td title="${j.schedule}">${j.schedule_desc || j.schedule}</td>
-            <td>${j.last_result ? statusBadge(j.last_result) : '\u2014'}</td>
+            <td>${j.last_result ? statusBadge(j.last_result, j.last_error) : '\u2014'}</td>
             <td>${timeAgo(j.last_run_at)}</td>
             <td>${timeUntil(j.next_at)}</td>
         </tr>
@@ -604,14 +605,14 @@ async function loadStatus() {
             const pct = Math.max(8, (logMs / logMax) * 100);
             const cls = !h.ok ? 'bar-fail' : h.ms > 500 ? 'bar-slow' : 'bar-ok';
             const dt = new Date(h.ts * 1000);
-            const tip = dt.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit'}) + ' \\u2014 ' + h.ms + 'ms';
+            const tip = dt.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit'}) + ' \u2014 ' + h.ms + 'ms';
             return `<div class="bar ${cls}" style="height:${pct}%" title="${tip}"></div>`;
         }).join('');
 
         bridgeEl.innerHTML = `
             <div class="bridge-card">
                 <div class="bridge-header">
-                    <h3><span class="status-dot ${dotClass}"></span> Obsidian Bridge \\u2014 ${statusLabel}</h3>
+                    <h3><span class="status-dot ${dotClass}"></span> Obsidian Bridge \u2014 ${statusLabel}</h3>
                     <div class="bridge-stats">
                         <div>Latency <span class="bridge-stat-value" style="color:${latencyColor}">${b.latency_ms}ms</span></div>
                         <div>Trend <span class="bridge-stat-value">${b.ema_ms || 0}ms</span>${(() => {
@@ -726,7 +727,7 @@ async function loadStatus() {
                     ? '<span class="type-pill request1" style="font-size:9px;padding:1px 6px">REQUEST</span>'
                     : '<span class="type-pill note1" style="font-size:9px;padding:1px 6px">NOTE</span>';
                 const sid = e.short_id ? ' <code>#' + e.short_id + '</code>' : '';
-                const surfaces = (e.surfaces || []).join(', ') || '\\u2014';
+                const surfaces = (e.surfaces || []).join(', ') || '\u2014';
                 return '<tr>'
                     + '<td style="white-space:nowrap;color:var(--text-muted)">' + time + '</td>'
                     + '<td>' + pill + '</td>'
@@ -872,8 +873,8 @@ function renderChatHeader(meta) {
         + '</div>'
         + '<div class="chats-hdr-right">'
         + '<button class="chats-hdr-btn" onclick="chatsToggleInSearch()">Search</button>'
-        + '<button class="chats-hdr-btn' + (chatsState.roleFilter === 'user' ? ' active' : '') + '" onclick="chatsFilterRole(\\'user\\')">User</button>'
-        + '<button class="chats-hdr-btn' + (chatsState.roleFilter === 'assistant' ? ' active' : '') + '" onclick="chatsFilterRole(\\'assistant\\')">Assistant</button>'
+        + '<button class="chats-hdr-btn' + (chatsState.roleFilter === 'user' ? ' active' : '') + '" onclick="chatsFilterRole(&#39;user&#39;)">User</button>'
+        + '<button class="chats-hdr-btn' + (chatsState.roleFilter === 'assistant' ? ' active' : '') + '" onclick="chatsFilterRole(&#39;assistant&#39;)">Assistant</button>'
         + '<button class="chats-hdr-btn' + (!chatsState.roleFilter ? ' active' : '') + '" onclick="chatsFilterRole(null)">All</button>'
         + '</div>';
 }
@@ -1167,7 +1168,7 @@ async function chatsGlobalSearch() {
 
         // Session header — clicking opens the chat at the top
         html += '<div class="chats-search-session-group">'
-            + '<div class="chats-search-session-hdr" onclick="chatsOpenFromSearch(\\'' + sess.session_id + '\\')">'
+            + '<div class="chats-search-session-hdr" onclick="chatsOpenFromSearch(&#39;' + sess.session_id + '&#39;)">'
             + '<div style="display:flex;justify-content:space-between;align-items:center;">'
             + '<span>'
             + '<span class="chats-hit-score" style="margin-right:6px;">#' + (gi + 1) + '</span>'
@@ -1185,7 +1186,7 @@ async function chatsGlobalSearch() {
 
         // Individual chunk hits — clicking jumps to that exact location
         (sess.chunks || []).forEach(function(chunk) {
-            html += '<div class="chats-search-chunk" onclick="chatsJumpToHit(\\'' + sess.session_id + '\\',' + chunk.span_index + ')">'
+            html += '<div class="chats-search-chunk" onclick="chatsJumpToHit(&#39;' + sess.session_id + '&#39;,' + chunk.span_index + ')">'
                 + '<div style="font-size:12px;color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">'
                 + escapeHtml(cleanMsgText(chunk.display_text)) + '</div>'
                 + '</div>';
@@ -1244,7 +1245,7 @@ async function chatsCommitSearch(q) {
         var msgCount = chatInfo ? (chatInfo.message_count || '') : '';
 
         html += '<div class="chats-search-session-group">'
-            + '<div class="chats-search-session-hdr" onclick="chatsOpenFromSearch(\\'' + sess.session_id + '\\')">'
+            + '<div class="chats-search-session-hdr" onclick="chatsOpenFromSearch(&#39;' + sess.session_id + '&#39;)">'
             + '<div style="display:flex;justify-content:space-between;align-items:center;">'
             + '<span>'
             + '<span class="chats-hit-score" style="margin-right:6px;">#' + (gi + 1) + '</span>'
@@ -1261,8 +1262,8 @@ async function chatsCommitSearch(q) {
         (sess.commits || []).forEach(function(commit) {
             var hasIdx = commit.message_index != null;
             var clickFn = hasIdx
-                ? 'chatsJumpToCommitSearch(\\'' + sess.session_id + '\\',' + commit.message_index + ')'
-                : 'chatsOpenFromSearch(\\'' + sess.session_id + '\\')';
+                ? 'chatsJumpToCommitSearch(&#39;' + sess.session_id + '&#39;,' + commit.message_index + ')'
+                : 'chatsOpenFromSearch(&#39;' + sess.session_id + '&#39;)';
             html += '<div class="chats-search-chunk" onclick="' + clickFn + '">'
                 + '<div class="chat-commit-marker" style="margin:0;">'
                 + '<code>' + (commit.hash || '') + '</code> '

--- a/work_buddy/dashboard/frontend/script_notifications.py
+++ b/work_buddy/dashboard/frontend/script_notifications.py
@@ -67,7 +67,7 @@ window.showToast = function showToast(title, body, tabName, viewId, view, isRequ
                 ${pillHtml}
                 <span class="toast-title">${title}${shortId}</span>
             </div>
-            <button class="toast-close">\\u2715</button>
+            <button class="toast-close">\u2715</button>
         </div>
         <div class="toast-body">${body}</div>
         <div style="font-size:10px;color:var(--text-muted);margin-top:2px">${actionLabel}</div>
@@ -137,10 +137,10 @@ registerViewRenderer('capability_consent', async function(container, viewId, pay
 
     // Buttons
     html += '<div id="cc-btns-'+viewId+'" class="nb-btn-group">';
-    html += '<button class="nb-btn nb-btn-request" onclick="capConsentRespond(\\''+viewId+'\\',\\'always\\')">Allow always</button>';
-    html += '<button class="nb-btn nb-btn-neutral" onclick="capConsentRespond(\\''+viewId+'\\',\\'temporary\\')">Allow for '+ttl+' min</button>';
-    html += '<button class="nb-btn nb-btn-ghost" onclick="capConsentRespond(\\''+viewId+'\\',\\'once\\')">Allow once</button>';
-    html += '<button class="nb-btn nb-btn-deny" onclick="capConsentRespond(\\''+viewId+'\\',\\'deny\\')">Deny</button>';
+    html += '<button class="nb-btn nb-btn-request" onclick="capConsentRespond(&#39;'+viewId+'&#39;,&#39;always&#39;)">Allow always</button>';
+    html += '<button class="nb-btn nb-btn-neutral" onclick="capConsentRespond(&#39;'+viewId+'&#39;,&#39;temporary&#39;)">Allow for '+ttl+' min</button>';
+    html += '<button class="nb-btn nb-btn-ghost" onclick="capConsentRespond(&#39;'+viewId+'&#39;,&#39;once&#39;)">Allow once</button>';
+    html += '<button class="nb-btn nb-btn-deny" onclick="capConsentRespond(&#39;'+viewId+'&#39;,&#39;deny&#39;)">Deny</button>';
     html += '</div>';
 
     html += '</div></div></div>';
@@ -153,7 +153,7 @@ window.capConsentRespond = async function(viewId, value) {
         if (value === 'deny') {
             btns.innerHTML = '<span style="color:var(--text-muted)">Denied</span>';
         } else {
-            btns.innerHTML = '<span style="color:var(--green,#4caf50);font-weight:600">Granted \\u2014 re-executing...</span>';
+            btns.innerHTML = '<span style="color:var(--green,#4caf50);font-weight:600">Granted \u2014 re-executing...</span>';
         }
     }
     try {
@@ -183,7 +183,7 @@ registerViewRenderer('workflow_consent', async function(container, viewId, paylo
     html += '<div class="wv-group-header-left">';
     html += '<div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">';
     html += '<span class="type-pill request3" style="font-size:11px;padding:3px 10px">WORKFLOW</span>';
-    html += '<span style="color:var(--orange, #e5a045);font-size:13px;font-weight:600">\\u2699 Agent Session</span>';
+    html += '<span style="color:var(--orange, #e5a045);font-size:13px;font-weight:600">\u2699 Agent Session</span>';
     html += '</div>';
     html += '<div class="wv-group-intent" style="font-size:17px">' + escapeHtml(title) + '</div>';
     html += '<div style="display:flex;align-items:center;gap:8px;margin-top:4px">';
@@ -219,8 +219,8 @@ registerViewRenderer('workflow_consent', async function(container, viewId, paylo
 
     // Buttons
     html += '<div id="wfc-btns-'+viewId+'" class="nb-btn-group stretch">';
-    html += '<button class="nb-btn nb-btn-approve" onclick="wfConsentRespond(\\''+viewId+'\\',\\'launch\\')">Launch</button>';
-    html += '<button class="nb-btn nb-btn-deny" onclick="wfConsentRespond(\\''+viewId+'\\',\\'cancel\\')">Cancel</button>';
+    html += '<button class="nb-btn nb-btn-approve" onclick="wfConsentRespond(&#39;'+viewId+'&#39;,&#39;launch&#39;)">Launch</button>';
+    html += '<button class="nb-btn nb-btn-deny" onclick="wfConsentRespond(&#39;'+viewId+'&#39;,&#39;cancel&#39;)">Cancel</button>';
     html += '</div>';
 
     html += '</div></div></div>';

--- a/work_buddy/dashboard/frontend/script_palette.py
+++ b/work_buddy/dashboard/frontend/script_palette.py
@@ -48,7 +48,7 @@ def _command_palette_script() -> str:
                     for (const [k, v] of Object.entries(prov)) {
                         parts.push(k + ': ' + (v.count || 0));
                     }
-                    statusLeft.textContent = parts.join(' \\u00b7 ') || 'Ready';
+                    statusLeft.textContent = parts.join(' \u00b7 ') || 'Ready';
                 }
             } catch (e) {
                 results.innerHTML = '<div class="cp-empty">Failed to load commands</div>';
@@ -180,9 +180,9 @@ def _command_palette_script() -> str:
                 const typeIcon = document.createElement('span');
                 const ctype = cmd.command_type || 'inline';
                 typeIcon.className = 'cp-type-icon cp-type-' + ctype;
-                const typeSymbols = { inline: '\\u25B8', parameterized: '\\u25A3', workflow: '\\u2699' };
+                const typeSymbols = { inline: '\u25B8', parameterized: '\u25A3', workflow: '\u2699' };
                 const typeTitles = { inline: 'Runs instantly', parameterized: 'Opens parameter form', workflow: 'Launches agent session' };
-                typeIcon.textContent = typeSymbols[ctype] || '\\u25B8';
+                typeIcon.textContent = typeSymbols[ctype] || '\u25B8';
                 typeIcon.title = typeTitles[ctype] || '';
                 item.appendChild(typeIcon);
 
@@ -276,7 +276,7 @@ def _command_palette_script() -> str:
         toast.innerHTML = '<div class="toast-header">'
             + '<div style="display:flex;align-items:center;gap:6px">' + pill
             + '<span class="toast-title">' + _esc(title) + '</span></div>'
-            + '<button class="toast-close">\\u2715</button></div>'
+            + '<button class="toast-close">\u2715</button></div>'
             + '<div class="toast-body">' + _esc(body) + '</div>';
         toast.addEventListener('click', () => toast.remove());
         container.appendChild(toast);

--- a/work_buddy/dashboard/frontend/script_threads.py
+++ b/work_buddy/dashboard/frontend/script_threads.py
@@ -34,12 +34,12 @@ def _thread_chat_script() -> str:
         if (msg.status === 'pending' && msg.message_type === 'question') {
             if (msg.response_type === 'boolean') {
                 bubble += '<div class="msg-choices">'
-                  + '<button onclick="threadRespond(\\'' + tid + '\\',\\'true\\')">Yes</button>'
-                  + '<button onclick="threadRespond(\\'' + tid + '\\',\\'false\\')">No</button></div>';
+                  + '<button onclick="threadRespond(&#39;' + tid + '&#39;,&#39;true&#39;)">Yes</button>'
+                  + '<button onclick="threadRespond(&#39;' + tid + '&#39;,&#39;false&#39;)">No</button></div>';
             } else if (msg.response_type === 'choice' && msg.choices) {
                 bubble += '<div class="msg-choices">';
                 for (const c of msg.choices) {
-                    bubble += '<button onclick="threadRespond(\\'' + tid + '\\',\\'' + _esc(c.key) + '\\')">'
+                    bubble += '<button onclick="threadRespond(&#39;' + tid + '&#39;,&#39;' + _esc(c.key) + '&#39;)">'
                        + _esc(c.label) + '</button>';
                 }
                 bubble += '</div>';
@@ -76,8 +76,8 @@ def _thread_chat_script() -> str:
             + (isOpen
                 ? '<div class="thread-input" id="tc-input-' + tid + '">'
                   + '<input type="text" placeholder="Type a message..." '
-                  + 'onkeydown="if(event.key===\\'Enter\\'&&!event.shiftKey){event.preventDefault();threadSendInput(\\'' + tid + '\\')}" />'
-                  + '<button onclick="threadSendInput(\\'' + tid + '\\')">Send</button></div>'
+                  + 'onkeydown="if(event.key===&#39;Enter&#39;&&!event.shiftKey){event.preventDefault();threadSendInput(&#39;' + tid + '&#39;)}" />'
+                  + '<button onclick="threadSendInput(&#39;' + tid + '&#39;)">Send</button></div>'
                 : '')
             + (status ? '<div class="thread-status-bar">' + _esc(status) + '</div>' : '')
             + '</div>';

--- a/work_buddy/dashboard/frontend/script_workflows.py
+++ b/work_buddy/dashboard/frontend/script_workflows.py
@@ -71,7 +71,7 @@ function createWorkflowTab(view) {
 
     const closeBtn = document.createElement('span');
     closeBtn.className = 'tab-close';
-    closeBtn.textContent = '\\u2715';
+    closeBtn.textContent = '\u2715';
     closeBtn.title = 'Close tab';
     closeBtn.addEventListener('click', (e) => {
         e.stopPropagation();
@@ -202,8 +202,8 @@ registerViewRenderer('generic', async function(container, viewId, payload) {
 
     if (respType === 'boolean') {
         html += '<div class="nb-btn-group stretch">';
-        html += '<button class="nb-btn nb-btn-approve" onclick="submitGenericResponse(\\''+viewId+'\\',\\'yes\\')">Yes</button>';
-        html += '<button class="nb-btn nb-btn-deny" onclick="submitGenericResponse(\\''+viewId+'\\',\\'no\\')">No</button>';
+        html += '<button class="nb-btn nb-btn-approve" onclick="submitGenericResponse(&#39;'+viewId+'&#39;,&#39;yes&#39;)">Yes</button>';
+        html += '<button class="nb-btn nb-btn-deny" onclick="submitGenericResponse(&#39;'+viewId+'&#39;,&#39;no&#39;)">No</button>';
         html += '</div>';
     } else if (respType === 'choice') {
         let choices = (data.choices && data.choices.length) ? data.choices : [];
@@ -215,14 +215,14 @@ registerViewRenderer('generic', async function(container, viewId, payload) {
             for (const c of choices) {
                 const key = c.key||'', label = c.label||key, desc = c.description||'';
                 const cls = btnClassMap[key] || 'nb-btn nb-btn-request';
-                html += '<button class="'+cls+'" onclick="submitGenericResponse(\\''+viewId+'\\',\\''+key+'\\')" title="'+escapeHtml(desc)+'">'+escapeHtml(label)+'</button>';
+                html += '<button class="'+cls+'" onclick="submitGenericResponse(&#39;'+viewId+'&#39;,&#39;'+key+'&#39;)" title="'+escapeHtml(desc)+'">'+escapeHtml(label)+'</button>';
             }
             html += '</div>';
         }
     } else if (respType === 'freeform') {
         html += '<div style="margin-top:8px">';
         html += '<textarea id="freeform-'+viewId+'" rows="4" style="width:100%;background:var(--bg-tertiary);border:1px solid var(--border);border-radius:8px;color:var(--text-primary);padding:12px;font-family:inherit;font-size:14px;resize:vertical;line-height:1.5" placeholder="Type your response..."></textarea>';
-        html += '<button class="nb-btn nb-btn-approve" onclick="submitFreeformResponse(\\''+viewId+'\\',\\'freeform-'+viewId+'\\')" style="margin-top:10px;width:100%">Submit</button>';
+        html += '<button class="nb-btn nb-btn-approve" onclick="submitFreeformResponse(&#39;'+viewId+'&#39;,&#39;freeform-'+viewId+'&#39;)" style="margin-top:10px;width:100%">Submit</button>';
         html += '</div>';
     }
 

--- a/work_buddy/dashboard/service.py
+++ b/work_buddy/dashboard/service.py
@@ -1449,7 +1449,8 @@ def _start_acknowledge_poller():
                     method="GET",
                 )
                 resp = _urlopen(req, timeout=5)
-                messages = json.loads(resp.read().decode("utf-8"))
+                data = json.loads(resp.read().decode("utf-8"))
+                messages = data.get("messages", []) if isinstance(data, dict) else data
 
                 for msg in messages:
                     if msg.get("subject") != "notification_acknowledge":

--- a/work_buddy/sidecar/dispatch/executor.py
+++ b/work_buddy/sidecar/dispatch/executor.py
@@ -86,6 +86,10 @@ def _execute_capability(name: str, params: dict[str, Any]) -> dict[str, Any]:
         entry = registry.get(name)
 
         if entry is None:
+            from work_buddy.mcp_server.registry import DISABLED_CAPABILITIES
+            missing = DISABLED_CAPABILITIES.get(name)
+            if missing:
+                return {"status": "error", "error": f"Capability '{name}' unavailable: requires {', '.join(missing)}"}
             return {"status": "error", "error": f"Capability '{name}' not found in registry."}
 
         if not isinstance(entry, Capability):

--- a/work_buddy/sidecar/scheduler/engine.py
+++ b/work_buddy/sidecar/scheduler/engine.py
@@ -177,11 +177,13 @@ class Scheduler:
             summary = _summarize_job_result(status, detail)
             job.last_run_at = time.time()
             job.last_result = status
+            job.last_error = result.get("error", "") if status == "error" else ""
             if self._event_log:
                 self._event_log.emit("job_completed", job.name, summary)
         except Exception as exc:
             job.last_run_at = time.time()
             job.last_result = "error"
+            job.last_error = str(exc)
             if self._event_log:
                 self._event_log.emit(
                     "job_failed", job.name, f"Failed: {exc}",
@@ -204,10 +206,10 @@ class Scheduler:
         if new_fps != self._job_fingerprints:
             old_count = len(self.jobs)
             # Carry forward runtime state from old jobs
-            old_state = {j.name: (j.last_run_at, j.last_result) for j in self.jobs}
+            old_state = {j.name: (j.last_run_at, j.last_result, j.last_error) for j in self.jobs}
             for job in new_jobs:
                 if job.name in old_state:
-                    job.last_run_at, job.last_result = old_state[job.name]
+                    job.last_run_at, job.last_result, job.last_error = old_state[job.name]
             self.jobs = new_jobs
             self._job_fingerprints = new_fps
             if self._event_log:
@@ -247,6 +249,7 @@ class Scheduler:
                 next_at=next_at,
                 last_run_at=job.last_run_at,
                 last_result=job.last_result,
+                last_error=job.last_error,
             ))
 
         state.set_job_states(job_states)

--- a/work_buddy/sidecar/scheduler/jobs.py
+++ b/work_buddy/sidecar/scheduler/jobs.py
@@ -54,6 +54,7 @@ class Job:
     # Runtime state (not persisted in .md frontmatter — populated by scheduler)
     last_run_at: float = 0.0
     last_result: str = ""  # ok | error
+    last_error: str = ""  # human-readable error reason (set on failure)
 
 
 def _parse_bool(value: Any) -> bool:

--- a/work_buddy/sidecar/state.py
+++ b/work_buddy/sidecar/state.py
@@ -43,6 +43,7 @@ class JobState:
     next_at: float = 0.0  # epoch seconds
     last_run_at: float = 0.0
     last_result: str = ""  # ok | error | skipped
+    last_error: str = ""  # human-readable error reason
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Fix JS `SyntaxError` from double-escaped quotes (`\'`) in onclick handlers across 5 frontend files — replaced with `&#39;` HTML entities
- Fix broken Unicode glyphs (`\uXXXX` → `\uXXXX`) rendering as literal text instead of symbols across 5 frontend files
- Fix ack-poller crash: messaging API returns `{messages: [...]}` but code iterated the top-level dict
- Add `last_error` field to `Job`/`JobState` so the dashboard Overview shows error reasons on hover
- Improve executor error message for capabilities gated on offline tools (e.g. "requires obsidian" instead of "not found in registry")

## Test plan
- [ ] Load dashboard — no console `SyntaxError`
- [ ] Verify Unicode glyphs render correctly (chevrons, checkmarks, dashes, close buttons)
- [ ] Verify boolean/choice/freeform response buttons work (onclick handlers)
- [ ] Check Overview tab job status badges show tooltip on hover when in error state
- [ ] Trigger a job failure with Obsidian closed — verify error message says "requires obsidian"

🤖 Generated with [Claude Code](https://claude.com/claude-code)