### PR TITLE
Sidecar: take over existing instance on restart instead of aborting

### DIFF
--- a/work_buddy/sidecar/daemon.py
+++ b/work_buddy/sidecar/daemon.py
@@ -28,6 +28,7 @@ from work_buddy.sidecar.pid import (
     PID_FILE,
     check_existing_daemon,
     cleanup_pid_file,
+    takeover_existing_daemon,
     write_pid_file,
 )
 from work_buddy.sidecar.state import (
@@ -263,11 +264,18 @@ def run(foreground: bool = True) -> None:
     cfg = load_config()
     sidecar_cfg = cfg.get("sidecar", {})
 
-    # --- Check for existing daemon ---
+    # --- Check for existing daemon — if one's alive, take it over ---
+    # We enforce single-instance by replacement, not refusal: the user
+    # may be intentionally restarting in a visible terminal to regain
+    # control of a sidecar launched silently at login.
     existing = check_existing_daemon()
     if existing:
-        logger.error("Sidecar already running (pid=%d). Aborting.", existing)
-        sys.exit(1)
+        if not takeover_existing_daemon(existing):
+            logger.error(
+                "Sidecar already running (pid=%d) and could not be "
+                "terminated. Aborting.", existing,
+            )
+            sys.exit(1)
 
     # --- Write PID file + register signal handlers ---
     write_pid_file()

--- a/work_buddy/sidecar/pid.py
+++ b/work_buddy/sidecar/pid.py
@@ -76,6 +76,51 @@ def check_existing_daemon() -> int | None:
     return None
 
 
+def takeover_existing_daemon(pid: int, *, wait_seconds: float = 10.0) -> bool:
+    """Terminate an existing sidecar process so a new one can take over.
+
+    Sends SIGTERM first (so the old daemon's signal handler runs and
+    its atexit cleanup fires), then escalates to ``taskkill /F /T`` on
+    Windows / SIGKILL on Unix if it's still alive after half the
+    window. Returns True once the PID is confirmed dead.
+    """
+    import time as _time
+
+    from work_buddy.compat import _force_kill_pid  # type: ignore[attr-defined]
+
+    logger.info("Taking over existing sidecar (pid=%d)...", pid)
+
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except (OSError, ProcessLookupError):
+        pass
+
+    deadline = _time.monotonic() + wait_seconds
+    escalated = False
+    while _time.monotonic() < deadline:
+        if not _is_process_alive(pid):
+            _remove_pid_file()
+            logger.info("Previous sidecar (pid=%d) terminated.", pid)
+            return True
+        _time.sleep(0.2)
+        if not escalated and _time.monotonic() > (deadline - wait_seconds / 2):
+            escalated = True
+            logger.warning(
+                "Previous sidecar (pid=%d) did not exit on SIGTERM — "
+                "escalating to force-kill.", pid,
+            )
+            _force_kill_pid(pid)
+
+    if _is_process_alive(pid):
+        logger.error(
+            "Could not terminate existing sidecar (pid=%d) within %.0fs.",
+            pid, wait_seconds,
+        )
+        return False
+    _remove_pid_file()
+    return True
+
+
 def write_pid_file() -> None:
     """Write the current process PID to the PID file (atomic on NTFS)."""
     pid = os.getpid()


### PR DESCRIPTION
## Summary
- When the sidecar detects a live PID file, it now SIGTERMs the old daemon (letting its signal handler and atexit cleanup run), escalates to `taskkill /F /T` (Windows) / SIGKILL (Unix) after half the wait window, then proceeds with startup.
- Single-instance invariant is preserved — enforced by replacement instead of refusal.
- Orphaned child services from the old daemon are already handled by the existing `_kill_process_on_port` call in `_start_child`, so no extra teardown is needed.

## Why
Previously, re-running `python -m work_buddy.sidecar` when an instance was already live (e.g., auto-started in a hidden window at login) would refuse with `Sidecar already running (pid=...). Aborting.` This removes the user's ability to regain control in a visible terminal without hunting down the PID and killing it manually.

## Test plan
- [x] `pytest tests/test_sidecar_core.py tests/test_sidecar_cron.py` — 29/29 pass
- [x] Manually verified: re-running `python -m work_buddy.sidecar --dev` while a sidecar is already live terminates the old one and starts fresh