### PR TITLE
chore(gitignore): ignore Claude Code runtime lock files under .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,11 @@ knowledge/store.local/
 # Claude Code local settings (auto-generated permission rules, machine-specific)
 .claude/settings.local.json
 .claude/settings.json
+# Claude Code runtime lock files (e.g. scheduled_tasks.lock from the
+# scheduled-tasks MCP server). Contents are a process singleton —
+# {sessionId, pid, acquiredAt} — meaningful only on the host that
+# wrote them. Pattern catches similar future per-server lock files.
+.claude/*.lock
 
 # Cygwin / MSYS bash crash dumps (machine-specific noise, regenerated
 # every time bash crashes — not useful in version control)


### PR DESCRIPTION
## Summary
- Adds \`.claude/*.lock\` to \`.gitignore\` so Claude Code runtime lock files (currently \`.claude/scheduled_tasks.lock\` from the scheduled-tasks MCP server) stop showing up as untracked in every \`git status\`.
- Pattern intentionally catches future per-server lock files automatically.
- Fits the same shelf as the already-ignored \`.claude/settings*.json\` — machine-specific runtime state, regenerated each session, not authored.
- We do **not** wholesale-ignore \`.claude/\`: \`commands/\`, \`hooks/\`, and \`launch.json\` under there are project-shipped artifacts and must stay tracked.

## Test plan
- [x] \`git check-ignore -v .claude/scheduled_tasks.lock\` reports the new pattern (\`.gitignore:54:.claude/*.lock\`).
- [x] \`git status\` on a fresh clone (or after \`git rm --cached\` if any lock had ever been tracked — none were) no longer surfaces the lock file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)