### PR TITLE
Revert README logo back to static SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="docs/logo.gif" width="180" />
+    <img src="docs/logo.svg" width="180" />
 </p>
 
 <h1 align="center">work-buddy</h1>


### PR DESCRIPTION
## Summary
- Revert README logo from `docs/logo.gif` back to `docs/logo.svg`
- GIF files kept in `docs/` for future use

## Test plan
- [ ] Verify SVG logo renders correctly on GitHub README

🤖 Generated with [Claude Code](https://claude.com/claude-code)