### PR TITLE
Fix retry system: detect {success: false} as retryable failure

### DIFF
--- a/tests/unit/test_retry_queue.py
+++ b/tests/unit/test_retry_queue.py
@@ -832,3 +832,101 @@ class TestRetryQueueSummary:
         result = _retry_queue_summary()
         assert result["queued"] == 0
         assert result.get("exhausted") == 1
+
+
+# ---------------------------------------------------------------------------
+# 8. _result_error detects {success: False} pattern (Bug fix)
+# ---------------------------------------------------------------------------
+
+class TestResultErrorSuccessFalse:
+    """Test that _result_error() catches {success: False} results."""
+
+    def test_error_key_still_works(self):
+        from work_buddy.mcp_server.tools.gateway import _result_error
+        assert _result_error({"error": "something broke"}) == "something broke"
+
+    def test_success_false_with_message(self):
+        from work_buddy.mcp_server.tools.gateway import _result_error
+        result = {"success": False, "message": "Failed to write note"}
+        assert _result_error(result) == "Failed to write note"
+
+    def test_success_false_without_message(self):
+        from work_buddy.mcp_server.tools.gateway import _result_error
+        result = {"success": False}
+        assert _result_error(result) == "Operation returned success=false"
+
+    def test_success_false_empty_message(self):
+        from work_buddy.mcp_server.tools.gateway import _result_error
+        result = {"success": False, "message": ""}
+        assert _result_error(result) == "Operation returned success=false"
+
+    def test_success_true_returns_none(self):
+        from work_buddy.mcp_server.tools.gateway import _result_error
+        assert _result_error({"success": True, "data": "ok"}) is None
+
+    def test_no_error_no_success_returns_none(self):
+        from work_buddy.mcp_server.tools.gateway import _result_error
+        assert _result_error({"data": [1, 2, 3]}) is None
+
+    def test_non_dict_returns_none(self):
+        from work_buddy.mcp_server.tools.gateway import _result_error
+        assert _result_error("just a string") is None
+        assert _result_error(42) is None
+        assert _result_error(None) is None
+
+    def test_error_key_takes_priority_over_success_false(self):
+        """When both 'error' and 'success: False' are present, 'error' wins."""
+        from work_buddy.mcp_server.tools.gateway import _result_error
+        result = {"error": "explicit error", "success": False, "message": "msg"}
+        assert _result_error(result) == "explicit error"
+
+
+# ---------------------------------------------------------------------------
+# 9. retry_sweep._replay detects {success: False} (Bug fix)
+# ---------------------------------------------------------------------------
+
+class TestRetrySweepReplaySuccessFalse:
+    """Test that retry_sweep detects {success: False, message: ...} results."""
+
+    def test_replay_success_false_transient(self, sweep_ops_dir):
+        """success=False with a transient message should be a transient failure."""
+        from work_buddy.sidecar.retry_sweep import RetrySweep
+        sweep = RetrySweep()
+        record, _ = _make_queued_op(sweep_ops_dir)
+
+        mock_entry = MagicMock()
+        mock_entry.callable = MagicMock(
+            return_value={"success": False, "message": "Failed to write note: bridge timed out"}
+        )
+
+        from work_buddy.mcp_server.registry import Capability
+        with patch("work_buddy.mcp_server.registry.get_registry", return_value={
+            "sidecar_status": mock_entry
+        }):
+            mock_entry.__class__ = Capability
+            result = sweep._replay(record)
+
+        assert result["success"] is False
+        assert result["transient"] is True
+        assert "bridge" in result["error"].lower()
+
+    def test_replay_success_false_permanent(self, sweep_ops_dir):
+        """success=False with a non-transient message should be a permanent failure."""
+        from work_buddy.sidecar.retry_sweep import RetrySweep
+        sweep = RetrySweep()
+        record, _ = _make_queued_op(sweep_ops_dir)
+
+        mock_entry = MagicMock()
+        mock_entry.callable = MagicMock(
+            return_value={"success": False, "message": "Invalid parameter: bad_key"}
+        )
+
+        from work_buddy.mcp_server.registry import Capability
+        with patch("work_buddy.mcp_server.registry.get_registry", return_value={
+            "sidecar_status": mock_entry
+        }):
+            mock_entry.__class__ = Capability
+            result = sweep._replay(record)
+
+        assert result["success"] is False
+        assert result["transient"] is False

--- a/work_buddy/mcp_server/tools/gateway.py
+++ b/work_buddy/mcp_server/tools/gateway.py
@@ -122,13 +122,18 @@ def _result_error(result: Any) -> str | None:
     """Extract an error string from a result dict, if present.
 
     Capabilities that catch their own errors and return {"error": "..."}
-    instead of raising need to be recorded as failures so wb_retry can
-    replay them.  Returns None when the result is not a failure.
+    or {"success": False, "message": "..."} instead of raising need to be
+    recorded as failures so wb_retry can replay them.
+    Returns None when the result is not a failure.
     """
     if isinstance(result, dict):
         err = result.get("error")
         if err:  # non-None, non-empty
             return str(err)
+        # Also detect {"success": False, "message": "..."} pattern
+        if result.get("success") is False:
+            msg = result.get("message", "")
+            return str(msg) if msg else "Operation returned success=false"
     return None
 
 
@@ -998,13 +1003,64 @@ def register_tools(mcp: FastMCP) -> None:
                     "operation_id": operation_id,
                 })
             except Exception as exc:
-                _complete_operation(operation_id, error=f"{type(exc).__name__}: {exc}")
+                error_str = f"{type(exc).__name__}: {exc}"
+                _complete_operation(operation_id, error=error_str)
+
+                # Enqueue transient failures for sidecar retry
+                retry_policy = record.get("retry_policy", "replay")
+                from work_buddy.errors import classify_error as _classify
+                error_class = _classify(exc)
+                if (
+                    error_class == "transient"
+                    and retry_policy in ("replay", "verify_first")
+                ):
+                    _enqueue_for_retry(
+                        operation_id, error_str, error_class,
+                        originating_session_id=record.get("originating_session_id")
+                            or record.get("session_id"),
+                    )
+                    return _to_json({
+                        "error": f"Transient failure: {error_str}",
+                        "operation_id": operation_id,
+                        "queued_for_retry": True,
+                        "retry_hint": (
+                            "Retry failed due to a transient error "
+                            "and has been re-queued for automatic background retry."
+                        ),
+                    })
+
                 return _to_json({
-                    "error": f"Retry failed: {type(exc).__name__}: {exc}",
+                    "error": f"Retry failed: {error_str}",
                     "operation_id": operation_id,
                 })
 
-        _complete_operation(operation_id, result=result, error=_result_error(result))
+        # Check for soft transient failures in the result
+        result_err = _result_error(result)
+        if result_err:
+            retry_policy = record.get("retry_policy", "replay")
+            from work_buddy.errors import is_transient_result as _is_transient
+            if (
+                _is_transient(result)
+                and retry_policy in ("replay", "verify_first")
+            ):
+                _complete_operation(operation_id, result=result, error=result_err)
+                _enqueue_for_retry(
+                    operation_id, result_err, "transient",
+                    originating_session_id=record.get("originating_session_id")
+                        or record.get("session_id"),
+                )
+                return _to_json({
+                    "error": f"Transient failure: {result_err}",
+                    "operation_id": operation_id,
+                    "queued_for_retry": True,
+                    "attempt": record["attempt"],
+                    "retry_hint": (
+                        "Retry returned a transient error "
+                        "and has been re-queued for automatic background retry."
+                    ),
+                })
+
+        _complete_operation(operation_id, result=result, error=result_err)
         return _to_json({
             "type": "result",
             "capability": record["name"],

--- a/work_buddy/sidecar/retry_sweep.py
+++ b/work_buddy/sidecar/retry_sweep.py
@@ -172,7 +172,10 @@ class RetrySweep:
             # Check for soft errors in the result
             from work_buddy.errors import is_transient_result
             if isinstance(result, dict):
+                # Detect both {"error": "..."} and {"success": False, "message": "..."}
                 err = result.get("error")
+                if not err and result.get("success") is False:
+                    err = result.get("message", "Operation returned success=false")
                 if err:
                     if is_transient_result(result):
                         return {"success": False, "error": str(err), "transient": True}


### PR DESCRIPTION
## Summary
- Extended `_result_error()` to detect `{success: False, message: "..."}` payloads as failures (root cause: these were marked "completed" instead of "failed")
- Added transient error classification and re-enqueue logic to `wb_retry()` exception and soft-failure paths
- Fixed `retry_sweep._replay()` to also detect `{success: False}` results

## Test plan
- [x] All 89 retry queue tests pass (10 new tests added)
- [ ] Manual verification: trigger a capability that returns `{success: false}` and confirm it's queued for retry instead of marked completed

Task: t-f3867716