### PR TITLE
feat: resume a Claude Code session from the Chats view

### DIFF
--- a/knowledge/store/_generated_capabilities.json
+++ b/knowledge/store/_generated_capabilities.json
@@ -2664,7 +2664,7 @@
   "context/ir_index": {
     "kind": "capability",
     "name": "Ir Index",
-    "description": "Build or check the IR search index. Run 'build' to index conversations for semantic search. Run 'status' to check index health.",
+    "description": "Build or check the IR search index. Run 'build' to (re)encode dense vectors for indexed documents; 'status' returns per-source counts including dense_eligible_docs (how many docs CAN be encoded) and pending_eligible (real backlog — NOT doc_count vs vector_count, which is misleading because sources like conversation intentionally leave dense_text empty for tool-only spans).",
     "capability_name": "ir_index",
     "category": "context",
     "aliases": [
@@ -2874,7 +2874,7 @@
       "obsidian"
     ],
     "mutates_state": true,
-    "retry_policy": "manual",
+    "retry_policy": "verify_first",
     "tags": [
       "journal",
       "write"
@@ -4908,6 +4908,49 @@
       "context"
     ]
   },
+  "status/session_resume": {
+    "kind": "capability",
+    "name": "Session Resume",
+    "description": "Resume an existing Claude Code session in a new local terminal window. No prompt is sent and remote-control is off — the terminal opens directly into the conversation, ready for the user to type. cwd is auto-derived from the session's recorded working directory.",
+    "capability_name": "session_resume",
+    "category": "sidecar",
+    "aliases": [
+      "resume session",
+      "continue session",
+      "reopen chat",
+      "pick up conversation",
+      "claude --resume",
+      "reattach",
+      "open terminal to session"
+    ],
+    "parameters": {
+      "session_id": {
+        "type": "str",
+        "description": "Full or partial (>=8-char prefix) session UUID to resume.",
+        "required": true
+      },
+      "cwd": {
+        "type": "str",
+        "description": "Override the working directory. Defaults to the session's own recorded cwd, falling back to repo root.",
+        "required": false
+      },
+      "bypass_permissions": {
+        "type": "bool",
+        "description": "Add --dangerously-skip-permissions. Default: True.",
+        "required": false
+      }
+    },
+    "mutates_state": true,
+    "retry_policy": "manual",
+    "tags": [
+      "sidecar",
+      "session",
+      "resume"
+    ],
+    "parents": [
+      "status"
+    ]
+  },
   "context/session_search": {
     "kind": "capability",
     "name": "Session Search",
@@ -6219,7 +6262,7 @@
       "obsidian"
     ],
     "mutates_state": true,
-    "retry_policy": "manual",
+    "retry_policy": "verify_first",
     "tags": [
       "journal",
       "vault",

--- a/knowledge/store/_generated_parents.json
+++ b/knowledge/store/_generated_parents.json
@@ -152,6 +152,7 @@
       "status/remote_session_list",
       "status/service_health",
       "status/session_activity",
+      "status/session_resume",
       "status/session_summary",
       "status/setup_help",
       "status/setup_wizard",
@@ -160,7 +161,7 @@
       "status/tailscale_status"
     ],
     "content": {
-      "summary": "Container for 17 capabilities and workflows."
+      "summary": "Container for 18 capabilities and workflows."
     }
   },
   "messaging": {

--- a/knowledge/store/context.json
+++ b/knowledge/store/context.json
@@ -3,13 +3,32 @@
     "kind": "directions",
     "name": "Context Collection Directions",
     "description": "How to collect context and synthesize an orientation — priority order, flags, contract cross-reference",
-    "aliases": ["collect context", "orient", "context bundle", "current work state", "what am I working on"],
-    "tags": ["context", "collection", "orientation", "synthesis", "directions"],
-    "parents": ["context"],
+    "aliases": [
+      "collect context",
+      "orient",
+      "context bundle",
+      "current work state",
+      "what am I working on"
+    ],
+    "tags": [
+      "context",
+      "collection",
+      "orientation",
+      "synthesis",
+      "directions"
+    ],
+    "parents": [
+      "context"
+    ],
     "trigger": "user wants to know their current work state or collect context",
     "command": "wb-context-collect",
     "workflow": "context/collect-and-orient",
-    "capabilities": ["context/context_bundle", "context/context_git", "context/context_tasks", "contracts/active_contracts"],
+    "capabilities": [
+      "context/context_bundle",
+      "context/context_git",
+      "context/context_tasks",
+      "contracts/active_contracts"
+    ],
     "content": {
       "summary": "Collect via context_bundle, read in priority order (git -> tasks -> projects -> obsidian -> chats), synthesize 10-15 line orientation. Cross-reference against active contracts. Suggest one next action.",
       "full": "Use mcp__work-buddy__wb_run(\"context_bundle\") to collect. Scope options:\n- Default: config.yaml windows\n- Quick: {\"hours\": 24}\n- Last N days: {\"days\": 3}\n- Individual: context_git, context_chat, etc.\n\n## Synthesis instructions\n\nRead each context file in priority order (git -> tasks -> projects -> obsidian -> chats). Extract the signal -- don't dump raw contents.\n\nPresent a concise orientation covering:\n\nActive work (from git):\n- Which repos had recent commits? What kind of work?\n- Any dirty working trees? (uncommitted changes = in-progress work)\n\nProjects (from projects summary):\n- What projects are currently active? State?\n- Do active projects align with where time is spent?\n\nCurrent state (from Obsidian):\n- Journal entries today? Sign-in data?\n- Incomplete tasks? Any tagged as focused?\n\nRecent conversations (from chats):\n- Last few sessions about? Any unfinished work?\n\nFlags -- surface when data warrants. Name patterns only if they exist in the user's documented personal knowledge (knowledge_personal, any category they track); otherwise describe the signal plainly:\n- No journal entry today -> user hasn't checked in\n- Running Notes growing without triage\n- Git activity in repos not related to any contract -> potential drift\n- Lots of infra commits, no corresponding written output\n- Projects with no recent activity -> stale or abandoned?\n\n## Contract cross-reference\n\nCross-reference against active_contracts:\n- Does git activity align with any active contract?\n- Is there work happening that doesn't map to any contract?\n\nIf no contracts exist: 'No active contracts -- all work is currently unanchored.'\n\n## Suggest one next action\n\nBased on orientation, suggest one concrete next step -- highest-leverage action given current state.\n\n## Output format\n\nKeep to 10-15 lines max. The user doesn't need a report -- they need a mirror.\n\n## Don'ts\n- Don't read every file verbatim\n- Don't generate a 50-line report\n- Don't invent concerns not in the data\n- Don't skip the contract cross-reference\n- Don't import work_buddy.* modules when a wb_run capability exists"
@@ -19,13 +38,31 @@
     "kind": "directions",
     "name": "Context Review Directions",
     "description": "How to review an existing context bundle — freshness check, same synthesis rules as context-collect, no re-collection",
-    "aliases": ["review context", "review bundle", "check context", "latest bundle", "orient from existing bundle"],
-    "tags": ["context", "bundle", "review", "orientation", "synthesis", "directions"],
-    "parents": ["context"],
+    "aliases": [
+      "review context",
+      "review bundle",
+      "check context",
+      "latest bundle",
+      "orient from existing bundle"
+    ],
+    "tags": [
+      "context",
+      "bundle",
+      "review",
+      "orientation",
+      "synthesis",
+      "directions"
+    ],
+    "parents": [
+      "context"
+    ],
     "trigger": "user wants to orient from an existing context bundle without re-collecting",
     "command": "wb-context-review",
     "workflow": "context/review-latest-bundle",
-    "capabilities": ["context/context_bundle", "contracts/active_contracts"],
+    "capabilities": [
+      "context/context_bundle",
+      "contracts/active_contracts"
+    ],
     "content": {
       "summary": "Follow review-latest-bundle workflow to find and check freshness of the most recent bundle. Synthesize using same rules as context-collect: priority order, extract signal, cross-reference contracts, suggest one next action, max 10-15 lines.",
       "full": "Follow the review-latest-bundle workflow to find the latest bundle and check freshness. Then synthesize using the same rules as /wb-context-collect -- the behavioral rules are identical; only the data source differs (existing bundle vs fresh collection).\n\n<<wb:context/collect-directions>>\n\n## When to prefer this over collect-and-orient\n- The user just ran the collector manually and wants the results interpreted\n- You're mid-conversation and need a quick check -- re-collecting would break flow\n- The bundle is less than a few hours old and conditions haven't changed much"
@@ -35,13 +72,27 @@
     "kind": "directions",
     "name": "Session Find Uncommitted",
     "description": "How to invoke and present uncommitted session results — per-entry format and follow-up suggestion",
-    "aliases": ["find uncommitted", "uncommitted sessions", "sessions with dirty files", "who didn't commit"],
-    "tags": ["context", "session", "uncommitted", "git"],
-    "parents": ["context"],
+    "aliases": [
+      "find uncommitted",
+      "uncommitted sessions",
+      "sessions with dirty files",
+      "who didn't commit"
+    ],
+    "tags": [
+      "context",
+      "session",
+      "uncommitted",
+      "git"
+    ],
+    "parents": [
+      "context"
+    ],
     "trigger": "user asks which sessions left uncommitted changes, or wants to audit agent writes",
     "command": "wb-session-find-uncommitted",
     "workflow": null,
-    "capabilities": ["context/session_uncommitted"],
+    "capabilities": [
+      "context/session_uncommitted"
+    ],
     "content": {
       "summary": "Run session_uncommitted (optional days param, default 7). For each result: show 8-char session ID prefix, repo name, dirty files with git status codes. If other sessions have uncommitted changes, suggest resuming them.",
       "full": "Find which agent sessions wrote files that are still uncommitted.\n\nRun mcp__work-buddy__wb_run(\"session_uncommitted\") with optional days parameter (default 7).\n\nFor each result entry, report:\n- The session ID (8-char prefix is enough for session_get / session_search lookups)\n- The repo name\n- The dirty files and their git status (M = modified, ?? = untracked)\n\nIf any sessions besides the current one have uncommitted changes, suggest the user resume those sessions to commit or discard the changes."
@@ -74,7 +125,7 @@
     ],
     "content": {
       "summary": "ConversationSession wraps JSONL session files with lazy-loaded indexing, span-to-turn mapping, and metadata extraction. Capabilities: session_get (browse), session_search (hybrid search within session), session_expand (full context around a message), session_locate (jump from search hit to conversation), session_commits (git commits made by agents).",
-      "full": "Random-access into individual Claude Code conversation sessions. Provides paginated browsing, context expansion, and bridging from IR search hits to message-level results.\n\nWhen to use what:\n- Find which sessions mention X: context_search (then drill in)\n- Browse a session's messages: session_get with session_id + optional limit/offset/query/roles/message_types\n- Find messages in a known session: session_get with query param (substring filter)\n- Read full text around a message: session_expand with session_id + message_index\n- Jump from search hit to conversation: session_locate with session_id + span_index\n- Semantic/keyword search within session: session_search with session_id + query\n- Git commits from agent sessions: session_commits with optional days param\n- Git context with session attribution: context_git with annotate=true\n\nSession ID resolution: All IDs are 36-char UUIDs. All session_* capabilities accept partial prefix IDs (8 chars is canonical short form). Two resolvers: resolve_session_id(partial) returns full UUID, resolve_session_path(partial) returns (Path, full_uuid). Both raise FileNotFoundError on zero or ambiguous matches. Convention: store full UUIDs in data, truncate to 8 chars only at display boundaries.\n\nArchitecture: ConversationSession wraps a JSONL session file with lazy-loaded in-memory indexed turn list (via iter_session_turns from chat_collector.py). Span-to-turn mapping replays the IR chunking algorithm for reliable session_locate. Metadata: message count, duration, timestamps, tool usage summary.\n\nGit commit extraction: session_commits parses raw JSONL entries (bypassing iter_session_turns which drops tool I/O) to find Bash tool calls containing git commit and their results. build_session_map(days) returns {short_hash: full_session_id} for joining with git_collector output. context_git with annotate=true uses this map to tag commit lines.\n\nFiles: inspector.py (ConversationSession class, session ID resolvers, commit extraction, 6 gateway handlers), __init__.py (empty package init)."
+      "full": "Random-access into individual Claude Code conversation sessions. Provides paginated browsing, context expansion, and bridging from IR search hits to message-level results.\n\nWhen to use what:\n- Find which sessions mention X: context_search (then drill in)\n- Browse a session's messages: session_get with session_id + optional limit/offset/query/roles/message_types\n- Find messages in a known session: session_get with query param (substring filter)\n- Read full text around a message: session_expand with session_id + message_index\n- Jump from search hit to conversation: session_locate with session_id + span_index\n- Semantic/keyword search within session: session_search with session_id + query\n- Git commits from agent sessions: session_commits with optional days param\n- Git context with session attribution: context_git with annotate=true\n- Resume a session locally: the session_resume capability (registered in the sidecar category) opens a new terminal running `claude --resume <id>` without sending a prompt. cwd is auto-derived via get_session_cwd. Also exposed on the dashboard as a Resume button in each chat's header.\n\nSession ID resolution: All IDs are 36-char UUIDs. All session_* capabilities accept partial prefix IDs (8 chars is canonical short form). Three helpers on the same shape:\n- resolve_session_id(partial) returns full UUID.\n- resolve_session_path(partial) returns (Path, full_uuid).\n- get_session_cwd(partial) returns the working directory the session ran in (scanned from the first JSONL record carrying a cwd field), or None. Used by session_resume and begin_session to open the terminal in the right place.\n\nresolve_session_id and resolve_session_path raise FileNotFoundError on zero or ambiguous matches; get_session_cwd returns None instead of raising. Convention: store full UUIDs in data, truncate to 8 chars only at display boundaries.\n\nArchitecture: ConversationSession wraps a JSONL session file with lazy-loaded in-memory indexed turn list (via iter_session_turns from chat_collector.py). Span-to-turn mapping replays the IR chunking algorithm for reliable session_locate. Metadata: message count, duration, timestamps, tool usage summary.\n\nGit commit extraction: session_commits parses raw JSONL entries (bypassing iter_session_turns which drops tool I/O) to find Bash tool calls containing git commit and their results. build_session_map(days) returns {short_hash: full_session_id} for joining with git_collector output. context_git with annotate=true uses this map to tag commit lines.\n\nFiles: inspector.py (ConversationSession class, session ID + cwd resolvers, commit extraction, 6 gateway handlers), __init__.py (empty package init)."
     }
   }
 }

--- a/work_buddy/dashboard/frontend/script_main.py
+++ b/work_buddy/dashboard/frontend/script_main.py
@@ -1219,8 +1219,9 @@ function renderChatHeader(meta) {
         + (meta.start_time ? ' &middot; ' + formatTimestamp(meta.start_time) : '')
         + '</div>'
         + '<div class="chats-hdr-right">'
-        + '<button class="chats-hdr-btn primary" id="chats-hdr-resume" onclick="chatsResumeSession()" title="Open a local terminal and resume this session (claude --resume). No prompt sent.">Resume</button>'
+        + '<button class="chats-hdr-btn" id="chats-hdr-resume" onclick="chatsResumeSession()" title="Open a new local terminal and resume this session (claude --resume). No prompt sent.">Resume</button>'
         + '<button class="chats-hdr-btn" onclick="chatsToggleInSearch()">Search</button>'
+        + '<span class="chats-hdr-divider"></span>'
         + '<button class="chats-hdr-btn' + (chatsState.roleFilter === 'user' ? ' active' : '') + '" onclick="chatsFilterRole(&#39;user&#39;)">User</button>'
         + '<button class="chats-hdr-btn' + (chatsState.roleFilter === 'assistant' ? ' active' : '') + '" onclick="chatsFilterRole(&#39;assistant&#39;)">Assistant</button>'
         + '<button class="chats-hdr-btn' + (!chatsState.roleFilter ? ' active' : '') + '" onclick="chatsFilterRole(null)">All</button>'
@@ -1230,6 +1231,7 @@ function renderChatHeader(meta) {
 async function chatsResumeSession() {
     var sid = chatsState.selectedId;
     if (!sid) return;
+    if (!confirm('Open a new Claude Code terminal and resume this session? (claude --resume — no prompt sent, but a new window will appear on your desktop.)')) return;
     var btn = document.getElementById('chats-hdr-resume');
     var originalLabel = btn ? btn.textContent : 'Resume';
     if (btn) { btn.disabled = true; btn.textContent = 'Opening…'; }

--- a/work_buddy/dashboard/frontend/script_main.py
+++ b/work_buddy/dashboard/frontend/script_main.py
@@ -1219,11 +1219,40 @@ function renderChatHeader(meta) {
         + (meta.start_time ? ' &middot; ' + formatTimestamp(meta.start_time) : '')
         + '</div>'
         + '<div class="chats-hdr-right">'
+        + '<button class="chats-hdr-btn primary" id="chats-hdr-resume" onclick="chatsResumeSession()" title="Open a local terminal and resume this session (claude --resume). No prompt sent.">Resume</button>'
         + '<button class="chats-hdr-btn" onclick="chatsToggleInSearch()">Search</button>'
         + '<button class="chats-hdr-btn' + (chatsState.roleFilter === 'user' ? ' active' : '') + '" onclick="chatsFilterRole(&#39;user&#39;)">User</button>'
         + '<button class="chats-hdr-btn' + (chatsState.roleFilter === 'assistant' ? ' active' : '') + '" onclick="chatsFilterRole(&#39;assistant&#39;)">Assistant</button>'
         + '<button class="chats-hdr-btn' + (!chatsState.roleFilter ? ' active' : '') + '" onclick="chatsFilterRole(null)">All</button>'
         + '</div>';
+}
+
+async function chatsResumeSession() {
+    var sid = chatsState.selectedId;
+    if (!sid) return;
+    var btn = document.getElementById('chats-hdr-resume');
+    var originalLabel = btn ? btn.textContent : 'Resume';
+    if (btn) { btn.disabled = true; btn.textContent = 'Opening…'; }
+    try {
+        var resp = await fetch('/api/chats/' + encodeURIComponent(sid) + '/resume', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: '{}',
+        });
+        var data = await resp.json().catch(function() { return {}; });
+        if (!resp.ok || !data.success) {
+            alert('Resume failed: ' + (data.error || resp.statusText));
+            if (btn) { btn.textContent = originalLabel; btn.disabled = false; }
+            return;
+        }
+        if (btn) { btn.textContent = 'Opened'; }
+        setTimeout(function() {
+            if (btn) { btn.textContent = originalLabel; btn.disabled = false; }
+        }, 2000);
+    } catch (err) {
+        alert('Resume request failed: ' + err);
+        if (btn) { btn.textContent = originalLabel; btn.disabled = false; }
+    }
 }
 
 function renderMessages() {

--- a/work_buddy/dashboard/frontend/styles.py
+++ b/work_buddy/dashboard/frontend/styles.py
@@ -2123,9 +2123,10 @@ body {
 }
 .chats-hdr-btn:hover { color: var(--text-primary); border-color: var(--accent); }
 .chats-hdr-btn.active { border-color: var(--accent); color: var(--accent); }
-.chats-hdr-btn.primary { border-color: var(--accent); color: var(--accent); }
-.chats-hdr-btn.primary:hover { background: var(--accent); color: #fff; }
 .chats-hdr-btn[disabled] { opacity: 0.5; cursor: wait; }
+.chats-hdr-divider {
+    width: 1px; background: var(--border); align-self: stretch; margin: 0 2px;
+}
 .chats-in-search {
     padding: 8px 12px; background: var(--bg-secondary);
     border: 1px solid var(--border); border-top: none;

--- a/work_buddy/dashboard/frontend/styles.py
+++ b/work_buddy/dashboard/frontend/styles.py
@@ -2123,6 +2123,9 @@ body {
 }
 .chats-hdr-btn:hover { color: var(--text-primary); border-color: var(--accent); }
 .chats-hdr-btn.active { border-color: var(--accent); color: var(--accent); }
+.chats-hdr-btn.primary { border-color: var(--accent); color: var(--accent); }
+.chats-hdr-btn.primary:hover { background: var(--accent); color: #fff; }
+.chats-hdr-btn[disabled] { opacity: 0.5; cursor: wait; }
 .chats-in-search {
     padding: 8px 12px; background: var(--bg-secondary);
     border: 1px solid var(--border); border-top: none;

--- a/work_buddy/dashboard/service.py
+++ b/work_buddy/dashboard/service.py
@@ -1854,6 +1854,59 @@ def api_investigate():
 # Agent launch
 # ---------------------------------------------------------------------------
 
+@app.post("/api/chats/<session_id>/resume")
+def api_chat_resume(session_id: str):
+    """Resume a Claude Code session in a new local terminal.
+
+    No prompt is sent; remote-control is off. The terminal opens into the
+    session's recorded working directory, ready for the user to type.
+    """
+    blocked = _reject_read_only()
+    if blocked:
+        return blocked
+    if not session_id:
+        return jsonify({"success": False, "error": "session_id required."}), 400
+
+    try:
+        from work_buddy.consent import grant_consent
+        from work_buddy.session_launcher import begin_session
+        from work_buddy.sessions.inspector import resolve_session_id
+
+        # Verify the session exists before spending a terminal spawn on it —
+        # begin_session falls back to a bare `claude --resume` if resolution
+        # fails, which opens a useless window.
+        try:
+            resolved_id = resolve_session_id(session_id)
+        except FileNotFoundError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 404
+
+        # Clicking the dashboard button IS the user's consent, matching the
+        # pattern in api_launch_agent.
+        grant_consent("sidecar:remote_session_launch", mode="always")
+
+        result = begin_session(
+            session_id=resolved_id,
+            remote_control=False,
+            bypass_permissions=True,
+        )
+        if result.get("status") != "ok":
+            return jsonify({
+                "success": False,
+                "error": result.get("error", "Resume failed."),
+            }), 500
+
+        return jsonify({
+            "success": True,
+            "pid": result.get("pid"),
+            "session_id": result.get("session_id"),
+            "cwd": result.get("cwd"),
+            "message": result.get("message", "Session resumed."),
+        })
+    except Exception as exc:
+        logger.error("Failed to resume chat session %s: %s", session_id, exc)
+        return jsonify({"success": False, "error": str(exc)}), 500
+
+
 @app.post("/api/launch-agent")
 def api_launch_agent():
     """Launch an agent session — desktop (no remote) or mobile (remote control).

--- a/work_buddy/mcp_server/registry.py
+++ b/work_buddy/mcp_server/registry.py
@@ -4036,6 +4036,7 @@ def _remote_session_capabilities() -> list[Capability]:
             ],
             mutates_state=True,
             retry_policy="manual",
+            consent_operations=["sidecar:remote_session_launch"],
         ),
         Capability(
             name="remote_session_list",

--- a/work_buddy/mcp_server/registry.py
+++ b/work_buddy/mcp_server/registry.py
@@ -3925,6 +3925,27 @@ def _remote_session_capabilities() -> list[Capability]:
             bypass_permissions=bypass_permissions,
         )
 
+    def _session_resume(
+        session_id: str,
+        cwd: str | None = None,
+        bypass_permissions: bool = True,
+    ) -> dict:
+        # Resume into a local terminal — no remote-control, no prompt.
+        # cwd defaults to the session's own recorded cwd via begin_session.
+        # Validate up-front: begin_session falls back to a bare `claude
+        # --resume` if resolution fails, which spawns a useless terminal.
+        from work_buddy.sessions.inspector import resolve_session_id
+        try:
+            resolved = resolve_session_id(session_id)
+        except FileNotFoundError as exc:
+            return {"status": "error", "error": str(exc)}
+        return begin_session(
+            cwd=cwd,
+            session_id=resolved,
+            bypass_permissions=bypass_permissions,
+            remote_control=False,
+        )
+
     def _remote_list(cwd: str | None = None) -> dict:
         sessions = list_resumable_sessions(cwd=cwd or str(_REPO_ROOT))
         return {
@@ -3976,6 +3997,42 @@ def _remote_session_capabilities() -> list[Capability]:
                 "remote control", "visible session", "phone session",
                 "telegram", "remote launch", "resume session",
                 "continue session", "reconnect",
+            ],
+            mutates_state=True,
+            retry_policy="manual",
+        ),
+        Capability(
+            name="session_resume",
+            description=(
+                "Resume an existing Claude Code session in a new local "
+                "terminal window. No prompt is sent and remote-control is "
+                "off — the terminal opens directly into the conversation, "
+                "ready for the user to type. cwd is auto-derived from the "
+                "session's recorded working directory."
+            ),
+            category="sidecar",
+            parameters={
+                "session_id": {
+                    "type": "str",
+                    "description": "Full or partial (>=8-char prefix) session UUID to resume.",
+                    "required": True,
+                },
+                "cwd": {
+                    "type": "str",
+                    "description": "Override the working directory. Defaults to the session's own recorded cwd, falling back to repo root.",
+                    "required": False,
+                },
+                "bypass_permissions": {
+                    "type": "bool",
+                    "description": "Add --dangerously-skip-permissions. Default: True.",
+                    "required": False,
+                },
+            },
+            callable=_session_resume,
+            search_aliases=[
+                "resume session", "continue session", "reopen chat",
+                "pick up conversation", "claude --resume", "reattach",
+                "open terminal to session",
             ],
             mutates_state=True,
             retry_policy="manual",

--- a/work_buddy/session_launcher.py
+++ b/work_buddy/session_launcher.py
@@ -374,11 +374,19 @@ def begin_session(
             "default_ttl": 30,
         }
 
-    if cwd is None:
-        cwd = str(_REPO_ROOT)
-
     # --- Resume path ---
     if session_id or session_name:
+        # When resuming, prefer the session's own recorded cwd over the repo
+        # root default — otherwise `claude --resume` opens in the wrong dir.
+        if cwd is None and session_id:
+            try:
+                from work_buddy.sessions.inspector import get_session_cwd
+                cwd = get_session_cwd(session_id)
+            except Exception as exc:
+                logger.debug("get_session_cwd failed for '%s': %s", session_id, exc)
+                cwd = None
+        if cwd is None:
+            cwd = str(_REPO_ROOT)
         return _do_resume(
             session_id=session_id,
             session_name=session_name,
@@ -386,6 +394,9 @@ def begin_session(
             bypass_permissions=bypass_permissions,
             remote_control=remote_control,
         )
+
+    if cwd is None:
+        cwd = str(_REPO_ROOT)
 
     # --- New session path ---
     return _do_start(cwd=cwd, prompt=prompt, bypass_permissions=bypass_permissions,

--- a/work_buddy/sessions/inspector.py
+++ b/work_buddy/sessions/inspector.py
@@ -74,6 +74,35 @@ def resolve_session_id(session_id: str) -> str:
     return full_id
 
 
+def get_session_cwd(session_id: str) -> str | None:
+    """Recover the working directory a session ran in from its JSONL.
+
+    Claude Code stamps ``cwd`` onto every conversation turn after the first
+    few bookkeeping entries. We scan a small prefix of the file for the first
+    non-empty value. Returns ``None`` if the session can't be found or no
+    ``cwd`` is stamped in the first 50 records.
+    """
+    try:
+        path, _ = resolve_session_path(session_id)
+    except FileNotFoundError:
+        return None
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for i, line in enumerate(fh):
+                if i >= 50:
+                    break
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                cwd = rec.get("cwd")
+                if cwd:
+                    return str(cwd)
+    except OSError:
+        return None
+    return None
+
+
 # ---------------------------------------------------------------------------
 # ConversationSession
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- One-click **Resume** button in the dashboard Chats view — opens a new local terminal running `claude --resume <session_id> --dangerously-skip-permissions` in the session's own recorded cwd. No prompt sent, no remote-control.
- New `session_resume` MCP capability (sidecar category) so agents can do the same programmatically — gated by `sidecar:remote_session_launch` consent, with `consent_operations` declared so the gateway fires a pre-flight notification instead of returning an opaque dict.
- New `get_session_cwd(partial)` helper in `sessions.inspector` — scans the session JSONL for its `cwd` field; used by both the capability and `begin_session`'s resume path.

## Why
Previously you had to memorize `claude -r <full-uuid> --dangerously-skip-permissions` and `cd` to the right repo. The Chats view already knows both, so the click can just do it.

## Test plan
- [ ] Open dashboard Chats tab, pick any session, click **Resume** → confirm dialog appears → approve → new terminal opens in the correct repo with the conversation loaded.
- [ ] Unknown session id via `POST /api/chats/<bad-id>/resume` → 404, no terminal spawned.
- [ ] Call `session_resume` via `wb_run` as an agent without prior consent → consent notification fires on your approved surfaces → approve → terminal opens.
- [ ] Verify Resume button is gray (matches Search), not permanently highlighted orange, and sits to the left of a divider separating it from the User/Assistant/All filter toggles.

## Commits
- `141dfbb` feat(dashboard+sessions): resume a Claude Code session from the Chats view
- `5949974` fix(dashboard+session_resume): match Resume button to toggles + fire consent notification for agent callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)