### PR TITLE
feat(dashboard): link active contracts to Obsidian via 📓 icon

### DIFF
--- a/work_buddy/dashboard/api.py
+++ b/work_buddy/dashboard/api.py
@@ -696,6 +696,9 @@ def get_contracts_summary() -> dict[str, Any]:
                             "type": contract.get("type", ""),
                             "deadline": contract.get("deadline", ""),
                             "priority": contract.get("priority", ""),
+                            # Vault-relative path for obsidian:// URI in the dashboard.
+                            # Mirrors the config default (contracts.vault_path).
+                            "vault_path": f"work-buddy/contracts/{md_file.name}",
                         })
             except Exception:
                 continue

--- a/work_buddy/dashboard/frontend/script_main.py
+++ b/work_buddy/dashboard/frontend/script_main.py
@@ -2023,15 +2023,20 @@ async function loadContracts() {
         return;
     }
 
-    let rows = contracts.map(c => `
+    let rows = contracts.map(c => {
+        const noteLink = c.vault_path
+            ? `<a href="obsidian://open?vault=${encodeURIComponent(WB_VAULT_NAME)}&file=${encodeURIComponent(c.vault_path)}" title="Open contract in Obsidian" style="text-decoration:none;cursor:pointer;margin-left:6px;">&#x1F4D3;</a>`
+            : '';
+        return `
         <tr>
-            <td><strong>${c.title}</strong></td>
+            <td><strong>${c.title}</strong>${noteLink}</td>
             <td>${statusBadge(c.status)}</td>
             <td>${c.type || '—'}</td>
             <td>${c.deadline || '—'}</td>
             <td>${c.priority || '—'}</td>
         </tr>
-    `).join('');
+    `;
+    }).join('');
 
     document.getElementById('contracts-table').innerHTML = `
         <table class="data-table">


### PR DESCRIPTION
## Summary

- Added `vault_path` to `/api/contracts` payload (vault-relative path, e.g. `work-buddy/contracts/ecg-mcp.md`).
- Updated `loadContracts` in the dashboard frontend to render a 📓 icon next to each contract title, linking to the underlying markdown via `obsidian://open?vault=...&file=...` (same pattern as task note links).

Closes a UX gap: the Contracts panel previously showed titles as plain text with no way to open the underlying contract file. Discovered while reviewing the panel for the first time on a newly-activated contract.

## Test plan

- [ ] Refresh dashboard with at least one active contract → 📓 appears next to the title
- [ ] Click 📓 → Obsidian opens the contract markdown in the active vault
- [ ] Contracts with missing / malformed frontmatter still render (no 📓, but no JS error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)