### PR TITLE
feat(tasks): task_read capability + shared read helper

### DIFF
--- a/.claude/commands/wb-task-read.md
+++ b/.claude/commands/wb-task-read.md
@@ -1,0 +1,4 @@
+---
+short: Read task without claiming
+---
+Load directions via `mcp__work-buddy__wb_run("agent_docs", {"path": "tasks/task-read-directions", "depth": "full"})`, then call `task_read` with `$ARGUMENTS`.

--- a/knowledge/store/_generated_capabilities.json
+++ b/knowledge/store/_generated_capabilities.json
@@ -5496,6 +5496,38 @@
       "tasks"
     ]
   },
+  "tasks/task_read": {
+    "kind": "capability",
+    "name": "Task Read",
+    "description": "Read a task's full context (text, note, metadata) without claiming it for the current session",
+    "capability_name": "task_read",
+    "category": "tasks",
+    "aliases": [
+      "read task",
+      "view task",
+      "show task",
+      "inspect task",
+      "look at task"
+    ],
+    "parameters": {
+      "task_id": {
+        "type": "str",
+        "description": "Task ID (e.g., 't-a3f8c1e2')",
+        "required": true
+      }
+    },
+    "requires": [
+      "obsidian"
+    ],
+    "tags": [
+      "tasks",
+      "task",
+      "read"
+    ],
+    "parents": [
+      "tasks"
+    ]
+  },
   "tasks/task_review_inbox": {
     "kind": "capability",
     "name": "Task Review Inbox",

--- a/knowledge/store/_generated_parents.json
+++ b/knowledge/store/_generated_parents.json
@@ -227,6 +227,7 @@
       "tasks/task_create",
       "tasks/task_delete",
       "tasks/task_namespace_suggest",
+      "tasks/task_read",
       "tasks/task_review_inbox",
       "tasks/task_scattered",
       "tasks/task_set_tags",
@@ -236,7 +237,7 @@
       "tasks/weekly_review_data"
     ],
     "content": {
-      "summary": "Container for 15 capabilities and workflows."
+      "summary": "Container for 16 capabilities and workflows."
     }
   },
   "threads": {

--- a/knowledge/store/tasks.json
+++ b/knowledge/store/tasks.json
@@ -75,8 +75,24 @@
     "workflow": null,
     "capabilities": ["tasks/task_assign", "tasks/task_toggle"],
     "content": {
-      "summary": "Use MCP tool directly, never Python. Present: task text/state/urgency, contract, note preview with path, session count. State NOT changed by assignment. After completing deliverable, proactively ask to mark done — always confirm first.",
-      "full": "Assign via mcp__work-buddy__wb_run(\"task_assign\", {\"task_id\": \"<id>\"}). Do NOT use Python code.\n\nIf no argument provided, ask for the task ID.\n\n## Presentation after assignment\n\n1. Task: text and current state/urgency\n2. Contract: which contract it serves (if any)\n3. Note: preview of note content (if exists) + file path\n4. Sessions: how many sessions have worked on this task\n\n## State\n\nTask state is NOT changed by assignment. To mark focused, use task_change_state separately.\n\n## Completion tracking\n\nAfter committing code (or completing the deliverable), proactively ask: \"Task <id> looks complete -- should I mark it done?\"\n\nOn approval: mcp__work-buddy__wb_run(\"task_toggle\", {\"task_id\": \"<id>\", \"done\": true})\n\nDo not silently mark the task done -- always confirm first."
+      "summary": "Use MCP tool directly, never Python. task_assign = claim + read; use task_read when you only want to inspect. Present: task text/state/urgency, contract, note preview with path, session count. State NOT changed by assignment. After completing deliverable, proactively ask to mark done — always confirm first.",
+      "full": "Assign via mcp__work-buddy__wb_run(\"task_assign\", {\"task_id\": \"<id>\"}). Do NOT use Python code.\n\nIf no argument provided, ask for the task ID.\n\n## Assign vs read\n\n- **task_assign** = read the task AND record the current session against it (claim). Use when the user is starting work.\n- **task_read** = pure read, no session write. Use when you only need to inspect a task (e.g. user is browsing, or an upstream flow wants the payload without implying a claim).\n\nBoth return the same read payload. Internally, task_assign composes task_read with a session-tracker write, so agents can swap call sites without reshaping downstream code.\n\n## Presentation after assignment\n\n1. Task: text and current state/urgency\n2. Contract: which contract it serves (if any)\n3. Note: preview of note content (if exists) + file path\n4. Sessions: how many sessions have worked on this task\n\n## State\n\nTask state is NOT changed by assignment. To mark focused, use task_change_state separately.\n\n## Completion tracking\n\nAfter committing code (or completing the deliverable), proactively ask: \"Task <id> looks complete -- should I mark it done?\"\n\nOn approval: mcp__work-buddy__wb_run(\"task_toggle\", {\"task_id\": \"<id>\", \"done\": true})\n\nDo not silently mark the task done -- always confirm first."
+    }
+  },
+  "tasks/task-read-directions": {
+    "kind": "directions",
+    "name": "Task Read Directions",
+    "description": "How to read a task without claiming it — inspection-only path that does not write a session assignment",
+    "aliases": ["read task", "view task", "inspect task", "show task", "look at task"],
+    "tags": ["tasks", "read", "inspect", "directions"],
+    "parents": ["tasks"],
+    "trigger": "user runs /wb-task-read or asks to view a task without claiming it for the current session",
+    "command": "wb-task-read",
+    "workflow": null,
+    "capabilities": ["tasks/task_read"],
+    "content": {
+      "summary": "Pure-read path. Use task_read when the user wants to inspect a task without claiming it for the current session. No session-tracker write, no state change. Use task_assign instead when the user is starting work.",
+      "full": "Read via mcp__work-buddy__wb_run(\"task_read\", {\"task_id\": \"<id>\"}). Do NOT use Python code.\n\nIf no argument provided, ask for the task ID.\n\n## When to use task_read vs task_assign\n\n- **task_read** — pure inspection. No session is recorded against the task. Use when the user is browsing, auditing, or you only need the payload for an upstream flow.\n- **task_assign** — inspection PLUS claims the task for the current session. Use when the user is starting work on it.\n\nBoth return the same read payload (task text, metadata, note content, file + line, existing session list). If you assigned a task earlier in the conversation and only want to re-inspect it now, task_read is fine — assigning again just writes an idempotent duplicate session row.\n\n## Presentation\n\nSame as task_assign:\n\n1. Task: text and current state/urgency\n2. Contract: which contract it serves (if any)\n3. Note: preview of note content (if exists) + file path\n4. Sessions: how many sessions have worked on this task (read-only view)\n\n## Do NOT\n\n- Do not propose marking the task done from a read. Completion tracking belongs to the assign flow — a user who only asked to inspect has not committed to finishing it."
     }
   },
   "tasks/briefing-directions": {

--- a/work_buddy/mcp_server/registry.py
+++ b/work_buddy/mcp_server/registry.py
@@ -3124,6 +3124,7 @@ def _task_capabilities() -> list[Capability]:
         assign_task,
         create_task,
         delete_task,
+        read_task,
         set_task_tags_on_line,
         toggle_task,
     )
@@ -3274,6 +3275,17 @@ def _task_capabilities() -> list[Capability]:
             },
             callable=assign_task,
             search_aliases=["assign task", "claim task", "work on task", "start task"],
+            requires=["obsidian"],
+        ),
+        Capability(
+            name="task_read",
+            description="Read a task's full context (text, note, metadata) without claiming it for the current session",
+            category="tasks",
+            parameters={
+                "task_id": {"type": "str", "description": "Task ID (e.g., 't-a3f8c1e2')", "required": True},
+            },
+            callable=read_task,
+            search_aliases=["read task", "view task", "show task", "inspect task", "look at task"],
             requires=["obsidian"],
         ),
         Capability(

--- a/work_buddy/obsidian/tasks/mutations.py
+++ b/work_buddy/obsidian/tasks/mutations.py
@@ -936,22 +936,13 @@ def strip_legacy_tags_from_line(line: str) -> str:
     return _strip_legacy_tags(line)
 
 
-@bridge_retry()
-def assign_task(task_id: str) -> dict[str, Any]:
-    """Claim a task for the current agent session and return full context.
+def _load_task_payload(task_id: str) -> dict[str, Any]:
+    """Pure read: resolve task metadata, line, and linked note content.
 
-    Records the session against the task (idempotent), then returns
-    everything the agent needs to start working: task text, metadata,
-    note content (if any), and note file path.
-
-    Uses the plugin cache for task details when available, falls back
-    to the markdown file directly when the cache is cold.
+    Returns the same read-only fields that read_task/assign_task surface,
+    with no session-tracking write and no state mutation. On missing
+    store record, returns ``{"success": False, "message": ...}``.
     """
-    from work_buddy.agent_session import _get_session_id
-
-    session_id = _get_session_id()
-
-    # Get store metadata first — this is the hard requirement
     meta = store.get(task_id)
     if meta is None:
         return {
@@ -978,6 +969,14 @@ def assign_task(task_id: str) -> dict[str, Any]:
     # Fallback: scan the markdown file directly
     if not task_text:
         content = bridge.read_file(MASTER_TASK_FILE)
+        # Filesystem fallback when the bridge is down/flaky — mirrors the note-read path
+        if content is None:
+            from pathlib import Path
+            from work_buddy.config import load_config
+            fs_path = Path(load_config()["vault_root"]) / MASTER_TASK_FILE
+            if fs_path.exists():
+                content = fs_path.read_text(encoding="utf-8")
+                logger.info("Read master task list via filesystem fallback: %s", MASTER_TASK_FILE)
         if content:
             found = _find_task_line(content.split("\n"), task_id=task_id)
             if found:
@@ -990,9 +989,6 @@ def assign_task(task_id: str) -> dict[str, Any]:
                 desc = re.sub(r"\[\[[^\]]+\]\]", "", desc)
                 desc = re.sub(r"[🆔📅✅🔼⏫]\s*\S*", "", desc)
                 task_text = re.sub(r"\s+", " ", desc).strip()
-
-    # Record session assignment (idempotent)
-    store.assign_session(task_id, session_id)
 
     # Read note if one exists
     note_path = None
@@ -1009,9 +1005,6 @@ def assign_task(task_id: str) -> dict[str, Any]:
                 note_content = fs_path.read_text(encoding="utf-8")
                 logger.info("Read task note via filesystem fallback: %s", note_path)
 
-    # Get all assigned sessions
-    sessions = store.get_sessions(task_id)
-
     return {
         "success": True,
         "task_id": task_id,
@@ -1025,6 +1018,38 @@ def assign_task(task_id: str) -> dict[str, Any]:
         "contract": meta.get("contract"),
         "note_path": note_path,
         "note_content": note_content,
-        "assigned_sessions": sessions,
-        "session_id": session_id,
+        "assigned_sessions": store.get_sessions(task_id),
     }
+
+
+@bridge_retry()
+def read_task(task_id: str) -> dict[str, Any]:
+    """Read a task's full context without claiming it.
+
+    Returns task text, metadata, and linked note content. Does NOT record
+    a session assignment — use ``assign_task`` when you intend to claim
+    the task for the current session.
+    """
+    return _load_task_payload(task_id)
+
+
+@bridge_retry()
+def assign_task(task_id: str) -> dict[str, Any]:
+    """Claim a task for the current agent session and return full context.
+
+    Composes ``_load_task_payload`` with a session-tracker write. Returns
+    everything the agent needs to start working plus the claiming session_id.
+    """
+    from work_buddy.agent_session import _get_session_id
+
+    payload = _load_task_payload(task_id)
+    if not payload.get("success"):
+        return payload
+
+    session_id = _get_session_id()
+    store.assign_session(task_id, session_id)
+
+    # Refresh the session list so the caller sees their own claim
+    payload["assigned_sessions"] = store.get_sessions(task_id)
+    payload["session_id"] = session_id
+    return payload


### PR DESCRIPTION
## Summary
- Splits `assign_task` into a pure `_load_task_payload()` helper + session-tracker write; exposes the helper as a new read-only MCP capability `task_read` (no session write, same return shape).
- Adds a symmetric filesystem fallback for the master-task-list scan so bridge-down reads no longer silently empty `task_text`/`original_markdown` (this was also a latent bug in the old `assign_task`).
- New `/wb-task-read` slash command and `tasks/task-read-directions` knowledge unit; `tasks/assign-directions` updated with the read/assign distinction.

## Test plan
- [x] `tests/unit/test_task_mutations.py` — 12 passed
- [x] Smoke test live bridge: `task_read` on a with-note task, `task_read` on a noteless task, `task_assign` composed — all populated `task_text`/`original_markdown`/`line_number`/`note_content`, session row written only by `task_assign`
- [x] Smoke test bridge-down: same three calls — FS fallback populated everything; no regression

Task: t-22af36a9

🤖 Generated with [Claude Code](https://claude.com/claude-code)