### PR TITLE
feat(sidecar): startup banner + quieter LLM-fallback logs

### DIFF
--- a/work_buddy/llm/backends/_errors.py
+++ b/work_buddy/llm/backends/_errors.py
@@ -19,6 +19,35 @@ from typing import Any
 import httpx
 
 
+# Operational/recoverable kinds — these represent conditions where the
+# caller has a fallback path (different tier, retry later) and the
+# ``hint`` is user-actionable. The runner logs these as one-line
+# WARNINGs without a traceback because the wall-of-text from
+# ``logger.exception`` is noise: nothing was unexpected, and the
+# adapter that called us is going to log a more contextual WARNING of
+# its own.
+#
+# Anything NOT in this set ("malformed_response", "unknown") suggests
+# either a bug in our integration or an unmodeled failure mode — those
+# get a full ERROR + traceback because we want to find them.
+#
+# When you add a new ``kind`` to ``LocalInferenceError``'s docstring,
+# decide its severity here in the same edit. Membership is consulted
+# by ``LocalInferenceError.is_recoverable``; nothing else reads it.
+_RECOVERABLE_KINDS: frozenset[str] = frozenset({
+    "timeout",
+    "server_unreachable",
+    "model_not_available",
+    "model_unsupported",
+    "context_exceeded",
+    "lm_link_dropped",
+    "mcp_gateway_timeout",
+    "mcp_fetch_failed",
+    "bad_request",
+    "server_error",
+})
+
+
 class LocalInferenceError(Exception):
     """Structured error for local inference failures.
 
@@ -64,6 +93,27 @@ class LocalInferenceError(Exception):
         self.kind = kind
         self.hint = hint
         self.raw = raw
+
+    @property
+    def is_recoverable(self) -> bool:
+        """Whether this represents an operational, caller-handled condition.
+
+        ``True`` for kinds where the caller is expected to fall back to
+        another tier or surface the hint to the user — these should be
+        logged at WARNING without a traceback. ``False`` for kinds that
+        suggest a bug (``unknown``, ``malformed_response``) — those want
+        a full stack trace.
+        """
+        return self.kind in _RECOVERABLE_KINDS
+
+    def format_caller_message(self) -> str:
+        """Combine the message and hint into one string for embedding
+        in a caller-facing error field (e.g. ``TaskResult.error``).
+
+        Centralized so the "append hint if present" idiom doesn't get
+        duplicated at every catch site.
+        """
+        return str(self) + (f" Hint: {self.hint}" if self.hint else "")
 
     def to_dict(self, *, model: str = "") -> dict[str, Any]:
         """Serialize for inclusion in an agent-facing response payload."""

--- a/work_buddy/llm/runner.py
+++ b/work_buddy/llm/runner.py
@@ -383,6 +383,50 @@ def run_task(
         )
 
 
+def _backend_failure_to_result(
+    exc: BaseException,
+    *,
+    backend_id: str,
+    model: str,
+) -> TaskResult:
+    """Log a backend-call failure at appropriate severity and convert
+    to a ``TaskResult``.
+
+    Recoverable ``LocalInferenceError`` kinds (timeout, server_unreachable,
+    model_not_available, …) get a one-line WARNING — these are operational
+    conditions where the caller has a fallback path, and the kind/hint
+    already carry everything an operator needs. Anything else gets a full
+    ERROR with traceback because it suggests a bug or unmodeled failure.
+
+    Centralized here so the policy "which failures deserve a stack trace"
+    lives in one place; the ``except`` clause in ``_run_profile`` is just
+    a one-liner that delegates here.
+    """
+    from work_buddy.llm.backends._errors import LocalInferenceError
+
+    if isinstance(exc, LocalInferenceError):
+        if exc.is_recoverable:
+            logger.warning(
+                "Profile %s backend call failed: kind=%s msg=%s",
+                backend_id, exc.kind, exc,
+            )
+        else:
+            logger.exception(
+                "Profile %s backend call failed (kind=%s)",
+                backend_id, exc.kind,
+            )
+        return TaskResult(
+            content="", error=exc.format_caller_message(), model=model,
+        )
+
+    logger.exception("Profile %s backend call failed", backend_id)
+    return TaskResult(
+        content="",
+        error=f"{type(exc).__name__}: {exc}",
+        model=model,
+    )
+
+
 def _run_profile(
     *,
     profile_info: dict,
@@ -493,17 +537,8 @@ def _run_profile(
                 model=resolved_model,
             )
     except Exception as exc:
-        from work_buddy.llm.backends._errors import LocalInferenceError
-        logger.exception("Profile %s backend call failed", backend_id)
-        if isinstance(exc, LocalInferenceError):
-            # Embed the hint in the error string so callers who only
-            # check .error still see the remedy without schema changes.
-            msg = str(exc) + (f" Hint: {exc.hint}" if exc.hint else "")
-            return TaskResult(content="", error=msg, model=resolved_model)
-        return TaskResult(
-            content="",
-            error=f"{type(exc).__name__}: {exc}",
-            model=resolved_model,
+        return _backend_failure_to_result(
+            exc, backend_id=backend_id, model=resolved_model,
         )
 
     content = backend_result["content"]

--- a/work_buddy/sidecar/daemon.py
+++ b/work_buddy/sidecar/daemon.py
@@ -209,6 +209,88 @@ def _get_conda_python() -> str:
     return sys.executable
 
 
+# ---------------------------------------------------------------------------
+# Startup banner
+# ---------------------------------------------------------------------------
+#
+# When a human starts the sidecar in a terminal, the most useful thing
+# we can hand them is the dashboard URL printed plainly on boot. Logger
+# output is too noisy and goes to a file in non-foreground runs; this
+# banner goes to stdout so it's visible regardless of log routing.
+
+def _supports_color(stream: Any) -> bool:
+    """Whether ANSI escape codes are likely to render on ``stream``.
+
+    Three-way decision:
+    - ``NO_COLOR`` env var set (any value) → no color (per no-color.org).
+    - Stream not a TTY (piped, redirected, captured) → no color.
+    - Otherwise → assume yes. Modern Windows Terminal / VS Code / WezTerm
+      all handle ANSI; cmd.exe on Win10+ does too once any process in
+      the session writes an escape sequence. Old cmd.exe will show
+      garbage, but anyone running a Python sidecar on Windows is
+      almost certainly on a modern terminal.
+    """
+    if os.environ.get("NO_COLOR"):
+        return False
+    isatty = getattr(stream, "isatty", None)
+    return bool(isatty and isatty())
+
+
+def _print_startup_banner(
+    children: list[ChildService], cfg: dict[str, Any],
+) -> None:
+    """Print a short banner with the dashboard URL(s).
+
+    Always shows the local URL (for the machine the sidecar is running
+    on). Additionally shows the remote URL when ``dashboard.external_url``
+    is configured — that's the project's canonical place for the
+    Tailscale-served HTTPS URL (e.g. ``https://<host>.<tailnet>.ts.net``),
+    populated by the user or the setup wizard. Reading it from config
+    rather than re-discovering it via ``tailscale serve status --json``
+    keeps the banner consistent with telegram links and notification
+    surfaces, which read the same field.
+
+    No-ops cleanly when there's no dashboard service configured (or
+    disabled) — printing a banner that points at nothing would be
+    worse than silence.
+    """
+    dashboard = next(
+        (c for c in children if c.name == "dashboard" and c.enabled),
+        None,
+    )
+    if dashboard is None:
+        return
+
+    local_url = f"http://localhost:{dashboard.port}"
+    remote_url = (cfg.get("dashboard", {}).get("external_url") or "").rstrip("/")
+    use_color = _supports_color(sys.stdout)
+
+    if use_color:
+        BOLD = "\x1b[1m"
+        DIM = "\x1b[2m"
+        CYAN = "\x1b[36m"
+        UNDERLINE = "\x1b[4m"
+        RESET = "\x1b[0m"
+    else:
+        BOLD = DIM = CYAN = UNDERLINE = RESET = ""
+
+    def fmt_link(url: str) -> str:
+        return f"{CYAN}{UNDERLINE}{url}{RESET}"
+
+    # Two-column-aligned, with ``Local``/``Remote`` labels when both are
+    # present — labels collapse to "Dashboard:" when only the local URL
+    # exists, since the distinction would be redundant.
+    print()
+    print(f"    {BOLD}Work Buddy sidecar is running{RESET}")
+    if remote_url:
+        print(f"    {DIM}Local: {RESET}  {fmt_link(local_url)}")
+        print(f"    {DIM}Remote:{RESET}  {fmt_link(remote_url)}")
+    else:
+        print(f"    {DIM}Dashboard:{RESET}  {fmt_link(local_url)}")
+    print()
+    sys.stdout.flush()
+
+
 def _start_child(svc: ChildService) -> None:
     """Start a child service as a direct subprocess.
 
@@ -592,6 +674,7 @@ def run(foreground: bool = True) -> None:
         "daemon_start", "daemon",
         f"Started (pid={os.getpid()}, {len(children)} services, {len(scheduler.jobs)} jobs)",
     )
+    _print_startup_banner(children, cfg)
 
     # --- Main loop ---
     try:


### PR DESCRIPTION
## Summary

- Sidecar prints a short banner on stdout once services are healthy, showing the local dashboard URL plus the remote URL when `dashboard.external_url` is configured. Color is gated on TTY + `NO_COLOR`. The remote URL is read from the same config field telegram links and notification surfaces use, so the banner can never disagree with them.
- LLM backend exception handling no longer logs routine local-LLM fallbacks as `ERROR` with a full traceback. `LocalInferenceError` now exposes an `is_recoverable` predicate (backed by `_RECOVERABLE_KINDS`); the runner delegates to a single `_backend_failure_to_result` helper that logs recoverable kinds (`timeout`, `server_unreachable`, `model_not_available`, …) at `WARNING` with no traceback, while preserving full `ERROR + traceback` for genuinely surprising kinds (`malformed_response`, `unknown`).
- Net effect on a cold-LM-Studio fallback to Claude Haiku: a wall-of-text traceback collapses to a single `WARNING` line, without hiding any actual bugs.

## Test plan

- [ ] Restart sidecar in a terminal and confirm the banner shows both `Local:` and `Remote:` URLs in color.
- [ ] Pipe sidecar to a file (or set `NO_COLOR=1`) and confirm the banner renders without ANSI escapes.
- [ ] Trigger a journal-segmentation call while LM Studio is cold; confirm the log shows a single `WARNING` line about the timeout instead of a multi-frame traceback, and that the cloud fallback still completes.
- [ ] `python -m pytest tests/unit/test_llm_error_interpretation.py tests/unit/test_llm_local_inference.py tests/unit/test_llm_with_tools.py tests/unit/test_llm_with_tools_hygiene.py tests/test_sidecar_core.py tests/test_sidecar_cron.py` (verified locally: 101 passed).

Task: t-1df52a76

🤖 Generated with [Claude Code](https://claude.com/claude-code)