### PR TITLE
test(inline): point send-to-agent tests at the new pipeline path

### DIFF
--- a/tests/inline/test_send_to_agent.py
+++ b/tests/inline/test_send_to_agent.py
@@ -80,10 +80,8 @@ def test_run_producer_catches_exceptions(monkeypatch) -> None:
         raise RuntimeError("LLM down")
 
     import importlib
-    mod = importlib.import_module(
-        "work_buddy.triage.capabilities.inline_triage_scan"
-    )
-    monkeypatch.setattr(mod, "inline_triage_scan", _boom)
+    mod = importlib.import_module("work_buddy.pipelines.inline")
+    monkeypatch.setattr(mod, "inline_capture", _boom)
     # Should not raise even though the inner call blew up
     handler_mod._run_producer(
         file_path="x", selection="y", paragraph="", cursor_line=0, hint="",
@@ -93,15 +91,17 @@ def test_run_producer_catches_exceptions(monkeypatch) -> None:
 def test_run_producer_invokes_scan(monkeypatch) -> None:
     seen: dict = {}
 
-    def _fake_scan(**kw):
+    def _fake_capture(**kw):
         seen.update(kw)
-        return {"status": "ok", "run_id": "r1", "submitted": 1}
+        return {
+            "status": "ok",
+            "umbrella_id": "u1",
+            "child_thread_ids": [],
+        }
 
     import importlib
-    mod = importlib.import_module(
-        "work_buddy.triage.capabilities.inline_triage_scan"
-    )
-    monkeypatch.setattr(mod, "inline_triage_scan", _fake_scan)
+    mod = importlib.import_module("work_buddy.pipelines.inline")
+    monkeypatch.setattr(mod, "inline_capture", _fake_capture)
 
     handler_mod._run_producer(
         file_path="Notes/a.md",
@@ -116,7 +116,6 @@ def test_run_producer_invokes_scan(monkeypatch) -> None:
     assert seen["paragraph"] == "para"
     assert seen["cursor_line"] == 4
     assert seen["hint"] == "hint"
-    assert seen["force"] is True
 
 
 class _FakeThread:


### PR DESCRIPTION
## Summary

- Two tests in `tests/inline/test_send_to_agent.py` were monkey-patching `work_buddy.triage.capabilities.inline_triage_scan` via `importlib.import_module`. That module was deleted in Phase 4 of the clarify→Threads migration (PR #95).
- Fix: patch `work_buddy.pipelines.inline.inline_capture` instead — that's what `_run_producer` now calls. Update the fake's return shape (`umbrella_id` / `child_thread_ids`) and drop the `force=True` assertion (parameter doesn't exist on `inline_capture`).
- Static grep for `from work_buddy.triage` missed these because the imports are dynamic string-literal `importlib.import_module` calls.

## Test plan

- [x] `python -m pytest tests/inline/test_send_to_agent.py -q` → 5/5 pass locally
- [ ] CI on PR goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)