### PR TITLE
feat: setup wizard with feature preferences and requirements validation

### DIFF
--- a/.claude/commands/wb-setup.md
+++ b/.claude/commands/wb-setup.md
@@ -1,0 +1,5 @@
+---
+short: Setup wizard
+workflow: setup_wizard
+---
+Load directions via `mcp__work-buddy__wb_run("agent_docs", {"path": "status/setup-wizard-directions", "depth": "full"})`, then call `setup_wizard` with `$ARGUMENTS`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,21 @@ Web dashboard for system observability, served as a sidecar-managed Flask servic
 - **Read-only mode**: `dashboard.read_only: true` in config.yaml gates mutating POST routes (403) and hides mutation controls in the frontend.
 - **CRITICAL for all agents modifying dashboard code**: Never add browser-side fetches to sibling localhost ports (5123, 5124, 27125, etc.) — these break on mobile. Gate new POST routes with `_reject_read_only()`. See `work_buddy/dashboard/README.md` "Development rules" for the full checklist.
 
+## Feature Preferences
+
+Users can opt in/out of components via `features:` in `config.local.yaml`. The setup wizard (`/wb-setup`) manages these preferences interactively.
+
+**Before recommending or using a feature, check preferences:**
+- If `wanted: false` — do **not** suggest, probe, or diagnose it. If the user asks "why isn't X working?", mention they opted out and point them to `/wb-setup preferences` to re-enable.
+- If `wanted: true` or `wanted: null` (undecided) — use normally.
+- Use `feature_status` to see preferences + tool availability in one call.
+
+**Requirements system:** Configuration-time checks (`work_buddy/health/requirements.py`) validate hidden assumptions — vault sections, plugin states, config keys. The wizard runs these and presents failures with fix instructions. Requirements are distinct from health checks (runtime) — requirements check "is it configured?" while health checks "is it running?"
+
+**Capabilities:**
+- `setup_wizard` — modes: `status` (overview), `guided` (interactive setup), `diagnose` (deep diagnostic), `preferences` (view/edit)
+- `feature_status` — includes `preferences` and `bootstrap_requirements` sections
+
 ## Consent system
 
 Some `work_buddy` functions are protected by a `@requires_consent` decorator. **The gateway handles consent transparently** — when you call `wb_run` on a consent-gated capability, the gateway automatically requests consent from the user, waits for approval, and retries the operation. You do not need to manually orchestrate consent.
@@ -645,8 +660,9 @@ All capabilities and workflows are invoked via `mcp__work-buddy__wb_run("name", 
 | `obsidian_retry` | function | Synchronous bridge-aware retry with health checks between attempts |
 | `llm_call` | function | Single LLM API call (Tier 2, cheaper than full agent) |
 | `llm_costs` | function | Token usage and cost breakdown |
-| `feature_status` | function | Tool probe results: available/disabled tools and affected capabilities |
-| `setup_help` | function | Interactive setup troubleshooting |
+| `feature_status` | function | Tool probe results, preferences, bootstrap requirements, disabled capabilities |
+| `setup_help` | function | Diagnose component health (legacy — prefer `setup_wizard`) |
+| `setup_wizard` | function | Comprehensive setup wizard: status, guided setup, diagnose, preferences |
 | `tailscale_status` | function | Tailscale network status |
 
 ### Knowledge (agent self-documentation)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 It runs locally, uses your own API keys, and stores everything on your machine. No cloud dependencies. Your workflows, your data, your agent.
 
-> **90+ capabilities** &bull; **15+ structured workflows** &bull; **34 slash commands** &bull; **205 Python modules** &bull; **Most commits authored by agents**
+> **90+ capabilities** &bull; **15+ structured workflows** &bull; **35 slash commands** &bull; **205 Python modules** &bull; **Most commits authored by agents**
 
 <p align="center">
     <img src="docs/hero_dashboard.png" alt="work-buddy dashboard — browsing agent session conversations" width="700" />
@@ -273,9 +273,14 @@ poetry install --extras all       # Everything
 ```bash
 cp config.example.yaml config.yaml
 # Edit: vault path, timezone, enabled services
+
+cp config.local.yaml.example config.local.yaml
+# Edit: machine-specific overrides (Tailscale URL, Hindsight bank, feature preferences)
 ```
 
-Machine-specific overrides (e.g., `hindsight.bank_id`) go in `config.local.yaml` (gitignored). Copy `config.local.example.yaml` as a starting point.
+Machine-specific overrides (e.g., `hindsight.bank_id`) go in `config.local.yaml` (gitignored).
+
+**First-time setup:** After connecting to Claude Code, run `/wb-setup guided` for an interactive walkthrough that validates your configuration, lets you choose which features to enable, and checks that everything is wired correctly. The wizard will flag missing requirements with fix instructions.
 
 ### Connect to Claude Code
 
@@ -432,7 +437,7 @@ curl http://127.0.0.1:5124/health   # Embedding
 curl http://127.0.0.1:5127/health   # Dashboard
 ```
 
-Or from within Claude Code: `/wb-setup-help` runs automated diagnostics that walk dependency chains and stop at the first failure with a fix suggestion.
+Or from within Claude Code: `/wb-setup` runs the setup wizard with automated diagnostics, requirement validation, and feature preference management. Use `/wb-setup-help` for targeted component diagnostics.
 
 <details>
 <summary><strong>Auto-start on login</strong></summary>
@@ -575,7 +580,7 @@ Set `dashboard.external_url` in `config.yaml` to enable "View in dashboard" link
 
 ## Slash Commands
 
-All 33 commands are prefixed `wb-` for easy discovery. Highlights:
+All 35 commands are prefixed `wb-` for easy discovery. Highlights:
 
 | Command | What it does |
 |---------|-------------|
@@ -585,6 +590,7 @@ All 33 commands are prefixed `wb-` for easy discovery. Highlights:
 | `/wb-journal-update` | Detect recent activity, append to today's journal |
 | `/wb-meta-blindspots` | Check work against documented failure patterns |
 | `/wb-dev` | Enter development mode with architecture orientation |
+| `/wb-setup` | Setup wizard: validate config, choose features, diagnose issues |
 | `/wb-task-handoff` | Create a task with full handoff context for a new session |
 
 ---
@@ -602,12 +608,12 @@ work_buddy/              # Python package (205 modules, ~58k LOC)
   telegram/              # Telegram bot sidecar
   obsidian/              # Obsidian bridge + plugin integrations
   knowledge/             # Typed JSON documentation store
-  health/                # Feature toggles + diagnostics
+  health/                # Feature toggles, diagnostics, setup wizard, requirements
   sessions/              # Conversation inspection + search
 
 knowledge/               # Agent documentation + workflow DAGs (canonical store)
 contracts/               # Work commitment tracking
-.claude/commands/        # 34 slash commands (wb-* prefix)
+.claude/commands/        # 35 slash commands (wb-* prefix)
 tests/                   # pytest + freezegun test suite
 ```
 
@@ -620,8 +626,10 @@ Each subsystem has its own README.
 Layered config system:
 
 - `config.yaml` — project-wide settings (checked in)
-- `config.local.yaml` — machine-specific overrides (gitignored)
+- `config.local.yaml` — machine-specific overrides + feature preferences (gitignored)
 - `CLAUDE.local.md` — personal behavioral instructions for your agent (gitignored)
+
+Feature preferences live in `config.local.yaml` under a `features:` key. Set `wanted: false` on any component to opt out — agents won't suggest it, the dashboard hides it, and probes are skipped. Run `/wb-setup preferences` to manage these interactively.
 
 Features are modular. The dependency-aware toggle system lets you enable/disable subsystems based on what you have installed.
 

--- a/config.local.yaml.example
+++ b/config.local.yaml.example
@@ -1,0 +1,33 @@
+# Machine-specific overrides (gitignored)
+# Merged on top of config.yaml — only include keys you want to override.
+#
+# Copy this file to config.local.yaml and edit:
+#   cp config.local.yaml.example config.local.yaml
+
+# --- Dashboard remote access ---
+dashboard:
+  external_url: ""  # Your Tailscale HTTPS URL, e.g. "https://machine.tailnet.ts.net"
+
+# --- Hindsight personal memory ---
+# Only needed if you use the Hindsight memory system.
+# hindsight:
+#   bank_id: your-bank-name
+#   user_tag: user:yourname
+#   bank_mission: 'Your custom mission statement for the memory bank.'
+
+# --- Feature preferences ---
+# Control which components the setup wizard tracks.
+# wanted: true  — Probe, show in dashboard, agents will use it.
+# wanted: false — Skip probes, hide from dashboard, agents won't suggest it.
+# Omit a component to leave it undecided (treated as wanted by default).
+#
+# features:
+#   hindsight:
+#     wanted: false
+#     reason: "Not using personal memory system"
+#   telegram:
+#     wanted: false
+#   obsidian:
+#     wanted: true
+#   chrome_extension:
+#     wanted: true

--- a/knowledge/store/status.json
+++ b/knowledge/store/status.json
@@ -15,6 +15,22 @@
       "full": "Run mcp__work-buddy__wb_run(\"setup_help\", {\"component\": \"$ARGUMENTS\"}). If no argument, pass \"all\".\n\nPresent:\n1. Summary -- N healthy, N unhealthy, N disabled\n2. Issues -- for each unhealthy component: name, status, root cause, fix suggestion\n3. Dependency chain -- if failure is caused by a dependency, show the chain\n\nKeep actionable. Lead with the fix, not the architecture."
     }
   },
+  "status/setup-wizard-directions": {
+    "kind": "directions",
+    "name": "Setup Wizard Directions",
+    "description": "How to run the setup wizard — modes, feature preferences, requirements, guided setup",
+    "aliases": ["setup wizard", "configure work-buddy", "feature preferences", "onboarding", "first-time setup"],
+    "tags": ["status", "setup", "wizard", "preferences", "requirements", "directions"],
+    "parents": ["status"],
+    "trigger": "user runs /wb-setup, asks to configure features, or wants to know what's set up",
+    "command": "wb-setup",
+    "workflow": null,
+    "capabilities": ["status/setup_wizard"],
+    "content": {
+      "summary": "Four modes: status (quick overview), guided (interactive walkthrough), diagnose (deep diagnostic for one component), preferences (view/edit wanted features). Default is status.",
+      "full": "Run mcp__work-buddy__wb_run(\"setup_wizard\", {\"mode\": \"<mode>\", ...}).\n\nModes:\n\n1. **status** (default, no args): Quick overview of bootstrap requirements, component health, and requirement validation for wanted components. Present: bootstrap pass/fail, then per-component health + any requirement failures with fix hints.\n\n2. **guided** (first-time setup): Returns structured steps. Walk the user through:\n   - Step 1: Bootstrap — fix any core/config failures first\n   - Step 2: Features — ask which components they want (present by category)\n   - Step 3: Requirements — show failures for wanted features with fix hints\n   - Step 4: Health — check running services\n   Save preferences with: wb_run(\"setup_wizard\", {\"mode\": \"preferences\", \"updates\": {\"hindsight\": {\"wanted\": false}}})\n\n3. **diagnose** (targeted): Requires component param. Deep diagnostic combining requirements + health + check sequences. Lead with the fix.\n   Example: wb_run(\"setup_wizard\", {\"mode\": \"diagnose\", \"component\": \"hindsight\"})\n\n4. **preferences** (view/edit): Show or update feature preferences.\n   View: wb_run(\"setup_wizard\", {\"mode\": \"preferences\"})\n   Update: wb_run(\"setup_wizard\", {\"mode\": \"preferences\", \"updates\": {\"telegram\": {\"wanted\": false, \"reason\": \"...\"}, \"hindsight\": {\"wanted\": true}}})\n\nKey principles:\n- If a feature is wanted:false, don't suggest it or show it as broken.\n- If a user asks 'why isn't X working?', check preferences first — they may have opted out.\n- Bootstrap failures block everything — fix those first.\n- Requirements are configuration issues (fix once). Health checks are runtime issues (may need restart)."
+    }
+  },
   "status/tailscale-status-directions": {
     "kind": "directions",
     "name": "Tailscale Status Directions",

--- a/tests/unit/test_config_local.py
+++ b/tests/unit/test_config_local.py
@@ -1,0 +1,104 @@
+"""Unit tests for config.local.yaml helpers in config.py."""
+
+import pytest
+import yaml
+from pathlib import Path
+
+from work_buddy.config import (
+    config_local_path,
+    read_config_local,
+    write_config_local,
+)
+
+
+class TestConfigLocalPath:
+    def test_returns_path_object(self):
+        result = config_local_path()
+        assert isinstance(result, Path)
+        assert result.name == "config.local.yaml"
+
+    def test_is_sibling_of_config_yaml(self):
+        result = config_local_path()
+        assert (result.parent / "config.yaml").exists() or True  # may not exist in CI
+
+
+class TestReadConfigLocal:
+    def test_returns_empty_when_missing(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "work_buddy.config.config_local_path",
+            lambda: tmp_path / "config.local.yaml",
+        )
+        result = read_config_local()
+        assert result == {}
+
+    def test_reads_yaml(self, monkeypatch, tmp_path):
+        local = tmp_path / "config.local.yaml"
+        local.write_text("dashboard:\n  external_url: test\n", encoding="utf-8")
+        monkeypatch.setattr(
+            "work_buddy.config.config_local_path",
+            lambda: local,
+        )
+        result = read_config_local()
+        assert result["dashboard"]["external_url"] == "test"
+
+    def test_empty_file_returns_empty_dict(self, monkeypatch, tmp_path):
+        local = tmp_path / "config.local.yaml"
+        local.write_text("", encoding="utf-8")
+        monkeypatch.setattr(
+            "work_buddy.config.config_local_path",
+            lambda: local,
+        )
+        result = read_config_local()
+        assert result == {}
+
+
+class TestWriteConfigLocal:
+    def test_creates_file_if_missing(self, monkeypatch, tmp_path):
+        local = tmp_path / "config.local.yaml"
+        monkeypatch.setattr(
+            "work_buddy.config.config_local_path",
+            lambda: local,
+        )
+        # Also patch read to use same path
+        monkeypatch.setattr(
+            "work_buddy.config.read_config_local",
+            lambda: yaml.safe_load(local.read_text(encoding="utf-8")) if local.exists() else {},
+        )
+        write_config_local("features", {"hindsight": {"wanted": False}})
+        assert local.exists()
+        data = yaml.safe_load(local.read_text(encoding="utf-8"))
+        assert data["features"]["hindsight"]["wanted"] is False
+
+    def test_preserves_other_sections(self, monkeypatch, tmp_path):
+        local = tmp_path / "config.local.yaml"
+        local.write_text("dashboard:\n  external_url: test\n", encoding="utf-8")
+        monkeypatch.setattr(
+            "work_buddy.config.config_local_path",
+            lambda: local,
+        )
+        monkeypatch.setattr(
+            "work_buddy.config.read_config_local",
+            lambda: yaml.safe_load(local.read_text(encoding="utf-8")) or {},
+        )
+        write_config_local("features", {"obsidian": {"wanted": True}})
+        data = yaml.safe_load(local.read_text(encoding="utf-8"))
+        assert data["dashboard"]["external_url"] == "test"
+        assert data["features"]["obsidian"]["wanted"] is True
+
+    def test_overwrites_section(self, monkeypatch, tmp_path):
+        local = tmp_path / "config.local.yaml"
+        local.write_text(
+            "features:\n  obsidian:\n    wanted: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "work_buddy.config.config_local_path",
+            lambda: local,
+        )
+        monkeypatch.setattr(
+            "work_buddy.config.read_config_local",
+            lambda: yaml.safe_load(local.read_text(encoding="utf-8")) or {},
+        )
+        write_config_local("features", {"obsidian": {"wanted": False}})
+        data = yaml.safe_load(local.read_text(encoding="utf-8"))
+        assert data["features"]["obsidian"]["wanted"] is False

--- a/tests/unit/test_preferences.py
+++ b/tests/unit/test_preferences.py
@@ -1,0 +1,197 @@
+"""Unit tests for the feature preferences system (health/preferences.py)."""
+
+import pytest
+import yaml
+
+from work_buddy.health.preferences import (
+    FeaturePreference,
+    get_preference,
+    is_wanted,
+    load_preferences,
+    save_preferences,
+    set_preference,
+)
+
+
+class TestFeaturePreference:
+    def test_default_wanted_is_none(self):
+        pref = FeaturePreference(component_id="obsidian")
+        assert pref.wanted is None
+        assert pref.reason is None
+
+    def test_to_dict_minimal(self):
+        pref = FeaturePreference(component_id="obsidian", wanted=True)
+        d = pref.to_dict()
+        assert d == {"wanted": True}
+        assert "reason" not in d
+
+    def test_to_dict_with_reason(self):
+        pref = FeaturePreference(
+            component_id="hindsight", wanted=False, reason="Not using"
+        )
+        d = pref.to_dict()
+        assert d == {"wanted": False, "reason": "Not using"}
+
+    def test_from_dict(self):
+        pref = FeaturePreference.from_dict("telegram", {"wanted": False, "reason": "No bot"})
+        assert pref.component_id == "telegram"
+        assert pref.wanted is False
+        assert pref.reason == "No bot"
+
+    def test_from_dict_missing_fields(self):
+        pref = FeaturePreference.from_dict("obsidian", {})
+        assert pref.wanted is None
+        assert pref.reason is None
+
+
+class TestLoadSavePreferences:
+    def test_load_empty_when_no_features_section(self, tmp_path, monkeypatch):
+        """No 'features:' in config.local.yaml → empty dict."""
+        local = tmp_path / "config.local.yaml"
+        local.write_text("dashboard:\n  external_url: x\n", encoding="utf-8")
+        monkeypatch.setattr(
+            "work_buddy.health.preferences.read_config_local",
+            lambda: yaml.safe_load(local.read_text(encoding="utf-8")) or {},
+        )
+        prefs = load_preferences()
+        assert prefs == {}
+
+    def test_load_empty_when_no_file(self, monkeypatch):
+        """config.local.yaml doesn't exist → empty dict."""
+        monkeypatch.setattr(
+            "work_buddy.health.preferences.read_config_local",
+            lambda: {},
+        )
+        prefs = load_preferences()
+        assert prefs == {}
+
+    def test_load_parses_features(self, monkeypatch):
+        monkeypatch.setattr(
+            "work_buddy.health.preferences.read_config_local",
+            lambda: {
+                "features": {
+                    "hindsight": {"wanted": False, "reason": "Not using"},
+                    "obsidian": {"wanted": True},
+                }
+            },
+        )
+        prefs = load_preferences()
+        assert len(prefs) == 2
+        assert prefs["hindsight"].wanted is False
+        assert prefs["hindsight"].reason == "Not using"
+        assert prefs["obsidian"].wanted is True
+
+    def test_load_handles_bare_bool(self, monkeypatch):
+        """features.telegram: false (bare bool, not dict)."""
+        monkeypatch.setattr(
+            "work_buddy.health.preferences.read_config_local",
+            lambda: {"features": {"telegram": False}},
+        )
+        prefs = load_preferences()
+        assert prefs["telegram"].wanted is False
+
+    def test_save_roundtrip(self, tmp_path, monkeypatch):
+        local_file = tmp_path / "config.local.yaml"
+        local_file.write_text("dashboard:\n  external_url: x\n", encoding="utf-8")
+
+        # Patch read/write to use tmp file
+        def _read():
+            if local_file.exists():
+                return yaml.safe_load(local_file.read_text(encoding="utf-8")) or {}
+            return {}
+
+        def _write(section, data):
+            existing = _read()
+            existing[section] = data
+            local_file.write_text(
+                yaml.safe_dump(existing, default_flow_style=False, sort_keys=False),
+                encoding="utf-8",
+            )
+
+        monkeypatch.setattr("work_buddy.health.preferences.read_config_local", _read)
+        monkeypatch.setattr("work_buddy.health.preferences.write_config_local", _write)
+
+        # Save preferences
+        prefs = {
+            "hindsight": FeaturePreference("hindsight", wanted=False, reason="No DB"),
+            "obsidian": FeaturePreference("obsidian", wanted=True),
+        }
+        save_preferences(prefs)
+
+        # Read back
+        loaded = load_preferences()
+        assert loaded["hindsight"].wanted is False
+        assert loaded["hindsight"].reason == "No DB"
+        assert loaded["obsidian"].wanted is True
+
+        # Verify other sections preserved
+        data = yaml.safe_load(local_file.read_text(encoding="utf-8"))
+        assert data["dashboard"]["external_url"] == "x"
+
+
+class TestGetPreference:
+    def test_returns_undecided_for_unknown(self, monkeypatch):
+        monkeypatch.setattr(
+            "work_buddy.health.preferences.read_config_local",
+            lambda: {},
+        )
+        pref = get_preference("nonexistent")
+        assert pref.wanted is None
+        assert pref.component_id == "nonexistent"
+
+    def test_returns_explicit_preference(self, monkeypatch):
+        monkeypatch.setattr(
+            "work_buddy.health.preferences.read_config_local",
+            lambda: {"features": {"hindsight": {"wanted": False}}},
+        )
+        pref = get_preference("hindsight")
+        assert pref.wanted is False
+
+
+class TestIsWanted:
+    def test_none_for_undecided(self, monkeypatch):
+        monkeypatch.setattr(
+            "work_buddy.health.preferences.read_config_local",
+            lambda: {},
+        )
+        assert is_wanted("obsidian") is None
+
+    def test_false_for_opted_out(self, monkeypatch):
+        monkeypatch.setattr(
+            "work_buddy.health.preferences.read_config_local",
+            lambda: {"features": {"hindsight": {"wanted": False}}},
+        )
+        assert is_wanted("hindsight") is False
+
+    def test_true_for_explicitly_wanted(self, monkeypatch):
+        monkeypatch.setattr(
+            "work_buddy.health.preferences.read_config_local",
+            lambda: {"features": {"obsidian": {"wanted": True}}},
+        )
+        assert is_wanted("obsidian") is True
+
+
+class TestSetPreference:
+    def test_set_persists(self, tmp_path, monkeypatch):
+        local_file = tmp_path / "config.local.yaml"
+        local_file.write_text("{}", encoding="utf-8")
+
+        def _read():
+            return yaml.safe_load(local_file.read_text(encoding="utf-8")) or {}
+
+        def _write(section, data):
+            existing = _read()
+            existing[section] = data
+            local_file.write_text(
+                yaml.safe_dump(existing, default_flow_style=False, sort_keys=False),
+                encoding="utf-8",
+            )
+
+        monkeypatch.setattr("work_buddy.health.preferences.read_config_local", _read)
+        monkeypatch.setattr("work_buddy.health.preferences.write_config_local", _write)
+
+        set_preference("telegram", wanted=False, reason="No bot")
+
+        loaded = load_preferences()
+        assert loaded["telegram"].wanted is False
+        assert loaded["telegram"].reason == "No bot"

--- a/tests/unit/test_requirements.py
+++ b/tests/unit/test_requirements.py
@@ -1,0 +1,538 @@
+"""Unit tests for the requirements system (health/requirements.py + requirement_checks.py)."""
+
+import json
+import os
+import pytest
+
+from work_buddy.health.requirements import (
+    REQUIREMENT_REGISTRY,
+    RequirementChecker,
+    RequirementDef,
+    RequirementResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry sanity
+# ---------------------------------------------------------------------------
+
+class TestRequirementRegistry:
+    def test_registry_not_empty(self):
+        assert len(REQUIREMENT_REGISTRY) >= 20
+
+    def test_all_ids_are_hierarchical(self):
+        """Every ID must have at least 2 slashes (domain/subsystem/name)."""
+        for req_id in REQUIREMENT_REGISTRY:
+            parts = req_id.split("/")
+            assert len(parts) >= 3, f"ID '{req_id}' needs at least 3 path segments"
+
+    def test_valid_domains(self):
+        valid_domains = {"core", "obsidian", "integrations", "services"}
+        for req_id in REQUIREMENT_REGISTRY:
+            domain = req_id.split("/")[0]
+            assert domain in valid_domains, f"ID '{req_id}' has invalid domain '{domain}'"
+
+    def test_valid_severity(self):
+        for req in REQUIREMENT_REGISTRY.values():
+            assert req.severity in ("required", "recommended"), (
+                f"{req.id} has invalid severity '{req.severity}'"
+            )
+
+    def test_core_requirements_have_no_component(self):
+        for req in REQUIREMENT_REGISTRY.values():
+            if req.id.startswith("core/"):
+                assert req.component is None, (
+                    f"Core requirement {req.id} should have component=None"
+                )
+
+    def test_non_core_requirements_have_component(self):
+        for req in REQUIREMENT_REGISTRY.values():
+            if not req.id.startswith("core/"):
+                assert req.component is not None, (
+                    f"Non-core requirement {req.id} should have a component"
+                )
+
+    def test_check_fn_is_importable_string(self):
+        for req in REQUIREMENT_REGISTRY.values():
+            parts = req.check_fn.rsplit(".", 1)
+            assert len(parts) == 2, f"{req.id} check_fn must be module.function"
+
+    def test_setup_groups_are_set(self):
+        for req in REQUIREMENT_REGISTRY.values():
+            assert req.setup_group, f"{req.id} is missing setup_group"
+
+    def test_bootstrap_group_for_core(self):
+        for req in REQUIREMENT_REGISTRY.values():
+            if req.id.startswith("core/"):
+                assert req.setup_group == "bootstrap", (
+                    f"Core requirement {req.id} should have setup_group='bootstrap'"
+                )
+
+
+# ---------------------------------------------------------------------------
+# RequirementResult
+# ---------------------------------------------------------------------------
+
+class TestRequirementResult:
+    def test_to_dict_pass(self):
+        r = RequirementResult(
+            id="core/config/vault-root",
+            ok=True,
+            detail="vault exists",
+            fix_hint="Set vault_root",
+            severity="required",
+            component=None,
+        )
+        d = r.to_dict()
+        assert d["ok"] is True
+        assert d["fix_hint"] == ""  # suppressed on pass
+
+    def test_to_dict_fail(self):
+        r = RequirementResult(
+            id="core/config/vault-root",
+            ok=False,
+            detail="vault missing",
+            fix_hint="Set vault_root",
+            severity="required",
+            component=None,
+        )
+        d = r.to_dict()
+        assert d["ok"] is False
+        assert d["fix_hint"] == "Set vault_root"
+
+
+# ---------------------------------------------------------------------------
+# RequirementChecker
+# ---------------------------------------------------------------------------
+
+class TestRequirementChecker:
+    def test_check_bootstrap_returns_only_core(self):
+        checker = RequirementChecker()
+        results = checker.check_bootstrap()
+        for r in results:
+            assert r.id.startswith("core/"), f"Bootstrap returned non-core: {r.id}"
+
+    def test_check_bootstrap_count(self):
+        checker = RequirementChecker()
+        results = checker.check_bootstrap()
+        core_count = sum(1 for r in REQUIREMENT_REGISTRY if r.startswith("core/"))
+        assert len(results) == core_count
+
+    def test_check_component_filters(self):
+        checker = RequirementChecker()
+        results = checker.check_component("obsidian")
+        for r in results:
+            assert r.component == "obsidian"
+        assert len(results) > 0
+
+    def test_check_component_unknown_returns_empty(self):
+        checker = RequirementChecker()
+        results = checker.check_component("nonexistent_component")
+        assert results == []
+
+    def test_check_group(self):
+        checker = RequirementChecker()
+        results = checker.check_group("journal")
+        assert len(results) > 0
+        for r in results:
+            req = REQUIREMENT_REGISTRY[r.id]
+            assert req.setup_group == "journal"
+
+    def test_check_all_excludes_unwanted(self, monkeypatch):
+        """If hindsight is unwanted, its requirements should be skipped."""
+        import work_buddy.health.preferences as pmod
+        monkeypatch.setattr(pmod, "is_wanted",
+                            lambda cid: False if cid == "hindsight" else None)
+        checker = RequirementChecker()
+        results = checker.check_all(include_unwanted=False)
+        hindsight_results = [r for r in results if r.component == "hindsight"]
+        assert hindsight_results == []
+
+    def test_check_all_includes_unwanted_when_asked(self, monkeypatch):
+        import work_buddy.health.preferences as pmod
+        monkeypatch.setattr(pmod, "is_wanted",
+                            lambda cid: False if cid == "hindsight" else None)
+        checker = RequirementChecker()
+        results = checker.check_all(include_unwanted=True)
+        hindsight_results = [r for r in results if r.component == "hindsight"]
+        assert len(hindsight_results) > 0
+
+    def test_check_all_always_includes_core(self, monkeypatch):
+        """Core requirements run even if all components are unwanted."""
+        import work_buddy.health.preferences as pmod
+        monkeypatch.setattr(pmod, "is_wanted", lambda cid: False)
+        checker = RequirementChecker()
+        results = checker.check_all(include_unwanted=False)
+        core_results = [r for r in results if r.id.startswith("core/")]
+        assert len(core_results) > 0
+
+    def test_summarize(self):
+        results = [
+            RequirementResult("a", True, "ok", "", "required", None),
+            RequirementResult("b", False, "fail", "fix", "required", None),
+            RequirementResult("c", False, "fail", "fix", "recommended", "obsidian"),
+        ]
+        summary = RequirementChecker.summarize(results)
+        assert summary["total"] == 3
+        assert summary["passed"] == 1
+        assert summary["failed_required"] == 1
+        assert summary["failed_recommended"] == 1
+        assert summary["all_required_pass"] is False
+        assert len(summary["failures"]) == 2
+
+    def test_summarize_all_pass(self):
+        results = [
+            RequirementResult("a", True, "ok", "", "required", None),
+            RequirementResult("b", True, "ok", "", "recommended", None),
+        ]
+        summary = RequirementChecker.summarize(results)
+        assert summary["all_required_pass"] is True
+        assert summary["failures"] == []
+
+    def test_check_fn_error_returns_failure(self, monkeypatch):
+        """If a check function raises, the result should be ok=False with error detail."""
+        bad_req = RequirementDef(
+            id="test/bad/check",
+            component=None,
+            description="Intentionally broken",
+            check_fn="work_buddy.health.requirement_checks.nonexistent_function",
+            severity="required",
+            fix_hint="N/A",
+            setup_group="bootstrap",
+        )
+        checker = RequirementChecker()
+        result = checker._run_check(bad_req)
+        assert result.ok is False
+        assert "error" in result.detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# Individual check functions (with mocked filesystem)
+# ---------------------------------------------------------------------------
+
+class TestCheckFunctions:
+    """Tests that verify check functions against controlled filesystem state."""
+
+    def test_check_config_yaml_exists_pass(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._repo_root",
+            lambda: tmp_path,
+        )
+        (tmp_path / "config.yaml").write_text("vault_root: /test", encoding="utf-8")
+        from work_buddy.health.requirement_checks import check_config_yaml_exists
+        result = check_config_yaml_exists()
+        assert result["ok"] is True
+
+    def test_check_config_yaml_exists_fail(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._repo_root",
+            lambda: tmp_path,
+        )
+        from work_buddy.health.requirement_checks import check_config_yaml_exists
+        result = check_config_yaml_exists()
+        assert result["ok"] is False
+
+    def test_check_vault_root_pass(self, monkeypatch, tmp_path):
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._cfg",
+            lambda: {"vault_root": str(vault)},
+        )
+        from work_buddy.health.requirement_checks import check_vault_root
+        result = check_vault_root()
+        assert result["ok"] is True
+
+    def test_check_vault_root_empty(self, monkeypatch):
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._cfg",
+            lambda: {"vault_root": ""},
+        )
+        from work_buddy.health.requirement_checks import check_vault_root
+        result = check_vault_root()
+        assert result["ok"] is False
+
+    def test_check_vault_root_nonexistent(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._cfg",
+            lambda: {"vault_root": str(tmp_path / "nope")},
+        )
+        from work_buddy.health.requirement_checks import check_vault_root
+        result = check_vault_root()
+        assert result["ok"] is False
+
+    def test_check_timezone_valid(self, monkeypatch):
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._cfg",
+            lambda: {"timezone": "America/New_York"},
+        )
+        from work_buddy.health.requirement_checks import check_timezone
+        result = check_timezone()
+        assert result["ok"] is True
+
+    def test_check_timezone_invalid(self, monkeypatch):
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._cfg",
+            lambda: {"timezone": "Not/A/Timezone"},
+        )
+        from work_buddy.health.requirement_checks import check_timezone
+        result = check_timezone()
+        assert result["ok"] is False
+
+    def test_check_anthropic_api_key_set(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-123")
+        from work_buddy.health.requirement_checks import check_anthropic_api_key
+        result = check_anthropic_api_key()
+        assert result["ok"] is True
+
+    def test_check_anthropic_api_key_missing(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        from work_buddy.health.requirement_checks import check_anthropic_api_key
+        result = check_anthropic_api_key()
+        assert result["ok"] is False
+
+    def test_check_obsidian_dir_pass(self, monkeypatch, tmp_path):
+        vault = tmp_path / "vault"
+        (vault / ".obsidian").mkdir(parents=True)
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._vault_root",
+            lambda: vault,
+        )
+        from work_buddy.health.requirement_checks import check_obsidian_dir
+        result = check_obsidian_dir()
+        assert result["ok"] is True
+
+    def test_check_obsidian_dir_missing(self, monkeypatch, tmp_path):
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._vault_root",
+            lambda: vault,
+        )
+        from work_buddy.health.requirement_checks import check_obsidian_dir
+        result = check_obsidian_dir()
+        assert result["ok"] is False
+
+    def test_check_journal_dir_pass(self, monkeypatch, tmp_path):
+        vault = tmp_path / "vault"
+        (vault / "journal").mkdir(parents=True)
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._vault_root",
+            lambda: vault,
+        )
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._cfg",
+            lambda: {"obsidian": {"journal_dir": "journal"}},
+        )
+        from work_buddy.health.requirement_checks import check_journal_dir
+        result = check_journal_dir()
+        assert result["ok"] is True
+
+    def test_check_log_section_pass(self, monkeypatch, tmp_path):
+        from datetime import date
+        vault = tmp_path / "vault"
+        journal = vault / "journal"
+        journal.mkdir(parents=True)
+        today = date.today().strftime("%Y-%m-%d")
+        note = journal / f"{today}.md"
+        note.write_text("# Sign-In\nstuff\n# Log\n* 9:00 AM - did thing\n", encoding="utf-8")
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._vault_root",
+            lambda: vault,
+        )
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._cfg",
+            lambda: {"obsidian": {"journal_dir": "journal"}},
+        )
+        from work_buddy.health.requirement_checks import check_log_section
+        result = check_log_section()
+        assert result["ok"] is True
+
+    def test_check_log_section_missing(self, monkeypatch, tmp_path):
+        from datetime import date
+        vault = tmp_path / "vault"
+        journal = vault / "journal"
+        journal.mkdir(parents=True)
+        today = date.today().strftime("%Y-%m-%d")
+        note = journal / f"{today}.md"
+        note.write_text("# Sign-In\nstuff\n# Summary\n", encoding="utf-8")
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._vault_root",
+            lambda: vault,
+        )
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._cfg",
+            lambda: {"obsidian": {"journal_dir": "journal"}},
+        )
+        from work_buddy.health.requirement_checks import check_log_section
+        result = check_log_section()
+        assert result["ok"] is False
+
+    def test_check_log_section_bold_header(self, monkeypatch, tmp_path):
+        """Headers with bold formatting should still match."""
+        from datetime import date
+        vault = tmp_path / "vault"
+        journal = vault / "journal"
+        journal.mkdir(parents=True)
+        today = date.today().strftime("%Y-%m-%d")
+        note = journal / f"{today}.md"
+        note.write_text("# **Log**\n* entry\n", encoding="utf-8")
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._vault_root",
+            lambda: vault,
+        )
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._cfg",
+            lambda: {"obsidian": {"journal_dir": "journal"}},
+        )
+        from work_buddy.health.requirement_checks import check_log_section
+        result = check_log_section()
+        assert result["ok"] is True
+
+    def test_check_daily_note_not_yet_created(self, monkeypatch, tmp_path):
+        vault = tmp_path / "vault"
+        (vault / "journal").mkdir(parents=True)
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._vault_root",
+            lambda: vault,
+        )
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._cfg",
+            lambda: {"obsidian": {"journal_dir": "journal"}},
+        )
+        from work_buddy.health.requirement_checks import check_log_section
+        result = check_log_section()
+        assert result["ok"] is False
+        assert "does not exist" in result["detail"]
+
+    def test_check_tasks_plugin_pass(self, monkeypatch, tmp_path):
+        vault = tmp_path / "vault"
+        obs = vault / ".obsidian"
+        obs.mkdir(parents=True)
+        cp = obs / "community-plugins.json"
+        cp.write_text(json.dumps(["obsidian-tasks-plugin", "datacore"]), encoding="utf-8")
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._vault_root",
+            lambda: vault,
+        )
+        from work_buddy.health.requirement_checks import check_tasks_plugin
+        result = check_tasks_plugin()
+        assert result["ok"] is True
+
+    def test_check_tasks_plugin_missing(self, monkeypatch, tmp_path):
+        vault = tmp_path / "vault"
+        obs = vault / ".obsidian"
+        obs.mkdir(parents=True)
+        cp = obs / "community-plugins.json"
+        cp.write_text(json.dumps(["datacore"]), encoding="utf-8")
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._vault_root",
+            lambda: vault,
+        )
+        from work_buddy.health.requirement_checks import check_tasks_plugin
+        result = check_tasks_plugin()
+        assert result["ok"] is False
+
+    def test_check_master_task_list_pass(self, monkeypatch, tmp_path):
+        vault = tmp_path / "vault"
+        (vault / "tasks").mkdir(parents=True)
+        (vault / "tasks" / "master-task-list.md").write_text("# Tasks\n", encoding="utf-8")
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._vault_root",
+            lambda: vault,
+        )
+        from work_buddy.health.requirement_checks import check_master_task_list
+        result = check_master_task_list()
+        assert result["ok"] is True
+
+    def test_check_master_task_list_missing(self, monkeypatch, tmp_path):
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._vault_root",
+            lambda: vault,
+        )
+        from work_buddy.health.requirement_checks import check_master_task_list
+        result = check_master_task_list()
+        assert result["ok"] is False
+
+    def test_check_telegram_bot_token_env(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123:ABC")
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._cfg",
+            lambda: {"telegram": {"bot_token_env": "TELEGRAM_BOT_TOKEN"}},
+        )
+        from work_buddy.health.requirement_checks import check_telegram_bot_token
+        result = check_telegram_bot_token()
+        assert result["ok"] is True
+
+    def test_check_telegram_bot_token_dotenv(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._repo_root",
+            lambda: tmp_path,
+        )
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._cfg",
+            lambda: {"telegram": {"bot_token_env": "TELEGRAM_BOT_TOKEN"}},
+        )
+        env_file = tmp_path / ".env"
+        env_file.write_text("TELEGRAM_BOT_TOKEN=123:ABC\n", encoding="utf-8")
+        from work_buddy.health.requirement_checks import check_telegram_bot_token
+        result = check_telegram_bot_token()
+        assert result["ok"] is True
+
+    def test_check_telegram_bot_token_missing(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._repo_root",
+            lambda: tmp_path,
+        )
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._cfg",
+            lambda: {"telegram": {"bot_token_env": "TELEGRAM_BOT_TOKEN"}},
+        )
+        from work_buddy.health.requirement_checks import check_telegram_bot_token
+        result = check_telegram_bot_token()
+        assert result["ok"] is False
+
+    def test_check_daily_notes_plugin_migration_format(self, monkeypatch, tmp_path):
+        """core-plugins-migration.json uses {name: bool} format."""
+        vault = tmp_path / "vault"
+        obs = vault / ".obsidian"
+        obs.mkdir(parents=True)
+        (obs / "core-plugins-migration.json").write_text(
+            json.dumps({"daily-notes": True, "file-recovery": True}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._vault_root",
+            lambda: vault,
+        )
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._cfg",
+            lambda: {},
+        )
+        from work_buddy.health.requirement_checks import check_daily_notes_plugin
+        result = check_daily_notes_plugin()
+        assert result["ok"] is True
+
+    def test_check_daily_notes_plugin_disabled(self, monkeypatch, tmp_path):
+        vault = tmp_path / "vault"
+        obs = vault / ".obsidian"
+        obs.mkdir(parents=True)
+        (obs / "core-plugins-migration.json").write_text(
+            json.dumps({"daily-notes": False}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._vault_root",
+            lambda: vault,
+        )
+        monkeypatch.setattr(
+            "work_buddy.health.requirement_checks._cfg",
+            lambda: {},
+        )
+        from work_buddy.health.requirement_checks import check_daily_notes_plugin
+        result = check_daily_notes_plugin()
+        assert result["ok"] is False

--- a/tests/unit/test_wizard.py
+++ b/tests/unit/test_wizard.py
@@ -1,0 +1,199 @@
+"""Unit tests for the SetupWizard orchestrator (health/wizard.py)."""
+
+import json
+import pytest
+
+from work_buddy.health.wizard import SetupWizard
+
+
+@pytest.fixture
+def mock_preferences(monkeypatch):
+    """Provide controllable preferences without touching config.local.yaml.
+
+    Patches the source module (work_buddy.health.preferences) so that all
+    consumers of ``from ... import is_wanted`` / ``load_preferences`` get
+    the mock via the module-level reference.
+    """
+    _prefs = {}
+
+    import work_buddy.health.preferences as pmod
+
+    def _load():
+        from work_buddy.health.preferences import FeaturePreference
+        return {
+            k: FeaturePreference(k, **v) if isinstance(v, dict) else FeaturePreference(k, wanted=v)
+            for k, v in _prefs.items()
+        }
+
+    def _get(cid):
+        from work_buddy.health.preferences import FeaturePreference
+        p = _prefs.get(cid)
+        if p is None:
+            return FeaturePreference(cid)
+        if isinstance(p, dict):
+            return FeaturePreference(cid, **p)
+        return FeaturePreference(cid, wanted=p)
+
+    def _is_wanted(cid):
+        p = _prefs.get(cid)
+        if p is None:
+            return None
+        return p.get("wanted") if isinstance(p, dict) else p
+
+    # Patch at the source module — all importers see the same mock
+    monkeypatch.setattr(pmod, "load_preferences", _load)
+    monkeypatch.setattr(pmod, "get_preference", _get)
+    monkeypatch.setattr(pmod, "is_wanted", _is_wanted)
+
+    return _prefs
+
+
+class TestWizardStatus:
+    def test_status_returns_three_sections(self, mock_preferences):
+        wizard = SetupWizard()
+        result = wizard.status()
+        assert result["mode"] == "status"
+        assert "bootstrap" in result
+        assert "health" in result
+        assert "requirements" in result
+
+    def test_status_bootstrap_has_summary(self, mock_preferences):
+        wizard = SetupWizard()
+        result = wizard.status()
+        bs = result["bootstrap"]
+        assert "summary" in bs
+        assert "results" in bs
+        assert bs["summary"]["total"] > 0
+
+    def test_status_health_has_summary(self, mock_preferences):
+        wizard = SetupWizard()
+        result = wizard.status()
+        health = result["health"]
+        assert "summary" in health
+        assert "components" in health
+
+    def test_status_requirements_has_summary(self, mock_preferences):
+        wizard = SetupWizard()
+        result = wizard.status()
+        reqs = result["requirements"]
+        assert "summary" in reqs
+        assert "results" in reqs
+
+
+class TestWizardGuided:
+    def test_guided_returns_four_steps(self, mock_preferences):
+        wizard = SetupWizard()
+        result = wizard.guided()
+        assert result["mode"] == "guided"
+        assert len(result["steps"]) == 4
+        step_names = [s["name"] for s in result["steps"]]
+        assert step_names == ["bootstrap", "features", "requirements", "health"]
+
+    def test_guided_features_step_groups_by_category(self, mock_preferences):
+        wizard = SetupWizard()
+        result = wizard.guided()
+        features_step = result["steps"][1]
+        components = features_step["components"]
+        # Should have at least some categories
+        assert len(components) > 0
+        # Each category should be a list
+        for cat, items in components.items():
+            assert isinstance(items, list)
+            for item in items:
+                assert "id" in item
+                assert "display_name" in item
+                assert "wanted" in item
+
+    def test_guided_includes_instructions(self, mock_preferences):
+        wizard = SetupWizard()
+        result = wizard.guided()
+        assert "instructions" in result
+        assert "Walk the user" in result["instructions"]
+
+
+class TestWizardDiagnose:
+    def test_diagnose_known_component(self, mock_preferences):
+        wizard = SetupWizard()
+        result = wizard.diagnose("obsidian")
+        assert result["mode"] == "diagnose"
+        assert result["component"] == "obsidian"
+        assert "preference" in result
+        assert "requirements" in result
+        assert "health" in result
+        assert "diagnostics" in result
+
+    def test_diagnose_unknown_component(self, mock_preferences):
+        wizard = SetupWizard()
+        result = wizard.diagnose("nonexistent")
+        assert result["mode"] == "diagnose"
+        assert "error" in result
+        assert "available_components" in result
+
+    def test_diagnose_shows_preference(self, mock_preferences):
+        mock_preferences["hindsight"] = {"wanted": False, "reason": "No DB"}
+        wizard = SetupWizard()
+        result = wizard.diagnose("hindsight")
+        assert result["preference"]["wanted"] is False
+        assert result["preference"]["reason"] == "No DB"
+
+
+class TestWizardPreferences:
+    def test_preferences_view(self, mock_preferences):
+        wizard = SetupWizard()
+        result = wizard.preferences()
+        assert result["mode"] == "preferences"
+        assert "components" in result
+        assert result["updated"] is False
+
+    def test_preferences_lists_all_components(self, mock_preferences):
+        from work_buddy.health.components import COMPONENT_CATALOG
+        wizard = SetupWizard()
+        result = wizard.preferences()
+        ids = {c["id"] for c in result["components"]}
+        for comp_id in COMPONENT_CATALOG:
+            assert comp_id in ids
+
+    def test_preferences_update_flag(self, mock_preferences, monkeypatch):
+        # Mock set_preference at the source module to avoid writing config
+        import work_buddy.health.preferences as pmod
+        called = []
+        monkeypatch.setattr(pmod, "set_preference",
+                            lambda *a, **kw: called.append((a, kw)))
+        wizard = SetupWizard()
+        result = wizard.preferences(updates={"hindsight": {"wanted": False}})
+        assert result["updated"] is True
+
+    def test_preferences_ignores_unknown_components(self, mock_preferences, monkeypatch):
+        import work_buddy.health.preferences as pmod
+        called = []
+        monkeypatch.setattr(pmod, "set_preference",
+                            lambda *a, **kw: called.append((a, kw)))
+        wizard = SetupWizard()
+        result = wizard.preferences(updates={"totally_fake": {"wanted": False}})
+        # Should not have called set_preference for unknown component
+        assert all("totally_fake" not in str(c) for c in called)
+
+
+class TestWizardPreferencePropagation:
+    """Verify that setting wanted=false affects health and requirements."""
+
+    def test_opted_out_component_disabled_in_health(self, mock_preferences):
+        mock_preferences["telegram"] = {"wanted": False}
+        wizard = SetupWizard()
+        result = wizard.status()
+        tg = next(
+            c for c in result["health"]["components"]
+            if c["id"] == "telegram"
+        )
+        assert tg["status"] == "disabled"
+        assert tg["wanted"] is False
+
+    def test_opted_out_requirements_excluded(self, mock_preferences):
+        mock_preferences["telegram"] = {"wanted": False}
+        wizard = SetupWizard()
+        result = wizard.status()
+        tg_reqs = [
+            r for r in result["requirements"]["results"]
+            if r["component"] == "telegram"
+        ]
+        assert tg_reqs == []

--- a/work_buddy/config.py
+++ b/work_buddy/config.py
@@ -144,6 +144,37 @@ def load_config(config_path: Path | None = None) -> dict[str, Any]:
     return cfg
 
 
+def _repo_root() -> Path:
+    """Return the work-buddy repo root (parent of work_buddy/)."""
+    return Path(__file__).parent.parent
+
+
+def config_local_path() -> Path:
+    """Return the path to config.local.yaml."""
+    return _repo_root() / "config.local.yaml"
+
+
+def read_config_local() -> dict[str, Any]:
+    """Read config.local.yaml, returning empty dict if it doesn't exist."""
+    path = config_local_path()
+    if not path.exists():
+        return {}
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def write_config_local(section: str, data: Any) -> None:
+    """Write a top-level section in config.local.yaml, preserving other sections.
+
+    If config.local.yaml doesn't exist, creates it.
+    """
+    path = config_local_path()
+    existing = read_config_local()
+    existing[section] = data
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(existing, f, default_flow_style=False, sort_keys=False)
+
+
 def _init_user_tz() -> ZoneInfo:
     """Compute the user timezone once at import time."""
     cfg = load_config()

--- a/work_buddy/dashboard/api.py
+++ b/work_buddy/dashboard/api.py
@@ -249,6 +249,31 @@ def get_system_state() -> dict[str, Any]:
         logger.warning("Failed to build health view: %s", exc)
         result["health"] = None
 
+    # Feature preferences (what the user wants/doesn't want)
+    try:
+        from work_buddy.health.preferences import load_preferences
+        prefs = load_preferences()
+        result["preferences"] = {
+            cid: p.to_dict() for cid, p in prefs.items()
+        }
+    except Exception as exc:
+        logger.warning("Failed to load preferences: %s", exc)
+        result["preferences"] = {}
+
+    # Requirements summary (configuration-time validation)
+    try:
+        from work_buddy.health.requirements import RequirementChecker
+        checker = RequirementChecker()
+        bootstrap = checker.check_bootstrap()
+        all_reqs = checker.check_all(include_unwanted=False)
+        result["requirements"] = {
+            "bootstrap": checker.summarize(bootstrap),
+            "all": checker.summarize(all_reqs),
+        }
+    except Exception as exc:
+        logger.warning("Failed to check requirements: %s", exc)
+        result["requirements"] = None
+
     return result
 
 

--- a/work_buddy/dashboard/frontend/script_main.py
+++ b/work_buddy/dashboard/frontend/script_main.py
@@ -158,24 +158,31 @@ function _renderDiagPanel(diag) {
         for (const step of diag.steps_run) {
             const icon = step.ok ? '\u2713' : '\u2717';
             const cls = step.ok ? '' : ' fail';
-            html += `<div class="health-diag-step${cls}">
-                <span class="step-icon">${icon}</span>
-                <span class="step-desc">${step.description}</span>
-                <span class="step-detail">${step.detail}</span>
-            </div>`;
+            html += '<div class="health-diag-step' + cls + '">'
+                + '<span class="step-icon">' + icon + '</span>'
+                + '<span class="step-desc">' + escapeHtml(step.description) + '</span>'
+                + '<span class="step-detail">' + escapeHtml(step.detail) + '</span>'
+                + '</div>';
         }
         html += '</div>';
     }
     if (diag.root_cause) {
-        html += `<div class="health-diag-cause">
-            <div class="cause-label">Root cause</div>
-            <div class="cause-text">${diag.root_cause}</div>
-        </div>`;
+        html += '<div class="health-diag-cause">'
+            + '<div class="cause-label">Root cause</div>'
+            + '<div class="cause-text">' + escapeHtml(diag.root_cause) + '</div>'
+            + '</div>';
     }
     if (diag.fix_suggestion) {
-        html += `<div class="health-diag-fix">
-            <div class="fix-label">How to fix</div>
-${diag.fix_suggestion}</div>`;
+        html += '<div class="health-diag-fix">'
+            + '<div class="fix-label">How to fix</div>'
+            + '<pre class="fix-text">' + escapeHtml(diag.fix_suggestion) + '</pre>'
+            + '</div>';
+    }
+    // Wizard hint — always shown when there's a failure
+    if (diag.status === 'failed' && diag.component_id) {
+        html += '<div class="health-diag-wizard">'
+            + '\ud83e\ude84 Run <code>/wb-setup ' + escapeHtml(diag.component_id) + '</code> in Claude Code for interactive diagnostics'
+            + '</div>';
     }
     if (diag.status === 'passed') {
         html += '<div style="color: var(--text-muted); padding: 4px 0;">All checks passed.</div>';
@@ -277,27 +284,43 @@ function _healthRow(c, indent) {
     `;
 }
 
-function renderHealthTree(health) {
+function renderHealthTree(health, requirements) {
     const comps = health.components || [];
     const summary = health.summary || {};
     const byId = {};
     comps.forEach(c => { byId[c.id] = c; });
 
-    // Summary bar
-    const total = summary.total || comps.length;
-    const pctHealthy = total > 0 ? Math.round((summary.healthy / total) * 100) : 0;
+    // Separate opted-out components from active ones
+    const activeComps = comps.filter(c => c.wanted !== false);
+    const optedOut = comps.filter(c => c.wanted === false);
+
+    // Summary bar — count only active components
+    const activeTotal = activeComps.length;
+    const activeHealthy = activeComps.filter(c => c.status === 'healthy').length;
+    const pctHealthy = activeTotal > 0 ? Math.round((activeHealthy / activeTotal) * 100) : 0;
     let html = `
         <div class="health-summary">
             <div class="health-bar">
                 <div class="health-bar-fill" style="width: ${pctHealthy}%"></div>
             </div>
             <div class="health-counts">
-                <span class="health-count healthy">${summary.healthy || 0} healthy</span>
-                <span class="health-count unhealthy">${summary.unhealthy || 0} issue${(summary.unhealthy || 0) !== 1 ? 's' : ''}</span>
-                ${summary.disabled ? `<span class="health-count disabled">${summary.disabled} disabled</span>` : ''}
+                <span class="health-count healthy">${activeHealthy} healthy</span>
+                <span class="health-count unhealthy">${activeTotal - activeHealthy} issue${(activeTotal - activeHealthy) !== 1 ? 's' : ''}</span>
+                ${optedOut.length ? `<span class="health-count disabled">${optedOut.length} opted out</span>` : ''}
             </div>
         </div>
     `;
+
+    // Requirements warning banner
+    if (requirements && requirements.all && !requirements.all.all_required_pass) {
+        const reqFails = requirements.all.failed_required || 0;
+        html += `
+            <div class="health-req-warn" style="margin:0.5rem 0;padding:0.5rem 0.75rem;background:var(--surface-2);border-left:3px solid var(--yellow);border-radius:4px;font-size:0.85rem;">
+                <strong>\u26a0\ufe0f ${reqFails} requirement${reqFails !== 1 ? 's' : ''} failing</strong>
+                <span style="opacity:0.7;margin-left:0.5rem;">Run <code>/wb-setup</code> to diagnose</span>
+            </div>
+        `;
+    }
 
     // Tree layout rules:
     //   - "external" components (e.g. postgresql) are NEVER top-level —
@@ -308,10 +331,12 @@ function renderHealthTree(health) {
     //   - Sub-items = depends_on (dependencies shown beneath, e.g. postgresql
     //     under hindsight) + dependents with plugin/external category
     //     (e.g. plugins under obsidian).
+    //   - Components with wanted=false are shown in a collapsed "Opted out"
+    //     section at the bottom, not mixed into the main tree.
 
     // Build reverse map: parent_id -> [components that depend on it]
     const dependents = {};
-    comps.forEach(c => {
+    activeComps.forEach(c => {
         (c.depends_on || []).forEach(depId => {
             if (!dependents[depId]) dependents[depId] = [];
             dependents[depId].push(c.id);
@@ -320,11 +345,11 @@ function renderHealthTree(health) {
 
     // Sub-items: depends_on (deps shown under me) + my dependents that are plugins
     const subItemMap = {};
-    comps.forEach(c => {
+    activeComps.forEach(c => {
         const subs = [];
         // My dependencies nest under me (e.g. postgresql under hindsight)
         (c.depends_on || []).forEach(depId => {
-            if (byId[depId]) subs.push(depId);
+            if (byId[depId] && byId[depId].wanted !== false) subs.push(depId);
         });
         // Components that depend on me AND are plugins/external nest under me
         (dependents[c.id] || []).forEach(depId => {
@@ -336,8 +361,8 @@ function renderHealthTree(health) {
         subItemMap[c.id] = subs;
     });
 
-    // Top-level = not external, not plugin
-    const topLevel = comps.filter(c => c.category !== 'external' && c.category !== 'plugin');
+    // Top-level = not external, not plugin, and not opted out
+    const topLevel = activeComps.filter(c => c.category !== 'external' && c.category !== 'plugin');
 
     // Render each top-level component as a collapsible item
     topLevel.forEach(c => {
@@ -388,6 +413,34 @@ function renderHealthTree(health) {
             `;
         }
     });
+
+    // Opted-out section (collapsed by default)
+    if (optedOut.length > 0) {
+        const optedNames = optedOut.map(c => c.display_name).join(', ');
+        html += `
+            <div class="health-item collapsed" data-component="_opted_out">
+                <div class="health-row" onclick="toggleHealthItem(this)" style="opacity:0.6;">
+                    <div class="health-row-main">
+                        <span class="health-chevron">\u25BE</span>
+                        <span class="status-dot stopped"></span>
+                        <span class="health-name">Opted out</span>
+                        <span class="health-sub-count">${optedOut.length}</span>
+                    </div>
+                </div>
+                <div class="health-sub">
+                    ${optedOut.map(c => `
+                        <div class="health-row" style="opacity:0.5;">
+                            <div class="health-row-main" style="padding-left:2rem;">
+                                <span class="status-dot stopped"></span>
+                                <span class="health-name">${c.display_name}</span>
+                                <span class="badge badge-muted">opted out</span>
+                            </div>
+                        </div>
+                    `).join('')}
+                </div>
+            </div>
+        `;
+    }
 
     return html;
 }
@@ -671,7 +724,7 @@ async function loadStatus() {
                 const id = el.dataset.component;
                 if (id) expanded.add(id);
             });
-            svcEl.innerHTML = renderHealthTree(health);
+            svcEl.innerHTML = renderHealthTree(health, data.requirements);
             // Restore: items start collapsed by default, expand the ones that were open
             if (expanded.size > 0) {
                 svcEl.querySelectorAll('.health-item.collapsed').forEach(el => {

--- a/work_buddy/dashboard/frontend/styles.py
+++ b/work_buddy/dashboard/frontend/styles.py
@@ -536,13 +536,12 @@ body {
     border-radius: 4px;
     background: var(--bg-tertiary);
     border-left: 3px solid var(--blue, #58a6ff);
-    white-space: pre-wrap;
-    font-family: var(--font-mono, monospace);
-    font-size: 11px;
     color: var(--text-secondary);
-    line-height: 1.5;
 }
 .health-diag-fix .fix-label { font-weight: 600; font-size: 11px; text-transform: uppercase; color: var(--text-muted); margin-bottom: 2px; font-family: var(--font-sans, system-ui); }
+.health-diag-fix .fix-text { margin: 0; white-space: pre-wrap; font-family: var(--font-mono, monospace); font-size: 11px; line-height: 1.5; }
+.health-diag-wizard { margin-top: 6px; padding: 6px 10px; border-radius: 4px; background: var(--surface-2); font-size: 12px; color: var(--text-secondary); }
+.health-diag-wizard code { background: var(--bg-tertiary); padding: 1px 5px; border-radius: 3px; font-size: 11px; }
 
 /* -- Event log --------------------------------------------------------- */
 

--- a/work_buddy/dashboard/service.py
+++ b/work_buddy/dashboard/service.py
@@ -200,6 +200,44 @@ def api_reprobe(component_id: str):
         return jsonify({"error": str(exc)}), 500
 
 
+@app.get("/api/requirements")
+def api_requirements():
+    """Full requirements validation results."""
+    try:
+        from work_buddy.health.requirements import RequirementChecker
+        checker = RequirementChecker()
+        bootstrap = checker.check_bootstrap()
+        all_reqs = checker.check_all(include_unwanted=False)
+        return jsonify({
+            "bootstrap": {
+                "summary": checker.summarize(bootstrap),
+                "results": [r.to_dict() for r in bootstrap],
+            },
+            "all": {
+                "summary": checker.summarize(all_reqs),
+                "results": [r.to_dict() for r in all_reqs],
+            },
+        })
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 500
+
+
+@app.get("/api/requirements/<component_id>")
+def api_requirements_component(component_id: str):
+    """Requirements for a specific component."""
+    try:
+        from work_buddy.health.requirements import RequirementChecker
+        checker = RequirementChecker()
+        results = checker.check_component(component_id)
+        return jsonify({
+            "component": component_id,
+            "summary": checker.summarize(results),
+            "results": [r.to_dict() for r in results],
+        })
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 500
+
+
 @app.get("/api/tasks")
 def api_tasks():
     """Task summaries from Obsidian Tasks."""

--- a/work_buddy/health/__init__.py
+++ b/work_buddy/health/__init__.py
@@ -22,6 +22,13 @@ Usage::
 from work_buddy.health.components import COMPONENT_CATALOG, CheckStep, ComponentDef
 from work_buddy.health.diagnostics import DiagnosticResult, DiagnosticRunner, StepResult
 from work_buddy.health.engine import ComponentHealth, HealthEngine
+from work_buddy.health.preferences import FeaturePreference
+from work_buddy.health.requirements import (
+    REQUIREMENT_REGISTRY,
+    RequirementChecker,
+    RequirementDef,
+    RequirementResult,
+)
 
 __all__ = [
     "COMPONENT_CATALOG",
@@ -30,6 +37,11 @@ __all__ = [
     "ComponentHealth",
     "DiagnosticResult",
     "DiagnosticRunner",
+    "FeaturePreference",
     "HealthEngine",
+    "REQUIREMENT_REGISTRY",
+    "RequirementChecker",
+    "RequirementDef",
+    "RequirementResult",
     "StepResult",
 ]

--- a/work_buddy/health/components.py
+++ b/work_buddy/health/components.py
@@ -13,7 +13,12 @@ from tools.py.
 
 from __future__ import annotations
 
+import platform
 from dataclasses import dataclass, field
+
+# Detect once at import time — used to select platform-specific fix hints.
+_IS_WINDOWS = platform.system() == "Windows"
+_IS_MAC = platform.system() == "Darwin"
 
 
 @dataclass
@@ -56,6 +61,7 @@ class ComponentDef:
     health_source: str = "tool_probe"
     check_sequence: list[CheckStep] = field(default_factory=list)
     sidecar_service: str | None = None
+    requirements: list[str] = field(default_factory=list)  # Requirement IDs from REQUIREMENT_REGISTRY
 
 
 # ---------------------------------------------------------------------------
@@ -81,10 +87,10 @@ _register(ComponentDef(
             description="PostgreSQL accepting connections on port 5432",
             check_fn="work_buddy.health.checks.check_postgresql",
             on_fail=(
-                "PostgreSQL is not running. Start it with:\n"
-                "  - pg_ctl start -D <data_dir>\n"
-                "  - Windows: Start-ScheduledTask 'Hindsight-PostgreSQL'\n"
-                "  - Linux: systemctl --user start hindsight-postgres"
+                "PostgreSQL is not running on port 5432. Start it:\n"
+                + ("  Start-ScheduledTask 'Hindsight-PostgreSQL'" if _IS_WINDOWS
+                   else "  systemctl --user start hindsight-postgres")
+                + "\n  Or manually: pg_ctl -D <data_dir> -l <logfile> start"
             ),
         ),
     ],
@@ -97,6 +103,18 @@ _register(ComponentDef(
     display_name="Obsidian Bridge",
     category="integration",
     health_source="tool_probe",
+    requirements=[
+        "obsidian/vault/obsidian-dir",
+        "obsidian/daily-note/plugin-enabled",
+        "obsidian/daily-note/dir-exists",
+        "obsidian/daily-note/log-section",
+        "obsidian/daily-note/sign-in-section",
+        "obsidian/daily-note/running-notes-section",
+        "obsidian/tasks/master-list-exists",
+        "obsidian/plugins/tasks-plugin",
+        "obsidian/contracts/dir-exists",
+        "obsidian/knowledge/personal-path",
+    ],
     check_sequence=[
         CheckStep(
             description="Obsidian bridge HTTP health endpoint",
@@ -117,11 +135,17 @@ _register(ComponentDef(
     depends_on=["postgresql"],
     health_source="composite",
     sidecar_service=None,  # not sidecar-managed, but has tool probe
+    requirements=["integrations/hindsight/pg-scheduled-task"],
     check_sequence=[
         CheckStep(
             description="PostgreSQL is running (dependency)",
             check_fn="work_buddy.health.checks.check_postgresql",
-            on_fail="Hindsight requires PostgreSQL. Start PostgreSQL first.",
+            on_fail=(
+                "Hindsight requires PostgreSQL. Start it first:\n"
+                + ("  Start-ScheduledTask 'Hindsight-PostgreSQL'" if _IS_WINDOWS
+                   else "  systemctl --user start hindsight-postgres")
+                + "\n  Or manually: pg_ctl -D <data_dir> -l <logfile> start"
+            ),
         ),
         CheckStep(
             description="Hindsight API responding on port 8888",
@@ -130,8 +154,17 @@ _register(ComponentDef(
                 "Hindsight API is not responding. This can happen when:\n"
                 "  1. PostgreSQL was not running when Hindsight started\n"
                 "  2. The API crashed but the async worker survived (half-dead state)\n"
-                "Fix: Kill any remaining Hindsight processes, ensure PostgreSQL "
-                "is running, then restart Hindsight via scripts/start-hindsight.sh"
+                "  3. The terminal window was accidentally closed\n"
+                "Fix:\n"
+                + ("  1. Kill remaining processes: Get-Process *hindsight* | Stop-Process\n"
+                   "  2. Ensure PostgreSQL is running (check port 5432)\n"
+                   "  3. Restart: Start-ScheduledTask 'Hindsight-API'\n"
+                   "     Or manually: conda activate work-buddy && hindsight-api"
+                   if _IS_WINDOWS else
+                   "  1. Kill remaining processes: pkill -f hindsight\n"
+                   "  2. Ensure PostgreSQL is running (check port 5432)\n"
+                   "  3. Restart: conda activate work-buddy && hindsight-api &")
+                + "\nSee also: scripts/start-hindsight.sh, SETUP.md"
             ),
         ),
     ],
@@ -142,6 +175,7 @@ _register(ComponentDef(
     display_name="Chrome Tab Extension",
     category="integration",
     health_source="tool_probe",
+    requirements=["integrations/chrome/native-host"],
     check_sequence=[
         CheckStep(
             description="Chrome tab export file exists and is fresh (<120s)",
@@ -158,6 +192,13 @@ _register(ComponentDef(
 
 # --- Sidecar-managed services ---
 
+_SIDECAR_LOG_HINT = (
+    "Check sidecar logs: data/logs/sidecar.log\n"
+    "Restart sidecar: "
+    + ("Start-ScheduledTask 'WB-Sidecar'" if _IS_WINDOWS
+       else "python -m work_buddy.sidecar &")
+)
+
 _register(ComponentDef(
     id="messaging",
     display_name="Messaging Service",
@@ -168,7 +209,7 @@ _register(ComponentDef(
         CheckStep(
             description="Messaging service health endpoint (port 5123)",
             check_fn="work_buddy.health.checks.check_sidecar_service_messaging",
-            on_fail="Messaging service is not running. Check sidecar logs.",
+            on_fail=f"Messaging service is not running.\n{_SIDECAR_LOG_HINT}",
         ),
     ],
 ))
@@ -183,7 +224,7 @@ _register(ComponentDef(
         CheckStep(
             description="Embedding service health endpoint (port 5124)",
             check_fn="work_buddy.health.checks.check_sidecar_service_embedding",
-            on_fail="Embedding service is not running. Check sidecar logs.",
+            on_fail=f"Embedding service is not running.\n{_SIDECAR_LOG_HINT}",
         ),
     ],
 ))
@@ -194,6 +235,7 @@ _register(ComponentDef(
     category="service",
     health_source="composite",
     sidecar_service="telegram",
+    requirements=["services/telegram/bot-token"],
     check_sequence=[
         CheckStep(
             description="Telegram bot service health endpoint (port 5125)",
@@ -218,7 +260,7 @@ _register(ComponentDef(
         CheckStep(
             description="Dashboard service health endpoint (port 5127)",
             check_fn="work_buddy.health.checks.check_sidecar_service_dashboard",
-            on_fail="Dashboard service is not running. Check sidecar logs.",
+            on_fail=f"Dashboard service is not running.\n{_SIDECAR_LOG_HINT}",
         ),
     ],
 ))

--- a/work_buddy/health/engine.py
+++ b/work_buddy/health/engine.py
@@ -43,6 +43,7 @@ class ComponentHealth:
     display_name: str
     category: str
     status: str  # healthy, degraded, unavailable, crashed, disabled, blocked, unknown
+    wanted: bool | None = None  # True/False/None from user preferences
     depends_on: list[str] = field(default_factory=list)
     details: dict[str, Any] = field(default_factory=dict)
     children: list[str] = field(default_factory=list)
@@ -157,12 +158,14 @@ class HealthEngine:
 
             {
                 "components": [ComponentHealth.to_dict(), ...],
-                "summary": {"healthy": N, "unhealthy": N, "disabled": N, "total": N},
+                "summary": {"healthy": N, "unhealthy": N, "disabled": N, "opted_out": N, "total": N},
             }
         """
         from work_buddy.health.components import COMPONENT_CATALOG
+        from work_buddy.health.preferences import load_preferences
 
         self._load()
+        prefs = load_preferences()
 
         components: list[ComponentHealth] = []
         status_counts: dict[str, int] = {}
@@ -176,9 +179,19 @@ class HealthEngine:
         # Resolve statuses
         resolved: dict[str, str] = {}
         for comp in COMPONENT_CATALOG.values():
+            pref = prefs.get(comp.id)
+            wanted = pref.wanted if pref else None
+
             status, details = self._merge_status(
                 comp.id, comp.health_source, comp.sidecar_service
             )
+
+            # If user opted out, mark as disabled regardless of probe state
+            if wanted is False and status != "disabled":
+                status = "disabled"
+                details["reason"] = details.get("reason", "User opted out")
+                if "user_opted_out" not in details:
+                    details["user_opted_out"] = True
 
             # If any parent is unhealthy, mark as blocked
             if status not in ("disabled", "blocked"):
@@ -196,6 +209,7 @@ class HealthEngine:
                 display_name=comp.display_name,
                 category=comp.category,
                 status=status,
+                wanted=wanted,
                 depends_on=comp.depends_on,
                 details=details,
                 children=child_map.get(comp.id, []),
@@ -205,6 +219,7 @@ class HealthEngine:
 
         healthy = status_counts.get("healthy", 0)
         disabled = status_counts.get("disabled", 0)
+        opted_out = sum(1 for c in components if c.wanted is False)
         total = len(components)
         unhealthy = total - healthy - disabled
 
@@ -214,6 +229,7 @@ class HealthEngine:
                 "healthy": healthy,
                 "unhealthy": unhealthy,
                 "disabled": disabled,
+                "opted_out": opted_out,
                 "total": total,
             },
         }
@@ -221,15 +237,21 @@ class HealthEngine:
     def get_component(self, component_id: str) -> ComponentHealth | None:
         """Get health for a single component."""
         from work_buddy.health.components import COMPONENT_CATALOG
+        from work_buddy.health.preferences import is_wanted
 
         self._load()
         comp = COMPONENT_CATALOG.get(component_id)
         if comp is None:
             return None
 
+        wanted = is_wanted(comp.id)
         status, details = self._merge_status(
             comp.id, comp.health_source, comp.sidecar_service
         )
+
+        if wanted is False and status != "disabled":
+            status = "disabled"
+            details["user_opted_out"] = True
 
         child_map: dict[str, list[str]] = {}
         for c in COMPONENT_CATALOG.values():
@@ -241,6 +263,7 @@ class HealthEngine:
             display_name=comp.display_name,
             category=comp.category,
             status=status,
+            wanted=wanted,
             depends_on=comp.depends_on,
             details=details,
             children=child_map.get(comp.id, []),

--- a/work_buddy/health/preferences.py
+++ b/work_buddy/health/preferences.py
@@ -1,0 +1,119 @@
+"""Feature preferences — what the user wants enabled or disabled.
+
+Preferences live in config.local.yaml under a ``features:`` key:
+
+.. code-block:: yaml
+
+    features:
+      hindsight:
+        wanted: false
+        reason: "Not using personal memory system"
+      telegram:
+        wanted: false
+      obsidian:
+        wanted: true
+
+Semantics:
+    - ``wanted: true`` — User wants this. Probe it, show it, diagnose it.
+    - ``wanted: false`` — User opted out. Don't probe, hide from dashboard,
+      agents won't suggest it.  But keep awareness for "why isn't X working?"
+    - ``wanted: null`` (or absent) — Undecided.  Probe normally, show normally.
+      The setup wizard will ask about these.
+
+``wanted: false`` implies ``tools.<id>.enabled: false`` (skip probe).
+``wanted: true`` + ``tools.<id>.enabled: false`` means "I want it but it's
+temporarily disabled for debugging".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from work_buddy.config import read_config_local, write_config_local
+
+
+@dataclass
+class FeaturePreference:
+    """User preference for a single component.
+
+    Attributes:
+        component_id: Matches ComponentDef.id and ToolProbe.id.
+        wanted: True (user wants it), False (opted out), None (undecided).
+        reason: User-supplied reason for opting out (optional).
+    """
+
+    component_id: str
+    wanted: bool | None = None
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"wanted": self.wanted}
+        if self.reason:
+            d["reason"] = self.reason
+        return d
+
+    @classmethod
+    def from_dict(cls, component_id: str, data: dict[str, Any]) -> FeaturePreference:
+        return cls(
+            component_id=component_id,
+            wanted=data.get("wanted"),
+            reason=data.get("reason"),
+        )
+
+
+def load_preferences() -> dict[str, FeaturePreference]:
+    """Load all feature preferences from config.local.yaml."""
+    local = read_config_local()
+    features = local.get("features", {})
+    if not isinstance(features, dict):
+        return {}
+    return {
+        comp_id: FeaturePreference.from_dict(comp_id, data)
+        if isinstance(data, dict)
+        else FeaturePreference(component_id=comp_id, wanted=data)
+        for comp_id, data in features.items()
+    }
+
+
+def get_preference(component_id: str) -> FeaturePreference:
+    """Get the preference for a single component.
+
+    Returns a preference with ``wanted=None`` if not explicitly set.
+    """
+    prefs = load_preferences()
+    return prefs.get(component_id, FeaturePreference(component_id=component_id))
+
+
+def save_preferences(prefs: dict[str, FeaturePreference]) -> None:
+    """Save feature preferences to config.local.yaml."""
+    features: dict[str, Any] = {}
+    for comp_id, pref in prefs.items():
+        entry: dict[str, Any] = {"wanted": pref.wanted}
+        if pref.reason:
+            entry["reason"] = pref.reason
+        features[comp_id] = entry
+    write_config_local("features", features)
+
+
+def set_preference(
+    component_id: str,
+    wanted: bool | None,
+    reason: str | None = None,
+) -> None:
+    """Set the preference for a single component and persist."""
+    prefs = load_preferences()
+    prefs[component_id] = FeaturePreference(
+        component_id=component_id,
+        wanted=wanted,
+        reason=reason,
+    )
+    save_preferences(prefs)
+
+
+def is_wanted(component_id: str) -> bool | None:
+    """Quick check: is this component wanted?
+
+    Returns True, False, or None (undecided).
+    """
+    return get_preference(component_id).wanted

--- a/work_buddy/health/requirement_checks.py
+++ b/work_buddy/health/requirement_checks.py
@@ -1,0 +1,346 @@
+"""Requirement check functions — configuration-time validation.
+
+Each function returns ``{"ok": bool, "detail": str}``.
+
+These are fast, deterministic checks — filesystem and config inspection only.
+No HTTP calls, no service pings, no bridge communication.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+def _cfg() -> dict[str, Any]:
+    """Load config lazily to avoid circular imports at module level."""
+    from work_buddy.config import load_config
+    return load_config()
+
+
+def _vault_root() -> Path:
+    """Resolve vault_root from config."""
+    return Path(_cfg().get("vault_root", ""))
+
+
+def _repo_root() -> Path:
+    """Work-buddy repo root."""
+    return Path(__file__).parent.parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Core / bootstrap checks
+# ---------------------------------------------------------------------------
+
+
+def check_config_yaml_exists() -> dict[str, Any]:
+    """Check that config.yaml exists in the repo root."""
+    path = _repo_root() / "config.yaml"
+    if path.exists():
+        return {"ok": True, "detail": f"config.yaml found at {path}"}
+    return {"ok": False, "detail": f"config.yaml not found at {path}"}
+
+
+def check_config_local_exists() -> dict[str, Any]:
+    """Check that config.local.yaml exists."""
+    path = _repo_root() / "config.local.yaml"
+    if path.exists():
+        return {"ok": True, "detail": f"config.local.yaml found at {path}"}
+    example = _repo_root() / "config.local.yaml.example"
+    hint = " (config.local.yaml.example exists — copy it)" if example.exists() else ""
+    return {"ok": False, "detail": f"config.local.yaml not found{hint}"}
+
+
+def check_vault_root() -> dict[str, Any]:
+    """Check that vault_root is set and points to an existing directory."""
+    cfg = _cfg()
+    vault_root = cfg.get("vault_root", "")
+    if not vault_root:
+        return {"ok": False, "detail": "vault_root is empty or not set in config"}
+    p = Path(vault_root)
+    if p.is_dir():
+        return {"ok": True, "detail": f"vault_root exists: {p}"}
+    return {"ok": False, "detail": f"vault_root does not exist: {p}"}
+
+
+def check_repos_root() -> dict[str, Any]:
+    """Check that repos_root is set and points to an existing directory."""
+    cfg = _cfg()
+    repos_root = cfg.get("repos_root", "")
+    if not repos_root:
+        return {"ok": False, "detail": "repos_root is empty or not set in config"}
+    p = Path(repos_root)
+    if p.is_dir():
+        return {"ok": True, "detail": f"repos_root exists: {p}"}
+    return {"ok": False, "detail": f"repos_root does not exist: {p}"}
+
+
+def check_timezone() -> dict[str, Any]:
+    """Check that timezone is a valid IANA timezone."""
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+    cfg = _cfg()
+    tz = cfg.get("timezone", "")
+    if not tz:
+        return {"ok": False, "detail": "timezone is empty or not set"}
+    try:
+        ZoneInfo(tz)
+        return {"ok": True, "detail": f"Valid timezone: {tz}"}
+    except (ZoneInfoNotFoundError, KeyError):
+        return {"ok": False, "detail": f"Invalid IANA timezone: '{tz}'"}
+
+
+def check_anthropic_api_key() -> dict[str, Any]:
+    """Check that ANTHROPIC_API_KEY environment variable is set."""
+    key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if key:
+        return {"ok": True, "detail": f"ANTHROPIC_API_KEY is set ({len(key)} chars)"}
+    return {"ok": False, "detail": "ANTHROPIC_API_KEY environment variable is not set"}
+
+
+def check_data_writable() -> dict[str, Any]:
+    """Check that the data/ directory exists and is writable."""
+    from work_buddy.paths import data_dir
+
+    try:
+        d = data_dir("runtime")
+        d.mkdir(parents=True, exist_ok=True)
+        # Test actual writability
+        test_file = d / ".write_test"
+        test_file.write_text("ok", encoding="utf-8")
+        test_file.unlink()
+        return {"ok": True, "detail": f"data/ is writable ({d.parent})"}
+    except Exception as exc:
+        return {"ok": False, "detail": f"data/ directory issue: {exc}"}
+
+
+# ---------------------------------------------------------------------------
+# Obsidian vault structure checks
+# ---------------------------------------------------------------------------
+
+
+def check_obsidian_dir() -> dict[str, Any]:
+    """Check that .obsidian/ exists in vault root."""
+    vault = _vault_root()
+    if not vault or not vault.is_dir():
+        return {"ok": False, "detail": "vault_root is not set or doesn't exist (run bootstrap checks first)"}
+    obs_dir = vault / ".obsidian"
+    if obs_dir.is_dir():
+        return {"ok": True, "detail": f".obsidian/ found in {vault}"}
+    return {"ok": False, "detail": f".obsidian/ not found in {vault}"}
+
+
+def check_daily_notes_plugin() -> dict[str, Any]:
+    """Check that the Daily Notes core plugin is enabled."""
+    vault = _vault_root()
+    if not vault or not vault.is_dir():
+        return {"ok": False, "detail": "vault_root is not set or doesn't exist"}
+    # Core plugins are stored in .obsidian/core-plugins-migration.json
+    # or .obsidian/core-plugins.json depending on Obsidian version
+    for filename in ("core-plugins-migration.json", "core-plugins.json"):
+        cp_file = vault / ".obsidian" / filename
+        if cp_file.exists():
+            try:
+                with open(cp_file, encoding="utf-8") as f:
+                    data = json.load(f)
+                # core-plugins-migration.json: {"daily-notes": true, ...}
+                if isinstance(data, dict):
+                    if data.get("daily-notes") is True:
+                        return {"ok": True, "detail": "Daily Notes core plugin is enabled"}
+                    if "daily-notes" in data:
+                        return {"ok": False, "detail": "Daily Notes core plugin is disabled"}
+                # core-plugins.json: ["daily-notes", ...]
+                if isinstance(data, list) and "daily-notes" in data:
+                    return {"ok": True, "detail": "Daily Notes core plugin is enabled"}
+            except (json.JSONDecodeError, OSError):
+                continue
+    return {"ok": False, "detail": "Could not determine Daily Notes plugin status"}
+
+
+def check_journal_dir() -> dict[str, Any]:
+    """Check that the journal directory exists."""
+    vault = _vault_root()
+    cfg = _cfg()
+    journal_dir_name = cfg.get("obsidian", {}).get("journal_dir", "journal")
+    journal_path = vault / journal_dir_name
+    if journal_path.is_dir():
+        return {"ok": True, "detail": f"Journal directory exists: {journal_path}"}
+    return {"ok": False, "detail": f"Journal directory not found: {journal_path}"}
+
+
+def _find_todays_note() -> Path | None:
+    """Find today's daily note file."""
+    from datetime import date
+    vault = _vault_root()
+    cfg = _cfg()
+    journal_dir = cfg.get("obsidian", {}).get("journal_dir", "journal")
+    today = date.today().strftime("%Y-%m-%d")
+    note_path = vault / journal_dir / f"{today}.md"
+    return note_path if note_path.exists() else None
+
+
+def _note_has_section(header_pattern: str) -> dict[str, Any]:
+    """Check if today's note has a section matching the pattern (case-insensitive)."""
+    import re
+    note = _find_todays_note()
+    if note is None:
+        return {"ok": False, "detail": "Today's daily note does not exist yet"}
+    try:
+        content = note.read_text(encoding="utf-8")
+        # Match markdown headers, ignoring bold/italic formatting
+        pattern = rf"^#+\s+\**{re.escape(header_pattern)}"
+        if re.search(pattern, content, re.MULTILINE | re.IGNORECASE):
+            return {"ok": True, "detail": f"Found '{header_pattern}' section in {note.name}"}
+        return {"ok": False, "detail": f"No '{header_pattern}' section found in {note.name}"}
+    except OSError as exc:
+        return {"ok": False, "detail": f"Could not read {note}: {exc}"}
+
+
+def check_log_section() -> dict[str, Any]:
+    """Check that today's note has a '# Log' section."""
+    return _note_has_section("Log")
+
+
+def check_sign_in_section() -> dict[str, Any]:
+    """Check that today's note has a '# Sign-In' section."""
+    return _note_has_section("Sign-In")
+
+
+def check_running_notes_section() -> dict[str, Any]:
+    """Check that today's note has a 'Running Notes' section."""
+    return _note_has_section("Running Notes")
+
+
+def check_master_task_list() -> dict[str, Any]:
+    """Check that the master task list file exists."""
+    vault = _vault_root()
+    task_file = vault / "tasks" / "master-task-list.md"
+    if task_file.exists():
+        return {"ok": True, "detail": f"Master task list found: {task_file}"}
+    return {"ok": False, "detail": f"Master task list not found: {task_file}"}
+
+
+def check_tasks_plugin() -> dict[str, Any]:
+    """Check that the Obsidian Tasks community plugin is installed and enabled.
+
+    Uses direct file inspection rather than importing plugins.py to avoid
+    triggering agent_session side-effects.
+    """
+    vault = _vault_root()
+    if not vault or not vault.is_dir():
+        return {"ok": False, "detail": "vault_root is not set or doesn't exist"}
+    cp_file = vault / ".obsidian" / "community-plugins.json"
+    if not cp_file.exists():
+        return {"ok": False, "detail": "community-plugins.json not found"}
+    try:
+        with open(cp_file, encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, list) and "obsidian-tasks-plugin" in data:
+            return {"ok": True, "detail": "Tasks plugin is active"}
+        return {"ok": False, "detail": "Tasks plugin is not in community-plugins.json"}
+    except (json.JSONDecodeError, OSError) as exc:
+        return {"ok": False, "detail": f"Could not read community-plugins.json: {exc}"}
+
+
+def check_contracts_dir() -> dict[str, Any]:
+    """Check that the contracts directory exists in the vault."""
+    vault = _vault_root()
+    cfg = _cfg()
+    contracts_path = cfg.get("contracts", {}).get("vault_path", "work-buddy/contracts")
+    full_path = vault / contracts_path
+    if full_path.is_dir():
+        return {"ok": True, "detail": f"Contracts directory found: {full_path}"}
+    return {"ok": False, "detail": f"Contracts directory not found: {full_path}"}
+
+
+def check_personal_knowledge_path() -> dict[str, Any]:
+    """Check that the personal knowledge vault path exists."""
+    vault = _vault_root()
+    cfg = _cfg()
+    pk_path = cfg.get("personal_knowledge", {}).get("vault_path", "Meta/WorkBuddy")
+    full_path = vault / pk_path
+    if full_path.is_dir():
+        return {"ok": True, "detail": f"Personal knowledge path found: {full_path}"}
+    return {"ok": False, "detail": f"Personal knowledge path not found: {full_path}"}
+
+
+# ---------------------------------------------------------------------------
+# Integration checks
+# ---------------------------------------------------------------------------
+
+
+def check_pg_scheduled_task() -> dict[str, Any]:
+    """Check Windows scheduled task for PostgreSQL (Windows-only)."""
+    if platform.system() != "Windows":
+        return {"ok": True, "detail": "Not Windows — skipping scheduled task check"}
+    try:
+        result = subprocess.run(
+            ["powershell.exe", "-Command",
+             "Get-ScheduledTask -TaskName 'Hindsight-PostgreSQL' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty TaskName"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if "Hindsight-PostgreSQL" in result.stdout:
+            return {"ok": True, "detail": "Windows scheduled task 'Hindsight-PostgreSQL' exists"}
+        return {"ok": False, "detail": "Windows scheduled task 'Hindsight-PostgreSQL' not found"}
+    except Exception as exc:
+        return {"ok": False, "detail": f"Could not check scheduled tasks: {exc}"}
+
+
+def check_chrome_native_host() -> dict[str, Any]:
+    """Check Chrome native messaging host manifest is registered.
+
+    The manifest can be named either ``com.work_buddy.tabs.json`` or
+    ``work_buddy_tabs.json`` depending on install method.
+    """
+    manifest_names = ("com.work_buddy.tabs.json", "work_buddy_tabs.json")
+
+    if platform.system() == "Windows":
+        search_dirs = [
+            Path(os.environ.get("APPDATA", "")) / "Google" / "Chrome" / "NativeMessagingHosts",
+            Path(os.environ.get("LOCALAPPDATA", "")) / "Google" / "Chrome" / "User Data" / "NativeMessagingHosts",
+        ]
+    elif platform.system() == "Darwin":
+        search_dirs = [
+            Path.home() / "Library" / "Application Support" / "Google" / "Chrome" / "NativeMessagingHosts",
+        ]
+    else:
+        search_dirs = [
+            Path.home() / ".config" / "google-chrome" / "NativeMessagingHosts",
+        ]
+
+    for d in search_dirs:
+        for name in manifest_names:
+            manifest = d / name
+            if manifest.exists():
+                return {"ok": True, "detail": f"Native host manifest found: {manifest}"}
+
+    return {"ok": False, "detail": "Native host manifest not found in Chrome NativeMessagingHosts"}
+
+
+# ---------------------------------------------------------------------------
+# Service checks
+# ---------------------------------------------------------------------------
+
+
+def check_telegram_bot_token() -> dict[str, Any]:
+    """Check that the Telegram bot token is configured."""
+    cfg = _cfg()
+    token_env = cfg.get("telegram", {}).get("bot_token_env", "TELEGRAM_BOT_TOKEN")
+    if os.environ.get(token_env):
+        return {"ok": True, "detail": f"${token_env} is set"}
+    # Check .env file in repo root
+    env_file = _repo_root() / ".env"
+    if env_file.exists():
+        try:
+            content = env_file.read_text(encoding="utf-8")
+            for line in content.splitlines():
+                line = line.strip()
+                if line.startswith(f"{token_env}=") and len(line.split("=", 1)[1].strip()) > 0:
+                    return {"ok": True, "detail": f"${token_env} found in .env file"}
+        except OSError:
+            pass
+    return {"ok": False, "detail": f"${token_env} not found in environment or .env file"}

--- a/work_buddy/health/requirements.py
+++ b/work_buddy/health/requirements.py
@@ -1,0 +1,423 @@
+"""Requirements system — configuration-time validation of hidden assumptions.
+
+Requirements answer "is the environment set up correctly for this subsystem
+to work?" — distinct from health checks ("is the service running right now?").
+
+Requirement IDs follow a strict hierarchy: ``{domain}/{subsystem}/{check-name}``
+
+Domains:
+    - ``core/`` — Fundamental bootstrap (must pass before anything else)
+    - ``obsidian/`` — Vault structure, plugins, templates
+    - ``services/`` — Sidecar and external services
+    - ``integrations/`` — Chrome, Hindsight, etc.
+
+Example IDs:
+    - ``core/config/vault-root``
+    - ``obsidian/daily-note/log-section``
+    - ``services/telegram/bot-token``
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import platform
+from dataclasses import dataclass, field
+from typing import Any
+
+_IS_WINDOWS = platform.system() == "Windows"
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class RequirementDef:
+    """Definition of a configuration-time requirement.
+
+    Attributes:
+        id: Hierarchical path, e.g. ``core/config/vault-root``.
+        component: Component ID this belongs to, or None for core requirements.
+        description: Human-readable description of what's checked.
+        check_fn: Dotted import path to callable returning ``{ok, detail}``.
+        severity: ``"required"`` or ``"recommended"``.
+        fix_hint: Human-readable fix instructions.
+        setup_group: Wizard grouping: ``"bootstrap"``, ``"journal"``, ``"tasks"``, etc.
+    """
+
+    id: str
+    component: str | None
+    description: str
+    check_fn: str
+    severity: str  # "required" | "recommended"
+    fix_hint: str
+    setup_group: str
+
+
+@dataclass
+class RequirementResult:
+    """Result of checking a single requirement."""
+
+    id: str
+    ok: bool
+    detail: str
+    fix_hint: str
+    severity: str
+    component: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "ok": self.ok,
+            "detail": self.detail,
+            "fix_hint": self.fix_hint if not self.ok else "",
+            "severity": self.severity,
+            "component": self.component,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Requirement registry
+# ---------------------------------------------------------------------------
+
+REQUIREMENT_REGISTRY: dict[str, RequirementDef] = {}
+
+
+def _register(req: RequirementDef) -> None:
+    REQUIREMENT_REGISTRY[req.id] = req
+
+
+def _check_fn_module(check_fn: str) -> str:
+    """Module path from a dotted check_fn."""
+    return check_fn.rsplit(".", 1)[0]
+
+
+# --- Bootstrap (core/) ---
+
+_register(RequirementDef(
+    id="core/config/config-yaml-exists",
+    component=None,
+    description="config.yaml exists in repo root",
+    check_fn="work_buddy.health.requirement_checks.check_config_yaml_exists",
+    severity="required",
+    fix_hint="Create config.yaml in the work-buddy repo root. Copy from config.yaml and adjust vault_root/repos_root.",
+    setup_group="bootstrap",
+))
+
+_register(RequirementDef(
+    id="core/config/config-local-exists",
+    component=None,
+    description="config.local.yaml exists (machine-specific overrides)",
+    check_fn="work_buddy.health.requirement_checks.check_config_local_exists",
+    severity="required",
+    fix_hint=(
+        "Create config.local.yaml from the example:\n"
+        "  cp config.local.yaml.example config.local.yaml\n"
+        "Then edit it with your machine-specific settings."
+    ),
+    setup_group="bootstrap",
+))
+
+_register(RequirementDef(
+    id="core/config/vault-root",
+    component=None,
+    description="vault_root points to an existing directory",
+    check_fn="work_buddy.health.requirement_checks.check_vault_root",
+    severity="required",
+    fix_hint="Set vault_root in config.yaml to your Obsidian vault path, e.g. '/path/to/your/vault'.",
+    setup_group="bootstrap",
+))
+
+_register(RequirementDef(
+    id="core/config/repos-root",
+    component=None,
+    description="repos_root points to an existing directory",
+    check_fn="work_buddy.health.requirement_checks.check_repos_root",
+    severity="recommended",
+    fix_hint="Set repos_root in config.yaml to your git repos directory.",
+    setup_group="bootstrap",
+))
+
+_register(RequirementDef(
+    id="core/config/timezone",
+    component=None,
+    description="timezone is a valid IANA timezone",
+    check_fn="work_buddy.health.requirement_checks.check_timezone",
+    severity="required",
+    fix_hint="Set timezone in config.yaml to a valid IANA timezone, e.g. 'America/New_York'.",
+    setup_group="bootstrap",
+))
+
+_register(RequirementDef(
+    id="core/env/anthropic-api-key",
+    component=None,
+    description="ANTHROPIC_API_KEY environment variable is set",
+    check_fn="work_buddy.health.requirement_checks.check_anthropic_api_key",
+    severity="required",
+    fix_hint="Set the ANTHROPIC_API_KEY environment variable with your Anthropic API key.",
+    setup_group="bootstrap",
+))
+
+_register(RequirementDef(
+    id="core/data/writable",
+    component=None,
+    description="data/ directory exists and is writable",
+    check_fn="work_buddy.health.requirement_checks.check_data_writable",
+    severity="required",
+    fix_hint="Ensure the data/ directory in the repo root exists and is writable.",
+    setup_group="bootstrap",
+))
+
+# --- Obsidian vault structure ---
+
+_register(RequirementDef(
+    id="obsidian/vault/obsidian-dir",
+    component="obsidian",
+    description=".obsidian/ directory exists in vault root",
+    check_fn="work_buddy.health.requirement_checks.check_obsidian_dir",
+    severity="required",
+    fix_hint="Open the vault in Obsidian at least once to create the .obsidian/ directory.",
+    setup_group="vault",
+))
+
+_register(RequirementDef(
+    id="obsidian/daily-note/plugin-enabled",
+    component="obsidian",
+    description="Daily Notes core plugin is enabled",
+    check_fn="work_buddy.health.requirement_checks.check_daily_notes_plugin",
+    severity="required",
+    fix_hint="Enable the 'Daily notes' core plugin in Obsidian Settings > Core Plugins.",
+    setup_group="journal",
+))
+
+_register(RequirementDef(
+    id="obsidian/daily-note/dir-exists",
+    component="obsidian",
+    description="Journal directory exists at configured path",
+    check_fn="work_buddy.health.requirement_checks.check_journal_dir",
+    severity="required",
+    fix_hint="Create the journal directory in your vault (default: vault_root/journal/).",
+    setup_group="journal",
+))
+
+_register(RequirementDef(
+    id="obsidian/daily-note/log-section",
+    component="obsidian",
+    description="Today's daily note has a '# Log' section",
+    check_fn="work_buddy.health.requirement_checks.check_log_section",
+    severity="recommended",
+    fix_hint=(
+        "Add a '# Log' section header to your daily note template.\n"
+        "The journal subsystem appends timestamped activity entries here."
+    ),
+    setup_group="journal",
+))
+
+_register(RequirementDef(
+    id="obsidian/daily-note/sign-in-section",
+    component="obsidian",
+    description="Today's daily note has a '# Sign-In' section",
+    check_fn="work_buddy.health.requirement_checks.check_sign_in_section",
+    severity="recommended",
+    fix_hint=(
+        "Add a '# Sign-In' section to your daily note template.\n"
+        "Used by the morning routine to record sleep, energy, and mood."
+    ),
+    setup_group="journal",
+))
+
+_register(RequirementDef(
+    id="obsidian/daily-note/running-notes-section",
+    component="obsidian",
+    description="Today's daily note has a 'Running Notes' section",
+    check_fn="work_buddy.health.requirement_checks.check_running_notes_section",
+    severity="recommended",
+    fix_hint=(
+        "Add a '# Running Notes / Considerations' section to your daily note template.\n"
+        "The backlog system processes carry-over notes from this section."
+    ),
+    setup_group="journal",
+))
+
+_register(RequirementDef(
+    id="obsidian/tasks/master-list-exists",
+    component="obsidian",
+    description="Master task list file exists",
+    check_fn="work_buddy.health.requirement_checks.check_master_task_list",
+    severity="required",
+    fix_hint="Create the master task list at tasks/master-task-list.md in your vault.",
+    setup_group="tasks",
+))
+
+_register(RequirementDef(
+    id="obsidian/plugins/tasks-plugin",
+    component="obsidian",
+    description="Obsidian Tasks plugin is installed and enabled",
+    check_fn="work_buddy.health.requirement_checks.check_tasks_plugin",
+    severity="required",
+    fix_hint="Install and enable the 'Tasks' community plugin in Obsidian.",
+    setup_group="tasks",
+))
+
+_register(RequirementDef(
+    id="obsidian/contracts/dir-exists",
+    component="obsidian",
+    description="Contracts directory exists in vault",
+    check_fn="work_buddy.health.requirement_checks.check_contracts_dir",
+    severity="recommended",
+    fix_hint="Create the contracts directory in your vault (default: work-buddy/contracts/).",
+    setup_group="contracts",
+))
+
+_register(RequirementDef(
+    id="obsidian/knowledge/personal-path",
+    component="obsidian",
+    description="Personal knowledge vault path exists",
+    check_fn="work_buddy.health.requirement_checks.check_personal_knowledge_path",
+    severity="recommended",
+    fix_hint="Create the personal knowledge directory in your vault (default: Meta/WorkBuddy/).",
+    setup_group="knowledge",
+))
+
+# --- Integrations ---
+
+_register(RequirementDef(
+    id="integrations/hindsight/pg-scheduled-task",
+    component="hindsight",
+    description=(
+        "Scheduled task for PostgreSQL auto-start exists"
+        if _IS_WINDOWS else "PostgreSQL auto-start is configured"
+    ),
+    check_fn="work_buddy.health.requirement_checks.check_pg_scheduled_task",
+    severity="recommended",
+    fix_hint=(
+        "Create a Windows scheduled task named 'Hindsight-PostgreSQL' to start\n"
+        "PostgreSQL on login. See scripts/start-hindsight.sh for the ordering."
+        if _IS_WINDOWS else
+        "Configure PostgreSQL to start on login via systemd user unit or shell profile.\n"
+        "See scripts/start-hindsight.sh for the startup ordering."
+    ),
+    setup_group="memory",
+))
+
+_register(RequirementDef(
+    id="integrations/chrome/native-host",
+    component="chrome_extension",
+    description="Chrome native messaging host manifest is registered",
+    check_fn="work_buddy.health.requirement_checks.check_chrome_native_host",
+    severity="required",
+    fix_hint=(
+        "Register the Chrome native messaging host:\n"
+        "  cd work_buddy/chrome_native_host && python install.py\n"
+        + ("Manifest location: %APPDATA%\\Google\\Chrome\\NativeMessagingHosts\\" if _IS_WINDOWS
+           else "Manifest location: ~/.config/google-chrome/NativeMessagingHosts/" if not platform.system() == "Darwin"
+           else "Manifest location: ~/Library/Application Support/Google/Chrome/NativeMessagingHosts/")
+        + "\nSee chrome_native_host/README.md for details."
+    ),
+    setup_group="chrome",
+))
+
+# --- Services ---
+
+_register(RequirementDef(
+    id="services/telegram/bot-token",
+    component="telegram",
+    description="Telegram bot token is configured",
+    check_fn="work_buddy.health.requirement_checks.check_telegram_bot_token",
+    severity="required",
+    fix_hint=(
+        "Set TELEGRAM_BOT_TOKEN in your .env file. Create a bot via @BotFather\n"
+        "on Telegram and copy the token."
+    ),
+    setup_group="telegram",
+))
+
+
+# ---------------------------------------------------------------------------
+# RequirementChecker
+# ---------------------------------------------------------------------------
+
+class RequirementChecker:
+    """Validates requirements against the current environment."""
+
+    def _run_check(self, req: RequirementDef) -> RequirementResult:
+        """Execute a single requirement check."""
+        try:
+            module_path, fn_name = req.check_fn.rsplit(".", 1)
+            module = importlib.import_module(module_path)
+            check_fn = getattr(module, fn_name)
+            result = check_fn()
+            return RequirementResult(
+                id=req.id,
+                ok=result.get("ok", False),
+                detail=result.get("detail", ""),
+                fix_hint=req.fix_hint,
+                severity=req.severity,
+                component=req.component,
+            )
+        except Exception as exc:
+            log.warning("Requirement check %s failed: %s", req.id, exc)
+            return RequirementResult(
+                id=req.id,
+                ok=False,
+                detail=f"Check raised an error: {exc}",
+                fix_hint=req.fix_hint,
+                severity=req.severity,
+                component=req.component,
+            )
+
+    def check_all(self, include_unwanted: bool = False) -> list[RequirementResult]:
+        """Validate all requirements, optionally filtering by user preferences.
+
+        If ``include_unwanted`` is False (default), skips requirements for
+        components the user has explicitly opted out of (``wanted: false``).
+        Core requirements (``component=None``) always run.
+        """
+        from work_buddy.health.preferences import is_wanted
+
+        results = []
+        for req in REQUIREMENT_REGISTRY.values():
+            if req.component is not None and not include_unwanted:
+                pref = is_wanted(req.component)
+                if pref is False:
+                    continue
+            results.append(self._run_check(req))
+        return results
+
+    def check_bootstrap(self) -> list[RequirementResult]:
+        """Check only core/* requirements (fast, no component filter)."""
+        return [
+            self._run_check(req)
+            for req in REQUIREMENT_REGISTRY.values()
+            if req.id.startswith("core/")
+        ]
+
+    def check_component(self, component_id: str) -> list[RequirementResult]:
+        """Check requirements for a specific component."""
+        return [
+            self._run_check(req)
+            for req in REQUIREMENT_REGISTRY.values()
+            if req.component == component_id
+        ]
+
+    def check_group(self, group_name: str) -> list[RequirementResult]:
+        """Check requirements for a setup group (e.g. 'journal', 'tasks')."""
+        return [
+            self._run_check(req)
+            for req in REQUIREMENT_REGISTRY.values()
+            if req.setup_group == group_name
+        ]
+
+    @staticmethod
+    def summarize(results: list[RequirementResult]) -> dict[str, Any]:
+        """Produce a summary from a list of results."""
+        passed = sum(1 for r in results if r.ok)
+        failed_required = [r for r in results if not r.ok and r.severity == "required"]
+        failed_recommended = [r for r in results if not r.ok and r.severity == "recommended"]
+        return {
+            "total": len(results),
+            "passed": passed,
+            "failed_required": len(failed_required),
+            "failed_recommended": len(failed_recommended),
+            "all_required_pass": len(failed_required) == 0,
+            "failures": [r.to_dict() for r in results if not r.ok],
+        }

--- a/work_buddy/health/wizard.py
+++ b/work_buddy/health/wizard.py
@@ -1,0 +1,247 @@
+"""Setup Wizard — orchestrates preferences, requirements, health, and diagnostics.
+
+The wizard capability supports four modes:
+
+    status    — Quick health + requirements summary for wanted components.
+    guided    — Interactive first-time setup (returns structured steps).
+    diagnose  — Deep diagnostic for a specific component.
+    preferences — View/edit feature preferences.
+
+The wizard is an MCP capability, not a workflow.  It returns structured data
+for the agent to present interactively — the agent drives the conversation.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+class SetupWizard:
+    """Orchestrates the full setup wizard flow."""
+
+    def __init__(self) -> None:
+        from work_buddy.health.engine import HealthEngine
+        from work_buddy.health.diagnostics import DiagnosticRunner
+        from work_buddy.health.requirements import RequirementChecker
+
+        self.engine = HealthEngine()
+        self.diagnostics = DiagnosticRunner()
+        self.requirements = RequirementChecker()
+
+    def status(self) -> dict[str, Any]:
+        """Quick health + requirements overview for all wanted components.
+
+        Returns bootstrap check results, component health, and requirement
+        validation — everything an agent needs to understand the current state.
+        """
+        # 1. Bootstrap checks (always run)
+        bootstrap = self.requirements.check_bootstrap()
+        bootstrap_summary = self.requirements.summarize(bootstrap)
+
+        # 2. Component health (respects preferences)
+        health = self.engine.get_all()
+
+        # 3. Requirement checks for wanted components
+        req_results = self.requirements.check_all(include_unwanted=False)
+        req_summary = self.requirements.summarize(req_results)
+
+        return {
+            "mode": "status",
+            "bootstrap": {
+                "summary": bootstrap_summary,
+                "results": [r.to_dict() for r in bootstrap],
+            },
+            "health": health,
+            "requirements": {
+                "summary": req_summary,
+                "results": [r.to_dict() for r in req_results],
+            },
+        }
+
+    def guided(self) -> dict[str, Any]:
+        """Interactive guided setup — returns structured steps for the agent.
+
+        The agent walks the user through each step, collecting choices and
+        applying fixes.  Each step includes all the data needed to present
+        it to the user.
+        """
+        from work_buddy.health.components import COMPONENT_CATALOG
+        from work_buddy.health.preferences import load_preferences
+
+        # Step 1: Bootstrap checks
+        bootstrap = self.requirements.check_bootstrap()
+        bootstrap_summary = self.requirements.summarize(bootstrap)
+
+        # Step 2: Feature inventory — all components grouped by category
+        prefs = load_preferences()
+        components_by_category: dict[str, list[dict[str, Any]]] = {}
+        for comp in COMPONENT_CATALOG.values():
+            pref = prefs.get(comp.id)
+            entry = {
+                "id": comp.id,
+                "display_name": comp.display_name,
+                "category": comp.category,
+                "wanted": pref.wanted if pref else None,
+                "reason": pref.reason if pref else None,
+                "depends_on": comp.depends_on,
+            }
+            components_by_category.setdefault(comp.category, []).append(entry)
+
+        # Step 3: Requirement checks for wanted components
+        req_results = self.requirements.check_all(include_unwanted=False)
+        req_summary = self.requirements.summarize(req_results)
+
+        # Step 4: Health check for wanted components
+        health = self.engine.get_all()
+        wanted_health = [
+            c for c in health["components"]
+            if c.get("wanted") is not False
+        ]
+
+        return {
+            "mode": "guided",
+            "steps": [
+                {
+                    "step": 1,
+                    "name": "bootstrap",
+                    "title": "Core Requirements",
+                    "description": "Validate fundamental work-buddy configuration.",
+                    "summary": bootstrap_summary,
+                    "results": [r.to_dict() for r in bootstrap],
+                },
+                {
+                    "step": 2,
+                    "name": "features",
+                    "title": "Feature Selection",
+                    "description": "Choose which components you want to use.",
+                    "components": components_by_category,
+                },
+                {
+                    "step": 3,
+                    "name": "requirements",
+                    "title": "Configuration Validation",
+                    "description": "Check that wanted features are configured correctly.",
+                    "summary": req_summary,
+                    "results": [r.to_dict() for r in req_results],
+                },
+                {
+                    "step": 4,
+                    "name": "health",
+                    "title": "Service Health",
+                    "description": "Verify running services for wanted features.",
+                    "summary": health["summary"],
+                    "components": wanted_health,
+                },
+            ],
+            "instructions": (
+                "Walk the user through each step:\n"
+                "1. Fix any bootstrap failures first (these block everything).\n"
+                "2. Ask which features they want — save preferences with set_preference().\n"
+                "3. Show requirement failures with fix hints — help them resolve.\n"
+                "4. Check service health — diagnose any unhealthy wanted components.\n"
+                "After all steps, save preferences to config.local.yaml."
+            ),
+        }
+
+    def diagnose(self, component: str) -> dict[str, Any]:
+        """Deep diagnostic for a specific component.
+
+        Combines requirements validation, health status, and diagnostic
+        check sequences.  Equivalent to the existing ``setup_help`` behavior
+        plus requirements checking.
+        """
+        from work_buddy.health.components import COMPONENT_CATALOG
+        from work_buddy.health.preferences import get_preference
+
+        comp = COMPONENT_CATALOG.get(component)
+        if comp is None:
+            available = sorted(COMPONENT_CATALOG.keys())
+            return {
+                "mode": "diagnose",
+                "error": f"Unknown component: '{component}'",
+                "available_components": available,
+            }
+
+        pref = get_preference(component)
+
+        # Requirements for this component
+        req_results = self.requirements.check_component(component)
+        req_summary = self.requirements.summarize(req_results)
+
+        # Health status
+        health = self.engine.get_component(component)
+
+        # Diagnostic check sequence
+        diag = self.diagnostics.diagnose(component)
+
+        return {
+            "mode": "diagnose",
+            "component": component,
+            "display_name": comp.display_name,
+            "preference": {
+                "wanted": pref.wanted,
+                "reason": pref.reason,
+            },
+            "requirements": {
+                "summary": req_summary,
+                "results": [r.to_dict() for r in req_results],
+            },
+            "health": health.to_dict() if health else None,
+            "diagnostics": diag.to_dict() if hasattr(diag, "to_dict") else {
+                "status": diag.status,
+                "steps_run": [s.__dict__ for s in diag.steps_run],
+                "root_cause": diag.root_cause,
+                "fix_suggestion": diag.fix_suggestion,
+            },
+        }
+
+    def preferences(
+        self,
+        updates: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """View or edit feature preferences.
+
+        If ``updates`` is provided, apply them first:
+        ``{"hindsight": {"wanted": false, "reason": "..."}, ...}``
+        """
+        from work_buddy.health.preferences import (
+            load_preferences,
+            set_preference,
+        )
+        from work_buddy.health.components import COMPONENT_CATALOG
+
+        # Apply updates if provided
+        if updates:
+            for comp_id, data in updates.items():
+                if comp_id not in COMPONENT_CATALOG:
+                    continue
+                if isinstance(data, dict):
+                    set_preference(
+                        comp_id,
+                        wanted=data.get("wanted"),
+                        reason=data.get("reason"),
+                    )
+                elif isinstance(data, bool) or data is None:
+                    set_preference(comp_id, wanted=data)
+
+        # Return current state
+        prefs = load_preferences()
+        components = []
+        for comp in COMPONENT_CATALOG.values():
+            pref = prefs.get(comp.id)
+            components.append({
+                "id": comp.id,
+                "display_name": comp.display_name,
+                "category": comp.category,
+                "wanted": pref.wanted if pref else None,
+                "reason": pref.reason if pref else None,
+            })
+
+        return {
+            "mode": "preferences",
+            "components": components,
+            "updated": bool(updates),
+        }

--- a/work_buddy/mcp_server/registry.py
+++ b/work_buddy/mcp_server/registry.py
@@ -746,6 +746,9 @@ def _status_capabilities() -> list[Capability]:
     def _feature_status(verbose: bool = False) -> dict:
         """Show which tools, features, and capabilities are available or disabled."""
         from work_buddy.tools import get_tool_status
+        from work_buddy.health.preferences import load_preferences
+        from work_buddy.health.requirements import RequirementChecker
+
         result = get_tool_status()
         if not verbose:
             # Compact: just tool names and disabled capability names
@@ -753,7 +756,50 @@ def _status_capabilities() -> list[Capability]:
                 tid: {"available": s["available"], "reason": s.get("reason", "")}
                 for tid, s in result.get("tools", {}).items()
             }
+
+        # Include user preferences
+        prefs = load_preferences()
+        result["preferences"] = {
+            comp_id: pref.to_dict()
+            for comp_id, pref in prefs.items()
+        }
+
+        # Include requirement summary (lightweight)
+        try:
+            checker = RequirementChecker()
+            req_results = checker.check_bootstrap()
+            result["bootstrap_requirements"] = checker.summarize(req_results)
+        except Exception:
+            result["bootstrap_requirements"] = {"error": "Could not check requirements"}
+
         return result
+
+    def _setup_wizard(
+        mode: str = "status",
+        component: str = "",
+        updates: dict | None = None,
+    ) -> dict:
+        """Setup wizard — comprehensive setup, diagnostics, and preferences.
+
+        Modes:
+            status      — Quick health + requirements overview (default).
+            guided      — Interactive first-time setup with structured steps.
+            diagnose    — Deep diagnostic for a specific component.
+            preferences — View/edit feature preferences.
+        """
+        from work_buddy.health.wizard import SetupWizard
+        wizard = SetupWizard()
+
+        if mode == "guided":
+            return wizard.guided()
+        elif mode == "diagnose":
+            if not component:
+                return {"error": "diagnose mode requires a component parameter"}
+            return wizard.diagnose(component)
+        elif mode == "preferences":
+            return wizard.preferences(updates=updates)
+        else:
+            return wizard.status()
 
     def _setup_help(component: str = "all") -> dict:
         """Diagnose component health. Runs automated check sequences.
@@ -849,9 +895,48 @@ def _status_capabilities() -> list[Capability]:
             },
             callable=_setup_help,
             search_aliases=[
-                "setup", "help", "diagnose", "troubleshoot", "debug",
+                "diagnose", "troubleshoot", "debug",
                 "why not working", "fix", "health check", "what's wrong",
             ],
+        ),
+        Capability(
+            name="setup_wizard",
+            description=(
+                "Comprehensive setup wizard for work-buddy. Validates bootstrap "
+                "requirements, checks feature health, manages user preferences "
+                "(wanted/unwanted features), and provides guided first-time setup. "
+                "Modes: 'status' (quick overview), 'guided' (interactive walkthrough), "
+                "'diagnose' (deep diagnostic for one component), 'preferences' (view/edit)."
+            ),
+            category="status",
+            parameters={
+                "mode": {
+                    "type": "str",
+                    "description": (
+                        "Wizard mode: 'status' (default), 'guided', 'diagnose', 'preferences'"
+                    ),
+                    "required": False,
+                },
+                "component": {
+                    "type": "str",
+                    "description": "Component ID for 'diagnose' mode",
+                    "required": False,
+                },
+                "updates": {
+                    "type": "dict",
+                    "description": (
+                        "Preference updates for 'preferences' mode. "
+                        "Dict of component_id -> {wanted: bool, reason: str}"
+                    ),
+                    "required": False,
+                },
+            },
+            callable=_setup_wizard,
+            search_aliases=[
+                "setup", "wizard", "configure", "preferences", "onboarding",
+                "first time", "requirements", "bootstrap", "wanted", "unwanted",
+            ],
+            slash_command="wb-setup",
         ),
         Capability(
             name="service_health",

--- a/work_buddy/mcp_server/tools/gateway.py
+++ b/work_buddy/mcp_server/tools/gateway.py
@@ -488,11 +488,34 @@ def register_tools(mcp: FastMCP) -> None:
         from work_buddy.mcp_server.activity_ledger import record_init
         record_init(session_id)
 
-        return _to_json({
+        # Quick bootstrap check — only fires when critical config is missing.
+        # Intentionally lightweight: filesystem checks only, no HTTP/bridge.
+        setup_hint = None
+        try:
+            from work_buddy.health.requirements import RequirementChecker
+            checker = RequirementChecker()
+            bootstrap = checker.check_bootstrap()
+            critical_failures = [
+                r for r in bootstrap
+                if not r.ok and r.severity == "required"
+            ]
+            if critical_failures:
+                names = [r.id.split("/")[-1] for r in critical_failures]
+                setup_hint = (
+                    f"Setup issues detected: {', '.join(names)}. "
+                    f"Run /wb-setup to diagnose and fix."
+                )
+        except Exception:
+            pass  # Don't block init on check failures
+
+        result = {
             "status": "initialized",
             "session_id": session_id,
             "message": "Session registered. All work-buddy tools are now available.",
-        })
+        }
+        if setup_hint:
+            result["setup_hint"] = setup_hint
+        return _to_json(result)
 
     @mcp.tool()
     async def wb_search(query: str, category: str | None = None, filter_n: int = 3, ctx: Context = None) -> str:
@@ -561,14 +584,32 @@ def register_tools(mcp: FastMCP) -> None:
         entry = registry.get_entry(capability)
 
         if entry is None:
-            from work_buddy.tools import DISABLED_CAPABILITIES
+            from work_buddy.tools import DISABLED_CAPABILITIES, get_tool_status
             missing_deps = DISABLED_CAPABILITIES.get(capability)
             if missing_deps:
+                # Check if any missing dep is opted-out vs genuinely unavailable
+                tool_status = get_tool_status().get("tools", {})
+                opted_out = [
+                    dep for dep in missing_deps
+                    if tool_status.get(dep, {}).get("user_opted_out")
+                ]
+                if opted_out:
+                    return _to_json({
+                        "error": (
+                            f"Capability {capability!r} is unavailable because "
+                            f"you opted out of: {', '.join(opted_out)}. "
+                            f"To re-enable, run: /wb-setup preferences"
+                        ),
+                        "disabled": True,
+                        "opted_out": opted_out,
+                        "requires": missing_deps,
+                    })
                 return _to_json({
                     "error": (
                         f"Capability {capability!r} is unavailable: "
                         f"requires {', '.join(missing_deps)}. "
-                        f"Start the missing dependencies and reload the registry."
+                        f"Run /wb-setup to diagnose, or start the missing "
+                        f"dependencies and reload the registry."
                     ),
                     "disabled": True,
                     "requires": missing_deps,

--- a/work_buddy/tools.py
+++ b/work_buddy/tools.py
@@ -178,6 +178,7 @@ def probe_all(force: bool = False) -> dict[str, dict[str, Any]]:
 
     from concurrent.futures import ThreadPoolExecutor, as_completed
     from work_buddy.config import load_config
+    from work_buddy.health.preferences import is_wanted
     cfg = load_config()
 
     # Topological order: probes with no dependencies first
@@ -192,6 +193,14 @@ def probe_all(force: bool = False) -> dict[str, dict[str, Any]]:
             "reason": "",
             "config_enabled": True,
         }
+        # Check user preference — if explicitly unwanted, skip probe
+        pref = is_wanted(probe.id)
+        if pref is False:
+            entry["config_enabled"] = False
+            entry["reason"] = "User opted out (features.{}.wanted: false)".format(probe.id)
+            entry["user_opted_out"] = True
+            return probe.id, entry
+
         # Check config toggle
         config_val = _get_config_enabled(cfg, probe.config_key)
         if config_val is False:


### PR DESCRIPTION
## Summary
- Add `/wb-setup` — comprehensive setup wizard with 4 modes: status overview, guided first-time walkthrough, deep component diagnostics, and feature preference management
- Feature preferences system (`config.local.yaml` `features:` section) — users opt in/out of components; propagated to tool probes, health engine, dashboard, gateway errors, and agent guidance
- Requirements validation system (20 checks with hierarchical IDs like `core/config/vault-root`, `obsidian/daily-note/log-section`) — surfaces hidden configuration assumptions with fix instructions
- `wb_init` bootstrap hint detects critical config issues on session start
- Dashboard hides opted-out components, shows requirement warning banners, adds 🪄 wizard hints on failed diagnostics
- Platform-aware fix instructions (Windows `Start-ScheduledTask` / Linux `systemctl` / macOS paths)
- Dashboard diagnostic panel whitespace fix (template literal indentation → string concatenation + `escapeHtml`)

## Test plan
- [x] 87 new unit tests across 4 test files (preferences, requirements, wizard, config helpers)
- [x] 429/429 full suite passing, zero regressions
- [x] E2E tested all 4 wizard modes via MCP (`wb_run("setup_wizard", ...)`)
- [x] E2E tested preference persistence roundtrip (set → verify in config.local.yaml → verify in feature_status)
- [x] E2E tested wb_init bootstrap hint (detected missing ANTHROPIC_API_KEY)
- [x] Verified dashboard diagnostic panel rendering (no whitespace, 🪄 hint visible)

Task: t-000936da (extension of the health/diagnostics subsystem)