### PR TITLE
fix(consent): close consent-delivery race + gate setup_wizard pref writes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,7 @@ Some `work_buddy` functions are protected by a `@requires_consent` decorator. **
 2. **Consent context** — when a consent-gated function executes, it establishes a thread-local context. Nested `@requires_consent` calls (e.g., `toggle_task` → `bridge.write_file`) pass through automatically — the outer consent subsumes inner ones. No manual bookkeeping or `*_raw` function variants needed.
 3. **Fallback** — if a `ConsentRequired` fires at runtime (unanticipated gate not covered by pre-flight or context), the gateway auto-requests and retries (max 2 retries).
 4. **You see**: success (normal result), denied (`{status: "denied"}`), or timeout (`{status: "timeout", operation_id: "op_xxx"}`).
-5. **On timeout** — the request stays pending on all surfaces. Once the user approves, retry with `mcp__work-buddy__wb_run("retry", {"operation_id": "op_xxx"})` to replay the original call without re-sending parameters.
+5. **On timeout** — the request stays pending on all surfaces. Once the user approves, retry with `mcp__work-buddy__wb_run("retry", {"operation_id": "op_xxx"})` to replay the original call without re-sending parameters. **For Obsidian-bridge operations, use `obsidian_retry` instead** — it accepts the same `{"operation_id": "op_xxx"}` shape and adds bridge health-checks between attempts. The gateway's timeout return tells you which to use.
 
 **Do NOT manually call `consent_request`** for `wb_run` operations — the gateway does it for you. You still need manual `consent_request` for sidecar operations not routed through `wb_run` (e.g., `agent_spawn` consent) or custom flows.
 

--- a/knowledge/store/notifications.json
+++ b/knowledge/store/notifications.json
@@ -52,7 +52,7 @@
     ],
     "content": {
       "summary": "The gateway handles consent transparently. Capabilities declare consent_operations for pre-flight bundling. On ConsentRequired, the gateway auto-requests + retries. Agents never see raw consent errors. On timeout, wb_run(\"retry\", ...) replays without re-sending params.",
-      "full": "The gateway handles consent transparently. Capabilities declare consent_operations for pre-flight bundling (UX enrichment — shows all covered operations in the notification). The consent context mechanism handles correctness: when a consent-gated function executes, nested @requires_consent calls pass through automatically via a thread-local context. This eliminates double-prompting for operations like toggle_task → write_file without manual bookkeeping. On ConsentRequired (unanticipated gate), the gateway auto-requests + retries. Agents never see raw consent errors. On timeout, wb_run(\"retry\", ...) replays without re-sending params."
+      "full": "The gateway handles consent transparently. Capabilities declare consent_operations for pre-flight bundling. On ConsentRequired, the gateway auto-requests + retries. Agents never see raw consent errors. On timeout, wb_run(\"retry\", {\"operation_id\": \"op_xxx\"}) replays the original call without re-sending params. For Obsidian-bridge operations, use obsidian_retry instead — same {\"operation_id\": \"op_xxx\"} shape, adds bridge health-checks between attempts. The gateway's timeout return includes the right hint."
     }
   },
   "notifications/surfaces": {

--- a/tests/unit/test_wizard.py
+++ b/tests/unit/test_wizard.py
@@ -156,18 +156,23 @@ class TestWizardPreferences:
     def test_preferences_update_flag(self, mock_preferences, monkeypatch):
         # Mock set_preference at the source module to avoid writing config
         import work_buddy.health.preferences as pmod
+        from work_buddy.consent import grant_consent
         called = []
         monkeypatch.setattr(pmod, "set_preference",
                             lambda *a, **kw: called.append((a, kw)))
+        # apply_preference_updates is consent-gated — grant it for the test
+        grant_consent("setup.write_preferences", mode="once")
         wizard = SetupWizard()
         result = wizard.preferences(updates={"hindsight": {"wanted": False}})
         assert result["updated"] is True
 
     def test_preferences_ignores_unknown_components(self, mock_preferences, monkeypatch):
         import work_buddy.health.preferences as pmod
+        from work_buddy.consent import grant_consent
         called = []
         monkeypatch.setattr(pmod, "set_preference",
                             lambda *a, **kw: called.append((a, kw)))
+        grant_consent("setup.write_preferences", mode="once")
         wizard = SetupWizard()
         result = wizard.preferences(updates={"totally_fake": {"wanted": False}})
         # Should not have called set_preference for unknown component

--- a/work_buddy/health/preferences.py
+++ b/work_buddy/health/preferences.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from work_buddy.config import read_config_local, write_config_local
+from work_buddy.consent import requires_consent
 
 
 @dataclass
@@ -109,6 +110,36 @@ def set_preference(
         reason=reason,
     )
     save_preferences(prefs)
+
+
+@requires_consent(
+    operation="setup.write_preferences",
+    reason="Modify feature preferences (features.* in config.local.yaml)",
+    risk="moderate",
+)
+def apply_preference_updates(updates: dict[str, Any]) -> list[str]:
+    """Apply a batch of feature-preference updates. Consent-gated.
+
+    ``updates`` maps component_id -> {"wanted": bool|None, "reason": str} or bool/None.
+    Returns the list of component_ids that were written.
+    """
+    from work_buddy.health.components import COMPONENT_CATALOG
+
+    written: list[str] = []
+    for comp_id, data in updates.items():
+        if comp_id not in COMPONENT_CATALOG:
+            continue
+        if isinstance(data, dict):
+            set_preference(
+                comp_id,
+                wanted=data.get("wanted"),
+                reason=data.get("reason"),
+            )
+            written.append(comp_id)
+        elif isinstance(data, bool) or data is None:
+            set_preference(comp_id, wanted=data)
+            written.append(comp_id)
+    return written
 
 
 def is_wanted(component_id: str) -> bool | None:

--- a/work_buddy/health/wizard.py
+++ b/work_buddy/health/wizard.py
@@ -208,24 +208,14 @@ class SetupWizard:
         ``{"hindsight": {"wanted": false, "reason": "..."}, ...}``
         """
         from work_buddy.health.preferences import (
+            apply_preference_updates,
             load_preferences,
-            set_preference,
         )
         from work_buddy.health.components import COMPONENT_CATALOG
 
-        # Apply updates if provided
+        # Apply updates if provided (consent-gated)
         if updates:
-            for comp_id, data in updates.items():
-                if comp_id not in COMPONENT_CATALOG:
-                    continue
-                if isinstance(data, dict):
-                    set_preference(
-                        comp_id,
-                        wanted=data.get("wanted"),
-                        reason=data.get("reason"),
-                    )
-                elif isinstance(data, bool) or data is None:
-                    set_preference(comp_id, wanted=data)
+            apply_preference_updates(updates)
 
         # Return current state
         prefs = load_preferences()

--- a/work_buddy/mcp_server/registry.py
+++ b/work_buddy/mcp_server/registry.py
@@ -939,6 +939,14 @@ def _status_capabilities() -> list[Capability]:
                 },
             },
             callable=_setup_wizard,
+            # `preferences` mode with `updates` is the only mutating path;
+            # other modes are read-only. Marked mutating because a single name
+            # covers both. The consent gate (setup.write_preferences on
+            # apply_preference_updates) fires only when `updates` is passed,
+            # so read-only calls don't prompt. Not listed in
+            # consent_operations because pre-flight would prompt on every
+            # call — gateway's runtime ConsentRequired fallback handles it.
+            mutates_state=True,
             search_aliases=[
                 "setup", "wizard", "configure", "preferences", "onboarding",
                 "first time", "requirements", "bootstrap", "wanted", "unwanted",
@@ -2211,15 +2219,33 @@ def _journal_capabilities() -> list[Capability]:
                 "retry task create", "bridge failure", "obsidian unavailable",
             ],
             parameters={
+                "operation_id": {
+                    "type": "str",
+                    "required": False,
+                    "description": (
+                        "Operation ID from a previously failed call. "
+                        "Capability name and params are loaded from the "
+                        "record, so the agent doesn't re-supply them. "
+                        "This is the canonical shape for retrying after a "
+                        "consent timeout (the timeout return includes "
+                        "operation_id). One of 'operation_id' or "
+                        "'capability' is required."
+                    ),
+                },
                 "capability": {
                     "type": "str",
-                    "required": True,
-                    "description": "Name of the registered capability to retry (e.g. 'task_create')",
+                    "required": False,
+                    "description": (
+                        "Name of the registered capability to retry "
+                        "(e.g. 'task_create'). Use this only when you don't "
+                        "have an operation_id to look up — otherwise pass "
+                        "operation_id."
+                    ),
                 },
                 "params": {
                     "type": "dict",
-                    "required": True,
-                    "description": "Parameters to pass to the capability",
+                    "required": False,
+                    "description": "Parameters to pass to the capability. Required when 'capability' is used without 'operation_id'.",
                 },
                 "max_retries": {
                     "type": "int",

--- a/work_buddy/mcp_server/tools/gateway.py
+++ b/work_buddy/mcp_server/tools/gateway.py
@@ -305,17 +305,53 @@ def _auto_consent_request(
             response = None
 
         if response is not None:
+            # Persist the response on the notification record so it doesn't
+            # sit forever in 'delivered' state and get lazily expired later.
+            from work_buddy.notifications.store import respond_to_notification
+            try:
+                respond_to_notification(nid, response)
+            except ValueError:
+                # Already responded by a surface handler — that's fine.
+                pass
             # First-response-wins: dismiss on other surfaces
             notif_fresh = _get_notif(nid)
             if notif_fresh and notif_fresh.delivered_surfaces:
                 try:
-                    dispatcher.dismiss(notif_fresh)
+                    dispatcher.dismiss_others(
+                        nid,
+                        responding_surface=response.surface,
+                        delivered_surfaces=notif_fresh.delivered_surfaces,
+                    )
                 except Exception:
                     pass
     else:
         response = None
 
     if response is None:
+        # Pick the right retry capability based on whether the underlying
+        # operation depends on the Obsidian bridge.  obsidian_retry is
+        # bridge-aware (probes health, waits, retries), so it recovers
+        # cleanly when the bridge was the reason the original call timed
+        # out — which is the common case for any *obsidian.* operation.
+        from work_buddy.mcp_server import registry as _registry
+        cap_entry = _registry.get_entry(capability_name)
+        is_obsidian_op = bool(
+            any(op.startswith("obsidian.") for op in operations)
+            or (cap_entry and "obsidian" in (getattr(cap_entry, "requires", []) or []))
+        )
+        if is_obsidian_op:
+            retry_hint = (
+                f"mcp__work-buddy__wb_run(\"obsidian_retry\", "
+                f"{{\"operation_id\": \"{op_id}\"}}) "
+                f"— this capability depends on the Obsidian bridge, so use "
+                f"obsidian_retry (bridge-aware) instead of plain retry. "
+                f"It loads the original capability + params from the record."
+            )
+        else:
+            retry_hint = (
+                f"mcp__work-buddy__wb_run(\"retry\", "
+                f"{{\"operation_id\": \"{op_id}\"}})"
+            )
         return {
             "status": "timeout",
             "request_id": nid,
@@ -323,7 +359,7 @@ def _auto_consent_request(
             "message": (
                 f"Consent request timed out, but still pending — "
                 f"the user can approve on any surface. Once approved, retry with: "
-                f"mcp__work-buddy__wb_run(\"retry\", {{\"operation_id\": \"{op_id}\"}})"
+                f"{retry_hint}"
             ),
         }
 

--- a/work_buddy/notifications/dispatcher.py
+++ b/work_buddy/notifications/dispatcher.py
@@ -54,13 +54,18 @@ class SurfaceDispatcher:
         except Exception as exc:
             logger.debug("Dashboard surface not available: %s", exc)
 
-        # Register Telegram if configured + enabled
+        # Register Telegram if configured + enabled + user hasn't opted out
         try:
             from work_buddy.config import load_config
             cfg = load_config()
-            if cfg.get("telegram", {}).get("enabled", False):
+            telegram_enabled = cfg.get("telegram", {}).get("enabled", False)
+            # Honor user preference: features.telegram.wanted=false means skip
+            wanted = cfg.get("features", {}).get("telegram", {}).get("wanted", True)
+            if telegram_enabled and wanted is not False:
                 from work_buddy.notifications.surfaces.telegram import TelegramSurface
                 dispatcher.register(TelegramSurface())
+            elif telegram_enabled and wanted is False:
+                logger.debug("Telegram surface skipped: features.telegram.wanted=false")
         except Exception as exc:
             logger.debug("Telegram surface not available: %s", exc)
 

--- a/work_buddy/obsidian/retry.py
+++ b/work_buddy/obsidian/retry.py
@@ -220,8 +220,9 @@ def bridge_retry(
 # ---------------------------------------------------------------------------
 
 def obsidian_retry(
-    capability: str,
+    capability: str | None = None,
     params: dict[str, Any] | None = None,
+    operation_id: str | None = None,
     max_retries: int = 3,
     wait_seconds: int = 60,
 ) -> dict[str, Any]:
@@ -236,8 +237,16 @@ def obsidian_retry(
     and captures latency context per attempt.
 
     Args:
-        capability: Name of the capability to retry.
-        params: Parameters to pass to the capability (default: {}).
+        capability: Name of the capability to retry. Optional if
+            ``operation_id`` is provided (will be loaded from the record).
+        params: Parameters to pass to the capability (default: {}). Same:
+            optional if ``operation_id`` is provided. If both are given,
+            the explicit values take precedence over the record's.
+        operation_id: An operation_id from a previous failed call. The
+            capability name and params are loaded from the record, so the
+            agent doesn't have to re-pass them. This is the canonical
+            way to retry after a consent timeout: the timeout return
+            includes the operation_id, and the agent forwards it here.
         max_retries: Maximum number of attempts (default: 3).
         wait_seconds: Seconds to wait between attempts (default: 60).
 
@@ -248,6 +257,30 @@ def obsidian_retry(
     from work_buddy.mcp_server.registry import get_registry
     from work_buddy.obsidian.bridge import is_available, get_latency_context
     from work_buddy.errors import classify_error
+
+    # Resolve capability/params from the operation record if requested.
+    if operation_id is not None:
+        from work_buddy.mcp_server.tools.gateway import _load_operation
+        record = _load_operation(operation_id)
+        if record is None:
+            return {
+                "success": False,
+                "error": f"Operation '{operation_id}' not found",
+            }
+        # Explicit args win, but normally agents pass only operation_id.
+        if capability is None:
+            capability = record.get("name")
+        if params is None:
+            params = record.get("params") or {}
+
+    if not capability:
+        return {
+            "success": False,
+            "error": (
+                "obsidian_retry requires either 'capability' (with optional "
+                "'params') or 'operation_id'."
+            ),
+        }
 
     params = params or {}
     registry = get_registry()

--- a/work_buddy/telegram/service.py
+++ b/work_buddy/telegram/service.py
@@ -294,6 +294,27 @@ def main() -> None:
         )
         raise SystemExit(1)
 
+    # Single-instance guard: if another telegram service is already serving
+    # the Flask port, exit immediately.  Two PTB processes against the same
+    # bot token cause getUpdates to alternate between them, stranding button
+    # responses in whichever in-memory PendingResponseStore didn't deliver.
+    sidecar_cfg = cfg.get("sidecar", {}).get("services", {}).get("telegram", {})
+    flask_port = sidecar_cfg.get("port", 5125)
+    try:
+        from urllib.request import Request, urlopen
+        probe = Request(f"http://127.0.0.1:{flask_port}/health", method="GET")
+        resp = urlopen(probe, timeout=2)
+        if resp.status == 200:
+            logger.error(
+                "Another telegram service is already running on port %d. "
+                "Refusing to start a second instance.", flask_port,
+            )
+            raise SystemExit(1)
+    except SystemExit:
+        raise
+    except Exception:
+        pass  # No existing instance — proceed.
+
     # Build bot state
     from work_buddy.telegram.bot import BotState, build_app
 
@@ -317,10 +338,28 @@ def main() -> None:
 
     _bot_app = build_app(token, _bot_state)
 
-    # Start Flask health/delivery API in background thread
-    sidecar_cfg = cfg.get("sidecar", {}).get("services", {}).get("telegram", {})
-    flask_port = sidecar_cfg.get("port", 5125)
+    # Rebuild pending-response prefix mappings from the on-disk store.
+    # PendingResponseStore is in-memory, so a clean restart would otherwise
+    # strand any consent buttons sent by the previous instance.
+    try:
+        from work_buddy.notifications.store import list_pending
+        rebuilt = 0
+        for n in list_pending():
+            if "telegram" in (n.delivered_surfaces or []):
+                _bot_state.pending_responses.add(n.notification_id)
+                if n.short_id:
+                    _bot_state.pending_responses.add_short_id(
+                        n.short_id, n.notification_id,
+                    )
+                rebuilt += 1
+        if rebuilt:
+            logger.info(
+                "Rebuilt %d pending-response mapping(s) from store", rebuilt,
+            )
+    except Exception as exc:
+        logger.warning("Failed to rebuild pending responses: %s", exc)
 
+    # Start Flask health/delivery API in background thread
     flask_thread = threading.Thread(
         target=_run_flask,
         args=(flask_port,),


### PR DESCRIPTION
## Summary

- **Root cause**: a duplicate `work_buddy.telegram.service` process was polling the same bot token. Telegram alternated `getUpdates` between them, so ~50% of consent button taps reached the instance that didn't have the prefix in its in-memory `PendingResponseStore` — producing `"This notification has expired or was already answered"` while the on-disk record was still pending. The originating operation timed out at 90s and retried, recreating the same prompt — a silent consent-failure storm.
- **Telegram service**: HTTP-probe single-instance guard on port 5125; on startup, rebuild `PendingResponseStore` from `list_pending()` so a clean restart doesn't strand consent buttons sent by the previous instance.
- **Dispatcher**: `from_config` now consults `features.<surface>.wanted` so user opt-outs are actually honored (previously only checked the static `telegram.enabled`).
- **Gateway**: after a successful consent poll, call `store.respond_to_notification` so on-disk records leave `delivered` state instead of sitting until lazy expiry. Also fix `dispatcher.dismiss(notif)` (which AttributeErrored silently inside `except: pass`) → use the correct `dismiss_others(nid, surface, delivered)`.
- **Gateway timeout hint**: branch by capability dependency. Obsidian-bridge ops get an `obsidian_retry` hint; everything else gets `retry`. Both shapes accept `{"operation_id": "op_xxx"}`.
- **`obsidian_retry` API fix**: now accepts `operation_id` directly. The original signature required the agent to re-pass `capability` + `params` after every consent timeout, which defeated the affordance. With `operation_id`, it loads the original capability and params from the operation record. Explicit `capability` / `params` remain as overrides.
- **Separately — consent gate on preferences**: `setup_wizard` was registered with `mutates_state=False` even though `mode="preferences"` with `updates` rewrites `config.local.yaml`. An autonomous agent silently opted the user out of Hindsight + Telegram via this hole 36 hours before this PR. Fix: new `apply_preference_updates()` decorated with `@requires_consent("setup.write_preferences", risk="moderate")`; wizard delegates writes to it; `setup_wizard` now correctly `mutates_state=True`. Read-only modes still don't prompt — the gate fires at runtime only when `updates` is present.

## Test plan

- [x] `pytest tests/test_consent_auto_request.py tests/unit/test_bridge_retry.py tests/unit/test_gateway_prepare.py tests/unit/test_preferences.py tests/unit/test_wizard.py` — 110 passed, 0 failed
- [x] End-to-end live: `task_create` with `summary` → consent prompt landed on Dashboard + Telegram (no Obsidian bridge available at the moment) → user approved on Telegram → no "expired" message → on-disk record transitioned `delivered → responded` → retry via `operation_id` completed (`task_id: t-572608e2`).
- [ ] Re-test once with Obsidian bridge up to confirm `obsidian_retry({"operation_id": ...})` shape works against the consent timeout hint.
- [ ] Confirm a fresh agent session can no longer call `setup_wizard(mode="preferences", updates={...})` without triggering a consent prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)