### PR TITLE
fix: correct DISABLED_CAPABILITIES import path in sidecar executor

### DIFF
--- a/work_buddy/sidecar/dispatch/executor.py
+++ b/work_buddy/sidecar/dispatch/executor.py
@@ -86,7 +86,7 @@ def _execute_capability(name: str, params: dict[str, Any]) -> dict[str, Any]:
         entry = registry.get(name)
 
         if entry is None:
-            from work_buddy.mcp_server.registry import DISABLED_CAPABILITIES
+            from work_buddy.tools import DISABLED_CAPABILITIES
             missing = DISABLED_CAPABILITIES.get(name)
             if missing:
                 return {"status": "error", "error": f"Capability '{name}' unavailable: requires {', '.join(missing)}"}


### PR DESCRIPTION
## Summary
- One-line fix: `executor.py` imported `DISABLED_CAPABILITIES` from `work_buddy.mcp_server.registry` where it only exists inside a function scope. Changed to import from `work_buddy.tools` where it's defined at module level.
- This caused `task_sync` (and any capability lookup for missing entries) to fail with `ImportError` on every sidecar run.

## Test plan
- [x] Sidecar starts without the `ImportError` on `task-sync` job