### PR TITLE
feat(consent): call-stack-aware risk reduction + update-journal workflow fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,9 @@ Before writing Python to interact with the vault, tasks, journal, contracts, or 
 | `mcp__work-buddy__wb_init(session_id)` | **REQUIRED first call.** Registers your session with the gateway. Pass your `WORK_BUDDY_SESSION_ID`. |
 | `mcp__work-buddy__wb_search(query)` | **Discover OR inspect.** Natural language → find capabilities. Exact name → get its full parameter schema. |
 | `mcp__work-buddy__wb_run(capability, params)` | Execute a discovered capability. Params: JSON string or dict. |
-| `mcp__work-buddy__wb_advance(run_id, result)` | Step through multi-step workflows. |
+| `mcp__work-buddy__wb_advance(workflow_run_id, result)` | Step through multi-step workflows. |
 | `mcp__work-buddy__wb_status()` | Check system health and active workflows. |
-| `mcp__work-buddy__wb_step_result(run_id, step_id, key?)` | Retrieve full step result data elided by the visibility system. |
+| `mcp__work-buddy__wb_step_result(workflow_run_id, step_id, key?)` | Retrieve full step result data elided by the visibility system. |
 
 These are **MCP tools**, not Python functions. They appear in the tool list as `mcp__work-buddy__wb_run`, `mcp__work-buddy__wb_search`, etc. **Always prefer these MCP tools over Python code** for work-buddy capabilities and workflows.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,9 +184,13 @@ Some `work_buddy` functions are protected by a `@requires_consent` decorator. **
 
 **All grants are session-scoped.** Consent is stored in a SQLite database at `data/agents/<session>/consent.db`. New sessions start with a clean slate — no grants carry over. "Always" means "always within this session" (max 24h TTL).
 
-**Workflow-level blanket consent:** Starting a workflow grants blanket consent for all its steps. The blanket is revoked when the workflow completes (3-hour default TTL). Individual steps can opt out via `requires_individual_consent: true` in the workflow definition, which temporarily suspends the blanket and requires per-step consent. Agents don't need to manage this — the conductor handles it automatically.
+**Workflow-level blanket consent:** Starting a workflow grants blanket consent for all its steps. The blanket is revoked when the workflow completes (3-hour default TTL). Individual steps can opt out via `requires_individual_consent: true` in the workflow definition, which temporarily suspends the blanket and requires per-step consent. Agents don't need to manage this — the conductor handles it automatically (both auto-run and main-execution steps).
 
 **Risk levels** must be one of: `"low"`, `"moderate"`, `"high"` (validated by the `Risk` enum).
+
+**Call-stack-aware risk reduction (`@reduces_risk_for`):** A function decorated with `@reduces_risk_for("some.op", "low")` declares itself a safe invoker of `some.op`. While it is on the call stack, inner `@requires_consent("some.op", ...)` checks auto-pass (for `"low"`) or prompt at the reduced risk (for `"moderate"`). Direct agent calls to the primitive — outside any safe-caller scope — still gate at the original risk.
+
+This is the mechanism that lets read-only capabilities (e.g. `daily_briefing`) internally call `obsidian.eval_js` (registered at `risk=high`) without spamming prompts, while preserving high-risk gating for direct `eval_js` invocations from agents or the local-model tool preset. Declarations are module-level code (not config) and inspectable via `list_risk_reducers()` — adding or expanding one is a reviewed PR, not a runtime grant.
 
 ## Notification system (human-in-the-loop)
 

--- a/knowledge/store/workflows.json
+++ b/knowledge/store/workflows.json
@@ -1061,12 +1061,20 @@
         "name": "Read today's journal and determine activity window",
         "step_type": "code",
         "depends_on": [],
+        "auto_run": {
+          "callable": "work_buddy.journal.read_journal_state",
+          "kwargs": {},
+          "timeout": 30
+        },
         "visibility": {
           "mode": "summary",
           "include_keys": [
-            "activity_window",
-            "existing_entries",
-            "journal_path"
+            "target_date",
+            "ambiguous",
+            "hint",
+            "collect_since",
+            "collect_until",
+            "last_log_ts"
           ]
         }
       },
@@ -1077,14 +1085,19 @@
         "depends_on": [
           "read-journal"
         ],
-        "execution": "subagent",
-        "workflow_ref": "collect-and-orient",
+        "auto_run": {
+          "callable": "work_buddy.journal.collect_scoped_context",
+          "input_map": {
+            "journal_state": "read-journal"
+          },
+          "timeout": 180
+        },
         "visibility": {
           "mode": "summary",
           "include_keys": [
-            "sources_collected",
-            "activity_window",
-            "bundle_id"
+            "bundle_path",
+            "collect_since",
+            "collect_until"
           ]
         }
       },
@@ -1102,7 +1115,8 @@
         "step_type": "reasoning",
         "depends_on": [
           "synthesize"
-        ]
+        ],
+        "requires_individual_consent": true
       }
     ],
     "tags": [

--- a/tests/unit/test_consent_risk_reduction.py
+++ b/tests/unit/test_consent_risk_reduction.py
@@ -1,0 +1,195 @@
+"""Call-stack-aware consent risk reduction (t-3629e1b1).
+
+A capability decorated with ``@reduces_risk_for("some.op", "low")`` declares
+itself a safe invoker of ``some.op``. While it is on the call stack, inner
+``@requires_consent("some.op", ...)`` calls auto-pass without prompting.
+Direct calls to the primitive from code NOT wrapped by that decorator must
+still go through the normal consent gate (and raise ``ConsentRequired``
+when no grant exists).
+
+These tests exercise the mechanism without touching Obsidian or the bridge.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _fresh_cache(monkeypatch, tmp_path):
+    """Swap the module-level ConsentCache for a tmp-path-backed one so the
+    tests can't leak grants into the real session DB.
+    """
+    from work_buddy import consent as c
+
+    # Fresh in-memory cache: reuse the ConsentCache class but point it at a
+    # tmp DB. The class's __init__ accepts no args, so we patch the path
+    # resolver.
+    from work_buddy import agent_session
+
+    monkeypatch.setattr(
+        agent_session, "get_session_consent_db_path",
+        lambda: tmp_path / "consent.db",
+    )
+    monkeypatch.setattr(
+        agent_session, "get_session_audit_path",
+        lambda: tmp_path / "audit.log",
+    )
+
+    c._cache = c.ConsentCache()
+    return c
+
+
+def test_direct_call_still_high_risk(monkeypatch, tmp_path):
+    c = _fresh_cache(monkeypatch, tmp_path)
+
+    @c.requires_consent("eval.test", "desc", risk="high", default_ttl=10)
+    def primitive():
+        return "ran"
+
+    # No grant, no safe caller → must raise at the declared (high) risk.
+    with pytest.raises(c.ConsentRequired) as exc_info:
+        primitive()
+    assert exc_info.value.risk == "high"
+
+
+def test_safe_caller_auto_passes(monkeypatch, tmp_path):
+    c = _fresh_cache(monkeypatch, tmp_path)
+
+    @c.requires_consent("eval.test", "desc", risk="high", default_ttl=10)
+    def primitive():
+        return "ran"
+
+    @c.reduces_risk_for("eval.test", "low")
+    def safe_caller():
+        return primitive()
+
+    # No grant required — safe_caller declares itself low-risk for eval.test.
+    assert safe_caller() == "ran"
+
+
+def test_unlisted_caller_still_high_risk(monkeypatch, tmp_path):
+    c = _fresh_cache(monkeypatch, tmp_path)
+
+    @c.requires_consent("eval.test", "desc", risk="high", default_ttl=10)
+    def primitive():
+        return "ran"
+
+    def unlisted_caller():
+        return primitive()
+
+    with pytest.raises(c.ConsentRequired) as exc_info:
+        unlisted_caller()
+    assert exc_info.value.risk == "high"
+
+
+def test_moderate_reduction_prompts_at_moderate(monkeypatch, tmp_path):
+    c = _fresh_cache(monkeypatch, tmp_path)
+
+    @c.requires_consent("eval.test", "desc", risk="high", default_ttl=10)
+    def primitive():
+        return "ran"
+
+    @c.reduces_risk_for("eval.test", "moderate")
+    def moderate_caller():
+        return primitive()
+
+    with pytest.raises(c.ConsentRequired) as exc_info:
+        moderate_caller()
+    # Risk should be surfaced as moderate (reduced), not high.
+    assert exc_info.value.risk == "moderate"
+
+
+def test_reducer_only_scopes_to_declared_operation(monkeypatch, tmp_path):
+    c = _fresh_cache(monkeypatch, tmp_path)
+
+    @c.requires_consent("eval.test", "desc", risk="high", default_ttl=10)
+    def primitive_a():
+        return "a"
+
+    @c.requires_consent("other.op", "desc2", risk="high", default_ttl=10)
+    def primitive_b():
+        return "b"
+
+    @c.reduces_risk_for("eval.test", "low")
+    def mixed_caller():
+        # a is covered by the declaration; b is not.
+        return primitive_a() + "+" + primitive_b()
+
+    with pytest.raises(c.ConsentRequired) as exc_info:
+        mixed_caller()
+    # The failing op must be other.op at its original risk.
+    assert exc_info.value.operation == "other.op"
+    assert exc_info.value.risk == "high"
+
+
+def test_stack_is_balanced_on_exception(monkeypatch, tmp_path):
+    c = _fresh_cache(monkeypatch, tmp_path)
+
+    @c.reduces_risk_for("eval.test", "low")
+    def safe_caller():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        safe_caller()
+    # Stack must be empty so subsequent direct calls don't leak the
+    # safe-caller scope.
+    assert c._safe_caller_ctx.stack == []
+
+
+def test_nested_safe_callers_innermost_wins(monkeypatch, tmp_path):
+    c = _fresh_cache(monkeypatch, tmp_path)
+
+    @c.requires_consent("eval.test", "desc", risk="high", default_ttl=10)
+    def primitive():
+        return "ran"
+
+    @c.reduces_risk_for("eval.test", "moderate")
+    def outer():
+        return inner()
+
+    @c.reduces_risk_for("eval.test", "low")
+    def inner():
+        return primitive()
+
+    # Inner declares "low" — should auto-pass even though outer only
+    # reduces to moderate.
+    assert outer() == "ran"
+
+
+def test_inner_consent_passes_through_under_safe_caller(monkeypatch, tmp_path):
+    """When a safe caller auto-passes, further @requires_consent calls
+    nested inside the primitive should pass through via the normal consent
+    context mechanism — NOT re-check each operation independently.
+    """
+    c = _fresh_cache(monkeypatch, tmp_path)
+
+    @c.requires_consent("inner.op", "desc", risk="high", default_ttl=10)
+    def inner_op():
+        return "inner"
+
+    @c.requires_consent("eval.test", "desc", risk="high", default_ttl=10)
+    def primitive():
+        # This inner call would normally raise ConsentRequired. But because
+        # primitive is running inside a safe-caller-established consent
+        # context, it should pass through.
+        return inner_op()
+
+    @c.reduces_risk_for("eval.test", "low")
+    def safe_caller():
+        return primitive()
+
+    assert safe_caller() == "inner"
+
+
+def test_list_risk_reducers_reports_declarations(monkeypatch, tmp_path):
+    c = _fresh_cache(monkeypatch, tmp_path)
+
+    @c.reduces_risk_for("audited.op", "low")
+    def audited():
+        return "ok"
+
+    declared = c.list_risk_reducers()
+    assert "audited.op" in declared
+    assert any(
+        risk == "low" and "audited" in qualname
+        for qualname, risk in declared["audited.op"].items()
+    )

--- a/tests/unit/test_journal_append.py
+++ b/tests/unit/test_journal_append.py
@@ -1,0 +1,82 @@
+"""Regression tests for journal log-entry appending, especially ordering
+across the midnight day-boundary.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from work_buddy.journal import (
+    _effective_minutes,
+    _find_chronological_insertion_point,
+    _append_to_journal_locked,
+)
+
+
+def test_effective_minutes_shifts_post_midnight_past_end_of_day():
+    # 10:29 PM = 22*60 + 29 = 1349
+    assert _effective_minutes("10:29 PM") == 1349
+    # 12:08 AM should sort AFTER 10:29 PM (same-day continuation)
+    assert _effective_minutes("12:08 AM") == 24 * 60 + 8  # 1448
+    # 2:05 AM still within post-midnight window
+    assert _effective_minutes("2:05 AM") == 24 * 60 + 125  # 1565
+    # 5:00 AM is not post-midnight (cutoff is strict <)
+    assert _effective_minutes("5:00 AM") == 5 * 60  # 300
+
+
+def test_effective_minutes_daytime_unchanged():
+    assert _effective_minutes("9:45 AM") == 9 * 60 + 45
+    assert _effective_minutes("1:00 PM") == 13 * 60
+    assert _effective_minutes("2:15 PM") == 14 * 60 + 15
+
+
+def _make_journal(tmp_path: Path) -> Path:
+    j = tmp_path / "journal" / "2026-04-16.md"
+    j.parent.mkdir(parents=True)
+    j.write_text(
+        "---\n---\n\n# **Log**\n"
+        '<font color="#a5a5a5">(CTRL-J for log entry capture)</font>\n'
+        "* 9:45 AM - Arrived.\n"
+        "* 1:00 PM - Meeting.\n"
+        "\n# **Next Section**\n",
+        encoding="utf-8",
+    )
+    return j
+
+
+def test_append_preserves_order_across_midnight(tmp_path, monkeypatch):
+    # Neutralize the consent decorator and bridge write so we exercise pure logic
+    from work_buddy import journal as jmod
+
+    # Force the direct-write path (no bridge)
+    import work_buddy.obsidian.bridge as bridge_mod
+    monkeypatch.setattr(bridge_mod, "is_available", lambda: False, raising=False)
+
+    journal_file = _make_journal(tmp_path)
+    entries = [
+        ("2:15 PM", "PM one"),
+        ("10:29 PM", "PM late"),
+        ("12:08 AM", "Post-midnight one"),
+        ("2:05 AM", "Post-midnight two"),
+    ]
+    result = _append_to_journal_locked(entries, journal_file, "2026-04-16")
+    assert result["success"] is True
+    assert result["entries_written"] == 4
+
+    content = journal_file.read_text(encoding="utf-8")
+    # Extract log body
+    log_body = content.split("# **Log**", 1)[1].split("# **Next Section**", 1)[0]
+
+    # Post-midnight entries must appear AFTER the latest PM entry
+    pm_late_pos = log_body.index("PM late")
+    pm1_pos = log_body.index("Post-midnight one")
+    pm2_pos = log_body.index("Post-midnight two")
+    pm_one_pos = log_body.index("PM one")
+    arrived_pos = log_body.index("Arrived")
+    meeting_pos = log_body.index("Meeting")
+
+    # Daytime stays chronological
+    assert arrived_pos < meeting_pos < pm_one_pos < pm_late_pos
+    # Post-midnight lands after PM late
+    assert pm_late_pos < pm1_pos < pm2_pos

--- a/tests/unit/test_workflow_individual_consent.py
+++ b/tests/unit/test_workflow_individual_consent.py
@@ -1,0 +1,106 @@
+"""Regression: workflow steps marked ``requires_individual_consent: true``
+must suspend the workflow blanket when they are handed to the agent (main
+execution path), then re-grant on advance. Prior to this fix, the flag was
+only honored for ``auto_run`` steps, so a main-execution step inside a
+workflow silently bypassed its ``@requires_consent`` gate.
+"""
+from __future__ import annotations
+
+
+def test_main_execution_individual_consent_suspends_blanket(monkeypatch):
+    from work_buddy import consent as c
+    from work_buddy.mcp_server import conductor
+
+    # Capture grant/revoke calls
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        c, "grant_workflow_consent",
+        lambda run_id, **_: calls.append(("grant", run_id)),
+    )
+    monkeypatch.setattr(
+        c, "revoke_workflow_consent",
+        lambda run_id="": calls.append(("revoke", run_id)),
+    )
+
+    # Build a minimal fake DAG node with requires_individual_consent set
+    class FakeDAG:
+        def __init__(self):
+            self._graph = _FakeGraph()
+            self._available = [{
+                "task_id": "write",
+                "name": "write step",
+                "metadata": {"requires_individual_consent": True},
+            }]
+
+        def next_available(self):
+            return self._available
+
+        def is_complete(self):
+            return False
+
+        def start_task(self, tid):
+            pass
+
+        def complete_task(self, tid, result=None):
+            self._available = []
+
+        def summary(self):
+            return "summary"
+
+        def get_all_results(self):
+            return {}
+
+        def save(self):
+            pass
+
+    class _NodeView:
+        _nodes = {
+            "write": {
+                "status": "running",
+                "metadata": {"requires_individual_consent": True},
+            },
+        }
+
+        def __call__(self, data=False):
+            if data:
+                return list(self._nodes.items())
+            return list(self._nodes.keys())
+
+        def __getitem__(self, key):
+            return self._nodes[key]
+
+    class _FakeGraph:
+        def __init__(self):
+            self.nodes = _NodeView()
+
+        def number_of_nodes(self):
+            return 1
+
+    dag = FakeDAG()
+    run_id = "wf_test"
+    conductor._ACTIVE_RUNS[run_id] = dag
+    try:
+        # Stub out helpers that need real DAG internals
+        monkeypatch.setattr(conductor, "_get_wf_def", lambda dag: None)
+        monkeypatch.setattr(conductor, "_visibility_filter_results", lambda dag: {})
+        monkeypatch.setattr(conductor, "_dag_to_mermaid", lambda dag: "")
+        monkeypatch.setattr(
+            conductor, "_safe_serialize", lambda x: x,
+        )
+
+        # Simulate handing the step to the agent — should revoke blanket
+        conductor._build_response(run_id, dag)
+        assert ("revoke", run_id) in calls, (
+            "Main-execution step with requires_individual_consent did not "
+            "suspend the workflow blanket"
+        )
+
+        # Simulate the agent completing the step — should re-grant blanket
+        calls.clear()
+        conductor.advance_workflow(run_id, step_result={"ok": True})
+        assert any(c[0] == "grant" and c[1] == run_id for c in calls), (
+            "Workflow blanket was not re-granted after individual-consent "
+            "step completed"
+        )
+    finally:
+        conductor._ACTIVE_RUNS.pop(run_id, None)

--- a/work_buddy/consent.py
+++ b/work_buddy/consent.py
@@ -81,6 +81,119 @@ class _ConsentContext(threading.local):
 _consent_ctx = _ConsentContext()
 
 
+# ---------------------------------------------------------------------------
+# Safe-caller context — call-stack-aware consent risk reduction
+# ---------------------------------------------------------------------------
+# A capability decorated with ``@reduces_risk_for("some.op", "low")`` declares
+# that, while IT is executing, calls to ``some.op`` should be treated as
+# low-risk (and auto-pass the consent gate) even if ``some.op`` itself is
+# registered as high-risk. This is the mechanism that lets read-only
+# capabilities like ``task_briefing`` call ``obsidian.eval_js`` internally
+# without triggering a high-risk prompt for every invocation, while DIRECT
+# agent calls to ``eval_js`` still prompt as high-risk.
+#
+# Scope: only reductions to "low" auto-pass in this revision. A reduction
+# to "moderate" falls through to the normal consent check (the user still
+# sees a prompt, but at moderate instead of high). Reductions can only lower
+# risk, never raise it.
+
+class _SafeCallerContext(threading.local):
+    """Thread-local stack of active safe-caller declarations.
+
+    Each stack entry is a dict ``{operation: effective_risk}`` contributed by
+    one active ``@reduces_risk_for``-decorated frame. The innermost entry for
+    a given operation wins on lookup.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.stack: list[dict[str, str]] = []
+
+
+_safe_caller_ctx = _SafeCallerContext()
+
+
+# Registry of declared safe invocations for inspection / audit.
+# Shape: {inner_operation: {caller_qualname: effective_risk}}
+_RISK_REDUCERS: dict[str, dict[str, str]] = {}
+
+
+def _active_reduced_risk(operation: str) -> str | None:
+    """Return the effective risk active for ``operation`` via the safe-caller
+    stack, or ``None`` if no reduction is active.
+
+    Innermost matching entry wins.
+    """
+    for layer in reversed(_safe_caller_ctx.stack):
+        if operation in layer:
+            return layer[operation]
+    return None
+
+
+def list_risk_reducers() -> dict[str, dict[str, str]]:
+    """Return a snapshot of all declared risk-reducing callers.
+
+    Shape: ``{inner_operation: {caller_qualname: effective_risk}}``.
+    Useful for audit / PR review of the security boundary.
+    """
+    return {
+        op: dict(callers) for op, callers in _RISK_REDUCERS.items()
+    }
+
+
+def reduces_risk_for(operation: str, effective_risk: str = "low"):
+    """Decorator: mark the wrapped function as a safe invoker of ``operation``.
+
+    While the decorated function is on the call stack, any
+    ``@requires_consent`` check for ``operation`` will use ``effective_risk``
+    instead of the operation's original risk. When ``effective_risk == "low"``,
+    the check auto-passes (no user prompt). The outer consent context is
+    established so any further nested ``@requires_consent`` calls inside
+    ``operation`` pass through as normal covered operations.
+
+    This does NOT disable consent for direct calls to the primitive from
+    code that is NOT wrapped by this decorator — only calls that happen
+    while this function is on the stack.
+
+    Example::
+
+        @reduces_risk_for("obsidian.eval_js", "low")
+        def daily_briefing():
+            # Internal eval_js calls here are low-risk (auto-pass).
+            ...
+
+    Args:
+        operation: The inner operation identifier this function declares
+            itself a safe invoker of (e.g. ``"obsidian.eval_js"``).
+        effective_risk: ``"low"``, ``"moderate"``, or ``"high"``. Only
+            ``"low"`` auto-passes; higher values let the usual consent gate
+            fire but with the reduced risk for prompt styling.
+    """
+    if effective_risk not in (r.value for r in Risk):
+        raise ValueError(
+            f"Invalid effective_risk: {effective_risk!r}. "
+            f"Must be one of: {', '.join(r.value for r in Risk)}"
+        )
+
+    def decorator(fn: Callable) -> Callable:
+        # Register for inspection (at decoration time, so it's visible
+        # even before the first call).
+        _RISK_REDUCERS.setdefault(operation, {})[fn.__qualname__] = effective_risk
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            entry = {operation: effective_risk}
+            _safe_caller_ctx.stack.append(entry)
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                _safe_caller_ctx.stack.pop()
+
+        return wrapper
+
+    return decorator
+
+
 def in_consent_context() -> bool:
     """Check if the current thread is inside a consented operation."""
     return _consent_ctx.depth > 0
@@ -408,6 +521,30 @@ def requires_consent(
                 )
                 return fn(*args, **kwargs)
 
+            # ── Call-stack-aware risk reduction ──
+            # If a declared-safe caller is active for this operation and the
+            # reduced risk is "low", auto-pass the gate. The outer frame
+            # becomes an implicit consent context so deeper @requires_consent
+            # calls nested inside this operation pass through normally.
+            reduced_risk = _active_reduced_risk(operation)
+            if reduced_risk == Risk.LOW.value:
+                _audit_log(
+                    "RISK_REDUCED_PASS", operation,
+                    f"safe_caller:{reduced_risk}",
+                )
+                prev_depth = _consent_ctx.depth
+                prev_outer = _consent_ctx.outer_operation
+                prev_covered = _consent_ctx.covered_operations
+                _consent_ctx.depth = prev_depth + 1
+                _consent_ctx.outer_operation = operation
+                _consent_ctx.covered_operations = []
+                try:
+                    return fn(*args, **kwargs)
+                finally:
+                    _consent_ctx.depth = prev_depth
+                    _consent_ctx.outer_operation = prev_outer
+                    _consent_ctx.covered_operations = prev_covered
+
             # ── Top-level: check consent cache ──
             if _cache.is_granted(operation):
                 # Determine consent source for audit
@@ -463,12 +600,16 @@ def requires_consent(
 
                 return result
 
-            # No valid consent — raise
-            _audit_log("BLOCKED", operation, "no_consent")
+            # No valid consent — raise. If a safe caller declared a
+            # reduced risk (not "low" — that would have auto-passed above),
+            # propagate that risk to the prompt so the user sees the
+            # caller-contextualized severity.
+            effective_risk = reduced_risk if reduced_risk is not None else risk
+            _audit_log("BLOCKED", operation, f"no_consent risk={effective_risk}")
             raise ConsentRequired(
                 operation=operation,
                 reason=reason,
-                risk=risk,
+                risk=effective_risk,
                 default_ttl=default_ttl,
             )
         return wrapper

--- a/work_buddy/journal.py
+++ b/work_buddy/journal.py
@@ -286,6 +286,46 @@ def get_activity_window(journal_content: str, journal_date: str | None = None) -
     return extract_frontmatter_time(journal_content)
 
 
+def collect_scoped_context(journal_state: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Auto-run helper for the ``update-journal`` workflow's ``collect`` step.
+
+    Takes the result of ``read_journal_state`` and runs ``context_bundle``
+    scoped to the activity window. If the state is ambiguous (e.g. early-AM
+    run without an explicit target), returns the ambiguity so the agent can
+    surface it to the user instead of collecting against a guess.
+    """
+    from work_buddy.mcp_server.context_wrappers import collect_bundle
+
+    state = journal_state or {}
+    if state.get("ambiguous"):
+        return {
+            "collected": False,
+            "ambiguous": True,
+            "hint": state.get("hint", ""),
+        }
+
+    since_str = state.get("collect_since")
+    until_str = state.get("collect_until")
+    hours = 16  # conservative default covering a full active day
+    if since_str and until_str:
+        try:
+            since_dt = datetime.fromisoformat(since_str)
+            until_dt = datetime.fromisoformat(until_str)
+            delta = until_dt - since_dt
+            hours = max(1, int(delta.total_seconds() // 3600) + 1)
+        except (TypeError, ValueError):
+            pass
+
+    bundle_result = collect_bundle(hours=hours)
+    return {
+        "collected": True,
+        "bundle_path": bundle_result.get("bundle_path"),
+        "collect_since": since_str,
+        "collect_until": until_str,
+        "hours": hours,
+    }
+
+
 def read_journal_state(target: str | None = None) -> dict[str, Any]:
     """Read the journal for a target date and return everything needed for the DAG.
 
@@ -425,6 +465,24 @@ def _parse_time_for_sort(time_str: str) -> float:
         return -1  # unparseable → sort to the top
 
 
+# Times between midnight and this cutoff are treated as post-midnight
+# continuation of the previous day and sort AFTER all same-day PM entries.
+_POST_MIDNIGHT_CUTOFF_MIN = 5 * 60
+
+
+def _effective_minutes(time_str: str) -> float:
+    """Like ``_parse_time_for_sort``, but shifts post-midnight times past the end
+    of the day so same-day chronological sorts place them last.
+
+    Example: ``12:08 AM`` → ``24*60 + 8`` = 1448, which sorts after ``10:29 PM``
+    (22*60 + 29 = 1349) instead of before ``2:15 PM`` (855).
+    """
+    minutes = _parse_time_for_sort(time_str)
+    if 0 <= minutes < _POST_MIDNIGHT_CUTOFF_MIN:
+        return minutes + 24 * 60
+    return minutes
+
+
 def _get_log_section_bounds(content: str) -> tuple[int, int] | None:
     """Return (start, end) byte offsets of the Log section body.
 
@@ -460,12 +518,7 @@ def _find_chronological_insertion_point(
 
     log_start, log_end = bounds
     log_body = content[log_start:log_end]
-    new_minutes = _parse_time_for_sort(new_time_str)
-
-    # Sleep-boundary rule: times between midnight and 5 AM are post-midnight
-    # continuation — they are always the latest activity in the day and should
-    # be appended to the end, never inserted chronologically by clock time.
-    is_post_midnight = 0 <= new_minutes < 5 * 60
+    new_minutes = _effective_minutes(new_time_str)
 
     # Parse each line's position and timestamp
     lines = log_body.split("\n")
@@ -482,8 +535,8 @@ def _find_chronological_insertion_point(
 
         # Try to extract timestamp from this line
         ts_match = _LOG_TIMESTAMP_RE.match(stripped)
-        if ts_match and not is_post_midnight:
-            existing_minutes = _parse_time_for_sort(ts_match.group(1))
+        if ts_match:
+            existing_minutes = _effective_minutes(ts_match.group(1))
             if new_minutes >= 0 and existing_minutes > new_minutes:
                 # This existing entry is later than our new one — insert before it
                 return line_abs_start
@@ -584,8 +637,10 @@ def _append_to_journal_locked(
             "message": "Could not find a Log section in the journal file.",
         }
 
-    # Sort new entries by time so we insert earliest first
-    sorted_entries = sorted(entries, key=lambda e: _parse_time_for_sort(e[0]))
+    # Sort new entries by time so we insert earliest first. Use effective
+    # minutes so post-midnight entries (e.g. 12:08 AM next-day) sort AFTER
+    # same-day PM entries instead of before them.
+    sorted_entries = sorted(entries, key=lambda e: _effective_minutes(e[0]))
 
     # Insert each entry chronologically — re-read content after each insert
     # because offsets shift

--- a/work_buddy/mcp_server/conductor.py
+++ b/work_buddy/mcp_server/conductor.py
@@ -178,6 +178,17 @@ def advance_workflow(
 
     dag.complete_task(current_id, result=serialized_result)
 
+    # If the completed step opted into individual consent, re-grant the
+    # workflow blanket so subsequent (non-opted-out) steps resume their
+    # covered-by-blanket behavior.
+    if current_meta.get("requires_individual_consent", False):
+        from work_buddy.consent import grant_workflow_consent
+        grant_workflow_consent(workflow_run_id)
+        logger.info(
+            "Main-execution step '%s' complete — workflow blanket re-granted",
+            current_id,
+        )
+
     # Check if workflow is now complete
     if dag.is_complete():
         result = _build_complete_response(workflow_run_id, dag)
@@ -475,7 +486,18 @@ def _build_response(
         auto_run_spec = meta.get("auto_run")
 
         if not auto_run_spec:
-            # Normal step — hand to the agent
+            # Normal step — hand to the agent.
+            # If this step opted into individual consent, suspend the workflow
+            # blanket so the agent's @requires_consent-gated calls actually
+            # surface a prompt. The blanket is re-granted in advance_workflow
+            # once the agent completes this step.
+            if meta.get("requires_individual_consent", False):
+                from work_buddy.consent import revoke_workflow_consent
+                revoke_workflow_consent(run_id)
+                logger.info(
+                    "Main-execution step '%s' requires explicit consent — "
+                    "workflow blanket temporarily suspended", task_id,
+                )
             break
 
         # --- Auto-execute this step ---

--- a/work_buddy/obsidian/tasks/manager.py
+++ b/work_buddy/obsidian/tasks/manager.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from datetime import date, timedelta
 from typing import Any
 
+from work_buddy.consent import reduces_risk_for
 from work_buddy.logging_config import get_logger
 from work_buddy.obsidian.tasks.env import (
     get_overdue_tasks,
@@ -95,6 +96,7 @@ def weekly_review_data() -> dict[str, Any]:
 # ── Intelligence functions ──────────────────────────────────────
 
 
+@reduces_risk_for("obsidian.eval_js", "low")
 def daily_briefing() -> dict[str, Any]:
     """Produce a structured task status summary for daily consumption.
 


### PR DESCRIPTION
## Summary

- **fix(journal+conductor)** — six issues from a `/wb-dev-retro` on `update-journal`: day-boundary ordering in `append_to_journal`, `requires_individual_consent` now honored for non-auto_run workflow steps, `update-journal` steps wired to real auto_run callables, CLAUDE.md param naming fix.
- **feat(consent)** — `@reduces_risk_for(operation, effective_risk)` decorator + thread-local safe-caller stack in `consent.py`. Closes **t-3629e1b1**. `daily_briefing` is the first migration (eval_js reduced to `low`); local-model preset reads will no longer spam high-risk consent prompts.

## Details

**Day-boundary ordering (`work_buddy/journal.py`)** — `_effective_minutes` shifts post-midnight times (0 ≤ min < 5 AM) past the end of the day so `12:08 AM` sorts *after* `10:29 PM`, not before `2:15 PM`. Used in both the outer entries sort and `_find_chronological_insertion_point` scan.

**Main-execution individual-consent (`work_buddy/mcp_server/conductor.py`)** — `requires_individual_consent: true` previously only applied to auto_run steps; `_build_response` now also revokes the workflow blanket when handing a main-execution step to the agent, and `advance_workflow` re-grants it on completion. `update-journal.write` is annotated accordingly so Obsidian writes actually surface a consent prompt.

**update-journal auto_run (`knowledge/store/workflows.json` + `work_buddy/journal.py`)** — the broken `execution: subagent` / `workflow_ref: collect-and-orient` path is replaced with real `auto_run` specs: `read-journal` calls `work_buddy.journal.read_journal_state`; new `collect_scoped_context` wires the activity window from `read-journal` into `collect_bundle`.

**Call-stack-aware consent (`work_buddy/consent.py`)** — new thread-local `_safe_caller_ctx` stack. `@reduces_risk_for("op", "low")` pushes/pops `{op: effective_risk}` around the wrapped call. `@requires_consent` consults `_active_reduced_risk(op)` after the nested-context check; `"low"` auto-passes (establishing an outer consent context so deeper gates pass through normally), `"moderate"` falls through to the normal cache check with the reduced risk surfaced on any `ConsentRequired` raise. `list_risk_reducers()` exposes declarations for PR-time audit. Direct agent calls without a safe caller on the stack still gate at the declared risk.

**First migration** — `daily_briefing` is now `@reduces_risk_for("obsidian.eval_js", "low")`. More readonly preset members can be annotated incrementally in follow-ups.

## Test plan

**Unit (passing locally — 609/609):**
- [x] `tests/unit/test_journal_append.py` — day-boundary ordering across midnight
- [x] `tests/unit/test_workflow_individual_consent.py` — main-execution step suspends/re-grants blanket
- [x] `tests/unit/test_consent_risk_reduction.py` (9 cases) — direct still high-risk; safe caller auto-passes; unlisted caller still high-risk; moderate reduction prompts at moderate; reducer scope is per-operation; stack balanced on exception; innermost-wins nesting; inner @requires_consent passes through under safe caller; list_risk_reducers reports declarations

**Live (all green on a real `update-journal` run against `2026-04-16`):**
- [x] Day-boundary ordering: `3:00 AM` test entry appended AFTER `2:05 AM` in the actual journal (then removed).
- [x] `update-journal` auto_run: `read-journal` and `collect` produced real `step_results` with `target_date`, `collect_since/until`, `bundle_path` (was empty `{}` before this PR).
- [x] Individual-consent prompt: `consent_list` flipped from `{__workflow_consent__}` on `synthesize` to `{}` on `write`; `journal_write` then fired a real consent notification delivered to dashboard+telegram+obsidian.
- [x] `@reduces_risk_for`: `task_briefing` returned a full result with no eval_js prompt; `consent_list` stayed empty throughout (no grant written — reducer-based pass, not cache grant).
- [x] `list_risk_reducers()` returns `{'obsidian.eval_js': {'daily_briefing': 'low'}}` after daily_briefing imports.

## Notes

- Incidental observation (out of scope for this PR): `consent_request_resolve(approved=true, mode="once")` on a `bundle:<capability>` notification doesn't expand into individual op grants — live testing required a follow-up `consent_grant("update_journal_entry", "once")` before the retry succeeded. Worth a separate issue if not already filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
