### PR TITLE
refactor(sidecar): drop unused allow_demotion job field

### DIFF
--- a/work_buddy/sidecar/dispatch/models.py
+++ b/work_buddy/sidecar/dispatch/models.py
@@ -16,9 +16,14 @@ Spawn modes
   ``--no-session-persistence``, so persistence is one-write — the initial
   run's context is preserved, but resume runs do not accumulate further
   state.
-- **interactive_persistent**: Reserved for launching a user-visible
-  interactive Claude Code session. Implementation deferred until the
-  interactive runner is configured. Placeholder raises ``NotImplementedError``.
+- **interactive_persistent**: Launches a user-visible interactive Claude
+  Code session via a hidden PTY. The session is registered and appears
+  in the user's Claude Code session picker so they can resume it on
+  their own schedule. Implemented in
+  ``executor._spawn_interactive_agent``; PTY backend in
+  ``dispatch/pty_adapter.py`` (``pywinpty`` on Windows, ``ptyprocess``
+  elsewhere — both declared as platform-conditional deps in
+  ``pyproject.toml``).
 
 Agent targets
 -------------

--- a/work_buddy/sidecar/scheduler/jobs.py
+++ b/work_buddy/sidecar/scheduler/jobs.py
@@ -49,7 +49,6 @@ class Job:
 
     # Agent spawn control (for type=prompt and workflow reasoning steps)
     spawn_mode: str = ""  # headless_ephemeral | headless_persistent | interactive_persistent
-    allow_demotion: bool = True  # Allow interactive→headless demotion if interactive unavailable
 
     # Runtime state (not persisted in .md frontmatter — populated by scheduler)
     last_run_at: float = 0.0
@@ -132,8 +131,6 @@ def _parse_job_file(file_path: Path) -> Job | None:
         )
         spawn_mode = ""
 
-    allow_demotion = _parse_bool(fm.get("allow_demotion", True))
-
     return Job(
         name=name,
         file_path=file_path,
@@ -147,7 +144,6 @@ def _parse_job_file(file_path: Path) -> Job | None:
         description=body.strip(),
         enabled=enabled,
         spawn_mode=spawn_mode,
-        allow_demotion=allow_demotion,
     )
 
 


### PR DESCRIPTION
## Summary

- Removes the `allow_demotion: bool = True` field from the `Job` dataclass and its frontmatter parsing in [work_buddy/sidecar/scheduler/jobs.py](work_buddy/sidecar/scheduler/jobs.py). Nothing read the flag and no scheduled job set it.
- Refreshes the stale `interactive_persistent` docstring in [work_buddy/sidecar/dispatch/models.py](work_buddy/sidecar/dispatch/models.py), which still claimed the mode was "deferred / placeholder raises NotImplementedError" long after it was implemented.

## Why

The `allow_demotion` flag was meant to opt-in to interactive→headless fallback when the PTY backend was unavailable. But the failure mode it guarded against (`winpty` missing on Windows) is already prevented at the dependency layer — [pyproject.toml:34-35](pyproject.toml) declares `pywinpty` as a Windows-only dep and `ptyprocess` as a non-Windows dep, both required. A correctly-installed work-buddy can't hit the failure mode, so the flag was speculative dead config.

Background context lives in task `t-47543773` (sidecar phase 2 follow-ups).

## Test plan

- [x] `python -m pytest tests/test_sidecar_core.py -q` — 15/15 passing on this branch
- [x] `grep -r "allow_demotion" .` returns zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)