### PR TITLE
fix(tasks): make projects/ first-class + rescue rare-leaf namespace tags

### DIFF
--- a/tests/unit/test_task_tag_cache.py
+++ b/tests/unit/test_task_tag_cache.py
@@ -65,19 +65,29 @@ class TestExtractTagsFromLine:
 
 class TestClassifyTags:
     def test_reserved_prefix_never_namespace(self):
-        counts = {"projects/ecg": 10, "todo": 50, "wb/todo": 5, "tasker/state/inbox": 2}
+        # `todo`, `wb/todo`, and anything under `tasker/` stay out of the
+        # tree. `projects/` is NOT reserved anymore — it's a first-class
+        # organizational axis.
+        counts = {"todo": 50, "wb/todo": 5, "tasker": 2, "tasker/state": 2, "tasker/state/inbox": 2}
         result = classify_tags(
             counts,
-            ["projects/ecg", "todo", "wb/todo", "tasker/state/inbox"],
+            ["todo", "wb/todo", "tasker/state/inbox"],
             threshold=2,
         )
         for _, is_ns in result:
             assert is_ns is False
 
+    def test_projects_prefix_is_namespace(self):
+        """`projects/<slug>` is the canonical project axis; it belongs in the tree."""
+        counts = {"projects": 10, "projects/ecg": 10}
+        result = classify_tags(counts, ["projects/ecg"], threshold=2)
+        assert result == [("projects/ecg", True)]
+
     def test_wb_prefix_is_namespace_except_reserved_exact(self):
         """`wb/` is the canonical work-buddy-dev namespace prefix.
         Only `wb/todo` and `wb/done` (inline-todo markers) are reserved."""
         counts = {
+            "wb": 38,
             "wb/consent": 5,
             "wb/workflow": 3,
             "wb/todo": 20,    # reserved — inline-TODO marker
@@ -93,44 +103,69 @@ class TestClassifyTags:
 
     def test_opt_in_prefix_always_namespace(self):
         # Even with count=1 and threshold=2, opt-in prefixes are namespaces.
-        counts = {"ns/foo": 1, "task/bar": 1}
+        counts = {"ns": 1, "ns/foo": 1, "task": 1, "task/bar": 1}
         result = classify_tags(
             counts, ["ns/foo", "task/bar"], threshold=2,
         )
         assert dict(result) == {"ns/foo": True, "task/bar": True}
 
     def test_discovery_threshold_below(self):
-        counts = {"paper/ecg": 1}
+        counts = {"paper": 1, "paper/ecg": 1}
         result = classify_tags(counts, ["paper/ecg"], threshold=2)
         assert result == [("paper/ecg", False)]
 
     def test_discovery_threshold_at_boundary(self):
-        counts = {"paper/ecg": 2}
+        counts = {"paper": 2, "paper/ecg": 2}
         result = classify_tags(counts, ["paper/ecg"], threshold=2)
         assert result == [("paper/ecg", True)]
 
+    def test_parent_rescues_rare_leaf(self):
+        # A one-off leaf (`research/electricrag/writing-prep` appears on
+        # a single task) is rescued by a popular parent prefix. This was
+        # the bug that hid the "Draft electricrag paper contract" task
+        # from the namespace tree.
+        counts = {
+            "research": 11,
+            "research/electricrag": 11,
+            "research/electricrag/quickhacks": 10,
+            "research/electricrag/writing-prep": 1,
+        }
+        result = classify_tags(
+            counts, ["research/electricrag/writing-prep"], threshold=2,
+        )
+        assert result == [("research/electricrag/writing-prep", True)]
+
+    def test_no_rescue_when_all_prefixes_rare(self):
+        # Single-segment rare tag with no popular ancestor stays out.
+        counts = {"admin": 1}
+        result = classify_tags(counts, ["admin"], threshold=2)
+        assert result == [("admin", False)]
+
     def test_mixed_tags(self):
         counts = {
-            "projects/ecg": 5,      # reserved → not namespace
+            "projects": 5,
+            "projects/ecg": 5,       # projects is first-class now → namespace
+            "paper": 3,
             "paper/ecg": 3,          # over threshold → namespace
             "admin": 1,              # under threshold → not namespace
+            "ns": 1,
             "ns/singleton": 1,       # opt-in → namespace
         }
         tags = ["projects/ecg", "paper/ecg", "admin", "ns/singleton"]
         result = dict(classify_tags(counts, tags, threshold=2))
         assert result == {
-            "projects/ecg": False,
+            "projects/ecg": True,
             "paper/ecg": True,
             "admin": False,
             "ns/singleton": True,
         }
 
     def test_reserved_wins_over_opt_in(self):
-        # Reserved check runs first; a `projects/...` tag is never a namespace
-        # even if someone were to also match an opt-in rule.
-        counts = {"projects/foo": 10}
-        result = classify_tags(counts, ["projects/foo"], threshold=2)
-        assert result == [("projects/foo", False)]
+        # Reserved check runs first; a `tasker/...` tag is never a namespace
+        # even if prefix counts would otherwise classify it as one.
+        counts = {"tasker": 10, "tasker/foo": 10}
+        result = classify_tags(counts, ["tasker/foo"], threshold=2)
+        assert result == [("tasker/foo", False)]
 
 
 # ── store: roundtrip ────────────────────────────────────────────

--- a/work_buddy/obsidian/tasks/sync.py
+++ b/work_buddy/obsidian/tasks/sync.py
@@ -44,15 +44,18 @@ TAG_RE = re.compile(r"(?<![\w/])#([a-z0-9][a-z0-9_/-]*)", re.IGNORECASE)
 
 # Tag prefixes that are never treated as user-defined namespaces.
 #
-# - `todo`: plugin/system marker
 # - `tasker/...`: legacy work-buddy metadata (being stripped elsewhere)
-# - `projects/...`: orthogonal identity link into the projects registry
+#
+# Note: `projects/` is NOT reserved — `#projects/<slug>` is both the registry
+# link AND a first-class organizational axis in the namespace tree. Keeping
+# it out of the tree previously forced users to invent parallel taxonomies
+# (e.g., `#research/<slug>`) just to surface tasks in the dashboard.
+#
 # Note: `wb/` is NOT reserved — it's the canonical work-buddy-dev namespace.
 # Only the specific inline-todo markers `wb/todo` and `wb/done` are excluded
 # (see RESERVED_TAG_EXACT).
 RESERVED_TAG_PREFIXES: tuple[str, ...] = (
     "tasker/",
-    "projects/",
 )
 
 # Specific tag values that are reserved regardless of prefix. These are
@@ -116,8 +119,18 @@ def extract_tags_from_line(line: str) -> list[str]:
     return out
 
 
+def _tag_prefixes(tag: str) -> list[str]:
+    """Return every ancestor prefix of a slash-separated tag, shallowest first.
+
+    ``research/electricrag/writing-prep`` → ``["research", "research/electricrag",
+    "research/electricrag/writing-prep"]``.
+    """
+    parts = [p for p in tag.lower().split("/") if p]
+    return ["/".join(parts[: i + 1]) for i in range(len(parts))]
+
+
 def classify_tags(
-    tag_counts: dict[str, int],
+    prefix_counts: dict[str, int],
     tag_list_for_this_task: list[str],
     *,
     threshold: int = 2,
@@ -126,15 +139,22 @@ def classify_tags(
 
     A tag is namespacey iff:
       - it is NOT in the reserved-prefix blocklist, AND
-      - it uses an opt-in prefix (ns/, task/), OR it appears on >= ``threshold``
-        open tasks globally (per ``tag_counts``).
+      - it uses an opt-in prefix (ns/, task/), OR *any* of its ancestor
+        prefixes (including itself) has >= ``threshold`` tasks carrying it
+        or a descendant (per ``prefix_counts``).
 
-    Reserved tags are still returned (so the cache can be queried for e.g.
-    `#projects/<slug>` linkages) but with ``is_namespace=False``.
+    The ancestor walk is what rescues rare leaves: a one-off like
+    ``research/electricrag/writing-prep`` inherits namespacey-ness from
+    a popular parent like ``research/electricrag`` or ``research``, so a
+    unique sub-bucket is not silently dropped from the tree.
+
+    Reserved tags are still returned (so the cache can be queried for
+    non-tree linkages) but with ``is_namespace=False``.
 
     Args:
-        tag_counts: Map of tag -> count of open tasks carrying that tag,
-                    computed once per sync across the whole vault.
+        prefix_counts: Map of prefix -> count of distinct tasks whose
+                       tags include that prefix *or any descendant of it*.
+                       Computed once per sync across the whole vault.
         tag_list_for_this_task: Tags parsed from this task's line.
         threshold: Minimum count for discovery-based classification.
     """
@@ -146,8 +166,10 @@ def classify_tags(
         if _is_opt_in(tag):
             result.append((tag, True))
             continue
-        count = tag_counts.get(tag.lower(), 0)
-        result.append((tag, count >= threshold))
+        rescued = any(
+            prefix_counts.get(p, 0) >= threshold for p in _tag_prefixes(tag)
+        )
+        result.append((tag, rescued))
     return result
 
 
@@ -225,12 +247,19 @@ def _rebuild_tag_cache(
     """
     threshold = _namespace_threshold()
 
-    # Global tag frequency across all parsed (open) tasks. Done tasks still
-    # contribute: a namespace doesn't vanish just because a task closed.
-    tag_counts: dict[str, int] = {}
+    # Prefix frequency across all parsed tasks: for each tag, we credit every
+    # ancestor prefix (so `research/electricrag/x` contributes one task-count
+    # to `research`, `research/electricrag`, and `research/electricrag/x`).
+    # Using a set per task avoids double-counting when two tags share a prefix
+    # on the same task. This is what lets the classifier rescue rare leaves
+    # whose parent prefix is popular.
+    prefix_counts: dict[str, int] = {}
     for info in file_tasks.values():
+        task_prefixes: set[str] = set()
         for tag in info.get("raw_tags", []):
-            tag_counts[tag.lower()] = tag_counts.get(tag.lower(), 0) + 1
+            task_prefixes.update(_tag_prefixes(tag))
+        for p in task_prefixes:
+            prefix_counts[p] = prefix_counts.get(p, 0) + 1
 
     written = 0
     for task_id in surviving_ids:
@@ -238,7 +267,7 @@ def _rebuild_tag_cache(
         if not info:
             continue
         classified = classify_tags(
-            tag_counts,
+            prefix_counts,
             info.get("raw_tags", []),
             threshold=threshold,
         )


### PR DESCRIPTION
## Summary

- Drop `projects/` from `RESERVED_TAG_PREFIXES`: `#projects/<slug>` is now a first-class organizational axis in the dashboard namespace tree, not an identity-only link. Previously forced users to invent parallel taxonomies (e.g., `#research/<slug>/...`) just to surface tasks.
- Add parent-rescue to `classify_tags`: walks ancestor prefixes so a rare leaf like `#research/electricrag/writing-prep` (count=1) inherits namespacey-ness from a popular parent prefix. Fixes the hidden-task bug where tasks with only a unique leaf tag vanished from the tree entirely.
- `_rebuild_tag_cache` builds prefix counts via a per-task set to avoid double-counting when two tags share an ancestor.

## Test plan

- [x] `tests/unit/test_task_tag_cache.py` — 23 pass (incl. new `test_parent_rescues_rare_leaf` and `test_no_rescue_when_all_prefixes_rare`)
- [ ] After merge: task previously hidden from dashboard tree (e.g. a task with only a unique leaf tag under a popular parent) should render under that parent's branch
- [ ] `#projects/<slug>` branches now appear in the namespace tree; no regression on `tasker/` reserved behavior

Task: t-ab3fa1f3

🤖 Generated with [Claude Code](https://claude.com/claude-code)