### PR TITLE
feat(sidecar): jitter high-frequency phase-aligned cron jobs

### DIFF
--- a/sidecar_jobs/inline-sync.md
+++ b/sidecar_jobs/inline-sync.md
@@ -1,6 +1,7 @@
 ---
 schedule: "*/10 * * * *"  # every 10 minutes
 recurring: true
+jitter_seconds: 180  # spread 10-minute pile-ups (especially at :00 / :30)
 type: capability
 capability: inline_sync
 params: {}

--- a/sidecar_jobs/ir-index-rebuild.md
+++ b/sidecar_jobs/ir-index-rebuild.md
@@ -1,6 +1,7 @@
 ---
 schedule: "*/5 * * * *"  # every 5 minutes
 recurring: true
+jitter_seconds: 90  # spread 5-minute pile-ups; lands at name+schedule-derived offset
 type: capability
 capability: ir_index
 params:

--- a/sidecar_jobs/task-note-index.md
+++ b/sidecar_jobs/task-note-index.md
@@ -1,6 +1,7 @@
 ---
 schedule: "*/5 * * * *"  # every 5 minutes
 recurring: true
+jitter_seconds: 90  # spread 5-minute pile-ups; lands off ir-index-rebuild's offset
 type: capability
 capability: ir_index
 params:


### PR DESCRIPTION
## Summary

Adopts the jitter mechanism from #86 on the three sidecar jobs whose schedules naturally coincide at common minute boundaries:

| Job                | Schedule    | jitter_seconds | Offset (deterministic) |
|--------------------|-------------|----------------|------------------------|
| ir-index-rebuild   | `*/5 * * * *`  | 90  | +55s |
| task-note-index    | `*/5 * * * *`  | 90  | +4s  |
| inline-sync        | `*/10 * * * *` | 180 | +32s |

`service-heartbeat` (`*/3`) intentionally left exact-time — health-status reporting wants punctual minute boundaries; the spread won.

## Stacks on

This PR targets `feat/jitter-seconds` (#86) so it can be reviewed individually but won't merge until the mechanism does.

## Test plan

- [ ] After merging #86, observe `sidecar_state.json` — `effective_at` for each of these three jobs should equal `next_at + offset` matching the table above.
- [ ] Watch the `job_fired` events: ir-index-rebuild and task-note-index used to fire within the same second; with these offsets they should fire ~51s apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)