### PR TITLE
feat(dashboard): surface jitter offset on Jobs tab

### DIFF
--- a/work_buddy/dashboard/frontend/scripts/tabs/jobs.py
+++ b/work_buddy/dashboard/frontend/scripts/tabs/jobs.py
@@ -335,13 +335,23 @@ function renderJobsTable(jobs, emptyHtml) {
                     ${_wbJobIcon('trash')}
                 </button>
             </td>` : '<td class="jobs-row-actions"></td>';
+        // Prefer effective_at (next_at + jitter offset, or queued
+        // pending due time) when present, falling back to next_at for
+        // back-compat with older sidecar_state.json shapes.
+        const fireAt = j.effective_at || j.next_at;
+        const jitter = j.jitter_seconds || 0;
+        const nextCell = jitter > 0
+            ? `${timeUntil(fireAt)}<span class="jobs-jitter-tag" title="`
+                + `Schedule has jitter_seconds=${jitter}; deterministic offset spreads firing.`
+                + `">+${jitter}s jit</span>`
+            : timeUntil(fireAt);
         return `
             <tr>
                 <td>${j.name}</td>
                 <td title="${j.schedule}">${j.schedule_desc || j.schedule}</td>
                 <td>${j.last_result ? statusBadge(j.last_result, j.last_error) : '\u2014'}</td>
                 <td>${timeAgo(j.last_run_at)}</td>
-                <td>${timeUntil(j.next_at)}</td>
+                <td>${nextCell}</td>
                 ${actions}
             </tr>
         `;

--- a/work_buddy/dashboard/frontend/styles.py
+++ b/work_buddy/dashboard/frontend/styles.py
@@ -3530,6 +3530,24 @@ body {
     color: var(--red);
 }
 
+/* Inline annotation on the "Next Run" cell when a job declares
+   jitter_seconds. The pill carries a tooltip explaining the offset;
+   it sits to the right of the relative time so the column still
+   sorts visually by upcoming-fire. Subtle background to match the
+   secondary status badges elsewhere on the dashboard. */
+.jobs-jitter-tag {
+    display: inline-block;
+    margin-left: 6px;
+    padding: 1px 6px;
+    border-radius: 9px;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-size: 11px;
+    font-weight: 500;
+    line-height: 1.4;
+    cursor: help;
+}
+
 /* In-form chat-walkthrough escape hatch. Sits at the top of the
    add-job form as a secondary entry point — visually paired with
    the form ("you can fill this out, or chat with me"). Outline-


### PR DESCRIPTION
## Summary

The Jobs tab's "Next Run" column reads `next_at` directly. With opt-in jitter from #86, the job actually fires at `next_at + offset` (or the queued pending due time once a fire is enqueued), not at the raw cron minute. Without this, the dashboard shows misleading times for any jittered job.

Changes:

- Renderer reads `effective_at` (falls back to `next_at` for old state files).
- Adds a small "+90s jit" pill next to jittered jobs' time, with a tooltip.
- New `.jobs-jitter-tag` style — subtle, secondary-text-colored pill.

## Stacks on

Targets `feat/jitter-seconds` (#86) — depends on `JobState.jitter_seconds` and `JobState.effective_at` being present.

## Test plan

- [x] `pytest tests/unit/test_dashboard_namespaces.py tests/unit/test_dashboard_form_bridge.py tests/unit/test_dashboard_event_bus.py -q` (25 passed)
- [x] `pytest tests/test_scheduler_jitter.py tests/test_sidecar_core.py tests/test_sidecar_cron.py -q` (61 passed)
- [ ] Optional manual: run sidecar with #87 merged, open dashboard Jobs tab, confirm `ir-index-rebuild` shows `+90s jit` and the time matches the +55s offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)