### PR TITLE
feat(triage): GTD Slice 1 — Pool: stop the bleeding

### DIFF
--- a/knowledge/store/_generated_capabilities.json
+++ b/knowledge/store/_generated_capabilities.json
@@ -711,6 +711,39 @@
       "context"
     ]
   },
+  "status/claude_code_usage_scan": {
+    "kind": "capability",
+    "name": "Claude Code Usage Scan",
+    "description": "Scan Claude Code's local transcript JSONLs into the cost cache (~/.claude/projects/**/*.jsonl). Incremental by default. Use full_rebuild=true after a pricing or schema change.",
+    "capability_name": "claude_code_usage_scan",
+    "category": "llm",
+    "aliases": [
+      "claude usage",
+      "claude code usage",
+      "transcript scan",
+      "ingest claude code activity",
+      "rescan costs"
+    ],
+    "parameters": {
+      "full_rebuild": {
+        "type": "bool",
+        "description": "Drop and rebuild the cache (default false).",
+        "required": false
+      }
+    },
+    "mutates_state": true,
+    "retry_policy": "manual",
+    "tags": [
+      "llm",
+      "claude",
+      "code",
+      "usage",
+      "scan"
+    ],
+    "parents": [
+      "status"
+    ]
+  },
   "artifacts/commit_record": {
     "kind": "capability",
     "name": "Commit Record",
@@ -2480,6 +2513,58 @@
       "context"
     ]
   },
+  "status/escalation_recent": {
+    "kind": "capability",
+    "name": "Escalation Recent",
+    "description": "Recent LLM-escalation observability records. Each record is one logical job (one LLMRunner.call OR one adapter-level escalation chain across multiple calls) with its full per-tier attempt list, final outcome, and trace correlation.",
+    "capability_name": "escalation_recent",
+    "category": "llm",
+    "aliases": [
+      "tier escalation",
+      "escalation log",
+      "what tier answered",
+      "did this escalate",
+      "fallback chain",
+      "model fallback",
+      "validation failed",
+      "tier observability"
+    ],
+    "parameters": {
+      "limit": {
+        "type": "int",
+        "description": "Max records to return (newest first). Default 50.",
+        "required": false
+      },
+      "trace_id": {
+        "type": "str",
+        "description": "Filter by exact trace_id correlation token.",
+        "required": false
+      },
+      "final_outcome": {
+        "type": "str",
+        "description": "Filter by final_outcome ('success', 'backend_error', 'validation_failed', 'empty_content', 'exhausted').",
+        "required": false
+      },
+      "source": {
+        "type": "str",
+        "description": "Filter by source ('llm_runner', 'journal_segmenter', 'verdict_call').",
+        "required": false
+      },
+      "summary": {
+        "type": "bool",
+        "description": "When true, return aggregate counts (by source / outcome / final_tier, plus 'escalated_past_first') instead of records.",
+        "required": false
+      }
+    },
+    "tags": [
+      "llm",
+      "escalation",
+      "recent"
+    ],
+    "parents": [
+      "status"
+    ]
+  },
   "status/feature_status": {
     "kind": "capability",
     "name": "Feature Status",
@@ -2591,7 +2676,7 @@
   "triage/inline_triage_scan": {
     "kind": "capability",
     "name": "Inline Triage Scan",
-    "description": "Run one triage pass over a single user-sent Obsidian selection (from the 'Send to agent' right-click command). Builds one TriageItem with source='inline', collects the user-context packet (active tasks / contracts / projects / recent commits), and asks Sonnet for a constrained-JSON verdict — parsed and written directly into the Review pool. Escalates to Opus on timeout / context-exceeded / empty content / rate-limited. User-initiated, so force=True by default.",
+    "description": "Run one triage pass over a single user-sent Obsidian selection (from the 'Send to agent' right-click or tag). Builds one TriageItem with source='inline'. When triage.verdict_pass.enabled=true, collects the user-context packet and asks Sonnet for a constrained-JSON verdict (escalates to Opus on timeout / context-exceeded / empty content / rate-limited). Slice 1 default is verdict_pass off — captures land in the pool as raw entries (verdict={raw: true}) until Slice 3 brings the GTD-shaped multi-record schema back. User-initiated, so force=True by default.",
     "capability_name": "inline_triage_scan",
     "category": "triage",
     "aliases": [
@@ -2780,7 +2865,7 @@
   "journal/journal_triage_scan": {
     "kind": "capability",
     "name": "Journal Triage Scan",
-    "description": "Run one background-triage pass over today's Running Notes section. Segments the same-day content into threads via the local LLM, enriches each with hybrid-IR context, and asks Sonnet (escalating to Opus on failure) for a constrained-JSON verdict per thread — written directly into the Review pool. Never mutates the vault. Idempotent on unchanged content. Cadence is a sidecar-job concern; safe to call manually for testing.",
+    "description": "Run one background-triage pass over today's Running Notes section. Segments the same-day content into threads via the local LLM, enriches each with hybrid-IR context, and (when triage.verdict_pass.enabled=true) asks Sonnet (escalating to Opus on failure) for a constrained-JSON verdict per thread. Slice 1 default is verdict_pass off — captures land in the pool as raw entries (verdict={raw: true}) until Slice 3 brings GTD-shaped verdicts back. Never mutates the vault. Idempotent on unchanged content. Cadence is a sidecar-job concern; safe to call manually for testing.",
     "capability_name": "journal_triage_scan",
     "category": "journal",
     "aliases": [
@@ -3281,6 +3366,82 @@
       "status",
       "llm",
       "costs"
+    ],
+    "parents": [
+      "status"
+    ]
+  },
+  "status/llm_costs_query": {
+    "kind": "capability",
+    "name": "Llm Costs Query",
+    "description": "Aggregate LLM cost / usage across one or both data sources (work-buddy's per-call internal log + Claude Code transcripts). Smart parameters: time window (named or ISO range), group_by (project, model, session, day, tool), source filter, min_cost / project / model filters, and previous-window comparison. Single capability covering most cost questions.",
+    "capability_name": "llm_costs_query",
+    "category": "llm",
+    "aliases": [
+      "llm costs",
+      "llm spend",
+      "how much have i spent",
+      "claude api costs",
+      "cost by project",
+      "cost by model",
+      "weekly spend",
+      "monthly spend",
+      "expensive sessions",
+      "burn rate",
+      "cost trend",
+      "spend comparison"
+    ],
+    "parameters": {
+      "window": {
+        "type": "str",
+        "description": "Time window. Named: 'today', 'yesterday', '7d', '30d', '90d', 'month_to_date', 'all'. ISO range: 'YYYY-MM-DD..YYYY-MM-DD'. Single day: 'YYYY-MM-DD'. Default '30d'.",
+        "required": false
+      },
+      "group_by": {
+        "type": "str",
+        "description": "Optional breakdown: 'project', 'model', 'session', 'day', 'tool'. Omit for top-line totals only.",
+        "required": false
+      },
+      "source": {
+        "type": "str",
+        "description": "'all' (default), 'internal' (work-buddy's runner calls), or 'claude_code' (Claude Code transcripts).",
+        "required": false
+      },
+      "min_cost": {
+        "type": "float",
+        "description": "Filter rows where cost_usd < this. Default 0.",
+        "required": false
+      },
+      "project": {
+        "type": "str",
+        "description": "Substring match on project name / cwd.",
+        "required": false
+      },
+      "model": {
+        "type": "str",
+        "description": "Exact-match model filter (e.g. 'claude-sonnet-4-6').",
+        "required": false
+      },
+      "top_n": {
+        "type": "int",
+        "description": "Cap on grouped rows. Default 10. Pass 0 for no cap.",
+        "required": false
+      },
+      "include_local": {
+        "type": "bool",
+        "description": "Include local-LLM rows? Default true.",
+        "required": false
+      },
+      "compare_to_previous": {
+        "type": "bool",
+        "description": "Include previous-equivalent-window comparison (delta_pct_cost, delta_pct_calls). Default true.",
+        "required": false
+      }
+    },
+    "tags": [
+      "llm",
+      "costs",
+      "query"
     ],
     "parents": [
       "status"
@@ -6056,6 +6217,48 @@
       "triage",
       "item",
       "detail"
+    ],
+    "parents": [
+      "context"
+    ]
+  },
+  "context/triage_pool_sweep": {
+    "kind": "capability",
+    "name": "Triage Pool Sweep",
+    "description": "Daily liveness pass over the triage pool (Slice 1). Walks every pending PoolEntry: marks expired entries as 'stale' (TTL from the source descriptor) and quarantines entries whose source no longer resolves (file deleted, journal text drifted beyond the match threshold, etc.). Source-specific behavior lives in the source descriptor registry (work_buddy/triage/sources.py). Non-destructive: state changes only; entries stay on disk.",
+    "capability_name": "triage_pool_sweep",
+    "category": "context",
+    "aliases": [
+      "sweep triage pool",
+      "quarantine stale triage",
+      "triage liveness check",
+      "drop ghost pool entries",
+      "purge stale triage"
+    ],
+    "parameters": {
+      "dry_run": {
+        "type": "bool",
+        "description": "When true, computes what would change but does not write back. Useful for rehearsal.",
+        "required": false
+      },
+      "source": {
+        "type": "str",
+        "description": "Optional source filter (e.g. 'journal_thread', 'inline'). Other sources untouched.",
+        "required": false
+      },
+      "max_entries": {
+        "type": "int",
+        "description": "Safety cap on entries inspected per pass.",
+        "required": false
+      }
+    },
+    "mutates_state": true,
+    "retry_policy": "manual",
+    "tags": [
+      "context",
+      "triage",
+      "pool",
+      "sweep"
     ],
     "parents": [
       "context"

--- a/knowledge/store/_generated_parents.json
+++ b/knowledge/store/_generated_parents.json
@@ -105,13 +105,14 @@
       "context/session_wb_activity",
       "context/triage_execute",
       "context/triage_item_detail",
+      "context/triage_pool_sweep",
       "context/triage_review_pool",
       "context/triage_submit",
       "context/workflow_create",
       "context/workflow_update"
     ],
     "content": {
-      "summary": "Container for 60 capabilities and workflows."
+      "summary": "Container for 61 capabilities and workflows."
     }
   },
   "artifacts": {
@@ -141,10 +142,13 @@
       "status"
     ],
     "children": [
+      "status/claude_code_usage_scan",
+      "status/escalation_recent",
       "status/feature_status",
       "status/list_sessions",
       "status/llm_call",
       "status/llm_costs",
+      "status/llm_costs_query",
       "status/llm_submit",
       "status/llm_with_tools",
       "status/mcp_registry_reload",
@@ -161,7 +165,7 @@
       "status/tailscale_status"
     ],
     "content": {
-      "summary": "Container for 18 capabilities and workflows."
+      "summary": "Container for 21 capabilities and workflows."
     }
   },
   "messaging": {

--- a/knowledge/store/triage.json
+++ b/knowledge/store/triage.json
@@ -1,0 +1,37 @@
+{
+  "triage/source-descriptors": {
+    "kind": "system",
+    "name": "Source Descriptors (Triage Pool)",
+    "description": "Per-source lifecycle declarations driving TTL and quarantine triggers in the daily pool sweep",
+    "content": {
+      "full": "# Source Descriptors\n\nEvery entry in the triage pool was captured from some **source** — a journal\nthread, a Chrome tab, an inline Obsidian selection, etc. Sources differ in\nlifecycle expectations:\n\n- A journal thread might be re-edited by the user as the day's running notes\n  evolve; the original captured text might no longer reflect the user's intent.\n- A Chrome tab can be closed; once gone, the captured page text is a ghost.\n- An inline `send-to-agent` selection is the user's affirmative capture;\n  treating it as transient would erode trust (V2a — capture promise integrity).\n\nRather than hard-coding per-source TTLs and quarantine rules in the sweeper,\neach source declares a `SourceDescriptor`. The daily sweep dispatches on the\ndescriptor; new sources register their own descriptor and inherit the sweep\nmachinery for free.\n\n## Anatomy of a descriptor\n\n```python\nSourceDescriptor(\n    name=\"journal_thread\",\n    ttl_days=5,\n    quarantine_triggers=[\n        \"source_removed\",\n        \"source_edited_beyond_match\",\n    ],\n    config={\n        \"edit_match_threshold\": 0.85,\n    },\n)\n```\n\n- `name` — the source identifier (matches `PoolEntry.source`).\n- `ttl_days` — soft expiry in days, or `None` for no auto-expiry. After this\n  many days, the sweep transitions `state` from `pending` to `stale`.\n- `quarantine_triggers` — ordered list of trigger names. The sweep evaluates\n  each in order; the first one that fires sets `quarantine_reason` and\n  transitions `state` to `quarantined`.\n- `config` — open dict of source-specific knobs the trigger functions read\n  (e.g. inline's `capture_tag`, journal's `edit_match_threshold`).\n\n## Defaults shipped (Slice 1)\n\n| Source            | TTL  | Triggers                                           |\n|-------------------|------|----------------------------------------------------|\n| `journal_thread`  | 5d   | `source_removed`, `source_edited_beyond_match`     |\n| `chrome_tab`      | 2d   | `source_removed`                                   |\n| `inline`          | null | `source_removed`                                   |\n\nInline TTL is intentionally `null`. User-affirmative captures should not\nauto-expire — see Slice 1's design discussion.\n\n## Override path\n\nUsers override per-source under `triage.pool.sources.<name>` in\n`config.local.yaml`. Deep-merges on top of code defaults; missing keys\ninherit:\n\n```yaml\ntriage:\n  pool:\n    sources:\n      journal_thread:\n        ttl_days: 14   # extend journal TTL; everything else inherits\n      inline:\n        config:\n          capture_tag: \"wb/saved\"   # override one config key, others inherit\n```\n\nNew sources register a fresh descriptor (any keys not specified default to\nempty / null).\n\n## Trigger functions\n\nLive in `work_buddy/triage/sources_triggers.py`. Dispatched by name from\nthe descriptor's `quarantine_triggers` list. Contract:\n\n```python\ndef trigger_<name>(\n    entry: PoolEntry,\n    descriptor: SourceDescriptor,\n) -> str | None\n```\n\nReturn `None` for \"did not fire\"; return a non-empty string for the\nhuman-readable reason that gets persisted to `quarantine_reason`.\n\n**Triggers MUST be defensive.** The sweep runs daily, unattended, against\nevery pending entry. A trigger that raises kills the whole pass. Catch\ntransport / filesystem failures and return `None` (treat ambiguous as\n\"still live\"); never raise.\n\nCurrently shipped:\n\n- `source_removed` — file / tab / journal-date no longer resolves.\n- `source_edited_beyond_match` — captured text no longer found in source\n  (difflib.SequenceMatcher.ratio < threshold; default 0.85).\n- `tag_removed` — placeholder for the future inline tag-write flow.\n  Currently a no-op.\n\n## Why this lives separate from `triage/config.py`\n\nThe config file holds *stage-shape* config — profile names, max_tokens,\nthe escalation chain. Knobs about HOW the LLM call runs.\n\nThe source registry holds *lifecycle* config — TTLs, quarantine triggers.\nKnobs about how entries AGE in the pool.\n\nDifferent concerns, different override surfaces, different consumers.\nKeeping them in separate files lets the migration script and the daily\nsweep import the lifecycle config without pulling in the LLM stack."
+    },
+    "tags": [
+      "triage",
+      "pool",
+      "sources",
+      "lifecycle",
+      "sweep",
+      "ttl",
+      "quarantine",
+      "registry"
+    ],
+    "aliases": [
+      "source descriptor",
+      "pool source registry",
+      "SOURCE_REGISTRY",
+      "source registry",
+      "quarantine triggers",
+      "pool TTL",
+      "per-source TTL"
+    ],
+    "parents": [
+      "triage"
+    ],
+    "dev_notes": "Naming: descriptor data lives in `sources.py`; trigger functions in `sources_triggers.py`. Keep these split — `sources.py` is data-only and importable from migration scripts without paying for bridge / vault helpers. Importing it must NOT pull in obsidian.bridge.\n\nAdding a trigger: append the name to `KNOWN_TRIGGERS` in `sources.py`, write the function in `sources_triggers.py` with signature `(entry, descriptor) -> str | None`, register in `_TRIGGER_DISPATCH`. Triggers MUST be defensive — return None on any failure (transport, ambiguity); never raise. The sweep is unattended, one bad trigger poisons the whole pass otherwise.\n\nDescriptors validate at construction: unknown trigger names raise. This is intentional — typos in user config should fail loudly at load, not silently leave entries un-quarantined forever.\n\nThe registry is cached at module level (`_REGISTRY_CACHE`); call `reset_for_tests()` between tests if you monkeypatch config. The pool's `_compute_expires_at` soft-imports this module to avoid an import cycle (sources imports background for type hints).\n\nWhy not put this in `triage/config.py`: that file holds stage-shape config (profile names, max_tokens, escalation chain) — knobs about HOW the LLM call runs. This file holds lifecycle config (TTLs, quarantine triggers) — knobs about how entries AGE in the pool. Different concerns; keep them split.",
+    "entry_points": [
+      "work_buddy.triage.sources",
+      "work_buddy.triage.sources_triggers"
+    ]
+  }
+}

--- a/scripts/migrate_pool_slice_1.py
+++ b/scripts/migrate_pool_slice_1.py
@@ -1,0 +1,178 @@
+"""One-shot migration over the live triage pool (Slice 1).
+
+Goals
+-----
+
+Bring every entry currently on disk into alignment with the new
+Slice 1 schema and lifecycle:
+
+1. **Backfill ``state``** — legacy entries get ``state=reviewed`` if
+   they have ``reviewed_at``, else ``state=pending``. (PoolEntry.from_dict
+   already infers this for reads, but we persist the field explicitly so
+   subsequent code doesn't need the fallback path.)
+2. **Recompute ``item_content_hash``** — the Slice 1 normalization is
+   stricter (NFKC + lowercase + markdown-bullet strip + whitespace
+   collapse). Existing hashes were computed under the looser rules, so
+   cross-run dedup is broken between old and new entries until we
+   rewrite them.
+3. **Backfill ``expires_at``** for pending entries — the source
+   descriptor's TTL (e.g. journal 5d) is computed from each entry's
+   ``created_at``. Entries whose computed ``expires_at`` is already in
+   the past will be marked ``state=stale`` by the next sweep.
+4. **Run ``triage_pool_sweep`` once** — sweeps the now-tagged pool and
+   transitions stale + quarantined entries based on live source state.
+
+Safety
+------
+
+- Pool snapshot is taken to ``data/triage_pool/pool.json.pre-migration-<ts>``
+  before any write.
+- Dry-run mode prints what would change without writing.
+- Idempotent: running twice produces the same result. Backfill skips
+  fields that are already populated.
+
+Usage
+-----
+
+::
+
+    # Rehearsal:
+    python scripts/migrate_pool_slice_1.py --dry-run
+
+    # Apply:
+    python scripts/migrate_pool_slice_1.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from work_buddy.triage.background import (
+    STATE_PENDING,
+    STATE_REVIEWED,
+    _compute_expires_at,
+    get_pool,
+    item_content_hash,
+)
+from work_buddy.triage.capabilities.triage_pool_sweep import triage_pool_sweep
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print what would change without writing.",
+    )
+    parser.add_argument(
+        "--skip-sweep", action="store_true",
+        help="Backfill only; don't run the sweep afterward.",
+    )
+    args = parser.parse_args(argv)
+
+    pool = get_pool()
+    index_path = pool._index_path
+    if not index_path.exists():
+        print(f"No pool index at {index_path} — nothing to migrate.")
+        return 0
+
+    raw_data = json.loads(index_path.read_text(encoding="utf-8"))
+    entries = raw_data.get("entries", [])
+    print(f"Loaded {len(entries)} entries from {index_path}")
+
+    # Snapshot before write
+    if not args.dry_run:
+        backup_path = index_path.with_suffix(
+            f".pre-migration-{datetime.now().strftime('%Y%m%d-%H%M%S')}.json"
+        )
+        shutil.copy2(index_path, backup_path)
+        print(f"Snapshot: {backup_path}")
+
+    # ---- Backfill counters ------------------------------------------------
+    state_backfilled = 0
+    hash_recomputed = 0
+    hash_changed = 0
+    expires_backfilled = 0
+    now_iso = _now_iso()
+
+    for entry in entries:
+        # 1. state backfill
+        if "state" not in entry or entry.get("state") is None:
+            entry["state"] = (
+                STATE_REVIEWED if entry.get("reviewed_at") else STATE_PENDING
+            )
+            entry["state_changed_at"] = entry.get("reviewed_at") or now_iso
+            state_backfilled += 1
+
+        # 2. hash recompute
+        item = entry.get("item") or {}
+        text = item.get("text", "") or ""
+        src = item.get("source", entry.get("source", "")) or ""
+        new_hash = item_content_hash(src, text)
+        old_hash = entry.get("item_content_hash")
+        if new_hash != old_hash:
+            entry["item_content_hash"] = new_hash
+            hash_recomputed += 1
+            if old_hash is not None:
+                hash_changed += 1
+
+        # 3. expires_at backfill (only for pending entries — reviewed
+        # entries don't need a TTL; they've already been actioned).
+        if (
+            entry.get("state") == STATE_PENDING
+            and not entry.get("expires_at")
+        ):
+            created_at = entry.get("created_at", "")
+            entry_source = entry.get("source", "")
+            new_expiry = _compute_expires_at(entry_source, created_at)
+            if new_expiry:
+                entry["expires_at"] = new_expiry
+                expires_backfilled += 1
+
+    print()
+    print(f"  state backfilled:     {state_backfilled}")
+    print(f"  hash recomputed:      {hash_recomputed}  (of which "
+          f"{hash_changed} actually changed)")
+    print(f"  expires_at backfilled: {expires_backfilled}")
+
+    # Hash-collision summary (post-recompute) — duplicate-hash counts.
+    from collections import Counter
+    counts = Counter()
+    for entry in entries:
+        if entry.get("state") == STATE_PENDING:
+            counts[entry.get("item_content_hash") or ""] += 1
+    dup_groups = {h: n for h, n in counts.items() if n > 1}
+    print(
+        f"  pending-entry duplicate hash groups: "
+        f"{len(dup_groups)} (max group size {max(dup_groups.values()) if dup_groups else 0})"
+    )
+
+    # Apply backfill
+    if not args.dry_run:
+        index_path.write_text(json.dumps(raw_data, indent=2), encoding="utf-8")
+        print(f"\nWrote backfill to {index_path}")
+    else:
+        print("\n(dry-run — no writes)")
+
+    # Run sweep
+    if args.skip_sweep:
+        print("\n(--skip-sweep — leaving lifecycle pass to the cron)")
+        return 0
+
+    print("\nRunning triage_pool_sweep ...")
+    sweep_result = triage_pool_sweep(dry_run=args.dry_run)
+    print(json.dumps(sweep_result, indent=2))
+
+    print("\nMigration complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sidecar_jobs/triage-pool-sweep.md
+++ b/sidecar_jobs/triage-pool-sweep.md
@@ -1,0 +1,34 @@
+---
+schedule: "5 4 * * *"  # daily at 04:05 — off-hours, no clash with 7 * * * * journal scan
+recurring: true
+type: capability
+capability: triage_pool_sweep
+params: {}
+---
+Daily liveness sweep over the triage pool (Slice 1).
+
+Walks every pending `PoolEntry`:
+
+- **TTL expiry**: entries past their `expires_at` (set at creation
+  from the source descriptor's TTL — journal 5d, chrome 2d, inline
+  null) transition `pending → stale`.
+- **Quarantine triggers**: each entry's source descriptor declares
+  trigger names (`source_removed`, `source_edited_beyond_match`,
+  `tag_removed`). The first one that fires sets the
+  `quarantine_reason` and transitions `pending → quarantined`.
+
+Quarantine takes precedence over stale (more specific signal — the
+source is GONE, not just old).
+
+Non-destructive: state changes only; every entry stays on disk for
+audit. The Review tab pulls only `state == "pending"` so stale and
+quarantined entries silently leave the active surface.
+
+Cadence (`schedule:` above) is a job-level concern — change it here
+without touching the capability. The capability itself has no
+opinion on how often it runs.
+
+Manual rehearsal:
+```
+mcp__work-buddy__wb_run("triage_pool_sweep", {"dry_run": true})
+```

--- a/tests/unit/test_consent_user_initiated.py
+++ b/tests/unit/test_consent_user_initiated.py
@@ -1,0 +1,199 @@
+"""Tests for the ``user_initiated`` consent context manager.
+
+The premise: UI clicks are themselves consent. ``@requires_consent``
+gates exist for autonomous agent actions, not for code paths the
+user explicitly invoked. ``user_initiated`` is the seam that lets
+endpoint handlers say "this came from a click — let nested gates
+pass through."
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from work_buddy import consent
+from work_buddy.consent import (
+    ConsentRequired,
+    Risk,
+    _cache,
+    in_consent_context,
+    requires_consent,
+    user_initiated,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_consent_cache():
+    """Each test starts with no granted consents."""
+    _cache._grants.clear() if hasattr(_cache, "_grants") else None
+    # Defensive — try a few possible internal-state shapes.
+    for attr in ("_grants", "_cache", "_data"):
+        store = getattr(_cache, attr, None)
+        if isinstance(store, dict):
+            store.clear()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Without user_initiated: gates fire as expected
+# ---------------------------------------------------------------------------
+
+
+def test_without_user_initiated_gate_blocks() -> None:
+    """Sanity: a moderate-risk @requires_consent function raises
+    ConsentRequired when called from a fresh context."""
+
+    @requires_consent(
+        operation="test.moderate_op",
+        risk="moderate",
+        reason="test",
+    )
+    def do_thing() -> str:
+        return "did it"
+
+    with pytest.raises(ConsentRequired):
+        do_thing()
+
+
+# ---------------------------------------------------------------------------
+# With user_initiated: gates pass through
+# ---------------------------------------------------------------------------
+
+
+def test_user_initiated_lets_moderate_op_pass() -> None:
+    """A moderate-risk op called inside ``user_initiated`` runs without
+    prompting."""
+
+    @requires_consent(
+        operation="test.moderate_op",
+        risk="moderate",
+        reason="test",
+    )
+    def do_thing() -> str:
+        return "did it"
+
+    with user_initiated("test.click"):
+        result = do_thing()
+    assert result == "did it"
+
+
+def test_user_initiated_lets_high_risk_op_pass() -> None:
+    """The pass-through is unconditional on the inner risk level —
+    the click is the consent for everything in the block."""
+
+    @requires_consent(
+        operation="test.high_op",
+        risk="high",
+        reason="test",
+    )
+    def do_thing() -> str:
+        return "high-risk action"
+
+    with user_initiated("test.click"):
+        result = do_thing()
+    assert result == "high-risk action"
+
+
+def test_in_consent_context_true_inside_user_initiated() -> None:
+    """``in_consent_context`` reflects the depth correctly."""
+    assert in_consent_context() is False
+    with user_initiated("test.click"):
+        assert in_consent_context() is True
+    assert in_consent_context() is False
+
+
+def test_user_initiated_restores_context_on_exception() -> None:
+    """Even if the block raises, the context must restore so the
+    next request starts clean."""
+
+    @requires_consent(
+        operation="test.moderate_op",
+        risk="moderate",
+        reason="test",
+    )
+    def do_thing() -> None:
+        raise RuntimeError("oops")
+
+    with pytest.raises(RuntimeError, match="oops"):
+        with user_initiated("test.click"):
+            do_thing()
+    assert in_consent_context() is False
+
+
+# ---------------------------------------------------------------------------
+# Reentrancy
+# ---------------------------------------------------------------------------
+
+
+def test_nested_user_initiated_blocks_compose() -> None:
+    """Nested user_initiated blocks each add a depth layer; the gate
+    passes through at any depth > 0."""
+
+    @requires_consent(
+        operation="test.moderate_op",
+        risk="moderate",
+        reason="test",
+    )
+    def do_thing() -> str:
+        return "ran"
+
+    with user_initiated("outer.click"):
+        with user_initiated("inner.click"):
+            result = do_thing()
+    assert result == "ran"
+    assert in_consent_context() is False
+
+
+# ---------------------------------------------------------------------------
+# Multiple operations cascade correctly
+# ---------------------------------------------------------------------------
+
+
+def test_two_inner_ops_both_covered_by_one_user_initiated() -> None:
+    """A single click can authorize a handler that performs multiple
+    consent-gated operations in sequence."""
+
+    @requires_consent(
+        operation="test.op_a",
+        risk="moderate",
+        reason="A",
+    )
+    def op_a() -> str:
+        return "A"
+
+    @requires_consent(
+        operation="test.op_b",
+        risk="high",
+        reason="B",
+    )
+    def op_b() -> str:
+        return "B"
+
+    with user_initiated("test.click"):
+        a = op_a()
+        b = op_b()
+    assert a == "A" and b == "B"
+
+
+# ---------------------------------------------------------------------------
+# Outside the context, unaffected operations are unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_after_block_gate_blocks_again() -> None:
+    """Leaving the block restores the gating behavior — the context
+    is scoped to the block, not 'always allowed' afterward."""
+
+    @requires_consent(
+        operation="test.moderate_op",
+        risk="moderate",
+        reason="test",
+    )
+    def do_thing() -> str:
+        return "ran"
+
+    with user_initiated("test.click"):
+        do_thing()  # passes
+
+    with pytest.raises(ConsentRequired):
+        do_thing()  # blocks again

--- a/tests/unit/test_review_execute_partial_submit.py
+++ b/tests/unit/test_review_execute_partial_submit.py
@@ -15,7 +15,11 @@ the full Flask app.
 from __future__ import annotations
 
 
-def _filter_keys(presentation: dict, decisions: dict) -> list[tuple[str, str]]:
+def _filter_keys(
+    presentation: dict,
+    decisions: dict,
+    executed: dict | None = None,
+) -> list[tuple[str, str]]:
     """Inline copy of the fixed filter logic so the test is hermetic.
 
     Mirrors the production logic in ``api_review_execute``; if the
@@ -27,6 +31,21 @@ def _filter_keys(presentation: dict, decisions: dict) -> list[tuple[str, str]]:
         if isinstance(idx, int):
             decided_indices.add(idx)
 
+    # Collect item_ids of successful ops from the executor result.
+    # When ``executed`` is omitted, treat all decided items as
+    # succeeded (legacy callers without success-tracking).
+    succeeded_item_ids: set[str] | None = None
+    if executed is not None:
+        succeeded_item_ids = set()
+        details = (executed or {}).get("details", {}) or {}
+        for bucket_name in (
+            "closed", "tasks_created", "tasks_recorded", "grouped", "left",
+        ):
+            for entry in details.get(bucket_name, []) or []:
+                for iid in entry.get("item_ids", []) or []:
+                    if iid:
+                        succeeded_item_ids.add(iid)
+
     keys: list[tuple[str, str]] = []
     for action_groups in presentation.get("groups_by_action", {}).values():
         for group in action_groups:
@@ -37,8 +56,14 @@ def _filter_keys(presentation: dict, decisions: dict) -> list[tuple[str, str]]:
                 continue
             for item in group.get("items", []) or []:
                 iid = item.get("id")
-                if iid:
-                    keys.append((run_id, iid))
+                if not iid:
+                    continue
+                if (
+                    succeeded_item_ids is not None
+                    and iid not in succeeded_item_ids
+                ):
+                    continue
+                keys.append((run_id, iid))
     return keys
 
 
@@ -191,3 +216,87 @@ def test_group_with_multiple_items() -> None:
     decisions = {"group_decisions": [{"group_index": 0, "action": "leave"}]}
     keys = _filter_keys(pres, decisions)
     assert sorted(keys) == [("bgt_TEST", "a"), ("bgt_TEST", "b"), ("bgt_TEST", "c")]
+
+
+# ---------------------------------------------------------------------------
+# Success-only filter (the second-fix gap)
+# ---------------------------------------------------------------------------
+
+
+def test_failed_op_does_not_mark_reviewed() -> None:
+    """When the executor reports a failure for an item, that item must
+    NOT be marked reviewed — it stays pending so the user can retry.
+
+    This is the bug that caused the user's "This is a test task!"
+    submit to silently disappear: the bridge timed out writing the
+    note, create_task raised ObsidianPostWriteUncertain, the executor
+    caught it into errors[]; but the dashboard still stamped the
+    entry reviewed because it didn't check success.
+    """
+    pres = _make_presentation(2)
+    decisions = {
+        "group_decisions": [
+            {"group_index": 0, "action": "create_task"},
+            {"group_index": 1, "action": "leave"},
+        ],
+    }
+    # Executor result: group 0's create_task failed (not in any
+    # success bucket; only in errors). Group 1's leave succeeded.
+    executed = {
+        "details": {
+            "left": [{"item_ids": ["j_001"]}],
+            "tasks_created": [],  # failed, no entry here
+            "errors": [
+                {"action": "create_task", "task_text": "...", "error": "bridge timed out"},
+            ],
+        }
+    }
+    keys = _filter_keys(pres, decisions, executed=executed)
+    # j_000 (the failed create_task) should NOT be stamped.
+    # j_001 (the successful leave) should be stamped.
+    assert keys == [("bgt_TEST", "j_001")]
+
+
+def test_successful_create_task_marks_reviewed() -> None:
+    """Sanity: when create_task succeeds, the item IS stamped reviewed."""
+    pres = _make_presentation(1)
+    decisions = {
+        "group_decisions": [{"group_index": 0, "action": "create_task"}],
+    }
+    executed = {
+        "details": {
+            "tasks_created": [
+                {"item_ids": ["j_000"], "task_id": "t-NEW", "task_text": "..."},
+            ],
+            "errors": [],
+        }
+    }
+    keys = _filter_keys(pres, decisions, executed=executed)
+    assert keys == [("bgt_TEST", "j_000")]
+
+
+def test_partial_success_only_marks_succeeded_items() -> None:
+    """A submit covering 3 cards: 2 succeed, 1 fails. Only the 2
+    successes get marked reviewed."""
+    pres = _make_presentation(3)
+    decisions = {
+        "group_decisions": [
+            {"group_index": 0, "action": "leave"},
+            {"group_index": 1, "action": "create_task"},
+            {"group_index": 2, "action": "leave"},
+        ],
+    }
+    executed = {
+        "details": {
+            "left": [
+                {"item_ids": ["j_000"]},
+                {"item_ids": ["j_002"]},
+            ],
+            "tasks_created": [],  # group 1's create_task failed
+            "errors": [
+                {"action": "create_task", "error": "consent denied"},
+            ],
+        }
+    }
+    keys = _filter_keys(pres, decisions, executed=executed)
+    assert sorted(keys) == [("bgt_TEST", "j_000"), ("bgt_TEST", "j_002")]

--- a/tests/unit/test_review_execute_partial_submit.py
+++ b/tests/unit/test_review_execute_partial_submit.py
@@ -1,0 +1,193 @@
+"""Slice 1 bug fix: api_review_execute should only mark reviewed the
+entries whose groups had decisions submitted — not the entire pool.
+
+Prior behavior walked all groups in the presentation and stamped every
+entry, so submitting one card via the per-group-submit frontend
+(``perGroupSubmit: true`` in script_review.py) caused every other card
+to silently disappear from the Review tab. Bug surfaced when raw
+entries (Slice 1's verdict-pass-off mode) all clustered in the
+``leave`` bucket, making the data-loss obvious.
+
+This test exercises the filter logic in isolation without booting
+the full Flask app.
+"""
+
+from __future__ import annotations
+
+
+def _filter_keys(presentation: dict, decisions: dict) -> list[tuple[str, str]]:
+    """Inline copy of the fixed filter logic so the test is hermetic.
+
+    Mirrors the production logic in ``api_review_execute``; if the
+    production logic changes shape, this test will need to follow.
+    """
+    decided_indices: set[int] = set()
+    for gd in (decisions.get("group_decisions") or []):
+        idx = gd.get("group_index")
+        if isinstance(idx, int):
+            decided_indices.add(idx)
+
+    keys: list[tuple[str, str]] = []
+    for action_groups in presentation.get("groups_by_action", {}).values():
+        for group in action_groups:
+            if group.get("index") not in decided_indices:
+                continue
+            run_id = group.get("pool_run_id")
+            if not run_id:
+                continue
+            for item in group.get("items", []) or []:
+                iid = item.get("id")
+                if iid:
+                    keys.append((run_id, iid))
+    return keys
+
+
+def _make_presentation(n_groups: int = 6) -> dict:
+    """A presentation with N groups, all bucketed under 'leave'
+    (the raw-entry case)."""
+    return {
+        "groups_by_action": {
+            "leave": [
+                {
+                    "index": i,
+                    "pool_run_id": "bgt_TEST",
+                    "items": [{"id": f"j_00{i}"}],
+                }
+                for i in range(n_groups)
+            ],
+            "create_task": [],
+            "close": [],
+            "group": [],
+            "record_into_task": [],
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_one_decision_marks_one_entry() -> None:
+    """User submits decision on group 2 only — only entry j_002 stamped."""
+    pres = _make_presentation(6)
+    decisions = {
+        "group_decisions": [{"group_index": 2, "action": "leave"}],
+    }
+    keys = _filter_keys(pres, decisions)
+    assert keys == [("bgt_TEST", "j_002")]
+
+
+def test_zero_decisions_marks_nothing() -> None:
+    """No decisions submitted — no entries should be stamped."""
+    pres = _make_presentation(6)
+    decisions = {"group_decisions": []}
+    keys = _filter_keys(pres, decisions)
+    assert keys == []
+
+
+def test_three_decisions_marks_three_entries() -> None:
+    pres = _make_presentation(6)
+    decisions = {
+        "group_decisions": [
+            {"group_index": 0, "action": "leave"},
+            {"group_index": 3, "action": "create_task"},
+            {"group_index": 5, "action": "close"},
+        ],
+    }
+    keys = _filter_keys(pres, decisions)
+    assert sorted(keys) == [
+        ("bgt_TEST", "j_000"),
+        ("bgt_TEST", "j_003"),
+        ("bgt_TEST", "j_005"),
+    ]
+
+
+def test_decision_for_nonexistent_group_is_safely_ignored() -> None:
+    """Decision references a group_index that's not in the presentation."""
+    pres = _make_presentation(3)
+    decisions = {"group_decisions": [{"group_index": 99, "action": "leave"}]}
+    keys = _filter_keys(pres, decisions)
+    assert keys == []
+
+
+def test_decision_with_non_int_index_is_skipped() -> None:
+    """Defensive: malformed payload with a string index doesn't blow up."""
+    pres = _make_presentation(3)
+    decisions = {
+        "group_decisions": [
+            {"group_index": "not-an-int", "action": "leave"},
+            {"group_index": 1, "action": "leave"},
+        ],
+    }
+    keys = _filter_keys(pres, decisions)
+    assert keys == [("bgt_TEST", "j_001")]
+
+
+def test_groups_in_different_action_buckets() -> None:
+    """A presentation with verdicted entries spread across action buckets."""
+    pres = {
+        "groups_by_action": {
+            "leave": [
+                {"index": 0, "pool_run_id": "bgt_TEST", "items": [{"id": "j_000"}]},
+            ],
+            "create_task": [
+                {"index": 1, "pool_run_id": "bgt_TEST", "items": [{"id": "j_001"}]},
+            ],
+            "close": [
+                {"index": 2, "pool_run_id": "bgt_TEST", "items": [{"id": "j_002"}]},
+            ],
+            "record_into_task": [],
+            "group": [],
+        }
+    }
+    decisions = {
+        "group_decisions": [
+            {"group_index": 0, "action": "leave"},
+            {"group_index": 2, "action": "close"},
+        ],
+    }
+    keys = _filter_keys(pres, decisions)
+    # Only groups 0 and 2 stamped, regardless of which bucket they're in.
+    assert sorted(keys) == [
+        ("bgt_TEST", "j_000"),
+        ("bgt_TEST", "j_002"),
+    ]
+
+
+def test_group_without_pool_run_id_skipped() -> None:
+    """Defensive: a group missing pool_run_id can't be stamped."""
+    pres = {
+        "groups_by_action": {
+            "leave": [
+                {"index": 0, "items": [{"id": "j_000"}]},  # no pool_run_id
+                {"index": 1, "pool_run_id": "bgt_TEST", "items": [{"id": "j_001"}]},
+            ]
+        }
+    }
+    decisions = {
+        "group_decisions": [
+            {"group_index": 0, "action": "leave"},
+            {"group_index": 1, "action": "leave"},
+        ],
+    }
+    keys = _filter_keys(pres, decisions)
+    assert keys == [("bgt_TEST", "j_001")]
+
+
+def test_group_with_multiple_items() -> None:
+    """If a group has multiple items, all of them get stamped together."""
+    pres = {
+        "groups_by_action": {
+            "leave": [
+                {
+                    "index": 0,
+                    "pool_run_id": "bgt_TEST",
+                    "items": [{"id": "a"}, {"id": "b"}, {"id": "c"}],
+                },
+            ]
+        }
+    }
+    decisions = {"group_decisions": [{"group_index": 0, "action": "leave"}]}
+    keys = _filter_keys(pres, decisions)
+    assert sorted(keys) == [("bgt_TEST", "a"), ("bgt_TEST", "b"), ("bgt_TEST", "c")]

--- a/tests/unit/test_review_execute_partial_submit.py
+++ b/tests/unit/test_review_execute_partial_submit.py
@@ -39,12 +39,16 @@ def _filter_keys(
         succeeded_item_ids = set()
         details = (executed or {}).get("details", {}) or {}
         for bucket_name in (
-            "closed", "tasks_created", "tasks_recorded", "grouped", "left",
+            "tasks_created", "tasks_recorded", "grouped",
+            "closed", "left",
         ):
             for entry in details.get(bucket_name, []) or []:
                 for iid in entry.get("item_ids", []) or []:
                     if iid:
                         succeeded_item_ids.add(iid)
+                single = entry.get("item_id")
+                if single:
+                    succeeded_item_ids.add(single)
 
     keys: list[tuple[str, str]] = []
     for action_groups in presentation.get("groups_by_action", {}).values():
@@ -273,6 +277,59 @@ def test_successful_create_task_marks_reviewed() -> None:
     }
     keys = _filter_keys(pres, decisions, executed=executed)
     assert keys == [("bgt_TEST", "j_000")]
+
+
+def test_leave_action_marks_reviewed_singular_item_id() -> None:
+    """The 'leave' bucket uses singular ``item_id`` (not ``item_ids``).
+    The success-filter must accept that form, otherwise every Leave-As-Is
+    submit would silently fail to mark the entry reviewed."""
+    pres = _make_presentation(1)
+    decisions = {"group_decisions": [{"group_index": 0, "action": "leave"}]}
+    executed = {
+        "details": {
+            "left": [
+                {"item_id": "j_000", "label": "..."},  # singular form!
+            ],
+            "errors": [],
+        }
+    }
+    keys = _filter_keys(pres, decisions, executed=executed)
+    assert keys == [("bgt_TEST", "j_000")]
+
+
+def test_close_action_marks_reviewed_singular_item_id() -> None:
+    """The 'closed' bucket also uses singular ``item_id`` (Chrome path)."""
+    pres = _make_presentation(1)
+    decisions = {"group_decisions": [{"group_index": 0, "action": "close"}]}
+    executed = {
+        "details": {
+            "closed": [
+                {"item_id": "j_000", "tab_id": 42, "label": "..."},
+            ],
+            "errors": [],
+        }
+    }
+    keys = _filter_keys(pres, decisions, executed=executed)
+    assert keys == [("bgt_TEST", "j_000")]
+
+
+def test_skipped_stale_does_not_mark_reviewed() -> None:
+    """``skipped_stale`` is intentionally excluded — the user should
+    have a chance to re-decide stale entries instead of having them
+    silently disappear."""
+    pres = _make_presentation(1)
+    decisions = {"group_decisions": [{"group_index": 0, "action": "close"}]}
+    executed = {
+        "details": {
+            "closed": [],
+            "skipped_stale": [
+                {"item_id": "j_000", "tab_id": 42, "reason": "URL changed"},
+            ],
+            "errors": [],
+        }
+    }
+    keys = _filter_keys(pres, decisions, executed=executed)
+    assert keys == []
 
 
 def test_partial_success_only_marks_succeeded_items() -> None:

--- a/tests/unit/test_triage_pool_state.py
+++ b/tests/unit/test_triage_pool_state.py
@@ -1,0 +1,338 @@
+"""Slice 1 schema additions to PoolEntry / TriagePool: state, expires_at,
+quarantine_reason, sweep helpers, raw submit, hardened normalization."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from work_buddy.triage import background as bg
+from work_buddy.triage import sources
+from work_buddy.triage.background import (
+    POOL_ENTRY_STATES,
+    PoolEntry,
+    STATE_PENDING,
+    STATE_QUARANTINED,
+    STATE_REVIEWED,
+    STATE_STALE,
+    TriagePool,
+    item_content_hash,
+)
+from work_buddy.triage.items import TriageItem
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_pool(tmp_path: Path, monkeypatch) -> TriagePool:
+    pool = TriagePool(pool_dir=tmp_path / "triage_pool")
+    bg.set_pool_for_tests(pool)
+    monkeypatch.setattr(
+        "work_buddy.artifacts.save",
+        lambda *a, **kw: type("R", (), {"id": "stub"})(),
+    )
+    # Stub vault_root so source-descriptor TTL lookups don't blow up.
+    monkeypatch.setattr(
+        "work_buddy.config.load_config",
+        lambda: {"vault_root": str(tmp_path / "vault")},
+    )
+    sources.reset_for_tests()
+    yield pool
+    bg.set_pool_for_tests(None)
+    sources.reset_for_tests()
+
+
+def _item(i: int = 0, text: str = "hello", source: str = "journal_thread") -> TriageItem:
+    return TriageItem(
+        id=f"j_{i:06x}",
+        text=text,
+        label=text[:20],
+        source=source,
+        metadata={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# PoolEntry: state field + backwards-compat
+# ---------------------------------------------------------------------------
+
+
+def test_new_entry_defaults_to_pending(isolated_pool: TriagePool) -> None:
+    items = [_item(1)]
+    isolated_pool.register_run(
+        run_id="r1", adapter="a", source="journal_thread", items=items,
+    )
+    isolated_pool.submit(
+        run_id="r1", item_id=items[0].id,
+        verdict={"recommended_action": "leave", "rationale": "x"},
+    )
+    pe = isolated_pool.pending()[0]
+    assert pe.state == STATE_PENDING
+    assert pe.state_changed_at is not None
+    assert pe.quarantine_reason is None
+
+
+def test_legacy_entry_without_state_inferred_from_reviewed_at() -> None:
+    """Pre-Slice-1 entries had no ``state``; from_dict must infer."""
+    raw_pending = {
+        "run_id": "old1", "adapter": "a", "source": "journal_thread",
+        "item_id": "x", "item": {}, "verdict": {}, "created_at": "...",
+        # No "state" key, no "reviewed_at" key.
+    }
+    pe = PoolEntry.from_dict(raw_pending)
+    assert pe.state == STATE_PENDING
+
+    raw_reviewed = {
+        **raw_pending,
+        "reviewed_at": "2026-04-01T00:00:00+00:00",
+        "review_outcome": "approved",
+    }
+    pe2 = PoolEntry.from_dict(raw_reviewed)
+    assert pe2.state == STATE_REVIEWED
+
+
+def test_known_states_set_complete() -> None:
+    """All five lifecycle states present in POOL_ENTRY_STATES."""
+    assert POOL_ENTRY_STATES == {
+        "pending", "stale", "quarantined", "reviewed", "dropped",
+    }
+
+
+# ---------------------------------------------------------------------------
+# expires_at from source descriptor
+# ---------------------------------------------------------------------------
+
+
+def test_journal_entry_gets_5d_expires_at(isolated_pool: TriagePool) -> None:
+    items = [_item(2)]
+    isolated_pool.register_run(
+        run_id="r2", adapter="a", source="journal_thread", items=items,
+    )
+    isolated_pool.submit(
+        run_id="r2", item_id=items[0].id,
+        verdict={"recommended_action": "leave", "rationale": "x"},
+    )
+    pe = isolated_pool.pending()[0]
+    assert pe.expires_at is not None
+    created = datetime.fromisoformat(pe.created_at)
+    expires = datetime.fromisoformat(pe.expires_at)
+    assert (expires - created) == timedelta(days=5)
+
+
+def test_inline_entry_has_no_expires_at(isolated_pool: TriagePool) -> None:
+    """Inline TTL is null per Slice 1 — no auto-expiry."""
+    items = [_item(3, source="inline")]
+    isolated_pool.register_run(
+        run_id="r3", adapter="a", source="inline", items=items,
+    )
+    isolated_pool.submit(
+        run_id="r3", item_id=items[0].id,
+        verdict={"recommended_action": "leave", "rationale": "x"},
+    )
+    pe = isolated_pool.pending()[0]
+    assert pe.expires_at is None
+
+
+def test_unknown_source_has_no_expires_at(isolated_pool: TriagePool) -> None:
+    """Unknown sources skip TTL — no descriptor, no expiry."""
+    items = [_item(4, source="frobnitz")]
+    isolated_pool.register_run(
+        run_id="r4", adapter="a", source="frobnitz", items=items,
+    )
+    isolated_pool.submit(
+        run_id="r4", item_id=items[0].id,
+        verdict={"recommended_action": "leave", "rationale": "x"},
+    )
+    pe = isolated_pool.pending()[0]
+    assert pe.expires_at is None
+
+
+# ---------------------------------------------------------------------------
+# Sweep helpers: pending_count, mark_state, quarantine, mark_stale
+# ---------------------------------------------------------------------------
+
+
+def test_pending_count_matches_pending(isolated_pool: TriagePool) -> None:
+    items = [_item(i) for i in range(5)]
+    isolated_pool.register_run(
+        run_id="rc", adapter="a", source="journal_thread", items=items,
+    )
+    for it in items:
+        isolated_pool.submit(
+            run_id="rc", item_id=it.id,
+            verdict={"recommended_action": "leave", "rationale": "x"},
+        )
+    assert isolated_pool.pending_count() == 5
+    assert isolated_pool.pending_count() == len(isolated_pool.pending())
+
+
+def test_quarantine_transitions_state_with_reason(isolated_pool: TriagePool) -> None:
+    items = [_item(10)]
+    isolated_pool.register_run(
+        run_id="rq", adapter="a", source="journal_thread", items=items,
+    )
+    isolated_pool.submit(
+        run_id="rq", item_id=items[0].id,
+        verdict={"recommended_action": "leave", "rationale": "x"},
+    )
+    n = isolated_pool.quarantine(
+        [("rq", items[0].id)], reason="source_removed",
+    )
+    assert n == 1
+    assert isolated_pool.pending_count() == 0
+    quarantined = isolated_pool.entries_in_state(STATE_QUARANTINED)
+    assert len(quarantined) == 1
+    assert quarantined[0].quarantine_reason == "source_removed"
+
+
+def test_mark_stale_transitions_state(isolated_pool: TriagePool) -> None:
+    items = [_item(11)]
+    isolated_pool.register_run(
+        run_id="rs", adapter="a", source="journal_thread", items=items,
+    )
+    isolated_pool.submit(
+        run_id="rs", item_id=items[0].id,
+        verdict={"recommended_action": "leave", "rationale": "x"},
+    )
+    n = isolated_pool.mark_stale([("rs", items[0].id)])
+    assert n == 1
+    assert isolated_pool.pending_count() == 0
+    assert len(isolated_pool.entries_in_state(STATE_STALE)) == 1
+
+
+def test_mark_state_no_double_stamp(isolated_pool: TriagePool) -> None:
+    """Idempotent — calling twice doesn't re-stamp state_changed_at."""
+    items = [_item(12)]
+    isolated_pool.register_run(
+        run_id="rd", adapter="a", source="journal_thread", items=items,
+    )
+    isolated_pool.submit(
+        run_id="rd", item_id=items[0].id,
+        verdict={"recommended_action": "leave", "rationale": "x"},
+    )
+    isolated_pool.quarantine(
+        [("rd", items[0].id)], reason="source_removed",
+    )
+    second = isolated_pool.quarantine(
+        [("rd", items[0].id)], reason="source_removed",
+    )
+    assert second == 0
+
+
+def test_mark_state_rejects_reviewed():
+    """mark_state refuses 'reviewed' — that path goes through mark_reviewed."""
+    pool = TriagePool()
+    with pytest.raises(ValueError, match="mark_reviewed"):
+        pool.mark_state([("a", "b")], state=STATE_REVIEWED)
+
+
+def test_entries_in_state_validates(isolated_pool: TriagePool) -> None:
+    with pytest.raises(ValueError, match="Unknown state"):
+        isolated_pool.entries_in_state("totally-fake")
+
+
+def test_mark_reviewed_also_sets_state(isolated_pool: TriagePool) -> None:
+    items = [_item(13)]
+    isolated_pool.register_run(
+        run_id="rr", adapter="a", source="journal_thread", items=items,
+    )
+    isolated_pool.submit(
+        run_id="rr", item_id=items[0].id,
+        verdict={"recommended_action": "leave", "rationale": "x"},
+    )
+    isolated_pool.mark_reviewed([("rr", items[0].id)], outcome="approved")
+    reviewed = isolated_pool.entries_in_state(STATE_REVIEWED)
+    assert len(reviewed) == 1
+    assert reviewed[0].review_outcome == "approved"
+    assert reviewed[0].state_changed_at is not None
+
+
+# ---------------------------------------------------------------------------
+# submit_raw (verdict-pass-disabled path)
+# ---------------------------------------------------------------------------
+
+
+def test_submit_raw_writes_raw_verdict(isolated_pool: TriagePool) -> None:
+    items = [_item(20)]
+    isolated_pool.register_run(
+        run_id="raw", adapter="a", source="journal_thread", items=items,
+    )
+    r = isolated_pool.submit_raw(run_id="raw", item_id=items[0].id)
+    assert r["status"] == "ok"
+    assert r["raw"] is True
+    pe = isolated_pool.pending()[0]
+    assert pe.verdict == {"raw": True}
+    assert pe.state == STATE_PENDING
+
+
+def test_submit_raw_rejects_unknown_run(isolated_pool: TriagePool) -> None:
+    r = isolated_pool.submit_raw(run_id="ghost", item_id="nope")
+    assert r["status"] == "error"
+    assert "Unknown run_id" in r["error"]
+
+
+def test_submit_raw_rejects_duplicate(isolated_pool: TriagePool) -> None:
+    items = [_item(21)]
+    isolated_pool.register_run(
+        run_id="rdup", adapter="a", source="journal_thread", items=items,
+    )
+    assert isolated_pool.submit_raw(
+        run_id="rdup", item_id=items[0].id,
+    )["status"] == "ok"
+    second = isolated_pool.submit_raw(
+        run_id="rdup", item_id=items[0].id,
+    )
+    assert second["status"] == "error"
+    assert "Duplicate" in second["error"]
+
+
+# ---------------------------------------------------------------------------
+# Hardened item_content_hash normalization
+# ---------------------------------------------------------------------------
+
+
+def test_hash_normalizes_unicode_forms() -> None:
+    """NFKC: precomposed and decomposed accents hash the same."""
+    a = item_content_hash("s", "café")          # precomposed é
+    b = item_content_hash("s", "café")    # combining é
+    assert a == b
+
+
+def test_hash_normalizes_case() -> None:
+    a = item_content_hash("s", "Hello World")
+    b = item_content_hash("s", "hello world")
+    assert a == b
+
+
+def test_hash_strips_leading_markdown_bullets() -> None:
+    """- foo, * foo, + foo, 1. foo, > foo all reduce to the same hash."""
+    plain = item_content_hash("s", "buy milk")
+    assert item_content_hash("s", "- buy milk") == plain
+    assert item_content_hash("s", "* buy milk") == plain
+    assert item_content_hash("s", "+ buy milk") == plain
+    assert item_content_hash("s", "1. buy milk") == plain
+    assert item_content_hash("s", "  - buy milk") == plain
+
+
+def test_hash_collapses_whitespace() -> None:
+    a = item_content_hash("s", "alpha   beta\n\ngamma")
+    b = item_content_hash("s", "alpha beta gamma")
+    assert a == b
+
+
+def test_hash_scopes_by_source() -> None:
+    a = item_content_hash("journal_thread", "same text")
+    b = item_content_hash("inline", "same text")
+    assert a != b
+
+
+def test_hash_empty_text_stable() -> None:
+    """Empty text doesn't crash; hashes deterministically."""
+    a = item_content_hash("s", "")
+    b = item_content_hash("s", None)  # type: ignore[arg-type]
+    assert a == b

--- a/tests/unit/test_triage_pool_sweep.py
+++ b/tests/unit/test_triage_pool_sweep.py
@@ -1,0 +1,329 @@
+"""Unit tests for triage_pool_sweep capability (Slice 1)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from work_buddy.triage import background as bg
+from work_buddy.triage import sources
+from work_buddy.triage.background import (
+    STATE_PENDING,
+    STATE_QUARANTINED,
+    STATE_STALE,
+    TriagePool,
+)
+from work_buddy.triage.capabilities.triage_pool_sweep import triage_pool_sweep
+from work_buddy.triage.items import TriageItem
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    root = tmp_path / "vault"
+    (root / "journal").mkdir(parents=True, exist_ok=True)
+    return root
+
+
+@pytest.fixture
+def isolated_pool(tmp_path: Path, vault: Path, monkeypatch) -> TriagePool:
+    pool = TriagePool(pool_dir=tmp_path / "triage_pool")
+    bg.set_pool_for_tests(pool)
+    monkeypatch.setattr(
+        "work_buddy.artifacts.save",
+        lambda *a, **kw: type("R", (), {"id": "stub"})(),
+    )
+    monkeypatch.setattr(
+        "work_buddy.config.load_config",
+        lambda: {
+            "vault_root": str(vault),
+            "obsidian": {"journal_dir": "journal"},
+        },
+    )
+    sources.reset_for_tests()
+    yield pool
+    bg.set_pool_for_tests(None)
+    sources.reset_for_tests()
+
+
+def _add_pending(
+    pool: TriagePool,
+    *,
+    run_id: str,
+    item_id: str,
+    source: str,
+    text: str = "x",
+    metadata: dict | None = None,
+) -> None:
+    """Register a one-item run, submit_raw the entry. Returns nothing —
+    the entry is now pending in the pool."""
+    item = TriageItem(
+        id=item_id, text=text, label=text[:20],
+        source=source, metadata=metadata or {},
+    )
+    pool.register_run(
+        run_id=run_id, adapter=source, source=source, items=[item],
+    )
+    pool.submit_raw(run_id=run_id, item_id=item_id)
+
+
+def _force_expires_at(pool: TriagePool, when: datetime) -> None:
+    """Mutate every entry's expires_at to ``when`` (test helper)."""
+    import json
+    raw = json.loads(pool._index_path.read_text(encoding="utf-8"))
+    for e in raw["entries"]:
+        e["expires_at"] = when.isoformat()
+    pool._index_path.write_text(json.dumps(raw, indent=2), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# TTL transitions
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_marks_expired_pending_as_stale(isolated_pool: TriagePool) -> None:
+    """An entry past its expires_at transitions pending → stale."""
+    _add_pending(
+        isolated_pool, run_id="ttl1", item_id="i1",
+        source="journal_thread",
+        # journal source doesn't matter much here — we override expires_at
+        # below to force expiry, and the journal file isn't on disk so
+        # source_removed would fire. Override the source's triggers
+        # to test TTL in isolation.
+        metadata={"source_dates": []},  # no dates → source_removed no-ops
+    )
+    yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+    _force_expires_at(isolated_pool, yesterday)
+
+    result = triage_pool_sweep()
+    assert result["status"] == "ok"
+    assert result["stale_marked"] == 1
+    assert result["quarantined"] == 0
+    assert isolated_pool.pending_count() == 0
+    assert len(isolated_pool.entries_in_state(STATE_STALE)) == 1
+
+
+def test_sweep_skips_unexpired(isolated_pool: TriagePool) -> None:
+    _add_pending(
+        isolated_pool, run_id="ttl2", item_id="i2",
+        source="journal_thread", metadata={"source_dates": []},
+    )
+    # Default journal TTL is 5 days; freshly created → not expired.
+    result = triage_pool_sweep()
+    assert result["stale_marked"] == 0
+    assert isolated_pool.pending_count() == 1
+
+
+def test_sweep_inline_no_ttl_never_stales(isolated_pool: TriagePool) -> None:
+    """Inline TTL=null. Even if we forge expires_at, inline never gets one
+    set on creation — submit_raw will leave expires_at=None for inline.
+    Sweep should leave it alone."""
+    _add_pending(
+        isolated_pool, run_id="ttl3", item_id="i3",
+        source="inline",
+        metadata={"file_path": "/tmp/does-not-resolve.md"},
+    )
+    pe = isolated_pool.pending()[0]
+    assert pe.expires_at is None  # inline has no TTL
+    # Sweep should NOT stale this (no expires_at to compare). It MAY
+    # quarantine via source_removed if the file isn't there — that's
+    # tested separately. For this test, point file_path at something
+    # that exists so source_removed doesn't fire.
+    pass  # covered by other tests; this one just confirms expires_at=None
+
+
+# ---------------------------------------------------------------------------
+# Quarantine via source_removed
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_quarantines_inline_with_missing_file(
+    isolated_pool: TriagePool, vault: Path,
+) -> None:
+    """An inline entry whose file_path doesn't exist → quarantined."""
+    _add_pending(
+        isolated_pool, run_id="q1", item_id="i_inline_gone",
+        source="inline",
+        metadata={"file_path": "ghost/nope.md"},
+    )
+    result = triage_pool_sweep()
+    assert result["quarantined"] == 1
+    quarantined = isolated_pool.entries_in_state(STATE_QUARANTINED)
+    assert quarantined[0].quarantine_reason == "source_removed"
+
+
+def test_sweep_leaves_inline_with_existing_file(
+    isolated_pool: TriagePool, vault: Path,
+) -> None:
+    """An inline entry whose file_path exists → still pending."""
+    target = vault / "real.md"
+    target.write_text("hi", encoding="utf-8")
+    _add_pending(
+        isolated_pool, run_id="q2", item_id="i_inline_alive",
+        source="inline",
+        metadata={"file_path": "real.md"},
+    )
+    result = triage_pool_sweep()
+    assert result["quarantined"] == 0
+    assert isolated_pool.pending_count() == 1
+
+
+def test_sweep_quarantines_journal_with_missing_date(
+    isolated_pool: TriagePool, vault: Path,
+) -> None:
+    """A journal entry whose source_dates file is gone → quarantined."""
+    _add_pending(
+        isolated_pool, run_id="q3", item_id="j_gone",
+        source="journal_thread", text="some thread",
+        metadata={"source_dates": ["2020-01-01"]},  # no journal file
+    )
+    result = triage_pool_sweep()
+    assert result["quarantined"] == 1
+    q = isolated_pool.entries_in_state(STATE_QUARANTINED)
+    assert q[0].quarantine_reason == "source_removed"
+
+
+def test_sweep_leaves_journal_with_existing_date(
+    isolated_pool: TriagePool, vault: Path,
+) -> None:
+    journal_md = vault / "journal" / "2026-04-25.md"
+    journal_md.write_text("some thread content here", encoding="utf-8")
+    _add_pending(
+        isolated_pool, run_id="q4", item_id="j_alive",
+        source="journal_thread", text="some thread content here",
+        metadata={"source_dates": ["2026-04-25"]},
+    )
+    result = triage_pool_sweep()
+    # Source exists AND text is contained → no quarantine.
+    assert result["quarantined"] == 0
+    assert isolated_pool.pending_count() == 1
+
+
+# ---------------------------------------------------------------------------
+# source_edited_beyond_match
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_quarantines_journal_when_text_drifted(
+    isolated_pool: TriagePool, vault: Path,
+) -> None:
+    """If the journal still exists but no longer contains the text
+    (cosine ratio < 0.85) → quarantined."""
+    journal_md = vault / "journal" / "2026-04-25.md"
+    journal_md.write_text(
+        "completely different content with no overlap",
+        encoding="utf-8",
+    )
+    _add_pending(
+        isolated_pool, run_id="q5", item_id="j_drifted",
+        source="journal_thread", text="original ETF tracking thread",
+        metadata={"source_dates": ["2026-04-25"]},
+    )
+    result = triage_pool_sweep()
+    assert result["quarantined"] == 1
+    q = isolated_pool.entries_in_state(STATE_QUARANTINED)
+    assert q[0].quarantine_reason == "source_edited_beyond_match"
+
+
+# ---------------------------------------------------------------------------
+# dry_run + filtering + cap
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_dry_run_does_not_mutate(
+    isolated_pool: TriagePool, vault: Path,
+) -> None:
+    _add_pending(
+        isolated_pool, run_id="dry1", item_id="i_dry",
+        source="inline", metadata={"file_path": "ghost/nope.md"},
+    )
+    result = triage_pool_sweep(dry_run=True)
+    assert result["dry_run"] is True
+    assert result["quarantined"] == 1  # would-be transitions
+    assert isolated_pool.pending_count() == 1  # but no actual writes
+    assert len(isolated_pool.entries_in_state(STATE_QUARANTINED)) == 0
+
+
+def test_sweep_source_filter_isolates(
+    isolated_pool: TriagePool, vault: Path,
+) -> None:
+    _add_pending(
+        isolated_pool, run_id="f1", item_id="i_inline_gone",
+        source="inline", metadata={"file_path": "ghost/nope.md"},
+    )
+    _add_pending(
+        isolated_pool, run_id="f2", item_id="j_gone",
+        source="journal_thread", metadata={"source_dates": ["2020-01-01"]},
+    )
+    # source filter limits inspection to inline only
+    result = triage_pool_sweep(source="inline")
+    assert result["checked"] == 1
+    assert result["quarantined"] == 1
+    # Journal entry untouched
+    assert isolated_pool.pending_count() == 1
+
+
+def test_sweep_max_entries_caps_inspection(
+    isolated_pool: TriagePool, vault: Path,
+) -> None:
+    for i in range(5):
+        _add_pending(
+            isolated_pool, run_id=f"m{i}", item_id=f"i_m{i}",
+            source="inline",
+            metadata={"file_path": f"ghost/nope{i}.md"},
+        )
+    result = triage_pool_sweep(max_entries=2)
+    assert result["checked"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Quarantine wins over stale
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_quarantine_wins_over_stale(
+    isolated_pool: TriagePool, vault: Path,
+) -> None:
+    """Entry both expired and source-gone — quarantine takes precedence
+    (more specific signal — the source is GONE, not just old)."""
+    _add_pending(
+        isolated_pool, run_id="qs", item_id="i_qs",
+        source="inline", metadata={"file_path": "ghost/nope.md"},
+    )
+    yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+    _force_expires_at(isolated_pool, yesterday)
+    result = triage_pool_sweep()
+    assert result["quarantined"] == 1
+    assert result["stale_marked"] == 0
+    q = isolated_pool.entries_in_state(STATE_QUARANTINED)
+    assert q[0].quarantine_reason == "source_removed"
+
+
+# ---------------------------------------------------------------------------
+# Per-source stats
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_returns_per_source_breakdown(
+    isolated_pool: TriagePool, vault: Path,
+) -> None:
+    _add_pending(
+        isolated_pool, run_id="b1", item_id="i_b1",
+        source="inline", metadata={"file_path": "ghost/x.md"},
+    )
+    _add_pending(
+        isolated_pool, run_id="b2", item_id="j_b2",
+        source="journal_thread", metadata={"source_dates": ["2020-01-01"]},
+    )
+    result = triage_pool_sweep()
+    by_source = result["by_source"]
+    assert by_source["inline"]["checked"] == 1
+    assert by_source["inline"]["quarantined"] == 1
+    assert by_source["journal_thread"]["checked"] == 1
+    assert by_source["journal_thread"]["quarantined"] == 1

--- a/tests/unit/test_triage_review_pool_raw.py
+++ b/tests/unit/test_triage_review_pool_raw.py
@@ -1,0 +1,160 @@
+"""Slice 1 follow-up: raw-entry rendering in _build_presentation_from_pool.
+
+Verdicted entries (verdict.recommended_action populated) keep their
+original presentation. Raw entries (verdict.raw=True) get a
+captured-text-led title, no IR context noise, and a clear rationale
+explaining the verdict-pending state.
+"""
+
+from __future__ import annotations
+
+from work_buddy.triage.background import PoolEntry
+from work_buddy.triage.capabilities.triage_review_pool import (
+    _build_presentation_from_pool,
+    _raw_intent_from_text,
+)
+
+
+# ---------------------------------------------------------------------------
+# _raw_intent_from_text
+# ---------------------------------------------------------------------------
+
+
+def test_strips_leading_capture_marker() -> None:
+    text = (
+        "> #wb/capture/mobile from Kaden McKeen (@kadenmckeen) at 2026-04-27 10:17\n"
+        "GTD: he has a nice sort of is this thing 2 minutes?"
+    )
+    intent = _raw_intent_from_text(text)
+    assert "GTD:" in intent
+    assert "wb/capture/mobile" not in intent
+    assert "Kaden McKeen" not in intent
+
+
+def test_keeps_topic_prefix_after_marker() -> None:
+    text = "> capture marker\nIdea: weekly ETF tracking habit"
+    intent = _raw_intent_from_text(text)
+    assert intent.startswith("Idea:")
+
+
+def test_returns_truncated_when_no_marker() -> None:
+    text = "Direct text, no capture marker, just a plain thought."
+    intent = _raw_intent_from_text(text, max_chars=30)
+    assert intent.startswith("Direct text")
+    assert len(intent) <= 31  # 30 chars + ellipsis
+
+
+def test_handles_empty_text() -> None:
+    assert "needs triage" in _raw_intent_from_text("")
+    assert "needs triage" in _raw_intent_from_text(None)  # type: ignore[arg-type]
+
+
+def test_collapses_internal_newlines() -> None:
+    text = "> marker\nFirst line of thought\nsecond line of thought"
+    intent = _raw_intent_from_text(text)
+    assert "\n" not in intent
+    assert "First line" in intent
+
+
+# ---------------------------------------------------------------------------
+# _build_presentation_from_pool with raw entries
+# ---------------------------------------------------------------------------
+
+
+def _make_raw_entry(item_id: str, text: str) -> PoolEntry:
+    return PoolEntry(
+        run_id="bgt_test",
+        adapter="journal_triage",
+        source="journal_thread",
+        item_id=item_id,
+        item={
+            "id": item_id,
+            "text": text,
+            "label": text[:30],
+            "source": "journal_thread",
+            "metadata": {
+                "ir_context": [
+                    {"display_text": "noisy IR hit 1", "score": 0.05},
+                    {"display_text": "noisy IR hit 2", "score": 0.04},
+                ],
+            },
+        },
+        verdict={"raw": True},
+        created_at="2026-04-27T10:00:00+00:00",
+    )
+
+
+def _make_verdicted_entry(item_id: str, text: str) -> PoolEntry:
+    return PoolEntry(
+        run_id="bgt_test",
+        adapter="journal_triage",
+        source="journal_thread",
+        item_id=item_id,
+        item={
+            "id": item_id,
+            "text": text,
+            "label": text[:30],
+            "source": "journal_thread",
+            "metadata": {"ir_context": [{"display_text": "old hit", "score": 0.02}]},
+        },
+        verdict={
+            "recommended_action": "create_task",
+            "rationale": "Real verdict rationale.",
+            "group_intent": "Real intent",
+            "confidence": 0.9,
+        },
+        created_at="2026-04-27T10:00:00+00:00",
+    )
+
+
+def test_raw_entry_intent_is_captured_text_not_ir_context() -> None:
+    """The captured text becomes the card title; IR context is dropped
+    from the visible context field."""
+    entry = _make_raw_entry(
+        "j_001",
+        "> #wb/capture/mobile from Kaden at 10:17\nGTD: do the thing",
+    )
+    pres = _build_presentation_from_pool([entry])
+    leave_group = pres["groups_by_action"]["leave"][0]
+    assert "GTD: do the thing" in leave_group["intent"]
+    assert "wb/capture" not in leave_group["intent"]
+    # IR context noise must not show up in the rendered context block.
+    assert "noisy IR hit" not in leave_group["context"]
+    assert leave_group["context"] == ""
+    assert leave_group["is_raw"] is True
+
+
+def test_raw_entry_rationale_explains_pending_state() -> None:
+    entry = _make_raw_entry("j_002", "> marker\nplain thought")
+    pres = _build_presentation_from_pool([entry])
+    leave_group = pres["groups_by_action"]["leave"][0]
+    assert "verdict pending" in leave_group["rationale"].lower()
+    assert "slice 3" in leave_group["rationale"].lower()
+
+
+def test_verdicted_entry_unchanged_by_raw_branch() -> None:
+    """Verdicted entries must keep their existing presentation —
+    rationale, group_intent, IR context all preserved."""
+    entry = _make_verdicted_entry("j_003", "verdicted text")
+    pres = _build_presentation_from_pool([entry])
+    create_group = pres["groups_by_action"]["create_task"][0]
+    assert create_group["intent"] == "Real intent"
+    assert create_group["rationale"] == "Real verdict rationale."
+    # IR context still rendered (shows up in the "context" field non-empty)
+    assert create_group["context"]  # non-empty
+    assert create_group["is_raw"] is False
+
+
+def test_mixed_raw_and_verdicted_entries() -> None:
+    """A pool with both kinds renders each correctly."""
+    entries = [
+        _make_raw_entry("j_004", "> marker\nraw thought"),
+        _make_verdicted_entry("j_005", "verdicted text"),
+    ]
+    pres = _build_presentation_from_pool(entries)
+    raw_group = pres["groups_by_action"]["leave"][0]
+    verdicted_group = pres["groups_by_action"]["create_task"][0]
+    assert raw_group["is_raw"] is True
+    assert verdicted_group["is_raw"] is False
+    assert "verdict pending" in raw_group["rationale"].lower()
+    assert "verdict pending" not in verdicted_group["rationale"].lower()

--- a/tests/unit/test_triage_sources.py
+++ b/tests/unit/test_triage_sources.py
@@ -1,0 +1,194 @@
+"""Unit tests for the triage source descriptor registry (Slice 1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from work_buddy.triage import sources
+from work_buddy.triage.sources import (
+    KNOWN_TRIGGERS,
+    SourceDescriptor,
+    TRIGGER_SOURCE_REMOVED,
+    TRIGGER_TAG_REMOVED,
+    _build_registry,
+    all_descriptors,
+    get_descriptor,
+    register_source,
+    reset_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Drop the module's cached registry between tests."""
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+def test_defaults_present(monkeypatch):
+    """The three core sources ship with descriptors out of the box."""
+    monkeypatch.setattr(
+        "work_buddy.config.load_config", lambda: {}
+    )
+    descriptors = {d.name: d for d in all_descriptors()}
+    assert "journal_thread" in descriptors
+    assert "chrome_tab" in descriptors
+    assert "inline" in descriptors
+
+
+def test_inline_default_has_no_ttl(monkeypatch):
+    """Inline TTL is intentionally ``None`` per Slice 1 design.
+
+    User-affirmative captures should not auto-expire — this is the
+    decision behind inline ttl_days=null.
+    """
+    monkeypatch.setattr("work_buddy.config.load_config", lambda: {})
+    inline = get_descriptor("inline")
+    assert inline is not None
+    assert inline.ttl_days is None
+
+
+def test_journal_default_has_edit_match(monkeypatch):
+    """Journal descriptor's config carries the cosine-equivalent threshold."""
+    monkeypatch.setattr("work_buddy.config.load_config", lambda: {})
+    journal = get_descriptor("journal_thread")
+    assert journal is not None
+    assert journal.config.get("edit_match_threshold") == 0.85
+    assert "source_edited_beyond_match" in journal.quarantine_triggers
+
+
+def test_chrome_default_no_edit_check(monkeypatch):
+    """Chrome only quarantines on tab-gone, not on edit-match."""
+    monkeypatch.setattr("work_buddy.config.load_config", lambda: {})
+    chrome = get_descriptor("chrome_tab")
+    assert chrome is not None
+    assert chrome.quarantine_triggers == [TRIGGER_SOURCE_REMOVED]
+
+
+# ---------------------------------------------------------------------------
+# Override merge
+# ---------------------------------------------------------------------------
+
+
+def test_user_override_extends_ttl(monkeypatch):
+    """Overrides under triage.pool.sources merge on top of defaults."""
+    monkeypatch.setattr(
+        "work_buddy.config.load_config",
+        lambda: {
+            "triage": {
+                "pool": {
+                    "sources": {
+                        "journal_thread": {"ttl_days": 14},
+                    }
+                }
+            }
+        },
+    )
+    journal = get_descriptor("journal_thread")
+    assert journal is not None
+    assert journal.ttl_days == 14
+    # Other defaults still in place
+    assert journal.config.get("edit_match_threshold") == 0.85
+
+
+def test_user_can_register_new_source(monkeypatch):
+    """Adding a source via override creates a fresh descriptor."""
+    monkeypatch.setattr(
+        "work_buddy.config.load_config",
+        lambda: {
+            "triage": {
+                "pool": {
+                    "sources": {
+                        "telegram": {
+                            "ttl_days": 3,
+                            "quarantine_triggers": ["source_removed"],
+                            "config": {"channel": "default"},
+                        }
+                    }
+                }
+            }
+        },
+    )
+    descriptor = get_descriptor("telegram")
+    assert descriptor is not None
+    assert descriptor.ttl_days == 3
+    assert descriptor.quarantine_triggers == ["source_removed"]
+
+
+def test_config_block_deep_merges(monkeypatch):
+    """Override of one config key preserves the other defaults."""
+    monkeypatch.setattr(
+        "work_buddy.config.load_config",
+        lambda: {
+            "triage": {
+                "pool": {
+                    "sources": {
+                        "inline": {
+                            "config": {"capture_tag": "wb/saved"},
+                        }
+                    }
+                }
+            }
+        },
+    )
+    inline = get_descriptor("inline")
+    # Override applied, but ttl_days still None and triggers unchanged
+    assert inline.config.get("capture_tag") == "wb/saved"
+    assert inline.ttl_days is None
+    assert inline.quarantine_triggers == [TRIGGER_SOURCE_REMOVED]
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_trigger_rejected_at_construction():
+    """Descriptors fail loudly on unknown trigger names."""
+    with pytest.raises(ValueError, match="unknown quarantine trigger"):
+        SourceDescriptor(
+            name="bad",
+            ttl_days=1,
+            quarantine_triggers=["does_not_exist"],
+        )
+
+
+def test_known_triggers_set_complete():
+    """Sanity: every named constant lives in KNOWN_TRIGGERS."""
+    assert TRIGGER_SOURCE_REMOVED in KNOWN_TRIGGERS
+    assert TRIGGER_TAG_REMOVED in KNOWN_TRIGGERS
+
+
+def test_get_descriptor_unknown_returns_none(monkeypatch):
+    """Unknown sources return None — the pool treats this as 'no TTL'."""
+    monkeypatch.setattr("work_buddy.config.load_config", lambda: {})
+    assert get_descriptor("not_a_real_source") is None
+
+
+# ---------------------------------------------------------------------------
+# Runtime registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_source_idempotent(monkeypatch):
+    """Calling register twice replaces, doesn't duplicate."""
+    monkeypatch.setattr("work_buddy.config.load_config", lambda: {})
+    # Force initial load so the cache exists
+    get_descriptor("inline")
+    register_source(SourceDescriptor(
+        name="custom",
+        ttl_days=10,
+        quarantine_triggers=[],
+    ))
+    register_source(SourceDescriptor(
+        name="custom",
+        ttl_days=20,
+        quarantine_triggers=[],
+    ))
+    assert get_descriptor("custom").ttl_days == 20

--- a/tests/unit/test_triage_verdict_gate.py
+++ b/tests/unit/test_triage_verdict_gate.py
@@ -1,0 +1,112 @@
+"""Producer-level test: verdict_pass_enabled=False uses submit_raw path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from work_buddy.triage import background as bg
+from work_buddy.triage import sources
+from work_buddy.triage.background import (
+    BackgroundTriageProducer,
+    TriagePool,
+)
+from work_buddy.triage.items import TriageItem
+
+
+@pytest.fixture
+def isolated_pool(tmp_path: Path, monkeypatch) -> TriagePool:
+    pool = TriagePool(pool_dir=tmp_path / "triage_pool")
+    bg.set_pool_for_tests(pool)
+    monkeypatch.setattr(
+        "work_buddy.artifacts.save",
+        lambda *a, **kw: type("R", (), {"id": "stub"})(),
+    )
+    monkeypatch.setattr(
+        "work_buddy.config.load_config",
+        lambda: {"vault_root": str(tmp_path / "vault")},
+    )
+    sources.reset_for_tests()
+    yield pool
+    bg.set_pool_for_tests(None)
+    sources.reset_for_tests()
+
+
+def _item(i: int = 0, text: str = "x") -> TriageItem:
+    return TriageItem(
+        id=f"j_{i:06x}", text=text, label=text[:20],
+        source="journal_thread", metadata={},
+    )
+
+
+def test_gate_off_writes_raw_entries(isolated_pool: TriagePool) -> None:
+    """When verdict_pass_enabled=False, the agent is never called and
+    every item lands as a raw entry (verdict={"raw": True})."""
+    items = [_item(1, "alpha"), _item(2, "beta")]
+    agent_called: list[str] = []
+
+    def stub_agent(item, run_id):
+        agent_called.append(item.id)
+        return {"content": "should not happen"}
+
+    producer = BackgroundTriageProducer(
+        adapter_name="gate_off",
+        source="journal_thread",
+        collect=lambda: (items, "HASH-A"),
+        agent=stub_agent,
+        enrich=False,
+        verdict_pass_enabled=False,
+    )
+    result = producer.run()
+    assert result.status == "ok"
+    assert result.submitted == 2
+    assert agent_called == []  # the agent must never be invoked
+
+    pending = isolated_pool.pending()
+    assert len(pending) == 2
+    for pe in pending:
+        assert pe.verdict == {"raw": True}
+        assert pe.state == "pending"
+
+
+def test_gate_on_uses_agent_path(isolated_pool: TriagePool) -> None:
+    """Sanity: with the gate ON the existing agent flow runs unchanged.
+
+    We verify by passing an agent that submits via triage_submit and
+    expecting submitted=1 with verdict.recommended_action populated.
+    """
+    from work_buddy.triage.capabilities.triage_submit import triage_submit
+
+    items = [_item(3, "gamma")]
+
+    def real_agent(item, run_id):
+        triage_submit(
+            run_id=run_id, item_id=item.id,
+            recommended_action="leave", rationale="r",
+        )
+        return {"content": "ok"}
+
+    producer = BackgroundTriageProducer(
+        adapter_name="gate_on",
+        source="journal_thread",
+        collect=lambda: (items, "HASH-B"),
+        agent=real_agent,
+        enrich=False,
+        verdict_pass_enabled=True,  # explicit
+    )
+    result = producer.run()
+    assert result.status == "ok"
+    assert result.submitted == 1
+
+    pe = isolated_pool.pending()[0]
+    assert pe.verdict.get("recommended_action") == "leave"
+    assert "raw" not in pe.verdict
+
+
+def test_gate_off_default_in_capability(monkeypatch, tmp_path) -> None:
+    """journal_triage_scan reads verdict_pass.enabled from config and
+    defaults to False — confirming the Slice-1 default behavior."""
+    from work_buddy.triage.config import load_triage_config
+    cfg = load_triage_config()
+    assert cfg.get("verdict_pass", {}).get("enabled") is False

--- a/work_buddy/consent.py
+++ b/work_buddy/consent.py
@@ -223,6 +223,88 @@ def get_consent_context_info() -> dict[str, Any] | None:
     }
 
 
+# ---------------------------------------------------------------------------
+# User-initiated consent context — the click IS the consent
+# ---------------------------------------------------------------------------
+#
+# Most ``@requires_consent`` gates exist because work-buddy's agents act
+# autonomously: cron-fired LLM calls, sidecar scans, background workflows.
+# The user isn't watching, so a moderate/high-risk operation needs explicit
+# permission before it fires.
+#
+# But UI endpoints are the inverse case: the user just clicked Submit on a
+# form. Pre-emptively prompting them to grant consent for the action they
+# explicitly initiated is bureaucratic UX — they already consented by
+# clicking. The endpoint is the consent boundary.
+#
+# ``user_initiated`` is the context manager for that case. Wrap the
+# critical section of a UI-driven Flask endpoint (or any code path
+# directly attributable to a user action) and nested ``@requires_consent``
+# calls pass through, with an audit-log entry recording the originating
+# action. It does NOT lower risk for OTHER threads or background workers
+# — the context is thread-local.
+#
+# Use sparingly. The right callers are: dashboard POST handlers that the
+# user reached via a button click; CLI scripts the user invoked
+# explicitly; slash-command handlers. Do NOT use this in code that an
+# agent can reach without a user click — that defeats the consent model.
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def user_initiated(operation: str):
+    """Mark a block as a user-initiated consent boundary.
+
+    Inside the block, ``@requires_consent``-gated calls pass through:
+    the user's UI action (button click, slash-command invocation, …) is
+    the consent. The audit log records ``USER_INITIATED`` with the
+    operation name and the inner operations that passed through.
+
+    Args:
+        operation: A short identifier for the user action — e.g.
+            ``"dashboard.review_submit"``, ``"cli.flag_density"``.
+            Shows up in audit logs so operations triggered through
+            this path are distinguishable from autonomous ones.
+
+    Example::
+
+        @app.post("/api/review/execute")
+        def api_review_execute():
+            decisions = request.get_json()
+            with user_initiated("dashboard.review_submit"):
+                executed = execute_triage_decisions(decisions, presentation)
+            return jsonify(executed)
+
+    Reentrant: nested ``user_initiated`` blocks are fine; each adds a
+    layer to the depth counter. Only the outermost frame writes the
+    summary audit entry.
+    """
+    prev_depth = _consent_ctx.depth
+    prev_outer = _consent_ctx.outer_operation
+    prev_covered = _consent_ctx.covered_operations
+
+    _consent_ctx.depth = prev_depth + 1
+    _consent_ctx.outer_operation = operation
+    _consent_ctx.covered_operations = []
+    _audit_log(
+        "USER_INITIATED", operation,
+        "ui_action_treated_as_consent",
+    )
+    try:
+        yield
+    finally:
+        covered = list(_consent_ctx.covered_operations)
+        if covered:
+            _audit_log(
+                "USER_INITIATED_COVERED", operation,
+                f"inner_ops={','.join(covered)}",
+            )
+        _consent_ctx.depth = prev_depth
+        _consent_ctx.outer_operation = prev_outer
+        _consent_ctx.covered_operations = prev_covered
+
+
 class Risk(str, Enum):
     """Risk levels for consent-gated operations."""
     LOW = "low"

--- a/work_buddy/dashboard/service.py
+++ b/work_buddy/dashboard/service.py
@@ -1190,19 +1190,31 @@ def api_review_execute():
             decided_indices.add(idx)
 
     # Walk the executor's per-action success buckets and collect every
-    # item_id that landed in one. Buckets the executor populates on
-    # success: closed, tasks_created, tasks_recorded, grouped, left.
-    # Failed ops only live in ``details.errors`` (not in any success
-    # bucket), so they're naturally excluded.
+    # item_id that landed in one. Failed ops only live in
+    # ``details.errors`` (not in any success bucket), so they're
+    # naturally excluded.
+    #
+    # The executor's bucket shapes are historically inconsistent: some
+    # buckets carry an ``item_ids`` list (tasks_created, tasks_recorded,
+    # grouped — naturally multi-item) and others carry a singular
+    # ``item_id`` (closed, left — naturally per-item). Handle both.
+    # ``skipped_stale`` is excluded so the user can re-decide stale
+    # entries instead of having them silently disappear.
     succeeded_item_ids: set[str] = set()
     details = (executed or {}).get("details", {}) or {}
     for bucket_name in (
-        "closed", "tasks_created", "tasks_recorded", "grouped", "left",
+        "tasks_created", "tasks_recorded", "grouped",
+        "closed", "left",
     ):
         for entry in details.get(bucket_name, []) or []:
+            # Plural form: item_ids list
             for iid in entry.get("item_ids", []) or []:
                 if iid:
                     succeeded_item_ids.add(iid)
+            # Singular form: item_id scalar
+            single = entry.get("item_id")
+            if single:
+                succeeded_item_ids.add(single)
 
     keys: list[tuple[str, str]] = []
     for action_groups in presentation.get("groups_by_action", {}).values():

--- a/work_buddy/dashboard/service.py
+++ b/work_buddy/dashboard/service.py
@@ -1162,13 +1162,24 @@ def api_review_execute():
         logger.exception("api_review_execute: execute failed")
         return jsonify({"status": "error", "error": str(exc)}), 500
 
-    # Stamp the affected pool entries reviewed. Identify them by the
-    # ``pool_run_id`` + item ids in the presentation's groups (the
-    # review-pool builder puts ``pool_run_id`` on every group for
-    # exactly this purpose).
+    # Slice 1 fix (data-loss bug): only mark reviewed the entries
+    # whose groups actually had decisions submitted. Previously this
+    # walked the entire presentation and stamped every entry —
+    # disastrous when the frontend uses per-group submit (each card
+    # has its own button), because submitting one card would mark all
+    # cards reviewed and they'd vanish from the Review tab on next
+    # load.
+    decided_indices: set[int] = set()
+    for gd in (decisions.get("group_decisions") or []):
+        idx = gd.get("group_index")
+        if isinstance(idx, int):
+            decided_indices.add(idx)
+
     keys: list[tuple[str, str]] = []
     for action_groups in presentation.get("groups_by_action", {}).values():
         for group in action_groups:
+            if group.get("index") not in decided_indices:
+                continue
             run_id = group.get("pool_run_id")
             if not run_id:
                 continue
@@ -1193,10 +1204,20 @@ def api_review_execute():
                 "pool_error": str(exc),
             })
 
+    # Slice 1 fix (silent-failure bug): surface per-operation errors
+    # at the top level so the frontend can show "Action failed:
+    # consent required" rather than swallowing them. ``executed``
+    # comes from ``triage_execute.execute_triage_decisions`` which
+    # catches per-op exceptions into ``details.errors``; the user
+    # had no way to see those before this surfacing.
+    op_errors = (executed or {}).get("details", {}).get("errors") or []
+    response_status = "partial" if op_errors else "ok"
+
     return jsonify({
-        "status": "ok",
+        "status": response_status,
         "executed": executed,
         "pool_updates": stamped,
+        "operation_errors": op_errors,  # explicit top-level surfacing
     })
 
 

--- a/work_buddy/dashboard/service.py
+++ b/work_buddy/dashboard/service.py
@@ -1170,18 +1170,39 @@ def api_review_execute():
         logger.exception("api_review_execute: execute failed")
         return jsonify({"status": "error", "error": str(exc)}), 500
 
-    # Slice 1 fix (data-loss bug): only mark reviewed the entries
-    # whose groups actually had decisions submitted. Previously this
-    # walked the entire presentation and stamped every entry —
-    # disastrous when the frontend uses per-group submit (each card
-    # has its own button), because submitting one card would mark all
-    # cards reviewed and they'd vanish from the Review tab on next
-    # load.
+    # Slice 1 fix (data-loss bug): only mark reviewed entries that
+    # were (a) decided on by this submit AND (b) whose op actually
+    # succeeded. The original code walked the entire presentation
+    # and stamped every entry — so submitting one card via the
+    # per-group-submit frontend marked all cards reviewed.
+    #
+    # The first fix narrowed by ``group_index in decided_indices``,
+    # but missed a second case: an op can FAIL (bridge timeout,
+    # consent denial, EditorConflict) and still get stamped, so the
+    # user sees the card disappear with no task created. The second
+    # filter — ``item_ids appears in a successful-op bucket`` —
+    # closes that gap. Failed entries stay pending so the user can
+    # retry.
     decided_indices: set[int] = set()
     for gd in (decisions.get("group_decisions") or []):
         idx = gd.get("group_index")
         if isinstance(idx, int):
             decided_indices.add(idx)
+
+    # Walk the executor's per-action success buckets and collect every
+    # item_id that landed in one. Buckets the executor populates on
+    # success: closed, tasks_created, tasks_recorded, grouped, left.
+    # Failed ops only live in ``details.errors`` (not in any success
+    # bucket), so they're naturally excluded.
+    succeeded_item_ids: set[str] = set()
+    details = (executed or {}).get("details", {}) or {}
+    for bucket_name in (
+        "closed", "tasks_created", "tasks_recorded", "grouped", "left",
+    ):
+        for entry in details.get(bucket_name, []) or []:
+            for iid in entry.get("item_ids", []) or []:
+                if iid:
+                    succeeded_item_ids.add(iid)
 
     keys: list[tuple[str, str]] = []
     for action_groups in presentation.get("groups_by_action", {}).values():
@@ -1193,8 +1214,11 @@ def api_review_execute():
                 continue
             for item in group.get("items", []) or []:
                 iid = item.get("id")
-                if iid:
-                    keys.append((run_id, iid))
+                if not iid:
+                    continue
+                if iid not in succeeded_item_ids:
+                    continue  # op failed for this item — keep pending
+                keys.append((run_id, iid))
 
     stamped = 0
     if keys:

--- a/work_buddy/dashboard/service.py
+++ b/work_buddy/dashboard/service.py
@@ -1155,9 +1155,17 @@ def api_review_execute():
 
     from work_buddy.triage.execute import execute_triage_decisions
     from work_buddy.triage.background import get_pool
+    from work_buddy.consent import user_initiated
 
+    # The user clicked Submit on a Review-tab card. That click IS the
+    # consent — pre-emptively prompting for ``tasks.create_task`` /
+    # ``obsidian.write_file`` would be redundant ceremony. Wrap the
+    # execute in a user_initiated context so nested @requires_consent
+    # gates pass through, with an audit-log entry distinguishing
+    # UI-driven actions from autonomous ones.
     try:
-        executed = execute_triage_decisions(decisions, presentation)
+        with user_initiated("dashboard.review_submit"):
+            executed = execute_triage_decisions(decisions, presentation)
     except Exception as exc:
         logger.exception("api_review_execute: execute failed")
         return jsonify({"status": "error", "error": str(exc)}), 500

--- a/work_buddy/mcp_server/registry.py
+++ b/work_buddy/mcp_server/registry.py
@@ -3056,11 +3056,14 @@ def _journal_capabilities() -> list[Capability]:
                 "Run one background-triage pass over today's Running Notes "
                 "section. Segments the same-day content into threads via "
                 "the local LLM, enriches each with hybrid-IR context, and "
-                "asks Sonnet (escalating to Opus on failure) for a "
-                "constrained-JSON verdict per thread — written directly "
-                "into the Review pool. Never mutates the vault. Idempotent "
-                "on unchanged content. Cadence is a sidecar-job concern; "
-                "safe to call manually for testing."
+                "(when triage.verdict_pass.enabled=true) asks Sonnet "
+                "(escalating to Opus on failure) for a constrained-JSON "
+                "verdict per thread. Slice 1 default is verdict_pass off — "
+                "captures land in the pool as raw entries (verdict={raw: "
+                "true}) until Slice 3 brings GTD-shaped verdicts back. "
+                "Never mutates the vault. Idempotent on unchanged content. "
+                "Cadence is a sidecar-job concern; safe to call manually "
+                "for testing."
             ),
             category="journal",
             search_aliases=[
@@ -3093,13 +3096,16 @@ def _journal_capabilities() -> list[Capability]:
             name="inline_triage_scan",
             description=(
                 "Run one triage pass over a single user-sent Obsidian "
-                "selection (from the 'Send to agent' right-click command). "
-                "Builds one TriageItem with source='inline', collects the "
-                "user-context packet (active tasks / contracts / projects / "
-                "recent commits), and asks Sonnet for a constrained-JSON "
-                "verdict — parsed and written directly into the Review pool. "
-                "Escalates to Opus on timeout / context-exceeded / empty "
-                "content / rate-limited. User-initiated, so force=True by default."
+                "selection (from the 'Send to agent' right-click or tag). "
+                "Builds one TriageItem with source='inline'. When "
+                "triage.verdict_pass.enabled=true, collects the "
+                "user-context packet and asks Sonnet for a constrained-JSON "
+                "verdict (escalates to Opus on timeout / context-exceeded / "
+                "empty content / rate-limited). Slice 1 default is "
+                "verdict_pass off — captures land in the pool as raw "
+                "entries (verdict={raw: true}) until Slice 3 brings the "
+                "GTD-shaped multi-record schema back. User-initiated, "
+                "so force=True by default."
             ),
             category="triage",
             search_aliases=[

--- a/work_buddy/mcp_server/registry.py
+++ b/work_buddy/mcp_server/registry.py
@@ -2093,6 +2093,37 @@ def _context_capabilities() -> list[Capability]:
             mutates_state=True,
             auto_retry=False,
         ),
+        Capability(
+            name="triage_pool_sweep",
+            description=(
+                "Daily liveness pass over the triage pool (Slice 1). Walks every "
+                "pending PoolEntry: marks expired entries as 'stale' (TTL from "
+                "the source descriptor) and quarantines entries whose source no "
+                "longer resolves (file deleted, journal text drifted beyond the "
+                "match threshold, etc.). Source-specific behavior lives in the "
+                "source descriptor registry (work_buddy/triage/sources.py). "
+                "Non-destructive: state changes only; entries stay on disk."
+            ),
+            category="context",
+            search_aliases=[
+                "sweep triage pool",
+                "quarantine stale triage",
+                "triage liveness check",
+                "drop ghost pool entries",
+                "purge stale triage",
+            ],
+            parameters={
+                "dry_run": {"type": "bool", "description": "When true, computes what would change but does not write back. Useful for rehearsal.", "required": False},
+                "source": {"type": "str", "description": "Optional source filter (e.g. 'journal_thread', 'inline'). Other sources untouched.", "required": False},
+                "max_entries": {"type": "int", "description": "Safety cap on entries inspected per pass.", "required": False},
+            },
+            callable=(lambda **kw: __import__(
+                "work_buddy.triage.capabilities.triage_pool_sweep",
+                fromlist=["triage_pool_sweep"],
+            ).triage_pool_sweep(**kw)),
+            mutates_state=True,
+            auto_retry=False,
+        ),
 
         # ── Chrome tab mutations ────────────────────────────────
         Capability(

--- a/work_buddy/triage/background.py
+++ b/work_buddy/triage/background.py
@@ -24,10 +24,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import threading
+import unicodedata
 import uuid
 from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -36,6 +38,35 @@ from work_buddy.paths import data_dir
 from work_buddy.triage.items import TRIAGE_ACTIONS, TriageItem
 
 logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Pool entry lifecycle states (Slice 1)
+# ---------------------------------------------------------------------------
+
+# Lifecycle states a :class:`PoolEntry` may be in.
+#
+# - ``pending``     — created by the producer, awaiting human review.
+# - ``stale``       — past its ``expires_at`` per the source descriptor's TTL.
+#                     Soft signal; not destructive. Hidden from the active
+#                     Review tab but still inspectable.
+# - ``quarantined`` — the source no longer resolves (file deleted, paragraph
+#                     edited beyond the match threshold, capture-tag removed,
+#                     etc. — per the source-descriptor's quarantine triggers).
+#                     Hidden from the Review tab; preserved on disk.
+# - ``reviewed``    — human reviewed it (terminal). Equivalent of
+#                     ``reviewed_at`` being non-null.
+# - ``dropped``     — explicitly removed (rare; reserved for future use).
+STATE_PENDING = "pending"
+STATE_STALE = "stale"
+STATE_QUARANTINED = "quarantined"
+STATE_REVIEWED = "reviewed"
+STATE_DROPPED = "dropped"
+
+POOL_ENTRY_STATES: frozenset[str] = frozenset({
+    STATE_PENDING, STATE_STALE, STATE_QUARANTINED,
+    STATE_REVIEWED, STATE_DROPPED,
+})
 
 
 # ---------------------------------------------------------------------------
@@ -54,7 +85,20 @@ _pool_lock = threading.Lock()
 
 @dataclass
 class PoolEntry:
-    """A single pending-review verdict in the pool."""
+    """A single pending-review verdict in the pool.
+
+    ``state`` is the canonical lifecycle marker (Slice 1). For legacy
+    entries that predate the field, :meth:`from_dict` infers it from
+    ``reviewed_at`` so they keep behaving the way callers expect.
+
+    ``expires_at`` is set at create time from the source descriptor's
+    TTL (see :mod:`work_buddy.triage.sources`). ``None`` means no
+    auto-expiry — the daily sweep skips TTL transitions for the entry.
+
+    ``quarantine_reason`` records WHY a quarantine fired
+    (``source_removed``, ``source_edited_beyond_match``, ``tag_removed``,
+    …) so the user can inspect after the fact.
+    """
 
     run_id: str
     adapter: str
@@ -72,6 +116,18 @@ class PoolEntry:
     # duplicate cards. Optional for backwards compat with entries
     # created before this field existed.
     item_content_hash: str | None = None
+    # Slice 1 lifecycle additions ------------------------------------
+    # State enum from POOL_ENTRY_STATES. Default ``pending``; legacy
+    # entries get the right value via ``from_dict``'s inference.
+    state: str = STATE_PENDING
+    # ISO8601. ``None`` for sources with no TTL (e.g. inline).
+    expires_at: str | None = None
+    # Set when state transitions to ``quarantined``. One of the
+    # quarantine_trigger names from the source descriptor.
+    quarantine_reason: str | None = None
+    # ISO8601. Stamped whenever ``state`` changes. Useful for audit
+    # and for the sweep's "skip if checked recently" optimization.
+    state_changed_at: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -82,7 +138,15 @@ class PoolEntry:
         # doesn't crash. Forward compat: newer fields just get
         # ignored.
         known = {f for f in cls.__dataclass_fields__}
-        return cls(**{k: v for k, v in d.items() if k in known})
+        kwargs = {k: v for k, v in d.items() if k in known}
+        # Backwards compat: if ``state`` is missing, infer it from
+        # ``reviewed_at``. Legacy entries (pre-Slice-1) had only the
+        # reviewed-or-not signal; preserve their meaning.
+        if "state" not in kwargs:
+            kwargs["state"] = (
+                STATE_REVIEWED if kwargs.get("reviewed_at") else STATE_PENDING
+            )
+        return cls(**kwargs)
 
 
 class TriagePool:
@@ -211,18 +275,23 @@ class TriagePool:
                     }
 
             item_dict = run["items"].get(item_id, {})
+            now = _now_iso()
+            entry_source = run.get("source", "")
             pe = PoolEntry(
                 run_id=run_id,
                 adapter=run.get("adapter", ""),
-                source=run.get("source", ""),
+                source=entry_source,
                 item_id=item_id,
                 item=item_dict,
                 verdict=_shape_verdict(verdict),
-                created_at=_now_iso(),
+                created_at=now,
                 item_content_hash=item_content_hash(
-                    item_dict.get("source", run.get("source", "")),
+                    item_dict.get("source", entry_source),
                     item_dict.get("text", ""),
                 ),
+                state=STATE_PENDING,
+                expires_at=_compute_expires_at(entry_source, now),
+                state_changed_at=now,
             )
             index.setdefault("entries", []).append(pe.to_dict())
             self._save_index(index)
@@ -232,6 +301,86 @@ class TriagePool:
             "run_id": run_id,
             "item_id": item_id,
             "recommended_action": action,
+        }
+
+    def submit_raw(
+        self,
+        *,
+        run_id: str,
+        item_id: str,
+    ) -> dict[str, Any]:
+        """Write a raw (un-verdicted) entry to the pool (Slice 1).
+
+        Used when the unattended LLM verdict pass is gated off — the
+        producer still segments and registers items but skips the
+        agent invocation, calling this method to write a placeholder
+        entry. Slice 3 brings GTD-shaped verdicts back; entries with
+        ``verdict == {"raw": True}`` are the ones Slice 3's migration
+        targets.
+
+        Validation mirrors :meth:`submit` (unknown run / wrong item /
+        duplicate are rejected with structured errors).
+        """
+        run = self.get_run(run_id)
+        if run is None:
+            return {
+                "status": "error",
+                "error": f"Unknown run_id: {run_id!r}",
+                "hint": "Only active triage runs accept submissions.",
+            }
+        if run.get("status") != "open":
+            return {
+                "status": "error",
+                "error": f"Run {run_id!r} is {run.get('status')!r}, not open.",
+            }
+        if item_id not in run.get("item_ids", []):
+            return {
+                "status": "error",
+                "error": (
+                    f"Item {item_id!r} does not belong to run {run_id!r}."
+                ),
+                "valid_item_ids": run.get("item_ids", []),
+            }
+
+        with _pool_lock:
+            index = self._load_index()
+            for entry in index.get("entries", []):
+                if entry["run_id"] == run_id and entry["item_id"] == item_id:
+                    return {
+                        "status": "error",
+                        "error": (
+                            f"Duplicate submission for item {item_id!r} "
+                            f"in run {run_id!r}."
+                        ),
+                    }
+
+            item_dict = run["items"].get(item_id, {})
+            now = _now_iso()
+            entry_source = run.get("source", "")
+            pe = PoolEntry(
+                run_id=run_id,
+                adapter=run.get("adapter", ""),
+                source=entry_source,
+                item_id=item_id,
+                item=item_dict,
+                verdict={"raw": True},
+                created_at=now,
+                item_content_hash=item_content_hash(
+                    item_dict.get("source", entry_source),
+                    item_dict.get("text", ""),
+                ),
+                state=STATE_PENDING,
+                expires_at=_compute_expires_at(entry_source, now),
+                state_changed_at=now,
+            )
+            index.setdefault("entries", []).append(pe.to_dict())
+            self._save_index(index)
+
+        return {
+            "status": "ok",
+            "run_id": run_id,
+            "item_id": item_id,
+            "raw": True,
         }
 
     # -- Read / review ------------------------------------------------------
@@ -252,7 +401,7 @@ class TriagePool:
         index = self._load_index()
         hashes: set[str] = set()
         for raw in index.get("entries", []):
-            if raw.get("reviewed_at"):
+            if not _is_active_pending(raw):
                 continue
             if source and raw.get("source") != source:
                 continue
@@ -279,11 +428,17 @@ class TriagePool:
         since: str | None = None,
         max_items: int | None = None,
     ) -> list[PoolEntry]:
-        """Return unreviewed entries, optionally filtered."""
+        """Return entries currently active for human review.
+
+        After Slice 1 this means ``state == "pending"``. Legacy
+        entries that predate the ``state`` field are treated as
+        pending iff they have no ``reviewed_at`` (handled by
+        :func:`_is_active_pending`).
+        """
         index = self._load_index()
         out: list[PoolEntry] = []
         for raw in index.get("entries", []):
-            if raw.get("reviewed_at"):
+            if not _is_active_pending(raw):
                 continue
             if source and raw.get("source") != source:
                 continue
@@ -296,13 +451,71 @@ class TriagePool:
                 break
         return out
 
+    def pending_count(
+        self,
+        *,
+        source: str | None = None,
+        adapter: str | None = None,
+    ) -> int:
+        """Cheap count of currently-pending entries (no PoolEntry build).
+
+        Used by the daily sweep for stats and (in future) by anyone
+        wanting to gate work on pool size without paying for the
+        full :meth:`pending` materialization.
+        """
+        index = self._load_index()
+        n = 0
+        for raw in index.get("entries", []):
+            if not _is_active_pending(raw):
+                continue
+            if source and raw.get("source") != source:
+                continue
+            if adapter and raw.get("adapter") != adapter:
+                continue
+            n += 1
+        return n
+
+    def entries_in_state(
+        self,
+        state: str,
+        *,
+        source: str | None = None,
+        adapter: str | None = None,
+    ) -> list[PoolEntry]:
+        """Explicit-state filter (Slice 1).
+
+        Distinct from :meth:`pending`, which collapses the legacy
+        no-``state`` case into ``pending``. This method only returns
+        entries whose ``state`` field exactly matches ``state``.
+        """
+        if state not in POOL_ENTRY_STATES:
+            raise ValueError(
+                f"Unknown state {state!r}; valid: {sorted(POOL_ENTRY_STATES)}"
+            )
+        index = self._load_index()
+        out: list[PoolEntry] = []
+        for raw in index.get("entries", []):
+            if raw.get("state") != state:
+                continue
+            if source and raw.get("source") != source:
+                continue
+            if adapter and raw.get("adapter") != adapter:
+                continue
+            out.append(PoolEntry.from_dict(raw))
+        return out
+
+    def all_entries(self) -> list[PoolEntry]:
+        """Every entry on disk, regardless of state. For audit/migration."""
+        index = self._load_index()
+        return [PoolEntry.from_dict(raw) for raw in index.get("entries", [])]
+
     def mark_reviewed(
         self,
         entry_keys: list[tuple[str, str]],
         *,
         outcome: str,
     ) -> int:
-        """Stamp ``reviewed_at`` on a set of ``(run_id, item_id)`` entries.
+        """Stamp ``reviewed_at`` + ``state=reviewed`` on entries.
 
         Returns the number of entries stamped.
         """
@@ -316,10 +529,72 @@ class TriagePool:
                 if key in key_set and not raw.get("reviewed_at"):
                     raw["reviewed_at"] = now
                     raw["review_outcome"] = outcome
+                    raw["state"] = STATE_REVIEWED
+                    raw["state_changed_at"] = now
                     stamped += 1
             if stamped:
                 self._save_index(index)
         return stamped
+
+    def mark_state(
+        self,
+        entry_keys: list[tuple[str, str]],
+        *,
+        state: str,
+        reason: str | None = None,
+    ) -> int:
+        """Generic state-change for the daily sweep (Slice 1).
+
+        Stamps ``state``, ``state_changed_at``, and (when applicable)
+        ``quarantine_reason``. Does NOT touch ``reviewed_at`` —
+        ``reviewed`` transitions go through :meth:`mark_reviewed`.
+
+        ``state`` must be one of :data:`POOL_ENTRY_STATES`. Entries
+        already in the target state are no-ops (won't double-stamp).
+        """
+        if state not in POOL_ENTRY_STATES:
+            raise ValueError(
+                f"Unknown state {state!r}; valid: {sorted(POOL_ENTRY_STATES)}"
+            )
+        if state == STATE_REVIEWED:
+            raise ValueError(
+                "Use mark_reviewed() for the reviewed transition; it stamps "
+                "reviewed_at + review_outcome too."
+            )
+        stamped = 0
+        now = _now_iso()
+        key_set = set(entry_keys)
+        with _pool_lock:
+            index = self._load_index()
+            for raw in index.get("entries", []):
+                key = (raw.get("run_id"), raw.get("item_id"))
+                if key not in key_set:
+                    continue
+                if raw.get("state") == state:
+                    continue
+                raw["state"] = state
+                raw["state_changed_at"] = now
+                if state == STATE_QUARANTINED and reason:
+                    raw["quarantine_reason"] = reason
+                stamped += 1
+            if stamped:
+                self._save_index(index)
+        return stamped
+
+    def quarantine(
+        self,
+        entry_keys: list[tuple[str, str]],
+        *,
+        reason: str,
+    ) -> int:
+        """Convenience wrapper around :meth:`mark_state` for quarantine."""
+        return self.mark_state(
+            entry_keys, state=STATE_QUARANTINED, reason=reason,
+        )
+
+    def mark_stale(self, entry_keys: list[tuple[str, str]]) -> int:
+        """Convenience wrapper around :meth:`mark_state` for TTL expiry."""
+        return self.mark_state(entry_keys, state=STATE_STALE)
 
     def apply_reviewer(
         self,
@@ -483,6 +758,7 @@ class BackgroundTriageProducer:
         pool: TriagePool | None = None,
         enrich: bool = True,
         ir_top_k: int = 5,
+        verdict_pass_enabled: bool = True,
     ) -> None:
         self.adapter_name = adapter_name
         self.source = source
@@ -491,6 +767,11 @@ class BackgroundTriageProducer:
         self._pool = pool or get_pool()
         self._enrich = enrich
         self._ir_top_k = ir_top_k
+        # Slice 1: when False, the producer skips the agent invocation
+        # and writes raw entries (verdict={"raw": True}) directly into
+        # the pool. The capability sets this from the triage config's
+        # ``verdict_pass.enabled`` flag (default off).
+        self._verdict_pass_enabled = verdict_pass_enabled
 
     # ---- Idempotence --------------------------------------------------
 
@@ -616,6 +897,30 @@ class BackgroundTriageProducer:
         errors: list[dict[str, Any]] = []
 
         for item in items:
+            # Slice 1 verdict-pass gate: when off, skip the agent
+            # entirely and write a raw entry. No LLM tokens spent;
+            # the capture still lands in the pool so the user sees
+            # it in the Review tab. Slice 3 fills these in with the
+            # new GTD-shaped verdict schema.
+            if not self._verdict_pass_enabled:
+                raw_result = self._pool.submit_raw(
+                    run_id=run_id, item_id=item.id,
+                )
+                if raw_result.get("status") == "ok":
+                    submitted += 1
+                else:
+                    unsubmitted.append(item.id)
+                    errors.append({
+                        "item_id": item.id,
+                        "error": raw_result.get("error", "raw_submit_failed"),
+                        "error_kind": "raw_submit_rejected",
+                    })
+                    logger.warning(
+                        "%s: item %s — raw submit rejected: %s",
+                        self.adapter_name, item.id, raw_result.get("error"),
+                    )
+                continue
+
             try:
                 result = self._agent(item, run_id)
             except Exception as exc:
@@ -691,9 +996,56 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _is_active_pending(raw: dict[str, Any]) -> bool:
+    """Decide whether a raw index entry counts as 'active for review'.
+
+    Slice 1 made ``state`` the canonical lifecycle marker. Legacy
+    entries (pre-Slice-1) may not have a ``state`` field; for those
+    we fall back to the old ``reviewed_at`` signal.
+
+    The rule:
+      - if ``state`` is present → active iff ``state == "pending"``
+      - else (legacy) → active iff ``reviewed_at`` is None
+    """
+    state = raw.get("state")
+    if state is not None:
+        return state == STATE_PENDING
+    return not raw.get("reviewed_at")
+
+
+def _compute_expires_at(source: str, created_at_iso: str) -> str | None:
+    """Look up the source descriptor and compute ``expires_at``.
+
+    Returns ``None`` when:
+      - the source has no registered descriptor (unknown source — leave
+        TTL unset rather than guess)
+      - the descriptor's ``ttl_days`` is ``None`` (e.g. inline)
+
+    Soft-imports :mod:`work_buddy.triage.sources` to avoid an import
+    cycle (sources imports background for type hints).
+    """
+    try:
+        from work_buddy.triage.sources import get_descriptor
+    except Exception:
+        return None
+    descriptor = get_descriptor(source)
+    if descriptor is None or descriptor.ttl_days is None:
+        return None
+    try:
+        created = datetime.fromisoformat(created_at_iso)
+    except ValueError:
+        return None
+    return (created + timedelta(days=descriptor.ttl_days)).isoformat()
+
+
 def _shape_verdict(verdict: dict[str, Any]) -> dict[str, Any]:
     """Keep only known verdict fields to avoid the agent smuggling
-    arbitrary payloads into the pool."""
+    arbitrary payloads into the pool.
+
+    ``raw`` is allowed (Slice 1) so :meth:`TriagePool.submit_raw` can
+    flag entries that landed without a verdict pass. Slice 3's
+    migration filters on ``verdict.get("raw") is True``.
+    """
     allowed = {
         "recommended_action",
         "rationale",
@@ -702,6 +1054,7 @@ def _shape_verdict(verdict: dict[str, Any]) -> dict[str, Any]:
         "target_task_id",
         "suggested_task_text",
         "related_item_ids",
+        "raw",
     }
     return {k: v for k, v in verdict.items() if k in allowed}
 
@@ -723,14 +1076,41 @@ def content_hash(parts: list[str]) -> str:
     return h.hexdigest()[:16]
 
 
+# Pattern for stripping per-line markdown bullet noise. Catches:
+#   "- foo", "* foo", "+ foo", "1. foo", "  > foo", combinations with
+#   nested indentation.
+_LEADING_LIST_RE = re.compile(r"^[\s>]*(?:[-*+]|\d+[.)])\s+", re.MULTILINE)
+
+
 def item_content_hash(source: str, text: str) -> str:
     """Stable per-item hash for cross-run dedup.
 
-    Normalizes whitespace so trivial reformatting doesn't defeat the
-    dedup, and scopes by source so a conversation and a journal
-    thread that happen to share text still count as distinct items.
-    Keeping it short (same length as ``content_hash``) keeps the
-    pool index readable in the filesystem.
+    Hardened in Slice 1 to catch byte-different / semantically-identical
+    re-emissions that the original whitespace-only normalization missed.
+    Pipeline:
+
+      1. NFKC Unicode normalization (collapses precomposed vs combining
+         forms — "é" written two different ways now hashes the same).
+      2. Lowercase (case drift across re-segmentations doesn't matter).
+      3. Strip leading markdown bullets per line (``- foo`` and
+         ``* foo`` and ``1. foo`` all reduce to ``foo``).
+      4. Collapse runs of whitespace within and across lines.
+
+    Scoped by ``source`` so a conversation and a journal thread that
+    happen to share text still count as distinct items.
+
+    NOTE: changes here invalidate cross-run dedup for entries whose
+    hashes were computed under the old normalization. The Slice 1
+    migration script recomputes ``item_content_hash`` for all existing
+    entries to bring them back into alignment.
     """
-    normalized = " ".join((text or "").split()).strip()
+    if not text:
+        return content_hash([source or "", ""])
+    normalized = unicodedata.normalize("NFKC", text)
+    normalized = normalized.lower()
+    normalized = _LEADING_LIST_RE.sub("", normalized)
+    # Whitespace collapse: split (any whitespace, including newlines) +
+    # rejoin on single spaces. Preserves word boundaries; kills any
+    # multi-line / multi-space artifacts.
+    normalized = " ".join(normalized.split()).strip()
     return content_hash([source or "", normalized])

--- a/work_buddy/triage/capabilities/inline_triage_scan.py
+++ b/work_buddy/triage/capabilities/inline_triage_scan.py
@@ -134,23 +134,44 @@ def inline_triage_scan(
             "items": [it.to_dict() for it in items],
         }
 
-    # Build the user-context packet once per pass. Sonnet's context
-    # window comfortably fits the full packet so we don't truncate —
-    # Sonnet can weigh all tasks/projects/commits itself rather than
-    # relying on a state-priority prefilter like the local path did.
-    from work_buddy.triage.recommend import build_triage_context
-    triage_context = build_triage_context() if enrich else {}
+    # Slice 1 verdict-pass gate. Even though inline is user-affirmative
+    # (right-click or tag), the verdict is throwaway during the
+    # Slice 1→3 interregnum — Slice 3 replaces the verdict schema.
+    # Gate uniformly with journal_triage_scan; capture still lands in
+    # the pool as a raw entry.
+    from work_buddy.triage.config import load_triage_config
+    cfg = load_triage_config()
+    verdict_pass_enabled = bool(
+        cfg.get("verdict_pass", {}).get("enabled", False)
+    )
 
-    runner = LLMRunner()
+    # Build the user-context packet once per pass when the verdict
+    # pass IS enabled. When disabled, we skip the build (no LLM call
+    # will need it) — saves an unnecessary tasks/contracts/commits
+    # collect on every invocation.
+    if verdict_pass_enabled:
+        from work_buddy.triage.recommend import build_triage_context
+        triage_context = build_triage_context() if enrich else {}
 
-    def _agent(item: TriageItem, run_id: str) -> dict[str, Any]:
-        return _invoke_agent(
-            runner=runner,
-            item=item,
-            run_id=run_id,
-            context=triage_context,
-            tier=tier,
-        )
+        runner = LLMRunner()
+
+        def _agent(item: TriageItem, run_id: str) -> dict[str, Any]:
+            return _invoke_agent(
+                runner=runner,
+                item=item,
+                run_id=run_id,
+                context=triage_context,
+                tier=tier,
+            )
+    else:
+        def _agent(item: TriageItem, run_id: str) -> dict[str, Any]:
+            return {
+                "content": "",
+                "error": (
+                    "verdict_pass disabled but agent invoked — this is a bug"
+                ),
+                "error_kind": "verdict_pass_disabled",
+            }
 
     # ``enrich=False`` on the producer disables IR enrichment — inline
     # uses the ``build_triage_context`` packet above instead, so per-item
@@ -161,6 +182,7 @@ def inline_triage_scan(
         collect=_collect,
         agent=_agent,
         enrich=False,
+        verdict_pass_enabled=verdict_pass_enabled,
     )
     return producer.run(force=force).to_dict()
 

--- a/work_buddy/triage/capabilities/journal_triage_scan.py
+++ b/work_buddy/triage/capabilities/journal_triage_scan.py
@@ -204,16 +204,38 @@ def journal_triage_scan(
             "items": [it.to_dict() for it in items],
         }
 
-    runner = LLMRunner()
+    # Slice 1 verdict-pass gate. When disabled (the default until
+    # Slice 3 ships the new schema), skip the LLM agent entirely;
+    # the producer writes raw entries (``verdict={"raw": True}``).
+    # Capture is preserved; the verdict is not.
+    verdict_pass_enabled = bool(
+        cfg.get("verdict_pass", {}).get("enabled", False)
+    )
 
-    def _agent(item: TriageItem, run_id: str) -> dict[str, Any]:
-        return _invoke_agent(
-            runner=runner,
-            item=item,
-            run_id=run_id,
-            tier=tier,
-            triage_context_block=triage_context_block,
-        )
+    if verdict_pass_enabled:
+        runner = LLMRunner()
+
+        def _agent(item: TriageItem, run_id: str) -> dict[str, Any]:
+            return _invoke_agent(
+                runner=runner,
+                item=item,
+                run_id=run_id,
+                tier=tier,
+                triage_context_block=triage_context_block,
+            )
+    else:
+        # No-op agent — the producer never calls it when the gate is off,
+        # but BackgroundTriageProducer requires a callable so we provide
+        # a stub. If someone ever turns the gate on mid-run, the stub
+        # surfaces the misconfiguration instead of silently 500'ing.
+        def _agent(item: TriageItem, run_id: str) -> dict[str, Any]:
+            return {
+                "content": "",
+                "error": (
+                    "verdict_pass disabled but agent invoked — this is a bug"
+                ),
+                "error_kind": "verdict_pass_disabled",
+            }
 
     producer = BackgroundTriageProducer(
         adapter_name="journal_triage",
@@ -222,6 +244,7 @@ def journal_triage_scan(
         agent=_agent,
         enrich=enrich and enrich_cfg.get("enabled", True),
         ir_top_k=enrich_cfg.get("top_k", 5),
+        verdict_pass_enabled=verdict_pass_enabled,
     )
     return producer.run(force=force).to_dict()
 

--- a/work_buddy/triage/capabilities/triage_pool_sweep.py
+++ b/work_buddy/triage/capabilities/triage_pool_sweep.py
@@ -1,0 +1,195 @@
+"""``triage_pool_sweep`` capability — daily liveness pass over the pool (Slice 1).
+
+Walks every pending :class:`PoolEntry`, checks two things:
+
+1. **TTL expiry.** If the entry is past its ``expires_at`` the state
+   transitions ``pending → stale``. Soft signal — entries are still
+   on disk; the Review tab just stops showing them.
+
+2. **Source-specific quarantine triggers.** Per the entry's source
+   descriptor (see :mod:`work_buddy.triage.sources`), the configured
+   quarantine triggers (``source_removed``,
+   ``source_edited_beyond_match``, …) are evaluated. The first one
+   that fires transitions ``pending → quarantined`` with a
+   ``quarantine_reason`` recorded for audit.
+
+Order
+-----
+
+Quarantine takes precedence over stale: if an entry would be both
+expired AND has a quarantine trigger firing, we quarantine (more
+specific signal — the source is GONE, not just old).
+
+Defensive
+---------
+
+The sweep is unattended. One bad entry must not poison the whole
+pass. Per-entry checks are wrapped; failures are logged and the
+entry is skipped (no transition). Trigger-function defensiveness is
+the responsibility of :mod:`sources_triggers`.
+
+Cadence
+-------
+
+Run daily via ``sidecar_jobs/triage-pool-sweep.md``. Manual runs
+via ``mcp__work-buddy__wb_run("triage_pool_sweep", {"dry_run": true})``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from work_buddy.logging_config import get_logger
+from work_buddy.triage.background import (
+    PoolEntry,
+    STATE_PENDING,
+    STATE_QUARANTINED,
+    STATE_STALE,
+    get_pool,
+)
+from work_buddy.triage.sources import (
+    SourceDescriptor,
+    get_descriptor,
+)
+from work_buddy.triage.sources_triggers import evaluate_triggers
+
+logger = get_logger(__name__)
+
+
+def triage_pool_sweep(
+    *,
+    dry_run: bool = False,
+    source: str | None = None,
+    max_entries: int | None = None,
+) -> dict[str, Any]:
+    """Sweep the pool for stale + quarantinable entries.
+
+    Args:
+        dry_run: When True, computes what would change but doesn't
+            write back. Useful for a rehearsal before the cron fires
+            and for manual inspection.
+        source: When set, only entries from this source are inspected
+            (e.g. ``"journal_thread"``). Other entries are untouched.
+        max_entries: Safety cap on entries inspected per pass.
+
+    Returns:
+        Stats dict: ``{
+            "checked": int,
+            "stale_marked": int,
+            "quarantined": int,
+            "errors": int,
+            "by_source": {
+                source_name: {checked, stale, quarantined, errors},
+                ...
+            },
+            "samples": [...],   # first few quarantine reasons (audit aid)
+            "dry_run": bool,
+        }``
+    """
+    pool = get_pool()
+    pending = pool.pending(source=source, max_items=max_entries)
+
+    now = datetime.now(timezone.utc)
+
+    stats_by_source: dict[str, dict[str, int]] = {}
+    samples: list[dict[str, Any]] = []
+    to_stale: list[tuple[str, str]] = []
+    to_quarantine: list[tuple[tuple[str, str], str]] = []
+    errors = 0
+
+    for entry in pending:
+        s = stats_by_source.setdefault(entry.source or "", {
+            "checked": 0, "stale": 0, "quarantined": 0, "errors": 0,
+        })
+        s["checked"] += 1
+
+        descriptor = get_descriptor(entry.source or "")
+
+        # 1. Quarantine triggers (more specific than TTL — run first).
+        quarantine_reason: str | None = None
+        if descriptor and descriptor.quarantine_triggers:
+            try:
+                quarantine_reason = evaluate_triggers(entry, descriptor)
+            except Exception as exc:  # defensive: log + skip
+                logger.warning(
+                    "triage_pool_sweep: trigger evaluation crashed for "
+                    "%s/%s: %s", entry.run_id, entry.item_id, exc,
+                )
+                s["errors"] += 1
+                errors += 1
+                continue
+
+        if quarantine_reason:
+            to_quarantine.append(
+                ((entry.run_id, entry.item_id), quarantine_reason),
+            )
+            s["quarantined"] += 1
+            if len(samples) < 8:
+                samples.append({
+                    "run_id": entry.run_id,
+                    "item_id": entry.item_id,
+                    "source": entry.source,
+                    "transition": "quarantined",
+                    "reason": quarantine_reason,
+                })
+            continue
+
+        # 2. TTL expiry — soft signal.
+        if entry.expires_at and _is_past(entry.expires_at, now):
+            to_stale.append((entry.run_id, entry.item_id))
+            s["stale"] += 1
+            if len(samples) < 8:
+                samples.append({
+                    "run_id": entry.run_id,
+                    "item_id": entry.item_id,
+                    "source": entry.source,
+                    "transition": "stale",
+                    "expires_at": entry.expires_at,
+                })
+
+    # Apply transitions (or skip in dry run).
+    stale_marked = 0
+    quarantined = 0
+    if not dry_run:
+        if to_stale:
+            stale_marked = pool.mark_stale(to_stale)
+        if to_quarantine:
+            # Group by reason so mark_state's reason field is correct.
+            by_reason: dict[str, list[tuple[str, str]]] = {}
+            for key, reason in to_quarantine:
+                by_reason.setdefault(reason, []).append(key)
+            for reason, keys in by_reason.items():
+                quarantined += pool.quarantine(keys, reason=reason)
+    else:
+        stale_marked = len(to_stale)
+        quarantined = len(to_quarantine)
+
+    result: dict[str, Any] = {
+        "status": "ok",
+        "dry_run": dry_run,
+        "checked": len(pending),
+        "stale_marked": stale_marked,
+        "quarantined": quarantined,
+        "errors": errors,
+        "by_source": stats_by_source,
+        "samples": samples,
+    }
+    logger.info(
+        "triage_pool_sweep: checked=%d stale=%d quarantined=%d errors=%d "
+        "dry_run=%s",
+        result["checked"], result["stale_marked"], result["quarantined"],
+        result["errors"], dry_run,
+    )
+    return result
+
+
+def _is_past(iso_ts: str, now: datetime) -> bool:
+    """Return True if ``iso_ts`` is strictly before ``now``."""
+    try:
+        ts = datetime.fromisoformat(iso_ts)
+    except ValueError:
+        return False
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts < now

--- a/work_buddy/triage/capabilities/triage_review_pool.py
+++ b/work_buddy/triage/capabilities/triage_review_pool.py
@@ -158,6 +158,15 @@ def _build_presentation_from_pool(
 
     all_item_ids: list[str] = []
     for i, pe in enumerate(entries):
+        # Slice 1: raw entries (verdict_pass gated off) carry no
+        # ``recommended_action``, no rationale, no group_intent. The
+        # default verdicted-card layout puts IR-context plumbing in the
+        # spotlight and buries the user's captured text. Render them
+        # differently: lead with the captured text, drop the IR
+        # context, mark them clearly as needing triage. Slice 3 brings
+        # GTD-shaped verdicts back; until then this is the right shape.
+        is_raw = bool(pe.verdict.get("raw"))
+
         action = pe.verdict.get("recommended_action", "leave")
         if action not in groups_by_action:
             action = "leave"
@@ -178,30 +187,49 @@ def _build_presentation_from_pool(
         if url:
             modal_item["url"] = url
 
-        # Prefer the agent-supplied group_intent (short, noun-phrase
-        # naming the *intent*). Fall back ladder:
-        #   1. explicit group_intent field (best)
-        #   2. suggested_task_text (agents emit this reliably for
-        #      create_task; it's usually a clean noun-phrase and
-        #      beats a rationale excerpt for a card title)
-        #   3. rationale first 120 chars (last resort; keeps
-        #      backwards compat with pre-group_intent pool entries)
-        intent = (
-            pe.verdict.get("group_intent")
-            or pe.verdict.get("suggested_task_text")
-            or _short(pe.verdict.get("rationale", ""), 120)
-        )
+        if is_raw:
+            # Card title = first ~80 chars of the captured text, with
+            # any leading capture-marker prose stripped so the user's
+            # actual thought is what shows up.
+            intent = _raw_intent_from_text(text)
+            rationale = (
+                "Raw capture — verdict pending. "
+                "Slice 3 will revisit with the new GTD-shaped schema; "
+                "for now, pick an action manually."
+            )
+            # Drop IR-context display: it's pre-LLM enrichment, not
+            # content. Showing it dominates the visual without value.
+            context_block = ""
+        else:
+            # Verdicted entry — original presentation. Prefer the
+            # agent-supplied group_intent (short, noun-phrase naming
+            # the *intent*). Fall back ladder:
+            #   1. explicit group_intent field (best)
+            #   2. suggested_task_text (agents emit this reliably for
+            #      create_task; it's usually a clean noun-phrase and
+            #      beats a rationale excerpt for a card title)
+            #   3. rationale first 120 chars (last resort; keeps
+            #      backwards compat with pre-group_intent pool entries)
+            intent = (
+                pe.verdict.get("group_intent")
+                or pe.verdict.get("suggested_task_text")
+                or _short(pe.verdict.get("rationale", ""), 120)
+            )
+            rationale = pe.verdict.get("rationale", "")
+            context_block = _render_context_block(ir_ctx)
+
         presentation_group: dict[str, Any] = {
             "index": i,
             "intent": intent,
             "confidence": _confidence_label(pe.verdict.get("confidence")),
             "items": [modal_item],
-            "rationale": pe.verdict.get("rationale", ""),
-            "context": _render_context_block(ir_ctx),
+            "rationale": rationale,
+            "context": context_block,
             "ambiguities": [],
             "likely_task_id": pe.verdict.get("target_task_id", "") or "",
             "suggested_action": action,
             "pool_run_id": pe.run_id,  # non-UI; used for mark_reviewed
+            "is_raw": is_raw,          # non-UI; lets renderers tag the card
         }
         if action == "create_task":
             presentation_group["suggested_task_text"] = (
@@ -227,6 +255,35 @@ def _build_presentation_from_pool(
         "has_clarifying_questions": False,
         "revisions": 0,
     }
+
+
+def _raw_intent_from_text(text: str, max_chars: int = 80) -> str:
+    """Build a card-title intent string for a raw entry.
+
+    The captured text often leads with a Telegram-capture marker like::
+
+        > #wb/capture/mobile from Kaden McKeen (@kadenmckeen) at 2026-04-27 10:17
+        GTD: he has a nice sort of is this thing 2 minutes? ...
+
+    Stripping the marker exposes the user's actual thought, which is
+    what makes a useful card title. The strip is conservative — if no
+    marker pattern is matched, return the leading ``max_chars`` of the
+    raw text as-is.
+    """
+    if not text:
+        return "(empty capture — needs triage)"
+    cleaned = text.strip()
+    # Drop a leading blockquote line (the ``> #wb/capture/...`` marker).
+    # If the next line starts with a "topic prefix" like ``GTD:`` or
+    # ``Idea:``, keep the topic prefix — it's content the user wrote.
+    if cleaned.startswith(">"):
+        nl = cleaned.find("\n")
+        if nl >= 0:
+            cleaned = cleaned[nl + 1:].lstrip()
+    cleaned = cleaned.replace("\n", " ").strip()
+    if not cleaned:
+        return "(empty capture — needs triage)"
+    return _short(cleaned, max_chars)
 
 
 def _short(text: str, n: int) -> str:

--- a/work_buddy/triage/config.py
+++ b/work_buddy/triage/config.py
@@ -41,6 +41,19 @@ from typing import Any
 # ---------------------------------------------------------------------------
 
 TRIAGE_DEFAULTS: dict[str, Any] = {
+    # Slice 1 verdict-pass gate. When ``enabled=False`` (the default
+    # post-Slice-1, pre-Slice-3), the producer skips the LLM agent
+    # invocation entirely and writes ``verdict={"raw": True}``
+    # entries via :meth:`TriagePool.submit_raw`. Slice 3 brings
+    # GTD-shaped verdicts back; until then full silence beats noisy
+    # stub verdicts.
+    #
+    # Override: set ``triage.verdict_pass.enabled: true`` in
+    # ``config.local.yaml`` to re-enable the legacy verdict pass.
+    "verdict_pass": {
+        "enabled": False,
+    },
+
     # Profile used by the per-item agent loop (llm_with_tools).
     # The agent is expected to call `triage_submit` exactly once.
     "agent_profile": "local_general",

--- a/work_buddy/triage/sources.py
+++ b/work_buddy/triage/sources.py
@@ -1,0 +1,258 @@
+"""Source descriptor registry for the triage pool (Slice 1).
+
+Every entry in the pool was captured from some **source** — a journal
+thread, a Chrome tab, an inline Obsidian selection, etc. Sources differ
+in lifecycle expectations:
+
+- A journal thread might be re-edited by the user as the day's running
+  notes evolve; the original captured text might no longer reflect the
+  user's intent.
+- A Chrome tab can be closed; once gone, the captured page text is a
+  ghost.
+- An inline ``send-to-agent`` selection is the user's affirmative
+  capture; treating it as transient would erode trust (V2a — capture
+  promise integrity).
+
+Rather than hard-coding per-source TTLs and quarantine rules in the
+sweeper, each source declares a :class:`SourceDescriptor` here. The
+sweep dispatches on the descriptor; new sources register their own
+descriptor and inherit the sweep machinery for free.
+
+Override model
+--------------
+
+Code defaults live in :data:`_DEFAULT_REGISTRY`. The
+:func:`load_source_registry` loader merges per-source overrides from
+``triage.pool.sources`` in ``config.yaml`` / ``config.local.yaml``
+on top of the defaults — same merge discipline as
+:mod:`work_buddy.triage.config`. Users tune one source by writing one
+nested block::
+
+    # config.local.yaml
+    triage:
+      pool:
+        sources:
+          journal_thread:
+            ttl_days: 7
+
+The trigger functions themselves live in
+:mod:`work_buddy.triage.sources_triggers` and are dispatched by name.
+This keeps the registry data-only (importable from migration scripts
+without paying the cost of bridge / vault helpers).
+
+Why a separate file
+-------------------
+
+The :mod:`work_buddy.triage.config` file holds **stage-shape** config
+(profile names, max_tokens, escalation chain) — knobs about HOW the
+LLM call runs. This file holds **lifecycle** config (TTLs, quarantine
+triggers) — knobs about how entries AGE in the pool. They overlap
+philosophically but cleanly separate by concern: stage-shape is about
+producing entries; lifecycle is about retiring them.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Trigger names
+# ---------------------------------------------------------------------------
+
+# Quarantine trigger names. Each maps to a function in
+# :mod:`work_buddy.triage.sources_triggers`. Keep this list small and
+# orthogonal — adding a new trigger means adding a new dispatch arm
+# in the sweeper, so casual additions accumulate cost.
+TRIGGER_SOURCE_REMOVED = "source_removed"
+TRIGGER_SOURCE_EDITED_BEYOND_MATCH = "source_edited_beyond_match"
+TRIGGER_TAG_REMOVED = "tag_removed"
+
+KNOWN_TRIGGERS: frozenset[str] = frozenset({
+    TRIGGER_SOURCE_REMOVED,
+    TRIGGER_SOURCE_EDITED_BEYOND_MATCH,
+    TRIGGER_TAG_REMOVED,
+})
+
+
+# ---------------------------------------------------------------------------
+# Descriptor dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SourceDescriptor:
+    """Lifecycle declaration for one capture source.
+
+    Attributes:
+        name: Source identifier (matches ``PoolEntry.source`` —
+            e.g. ``"journal_thread"``, ``"chrome_tab"``, ``"inline"``).
+        ttl_days: Soft expiry. After this many days, the sweep
+            transitions ``state`` from ``pending`` to ``stale``.
+            ``None`` means no TTL (e.g. inline captures, which are
+            user-affirmative and should not auto-expire).
+        quarantine_triggers: Ordered list of trigger names. The sweep
+            calls each trigger's checker function in order; the first
+            one that fires sets the quarantine reason.
+        config: Source-specific knobs the trigger functions read
+            (e.g. inline's ``capture_tag``; journal's
+            ``edit_match_threshold``). Open dict — descriptors can
+            store anything their triggers need.
+    """
+
+    name: str
+    ttl_days: int | None
+    quarantine_triggers: list[str] = field(default_factory=list)
+    config: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for trigger in self.quarantine_triggers:
+            if trigger not in KNOWN_TRIGGERS:
+                raise ValueError(
+                    f"Source {self.name!r} declares unknown quarantine "
+                    f"trigger {trigger!r}. Valid: {sorted(KNOWN_TRIGGERS)}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+# Code-side defaults. Overrides under ``triage.pool.sources.<name>``
+# in ``config.yaml`` / ``config.local.yaml`` deep-merge on top of these.
+_DEFAULT_REGISTRY: dict[str, dict[str, Any]] = {
+    # Journal threads — cron-segmented from today's running notes.
+    # 5-day TTL; quarantine when the journal file is gone or the
+    # captured text no longer matches what's in the file (cosine
+    # 0.85, soft check via difflib).
+    "journal_thread": {
+        "ttl_days": 5,
+        "quarantine_triggers": [
+            TRIGGER_SOURCE_REMOVED,
+            TRIGGER_SOURCE_EDITED_BEYOND_MATCH,
+        ],
+        "config": {
+            "edit_match_threshold": 0.85,
+        },
+    },
+
+    # Chrome tabs — captured from the live tab ledger.
+    # 2-day TTL; quarantine when the tab is no longer in the ledger
+    # (the user closed it).
+    "chrome_tab": {
+        "ttl_days": 2,
+        "quarantine_triggers": [TRIGGER_SOURCE_REMOVED],
+        "config": {},
+    },
+
+    # Inline ``send-to-agent`` captures. User-affirmative — should
+    # not auto-expire (ttl_days=None) and should not auto-quarantine
+    # on edit. The conservative trigger is ``source_removed`` (the
+    # source file no longer exists at all). ``tag_removed`` is
+    # available in the registry for the future when inline captures
+    # start writing back a confirmation tag (out of scope for Slice 1).
+    "inline": {
+        "ttl_days": None,
+        "quarantine_triggers": [TRIGGER_SOURCE_REMOVED],
+        "config": {
+            # Reserved for the future tag-removal flow; included now
+            # so users overriding inline can flip to ["tag_removed"]
+            # without also editing this default block.
+            "capture_tag": "wb/captured",
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Loader / module-level singleton
+# ---------------------------------------------------------------------------
+
+
+_REGISTRY_CACHE: dict[str, SourceDescriptor] | None = None
+
+
+def _build_registry(
+    overrides: dict[str, Any],
+) -> dict[str, SourceDescriptor]:
+    merged: dict[str, dict[str, Any]] = deepcopy(_DEFAULT_REGISTRY)
+    for source_name, override_block in (overrides or {}).items():
+        if not isinstance(override_block, dict):
+            continue
+        existing = merged.setdefault(source_name, {
+            "ttl_days": None,
+            "quarantine_triggers": [],
+            "config": {},
+        })
+        for key, value in override_block.items():
+            if (
+                key == "config"
+                and isinstance(existing.get("config"), dict)
+                and isinstance(value, dict)
+            ):
+                # Deep-merge config so users overriding one config
+                # key don't have to restate the whole block.
+                existing["config"] = {**existing["config"], **value}
+            else:
+                existing[key] = value
+    return {
+        name: SourceDescriptor(
+            name=name,
+            ttl_days=spec.get("ttl_days"),
+            quarantine_triggers=list(spec.get("quarantine_triggers") or []),
+            config=dict(spec.get("config") or {}),
+        )
+        for name, spec in merged.items()
+    }
+
+
+def load_source_registry() -> dict[str, SourceDescriptor]:
+    """Return the merged source registry (defaults + user overrides).
+
+    Cached. Call :func:`reset_for_tests` between tests if you've
+    monkeypatched config; otherwise the cache is fine for the
+    lifetime of the process.
+    """
+    global _REGISTRY_CACHE
+    if _REGISTRY_CACHE is None:
+        try:
+            from work_buddy.config import load_config
+            cfg = (load_config() or {}).get("triage", {}) or {}
+        except Exception:
+            cfg = {}
+        overrides = (cfg.get("pool", {}) or {}).get("sources", {}) or {}
+        _REGISTRY_CACHE = _build_registry(overrides)
+    return _REGISTRY_CACHE
+
+
+def get_descriptor(source: str) -> SourceDescriptor | None:
+    """Return the descriptor for ``source``, or ``None`` if unknown.
+
+    Returning ``None`` for unknown sources is intentional — the pool
+    code treats it as "no TTL, no quarantine triggers" rather than
+    crashing. New sources should register a descriptor explicitly.
+    """
+    return load_source_registry().get(source)
+
+
+def all_descriptors() -> list[SourceDescriptor]:
+    """For the daily sweep — iterate every known source."""
+    return list(load_source_registry().values())
+
+
+def register_source(descriptor: SourceDescriptor) -> None:
+    """Register (or replace) a source descriptor at runtime.
+
+    Useful for plugins / experiments that want to add a new source
+    without editing this file. Idempotent on ``descriptor.name``.
+    """
+    registry = load_source_registry()
+    registry[descriptor.name] = descriptor
+
+
+def reset_for_tests() -> None:
+    """Test hook — drop the cached registry so the next call rebuilds."""
+    global _REGISTRY_CACHE
+    _REGISTRY_CACHE = None

--- a/work_buddy/triage/sources_triggers.py
+++ b/work_buddy/triage/sources_triggers.py
@@ -1,0 +1,333 @@
+"""Quarantine trigger functions for the triage pool sweep (Slice 1).
+
+Each function decides whether a single :class:`PoolEntry` should
+transition to ``state=quarantined``. They are dispatched by name from
+the source descriptor's ``quarantine_triggers`` list.
+
+Trigger contract
+----------------
+
+Every trigger has the signature::
+
+    def trigger_<name>(
+        entry: PoolEntry,
+        descriptor: SourceDescriptor,
+    ) -> str | None
+
+Return value:
+
+- ``None`` — the trigger did not fire; entry stays in its current state.
+- A non-empty string — the trigger fired; the string is the
+  human-readable reason that gets persisted to ``quarantine_reason``
+  (e.g. ``"source_removed"``).
+
+Exceptions
+----------
+
+Triggers MUST be defensive. The sweep runs daily, unattended, against
+every pending entry — a single trigger raising would kill the whole
+pass. Catch transport / filesystem failures and return ``None``
+(treat ambiguous as "still live"); never raise. Use the module logger
+to surface degraded checks.
+
+Bridge access
+-------------
+
+For sources that need to consult the Obsidian bridge (journal, inline),
+use the soft-import pattern: import inside the function so module
+import doesn't pay the cost. Treat bridge unavailability as
+"can't decide → leave alone."
+"""
+
+from __future__ import annotations
+
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from work_buddy.logging_config import get_logger
+
+if TYPE_CHECKING:
+    from work_buddy.triage.background import PoolEntry
+    from work_buddy.triage.sources import SourceDescriptor
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _vault_root() -> Path | None:
+    """Return the configured vault root, or None if unconfigured.
+
+    Reads top-level ``vault_root`` from ``config.yaml``. Returns
+    ``None`` (rather than raising) on any config-load failure so
+    triggers running in unattended sweeps degrade gracefully.
+    """
+    try:
+        from work_buddy.config import load_config
+        root = (load_config() or {}).get("vault_root")
+        return Path(root) if root else None
+    except Exception:
+        return None
+
+
+def _journal_dir() -> Path | None:
+    """Return ``<vault_root>/<obsidian.journal_dir>``, or None if unset."""
+    root = _vault_root()
+    if root is None:
+        return None
+    try:
+        from work_buddy.config import load_config
+        rel = (
+            (load_config() or {})
+            .get("obsidian", {})
+            .get("journal_dir", "journal")
+        )
+    except Exception:
+        rel = "journal"
+    return root / rel
+
+
+def _resolve_vault_path(rel_path: str) -> Path | None:
+    """Resolve a vault-relative path, or absolute if already absolute."""
+    if not rel_path:
+        return None
+    candidate = Path(rel_path)
+    if candidate.is_absolute():
+        return candidate
+    root = _vault_root()
+    if root is None:
+        return None
+    return root / rel_path
+
+
+def _read_text_safe(path: Path) -> str | None:
+    """Read file text or return None on any failure (defensive)."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except Exception as exc:
+        logger.debug("trigger: read failed for %s: %s", path, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Triggers
+# ---------------------------------------------------------------------------
+
+
+def trigger_source_removed(
+    entry: "PoolEntry",
+    descriptor: "SourceDescriptor",
+) -> str | None:
+    """Fire when the entry's source no longer resolves.
+
+    Per-source resolution:
+
+    - ``inline`` — the source file at ``item.metadata.file_path``
+      no longer exists on disk.
+    - ``journal_thread`` — the journal file for ``item.metadata.source_dates``
+      (or today's date as fallback) no longer exists.
+    - ``chrome_tab`` — the tab id is absent from the live tab ledger
+      at ``data/chrome/tab_ledger.json``.
+
+    Defensive: when the check itself fails (vault root unconfigured,
+    ledger unreadable), returns ``None`` (treat as still live) and
+    logs at debug. We do NOT quarantine on ambiguity — that would be
+    destructive of user data.
+    """
+    source = entry.source or ""
+    meta = (entry.item or {}).get("metadata", {}) or {}
+
+    if source in {"inline"}:
+        rel = meta.get("file_path", "")
+        path = _resolve_vault_path(rel)
+        if path is None:
+            return None  # can't decide → leave alone
+        if not path.exists():
+            return "source_removed"
+        return None
+
+    if source == "journal_thread":
+        # Journal entries record source_dates as a list (e.g. ["2026-04-19"]).
+        # If the entry has multiple, only quarantine when ALL are gone —
+        # rare, but the conservative call.
+        dates = meta.get("source_dates") or []
+        if not dates:
+            return None
+        journal_dir = _journal_dir()
+        if journal_dir is None:
+            return None
+        all_gone = True
+        for date_str in dates:
+            candidate = journal_dir / f"{date_str}.md"
+            if candidate.exists():
+                all_gone = False
+                break
+        return "source_removed" if all_gone else None
+
+    if source == "chrome_tab":
+        from work_buddy.paths import data_dir
+        ledger_path = data_dir("chrome") / "tab_ledger.json"
+        if not ledger_path.exists():
+            return None  # ledger missing — can't decide
+        try:
+            import json
+            ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.debug("trigger: chrome ledger unreadable: %s", exc)
+            return None
+        tab_id = meta.get("tab_id") or entry.item_id
+        # Ledger shape varies — accept either dict-keyed or list-of-dicts.
+        if isinstance(ledger, dict):
+            tabs = ledger.get("tabs", ledger)
+        else:
+            tabs = ledger
+        if isinstance(tabs, dict):
+            present = tab_id in tabs
+        elif isinstance(tabs, list):
+            present = any(
+                (t.get("id") == tab_id or t.get("tab_id") == tab_id)
+                for t in tabs if isinstance(t, dict)
+            )
+        else:
+            present = True
+        return None if present else "source_removed"
+
+    # Unknown source — never quarantine.
+    return None
+
+
+def trigger_source_edited_beyond_match(
+    entry: "PoolEntry",
+    descriptor: "SourceDescriptor",
+) -> str | None:
+    """Fire when the captured text no longer appears in the source.
+
+    Currently scoped to ``journal_thread``. Compares the entry's
+    captured ``item.text`` against today's running notes (or the
+    entry's source dates) using :class:`difflib.SequenceMatcher` —
+    no embedding service dependency. Threshold comes from the
+    descriptor's ``config["edit_match_threshold"]`` (default 0.85).
+
+    Defensive: if the journal file isn't readable or the threshold
+    can't be evaluated, returns ``None``.
+
+    NOTE: difflib.ratio() is a coarse approximation of cosine
+    similarity — good enough for "is the captured text approximately
+    still present?" Switching to embedding-based similarity is a
+    future upgrade; the dispatch contract stays the same.
+    """
+    source = entry.source or ""
+    if source != "journal_thread":
+        return None
+
+    meta = (entry.item or {}).get("metadata", {}) or {}
+    captured = (entry.item or {}).get("text", "") or ""
+    if not captured:
+        return None
+
+    threshold = float(
+        (descriptor.config or {}).get("edit_match_threshold", 0.85)
+    )
+
+    dates = meta.get("source_dates") or []
+    if not dates:
+        return None
+
+    journal_dir = _journal_dir()
+    if journal_dir is None:
+        return None
+
+    # Best ratio across all source-date journals — if even one still
+    # contains the text, leave the entry alone.
+    best_ratio = 0.0
+    any_readable = False
+    for date_str in dates:
+        candidate = journal_dir / f"{date_str}.md"
+        text = _read_text_safe(candidate)
+        if text is None:
+            continue
+        any_readable = True
+        # SequenceMatcher.ratio() is O(n*m) — for short captured
+        # snippets against full-day journal files this is fine
+        # (~tens of KB; sub-second). For very long captures, fall
+        # back to a substring containment check first.
+        if captured in text:
+            best_ratio = 1.0
+            break
+        ratio = SequenceMatcher(None, captured, text).ratio()
+        if ratio > best_ratio:
+            best_ratio = ratio
+
+    if not any_readable:
+        return None  # can't decide — leave alone
+
+    return "source_edited_beyond_match" if best_ratio < threshold else None
+
+
+def trigger_tag_removed(
+    entry: "PoolEntry",
+    descriptor: "SourceDescriptor",
+) -> str | None:
+    """Fire when the entry's capture tag is no longer on the source paragraph.
+
+    Currently a placeholder — inline captures don't yet write back a
+    confirmation tag at capture time. The trigger function is wired
+    so that adding tag-write to the inline handler is a one-line
+    change (flip ``inline`` source's ``quarantine_triggers`` to
+    include ``tag_removed``).
+
+    Until then: returns ``None`` always (no-op).
+    """
+    # Implementation placeholder — see docstring. Returns None so
+    # configuring this trigger today is a no-op rather than a bug.
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+_TRIGGER_DISPATCH = {
+    "source_removed": trigger_source_removed,
+    "source_edited_beyond_match": trigger_source_edited_beyond_match,
+    "tag_removed": trigger_tag_removed,
+}
+
+
+def evaluate_triggers(
+    entry: "PoolEntry",
+    descriptor: "SourceDescriptor",
+) -> str | None:
+    """Run the descriptor's quarantine triggers; return first reason that fires.
+
+    ``None`` means the entry is still live. The order of triggers in
+    the descriptor is significant — first fire wins.
+
+    Defensive: any trigger that raises is logged and skipped (treated
+    as "did not fire"). The sweep is unattended; one bad trigger
+    must not poison the whole run.
+    """
+    for trigger_name in descriptor.quarantine_triggers:
+        fn = _TRIGGER_DISPATCH.get(trigger_name)
+        if fn is None:
+            logger.warning(
+                "evaluate_triggers: unknown trigger %r for source %r",
+                trigger_name, descriptor.name,
+            )
+            continue
+        try:
+            reason = fn(entry, descriptor)
+        except Exception as exc:
+            logger.warning(
+                "evaluate_triggers: %r raised on entry %s/%s: %s",
+                trigger_name, entry.run_id, entry.item_id, exc,
+            )
+            continue
+        if reason:
+            return reason
+    return None

--- a/work_buddy/triage/sources_triggers.py
+++ b/work_buddy/triage/sources_triggers.py
@@ -151,10 +151,13 @@ def trigger_source_removed(
         return None
 
     if source == "journal_thread":
-        # Journal entries record source_dates as a list (e.g. ["2026-04-19"]).
-        # If the entry has multiple, only quarantine when ALL are gone —
-        # rare, but the conservative call.
-        dates = meta.get("source_dates") or []
+        # Journal entries record source_dates as a list (e.g.
+        # ["2026-04-19"]) but legacy entries often left it empty
+        # and stored ``journal_date`` (singular) instead. Accept
+        # both. If neither is present, can't decide → leave alone.
+        dates = list(meta.get("source_dates") or [])
+        if not dates and meta.get("journal_date"):
+            dates = [meta["journal_date"]]
         if not dates:
             return None
         journal_dir = _journal_dir()
@@ -233,7 +236,9 @@ def trigger_source_edited_beyond_match(
         (descriptor.config or {}).get("edit_match_threshold", 0.85)
     )
 
-    dates = meta.get("source_dates") or []
+    dates = list(meta.get("source_dates") or [])
+    if not dates and meta.get("journal_date"):
+        dates = [meta["journal_date"]]
     if not dates:
         return None
 


### PR DESCRIPTION
## Summary

GTD redesign **Slice 1** — make the Review pool usable instead of a junk drawer. Foundational prerequisite for Slices 1.5 / 3 / etc.

The headline change: **stop the unattended LLM verdict pass on raw captures.** During the Slice 1 → Slice 3 interregnum the pool fills with raw inbox items only (`verdict={"raw": True}`); Slice 3 brings GTD-shaped verdicts back. *Full silence beats noisy stub verdicts* — this was the locked design call.

Refs `t-a97eb80f` (note carries the trimmed scope rationale + addendums for the design decisions made along the way).

## What's in the slice

### Foundational schema
- `PoolEntry` lifecycle: `state` enum (`pending | stale | quarantined | reviewed | dropped`), `expires_at`, `quarantine_reason`, `state_changed_at`. Backwards-compat `from_dict` infers state from legacy `reviewed_at`.
- New `TriagePool` methods: `pending_count`, `entries_in_state`, `mark_state`, `quarantine`, `mark_stale`, `submit_raw`, `all_entries`.

### Source-descriptor registry
- New `work_buddy/triage/sources.py` (data) + `sources_triggers.py` (logic).
- Per-source descriptors: `journal_thread` 5d TTL + source_removed/edit-match triggers; `chrome_tab` 2d + source_removed; `inline` no TTL + source_removed only (preserves user-affirmative captures).
- Override surface: `triage.pool.sources.<name>` in `config.local.yaml`.

### Verdict-pass gate (the load-bearing behavioral change)
- `triage.verdict_pass.enabled` in `TRIAGE_DEFAULTS` defaults to `false`.
- Both `journal_triage_scan` and `inline_triage_scan` route through `pool.submit_raw()` when off — agent never invoked, no LLM tokens spent, capture lands as `verdict={"raw": True}`.

### Daily liveness sweep
- New capability `triage_pool_sweep` + sidecar job at `5 4 * * *`.
- Walks pending entries: TTL-expired → `state=stale`; source-gone → `state=quarantined` with reason. Quarantine takes precedence over stale. Defensive throughout (one bad trigger doesn't poison the pass).

### Hardened `item_content_hash`
- NFKC + lowercase + per-line markdown-bullet strip + whitespace collapse. Catches semantically-identical re-emissions the old whitespace-only normalization missed.

### Review-tab presentation for raw entries
- `_build_presentation_from_pool` detects `verdict.raw` and renders raw cards with the captured text as the title (with leading capture-marker stripped), drops IR-context noise, sets a clear "verdict pending" rationale.

### Dashboard fixes (caught during live testing)
- **Bug A — data loss**: `api_review_execute` was marking *every* entry in the presentation reviewed when the user submitted *one* card. Now filters by `decisions.group_decisions[].group_index` AND by op success.
- **Bug B — silent failures**: per-op errors swallowed, status returned `ok` even on failure. Now surfaces `operation_errors` in response and downgrades status to `partial`.
- **Bug C — consent friction**: `tasks.create_task` is consent-gated for autonomy reasons; clicking Submit through the UI was triggering a redundant consent prompt. New `user_initiated(operation)` context manager in `work_buddy/consent.py` treats UI clicks as the consent boundary; nested `@requires_consent` calls pass through with audit-log entries distinguishing UI-driven actions from autonomous ones. Wired into `/api/review/execute`.
- **Bug D — singular vs plural bucket shape**: success-filter only handled `item_ids` (plural list); `closed` and `left` buckets use `item_id` (singular). Fixed.

### One-shot migration
- `scripts/migrate_pool_slice_1.py` — backfills state, recomputes hashes under new normalization, sets expires_at from descriptors. Idempotent. Run live against the 51-entry pool: **51 → 36 pending** (-29%), 13 stale (5d-old journal entries), 2 quarantined (inline files missing), worst duplicate-hash cluster collapsed 7 → 2.

## Test plan

- [x] Unit tests: 98 passing
  - `test_triage_pool_state.py`, `test_triage_sources.py`, `test_triage_pool_sweep.py`, `test_triage_verdict_gate.py`, `test_triage_review_pool_raw.py`, `test_consent_user_initiated.py`, `test_review_execute_partial_submit.py`
- [x] Live: `wb_run("triage_pool_sweep", {"dry_run": true})` — clean steady-state result on the live pool
- [x] Live: `wb_run("journal_triage_scan", {"force": true})` with verdict-pass off — 6 raw entries land cleanly, all with correct schema (`state="pending"`, `expires_at = created + 5d`, `verdict = {"raw": True}`)
- [x] Live UI: clicked Submit on multiple cards through the dashboard's Review tab — Create Task and Leave As-Is paths both work end-to-end
  - `Hola amigo!` task created at master-list top, note linked, store row written
  - Leave As-Is stamps reviewed without any Obsidian writes
  - Failed ops (bridge timeout) keep their cards pending instead of vanishing
- [x] One-shot migration ran successfully against live data; pool transitions correct

## What's deferred

- **Pool grouping at cosine 0.92** — moved to Slice 3 (composes existing `triage.cluster.cluster_items` + `recommend.group_intents`; Slice 3 task note has the addendum)
- **Producer back-pressure (>15 cap)** — unnecessary in the no-verdict world
- **Telegram + Obsidian capture-confirmation enhancements** — already exist
- **Dashboard direct-Python → MCP-gateway routing** — would pick up CP-A7 verify-then-decide for Obsidian bridge timeouts. Out of scope for Slice 1; failure today is at least clean and re-triable.

## Operational notes

- After merge, the daily sweep cron (`5 4 * * *`) starts firing automatically.
- `triage.verdict_pass.enabled = false` is the default — flip in `config.local.yaml` to re-enable the legacy verdict pass if needed.
- Slice 3 will read `verdict.raw == True` to find entries to re-process under the new schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)