### PR TITLE
Fix sidecar shutdown crash from Windows file-lock PermissionError

### DIFF
--- a/tests/test_state_lock.py
+++ b/tests/test_state_lock.py
@@ -1,0 +1,87 @@
+"""Test save_state retry and fallback under Windows file locks.
+
+Simulates the PermissionError crash from os.replace when another process
+holds an exclusive handle on sidecar_state.json.
+"""
+
+import json
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from work_buddy.sidecar.state import SidecarState, save_state
+import work_buddy.sidecar.state as state_mod
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32", reason="Windows file-locking test"
+)
+
+
+@pytest.fixture()
+def isolated_state_file(tmp_path):
+    """Patch STATE_FILE to a temp location for the test."""
+    state_file = tmp_path / "sidecar_state.json"
+    state_file.write_text("{}")
+    original = state_mod.STATE_FILE
+    state_mod.STATE_FILE = state_file
+    yield state_file
+    state_mod.STATE_FILE = original
+
+
+def _open_exclusive(path: Path):
+    """Open a file with no sharing flags via Win32 API."""
+    import ctypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    GENERIC_READ = 0x80000000
+    OPEN_EXISTING = 3
+    FILE_ATTRIBUTE_NORMAL = 0x80
+    handle = kernel32.CreateFileW(
+        str(path), GENERIC_READ, 0, None, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, None
+    )
+    assert handle != -1, f"CreateFileW failed: {ctypes.get_last_error()}"
+    return handle, kernel32
+
+
+def test_normal_save(isolated_state_file):
+    """Baseline: save works when nothing holds the file."""
+    s = SidecarState(started_at=1.0, pid=99)
+    save_state(s)
+    data = json.loads(isolated_state_file.read_text())
+    assert data["pid"] == 99
+
+
+def test_retry_recovers_after_lock_released(isolated_state_file):
+    """Lock is held briefly, released mid-retry — save should succeed."""
+    handle, kernel32 = _open_exclusive(isolated_state_file)
+
+    def release():
+        time.sleep(0.3)
+        kernel32.CloseHandle(handle)
+
+    threading.Thread(target=release, daemon=True).start()
+
+    t0 = time.time()
+    s = SidecarState(started_at=2.0, pid=100)
+    save_state(s, _retries=4)
+    elapsed = time.time() - t0
+
+    data = json.loads(isolated_state_file.read_text())
+    assert data["pid"] == 100
+    assert elapsed >= 0.1, "Should have needed at least one retry"
+
+
+def test_raises_when_permanently_locked(isolated_state_file):
+    """Lock held through all retries and fallback — should raise."""
+    handle, kernel32 = _open_exclusive(isolated_state_file)
+    try:
+        s = SidecarState(started_at=3.0, pid=101)
+        # Use 1 retry to keep the test fast
+        with pytest.raises(PermissionError):
+            save_state(s, _retries=1)
+    finally:
+        kernel32.CloseHandle(handle)

--- a/work_buddy/sidecar/daemon.py
+++ b/work_buddy/sidecar/daemon.py
@@ -31,6 +31,7 @@ from work_buddy.sidecar.pid import (
     write_pid_file,
 )
 from work_buddy.sidecar.state import (
+    STATE_FILE,
     SidecarState,
     ServiceHealth,
     cleanup_state_file,
@@ -402,7 +403,20 @@ def _shutdown(children: list[ChildService], state: SidecarState) -> None:
     # Write final state showing all services stopped
     for name in state.services:
         state.update_service(name, status="stopped", pid=None)
-    save_state(state)
+    try:
+        save_state(state)
+    except PermissionError as exc:
+        # On Windows, os.replace / write can fail with WinError 5 when
+        # another process holds a handle on the state file.  Not worth
+        # crashing the shutdown sequence for a stale status file.
+        state_path = str(STATE_FILE)
+        if (
+            (exc.filename and state_path in str(Path(exc.filename).resolve()))
+            or (exc.filename2 and state_path in str(Path(exc.filename2).resolve()))
+        ):
+            logger.warning("Failed to write final state (non-fatal): %s", exc)
+        else:
+            raise
 
     cleanup_pid_file()
     # Don't remove state file — leave it for observability (shows "stopped")

--- a/work_buddy/sidecar/state.py
+++ b/work_buddy/sidecar/state.py
@@ -67,8 +67,14 @@ class SidecarState:
         self.jobs = job_states
 
 
-def save_state(state: SidecarState) -> None:
-    """Atomically write the state to disk."""
+def save_state(state: SidecarState, *, _retries: int = 4) -> None:
+    """Atomically write the state to disk.
+
+    On Windows, ``os.replace`` can fail with ``PermissionError`` when
+    another process (antivirus, file indexer, dashboard reader) holds a
+    handle on the target file.  We retry with a short back-off before
+    giving up.
+    """
     data = asdict(state)
 
     fd, tmp_path = tempfile.mkstemp(
@@ -77,12 +83,45 @@ def save_state(state: SidecarState) -> None:
     try:
         os.write(fd, json.dumps(data, indent=2).encode())
         os.close(fd)
-        os.replace(tmp_path, STATE_FILE)
-    except Exception:
+        fd = -1  # mark closed so the except branch doesn't double-close
+
+        last_exc: Exception | None = None
+        for attempt in range(_retries + 1):
+            try:
+                os.replace(tmp_path, STATE_FILE)
+                return  # success
+            except PermissionError as exc:
+                last_exc = exc
+                if attempt < _retries:
+                    time.sleep(min(3.0, 0.15 * 3**attempt))  # 0.15, 0.45, 1.35, 3.0s
+
+        # All retries exhausted — fall back to non-atomic overwrite so the
+        # sidecar doesn't crash on a transient file lock.
         try:
-            os.close(fd)
+            STATE_FILE.write_bytes(Path(tmp_path).read_bytes())
+            os.unlink(tmp_path)
+            logger.debug(
+                "save_state: os.replace failed after %d retries, "
+                "used non-atomic fallback",
+                _retries,
+            )
+            return
+        except Exception:
+            pass  # if even the fallback fails, raise the original error
+
+        # Clean up tmp and propagate
+        try:
+            os.unlink(tmp_path)
         except OSError:
             pass
+        raise last_exc  # type: ignore[misc]
+
+    except Exception:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
         try:
             os.unlink(tmp_path)
         except OSError:


### PR DESCRIPTION
## Summary
- `save_state` now retries `os.replace` up to 4 times with exponential backoff (0.15–3s) when a `PermissionError` occurs from another process holding a read handle on `sidecar_state.json`
- Falls back to non-atomic direct write if all retries exhaust, so the sidecar doesn't crash on a transient file lock
- `_shutdown` catches only `PermissionError` targeting the state file path (resolved formally via `work_buddy.paths`), re-raising anything else
- Added Windows file-lock simulation tests using Win32 `CreateFileW` with exclusive access

## Test plan
- [x] All 29 existing sidecar/state tests pass
- [x] 3 new tests pass: normal save, retry-recovery after lock release, raises on permanent lock
- [ ] Monitor sidecar shutdown in production for recurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)