### PR TITLE
fix: Settings fix-flow + dashboard/scheduler runtime resilience

### DIFF
--- a/knowledge/store/_generated_capabilities.json
+++ b/knowledge/store/_generated_capabilities.json
@@ -1506,7 +1506,7 @@
   "context/context_projects": {
     "kind": "capability",
     "name": "Context Projects",
-    "description": "Active projects with identity, state, and trajectory — synthesized from vault directories, STATE.md files in repos, task tags, git activity, and contracts. Filters the rendered output to active + inferred by default; pass ``statuses`` to widen.",
+    "description": "Active projects with identity, state, and trajectory — synthesized from vault directories, STATE.md files in repos, task tags, git activity, and contracts. Filters the rendered output to active projects by default; pass ``statuses`` to widen.",
     "capability_name": "context_projects",
     "category": "context",
     "aliases": [
@@ -1520,7 +1520,7 @@
     "parameters": {
       "statuses": {
         "type": "list",
-        "description": "Project statuses to include in the rendered bundle. Default: active + inferred. Pass [\"active\", \"inferred\", \"future\", \"past\"] to include everything. Filters only the rendered output — every project is still scanned and synced to the registry.",
+        "description": "Project lifecycle statuses to include in the rendered bundle. Default: active only. Valid values: active, paused, future, past. Pass [\"active\", \"paused\", \"future\", \"past\"] to include everything (deleted is never rendered). Filters only the rendered output — every project is still scanned and synced to the registry.",
         "required": false
       }
     },

--- a/tests/unit/test_fix_params_current_values.py
+++ b/tests/unit/test_fix_params_current_values.py
@@ -1,0 +1,56 @@
+"""Tests for fix_params current-value enrichment.
+
+`fix_params_with_current_values` lets the dashboard fix form pre-fill a
+requirement's live configured value (so the form doubles as an editor),
+by resolving each field's declared `config_path` against the merged
+config. Secret fields declare no `config_path` and stay un-enriched.
+"""
+
+from __future__ import annotations
+
+from work_buddy.config import load_config
+from work_buddy.health.requirements import (
+    REQUIREMENT_REGISTRY,
+    _config_value_at,
+    fix_params_with_current_values,
+)
+
+
+class TestConfigValueAt:
+    def test_top_level_key(self):
+        assert _config_value_at({"timezone": "UTC"}, "timezone") == "UTC"
+
+    def test_nested_dotted_path(self):
+        cfg = {"backups": {"github": {"repo": "me/data"}}}
+        assert _config_value_at(cfg, "backups.github.repo") == "me/data"
+
+    def test_missing_path_returns_none(self):
+        assert _config_value_at({"a": {}}, "a.b.c") is None
+        assert _config_value_at({}, "nope") is None
+
+    def test_non_dict_hop_returns_none(self):
+        assert _config_value_at({"a": "scalar"}, "a.b") is None
+
+
+class TestFixParamsCurrentValues:
+    def test_config_path_field_gets_current_value(self):
+        req = REQUIREMENT_REGISTRY["core/config/timezone"]
+        enriched = fix_params_with_current_values(req)
+        assert enriched["timezone"]["current_value"] == load_config().get("timezone")
+
+    def test_secret_field_without_config_path_not_enriched(self):
+        # The Telegram bot token is input_required but secret — it
+        # declares no config_path, so the token is never echoed back.
+        req = REQUIREMENT_REGISTRY["services/telegram/bot-token"]
+        enriched = fix_params_with_current_values(req)
+        assert "current_value" not in enriched["bot_token"]
+
+    def test_does_not_mutate_the_requirement_def(self):
+        req = REQUIREMENT_REGISTRY["core/config/timezone"]
+        fix_params_with_current_values(req)
+        # The shared registry def must stay clean for the next caller.
+        assert "current_value" not in req.fix_params["timezone"]
+
+    def test_requirement_without_fix_params(self):
+        req = REQUIREMENT_REGISTRY["core/config/config-yaml-exists"]
+        assert fix_params_with_current_values(req) == {}

--- a/tests/unit/test_sidecar_daemon_helpers.py
+++ b/tests/unit/test_sidecar_daemon_helpers.py
@@ -1,0 +1,75 @@
+"""Tests for daemon helpers that keep a misconfiguration or a sustained
+fault from silently taking down the sidecar.
+
+``safe_port`` rejects an invalid ``sidecar.services.<svc>.port`` so the
+daemon skips that one service instead of crashing. ``TickFailureTracker``
+turns a run of failing ticks — otherwise caught as "non-fatal" and
+retried forever — into a single loud signal.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from work_buddy.sidecar.daemon import TickFailureTracker, safe_port
+
+
+class TestSafePort:
+    def test_valid_int_port(self):
+        assert safe_port(5127, service_name="dashboard") == 5127
+
+    def test_numeric_string_is_coerced(self):
+        assert safe_port("5123", service_name="messaging") == 5123
+
+    def test_non_numeric_is_rejected(self, caplog):
+        with caplog.at_level(logging.ERROR, logger="work_buddy.sidecar.daemon"):
+            assert safe_port("not-a-port", service_name="messaging") is None
+        assert any("messaging" in r.message for r in caplog.records)
+
+    def test_out_of_range_is_rejected(self, caplog):
+        with caplog.at_level(logging.ERROR, logger="work_buddy.sidecar.daemon"):
+            assert safe_port(99999, service_name="embedding") is None
+            assert safe_port(0, service_name="embedding") is None
+
+    def test_none_is_rejected(self):
+        assert safe_port(None, service_name="telegram") is None
+
+
+class TestTickFailureTracker:
+    def test_successes_never_escalate(self):
+        tracker = TickFailureTracker(threshold=3)
+        for _ in range(10):
+            assert tracker.record_success() is None
+
+    def test_escalates_once_at_threshold(self):
+        tracker = TickFailureTracker(threshold=3)
+        exc = RuntimeError("boom")
+        assert tracker.record_failure(exc) is None   # 1
+        assert tracker.record_failure(exc) is None   # 2
+        msg = tracker.record_failure(exc)            # 3 — crosses threshold
+        assert msg is not None and "3" in msg and "boom" in msg
+        # A continuing failure run does not re-escalate.
+        assert tracker.record_failure(exc) is None   # 4
+
+    def test_recovery_emits_once_after_escalation(self):
+        tracker = TickFailureTracker(threshold=2)
+        tracker.record_failure(RuntimeError("x"))
+        assert tracker.record_failure(RuntimeError("x")) is not None  # escalated
+        recovery = tracker.record_success()
+        assert recovery is not None and "recovered" in recovery.lower()
+        # Recovery is announced exactly once.
+        assert tracker.record_success() is None
+
+    def test_no_recovery_message_without_prior_escalation(self):
+        tracker = TickFailureTracker(threshold=3)
+        tracker.record_failure(RuntimeError("x"))   # 1, below threshold
+        assert tracker.record_success() is None     # never escalated → no message
+
+    def test_failure_run_resets_on_success(self):
+        tracker = TickFailureTracker(threshold=3)
+        tracker.record_failure(RuntimeError("x"))   # 1
+        tracker.record_failure(RuntimeError("x"))   # 2
+        tracker.record_success()                    # resets the run
+        # Counter restarted — two more failures must not escalate yet.
+        assert tracker.record_failure(RuntimeError("x")) is None  # 1
+        assert tracker.record_failure(RuntimeError("x")) is None  # 2

--- a/tests/unit/test_timezone_safety.py
+++ b/tests/unit/test_timezone_safety.py
@@ -57,3 +57,36 @@ class TestSchedulerTimezone:
     def test_missing_config_timezone_degrades_to_utc(self):
         engine = Scheduler({})
         assert engine._timezone == "UTC"
+
+
+class TestSchedulerTimezoneReloadDedup:
+    """A persistently-invalid timezone must not re-log the fallback
+    warning on every 30s config hot-reload — only when the value changes."""
+
+    def _invalid_warnings(self, caplog):
+        return [r for r in caplog.records if "Invalid timezone" in r.message]
+
+    def test_hot_reload_does_not_respam_unchanged_value(self, monkeypatch, caplog):
+        with caplog.at_level(logging.WARNING, logger="work_buddy.config"):
+            engine = Scheduler({"timezone": "Bad/Zone"})
+            assert engine._timezone == "UTC"
+            caplog.clear()  # drop the one construction-time warning
+            monkeypatch.setattr(
+                "work_buddy.config.load_config", lambda: {"timezone": "Bad/Zone"}
+            )
+            engine._hot_reload()
+            engine._hot_reload()
+        # Same invalid value as construction → no fresh warnings.
+        assert self._invalid_warnings(caplog) == []
+
+    def test_hot_reload_rewarns_when_value_changes(self, monkeypatch, caplog):
+        with caplog.at_level(logging.WARNING, logger="work_buddy.config"):
+            engine = Scheduler({"timezone": "Bad/Zone"})
+            caplog.clear()  # drop the construction-time warning
+            monkeypatch.setattr(
+                "work_buddy.config.load_config", lambda: {"timezone": "Other/Bad"}
+            )
+            engine._hot_reload()
+        # The value changed to a different invalid zone → warn exactly once.
+        assert len(self._invalid_warnings(caplog)) == 1
+        assert engine._timezone == "UTC"

--- a/tests/unit/test_timezone_safety.py
+++ b/tests/unit/test_timezone_safety.py
@@ -1,0 +1,59 @@
+"""Tests for timezone validation — the runtime must never crash on a
+bad configured timezone.
+
+An invalid ``timezone`` in config.yaml previously made ``ZoneInfo()``
+raise on every scheduler tick, silently halting all scheduled jobs.
+``safe_timezone`` validates once and degrades to UTC instead.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from work_buddy.config import safe_timezone
+from work_buddy.sidecar.scheduler.engine import Scheduler
+
+
+class TestSafeTimezone:
+    def test_valid_timezone_passes_through(self):
+        assert safe_timezone("America/New_York") == "America/New_York"
+        assert safe_timezone("Europe/London") == "Europe/London"
+        assert safe_timezone("UTC") == "UTC"
+
+    def test_invalid_timezone_falls_back_to_utc(self):
+        assert safe_timezone("WB_TEST_INVALID_TZ") == "UTC"
+        assert safe_timezone("Not/AZone") == "UTC"
+
+    def test_invalid_timezone_logs_a_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="work_buddy.config"):
+            safe_timezone("Bogus/Zone")
+        assert any("Bogus/Zone" in r.message for r in caplog.records)
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+    def test_none_and_empty_fall_back_silently(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="work_buddy.config"):
+            assert safe_timezone(None) == "UTC"
+            assert safe_timezone("") == "UTC"
+        # Absence is not an error — a missing value gets no warning.
+        assert not caplog.records
+
+    def test_custom_fallback_is_honored(self):
+        assert safe_timezone("Bogus/Zone", fallback="America/Toronto") == "America/Toronto"
+        assert safe_timezone(None, fallback="America/Toronto") == "America/Toronto"
+
+
+class TestSchedulerTimezone:
+    """The engine validates the configured timezone once at construction
+    (and on hot-reload) so cron matching never throws per-tick."""
+
+    def test_invalid_config_timezone_degrades_to_utc(self):
+        engine = Scheduler({"timezone": "WB_TEST_INVALID_TZ"})
+        assert engine._timezone == "UTC"
+
+    def test_valid_config_timezone_is_kept(self):
+        engine = Scheduler({"timezone": "America/New_York"})
+        assert engine._timezone == "America/New_York"
+
+    def test_missing_config_timezone_degrades_to_utc(self):
+        engine = Scheduler({})
+        assert engine._timezone == "UTC"

--- a/work_buddy/config.py
+++ b/work_buddy/config.py
@@ -1,10 +1,13 @@
 """Configuration loading for work-buddy context bundle collector."""
 
+import logging
 from pathlib import Path
 from typing import Any
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 
 DEFAULTS = {
@@ -192,12 +195,33 @@ def write_config_local(section: str, data: Any) -> None:
         yaml.safe_dump(existing, f, default_flow_style=False, sort_keys=False)
 
 
+def safe_timezone(name: str | None, *, fallback: str = "UTC") -> str:
+    """Return ``name`` if it is a valid IANA timezone, else ``fallback``.
+
+    Runtime code (the scheduler, display formatting) constructs
+    ``ZoneInfo`` from the configured timezone. An invalid value would
+    otherwise raise every time it is used — silently halting the
+    scheduler tick. Validate once here and degrade to a safe zone
+    instead of throwing; a set-but-invalid value logs a warning.
+    """
+    if not name:
+        return fallback
+    try:
+        ZoneInfo(name)
+        return name
+    except (ZoneInfoNotFoundError, KeyError, ValueError):
+        logger.warning(
+            "Invalid timezone %r in config; falling back to %s", name, fallback
+        )
+        return fallback
+
+
 _USER_TZ_CACHE: ZoneInfo | None = None
 
 
 def _compute_user_tz() -> ZoneInfo:
     cfg = load_config()
-    return ZoneInfo(cfg.get("timezone", "America/New_York"))
+    return ZoneInfo(safe_timezone(cfg.get("timezone")))
 
 
 def __getattr__(name: str):

--- a/work_buddy/control/graph.py
+++ b/work_buddy/control/graph.py
@@ -91,7 +91,11 @@ def _assemble() -> dict[str, ControlNode]:
     from work_buddy.health.components import COMPONENT_CATALOG
     from work_buddy.health.engine import HealthEngine
     from work_buddy.health.preferences import load_preferences
-    from work_buddy.health.requirements import REQUIREMENT_REGISTRY, RequirementChecker
+    from work_buddy.health.requirements import (
+        REQUIREMENT_REGISTRY,
+        RequirementChecker,
+        fix_params_with_current_values,
+    )
     from work_buddy.mcp_server.registry import (
         Capability,
         WorkflowDefinition,
@@ -260,7 +264,9 @@ def _assemble() -> dict[str, ControlNode]:
             component_id=req.component,
             status_reason=(result.detail if result else "Check not yet run"),
             fix_kind=getattr(req, "fix_kind", "none"),
-            fix_params=dict(getattr(req, "fix_params", {}) or {}),
+            # Enriched with each field's current configured value so the
+            # dashboard fix form can pre-fill (and double as an editor).
+            fix_params=fix_params_with_current_values(req),
             fix_preview=getattr(req, "fix_preview", None),
         )
 

--- a/work_buddy/dashboard/api.py
+++ b/work_buddy/dashboard/api.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -42,25 +43,45 @@ _BRIDGE_HISTORY: deque[dict[str, Any]] = deque(maxlen=60)  # ~30min at 30s refre
 _PROBE_REFRESH_INTERVAL = 60  # seconds between tool probe refreshes
 _last_probe_refresh: float = 0.0
 
+# Snapshot cache for get_system_state(). The build runs a requirement
+# sweep (and reads probe results) — work that can take 20s+ when an
+# optional dependency is offline and several requirement checks stack up
+# their timeouts. The endpoint serves the cached snapshot and refreshes
+# it on a background thread once stale, so no request after the first
+# ever pays that cost.
+_STATE_CACHE_TTL = 5.0  # seconds before a served snapshot is refreshed
+_state_cache: dict[str, Any] | None = None
+_state_cache_ts: float = 0.0
+_state_cache_lock = threading.Lock()
+_state_refreshing = False
+
 
 def _maybe_refresh_probes() -> None:
-    """Re-run tool probes if stale (>60s since last refresh).
+    """Kick off a tool-probe refresh in the background if stale (>60s).
 
-    This runs in the dashboard process, not the MCP server. It writes
-    fresh results to tool_status.json so the HealthEngine picks them up.
-    Probes are lightweight HTTP/TCP checks (~0.5-1s total).
+    Runs in the dashboard process (not the MCP server), writing fresh
+    results to tool_status.json for the HealthEngine to pick up.
+    ``probe_all()`` can stall for ~10s when an optional service (e.g. the
+    Obsidian bridge) is offline, so it runs on a background thread — the
+    request never waits on it; the next request sees the fresh data.
     """
     global _last_probe_refresh
     now = time.time()
     if now - _last_probe_refresh < _PROBE_REFRESH_INTERVAL:
         return
+    # Claim the slot before spawning so a burst of requests starts only
+    # one refresh thread.
     _last_probe_refresh = now
-    try:
-        from work_buddy.tools import _register_default_probes, probe_all
-        _register_default_probes()
-        probe_all(force=True)
-    except Exception as exc:
-        logger.debug("Probe refresh failed: %s", exc)
+
+    def _refresh() -> None:
+        try:
+            from work_buddy.tools import _register_default_probes, probe_all
+            _register_default_probes()
+            probe_all(force=True)
+        except Exception as exc:
+            logger.debug("Probe refresh failed: %s", exc)
+
+    threading.Thread(target=_refresh, name="probe-refresh", daemon=True).start()
 
 
 def _read_sidecar_state() -> dict[str, Any]:
@@ -215,7 +236,64 @@ def _describe_cron(expr: str) -> str:
         return expr
 
 
+def _kick_state_refresh() -> None:
+    """Rebuild the system-state snapshot on a background thread.
+
+    Single-flight: a refresh already in progress is not duplicated.
+    Keeps the slow ``_build_system_state`` off the request path entirely
+    once the cache is warm.
+    """
+    global _state_refreshing
+    with _state_cache_lock:
+        if _state_refreshing:
+            return
+        _state_refreshing = True
+
+    def _refresh() -> None:
+        global _state_cache, _state_cache_ts, _state_refreshing
+        try:
+            fresh = _build_system_state()
+            _state_cache = fresh
+            _state_cache_ts = time.time()
+        except Exception as exc:
+            logger.warning("Background system-state refresh failed: %s", exc)
+        finally:
+            _state_refreshing = False
+
+    threading.Thread(
+        target=_refresh, name="system-state-refresh", daemon=True,
+    ).start()
+
+
 def get_system_state() -> dict[str, Any]:
+    """Aggregated system snapshot, served from a background-refreshed cache.
+
+    ``_build_system_state`` runs a requirement sweep and reads probe
+    results — work that can take 20s+ when an optional dependency is
+    offline. Serving the (possibly slightly stale) cached snapshot and
+    refreshing it on a background thread keeps that cost off every
+    request after the first. Real-time changes still arrive via SSE —
+    this endpoint is the periodic reconcile, where a few seconds of
+    staleness is invisible.
+    """
+    global _state_cache, _state_cache_ts
+    cache = _state_cache
+    if cache is not None:
+        if time.time() - _state_cache_ts >= _STATE_CACHE_TTL:
+            _kick_state_refresh()  # stale — refresh for next time
+        return cache
+    # Cold start: nothing cached yet. Build once synchronously (the lock
+    # makes concurrent first-callers wait for the single build rather
+    # than each starting their own).
+    with _state_cache_lock:
+        if _state_cache is not None:
+            return _state_cache
+        _state_cache = _build_system_state()
+        _state_cache_ts = time.time()
+        return _state_cache
+
+
+def _build_system_state() -> dict[str, Any]:
     """Aggregated system snapshot: services, jobs, uptime."""
     state = _read_sidecar_state()
     if not state:

--- a/work_buddy/dashboard/frontend/scripts/core/helpers.py
+++ b/work_buddy/dashboard/frontend/scripts/core/helpers.py
@@ -70,13 +70,19 @@ function timeUntil(epoch) {
     return 'in ' + Math.floor(diff / 86400) + 'd';
 }
 
-async function fetchJSON(url, options) {
+async function fetchJSON(url, options, timeoutMs) {
     // Accept either ``fetchJSON(url)`` (GET) or ``fetchJSON(url, {method, body, headers})``.
     // Previously silently dropped the options argument, which meant POST
     // callers sent plain GETs and Flask replied 405 — see the Review tab
     // approve path that was a no-op until this fix landed (2026-04-20).
+    //
+    // timeoutMs (optional): abandon the request after N ms and return
+    // null. A plain try/catch does NOT cover a request that hangs
+    // without ever resolving or rejecting — only an abort signal does.
     try {
-        const r = await fetch(url, options);
+        const opts = {...(options || {})};
+        if (timeoutMs) opts.signal = AbortSignal.timeout(timeoutMs);
+        const r = await fetch(url, opts);
         return await r.json();
     } catch (e) {
         console.error('Fetch failed:', url, e);

--- a/work_buddy/dashboard/frontend/scripts/tabs/jobs.py
+++ b/work_buddy/dashboard/frontend/scripts/tabs/jobs.py
@@ -270,7 +270,7 @@ if (window.wbFormBridge && typeof window.wbFormBridge.register === 'function') {
 }
 
 async function loadJobs() {
-    const data = await fetchJSON('/api/state');
+    const data = await fetchJSON('/api/state', null, 5000);
     if (!data) return;
 
     const jobs = data.jobs || [];

--- a/work_buddy/dashboard/frontend/scripts/tabs/settings.py
+++ b/work_buddy/dashboard/frontend/scripts/tabs/settings.py
@@ -786,6 +786,24 @@ function _renderConfirmPanel(btnEl, reqId, preview) {
     li.appendChild(panel);
 }
 
+// Optimistically fold a fix endpoint's single-requirement `recheck`
+// result into the in-memory graph so the fixed row updates instantly,
+// without waiting on a full graph rebuild. Mirrors the server's
+// requirement-state derivation (see control/graph.py); the follow-up
+// loadSettings(false) is the authority that reconciles cascade
+// roll-ups onto parent components and domains.
+function _applyRecheck(reqId, recheck) {
+    if (!recheck || !WB_CONTROL_GRAPH || !WB_CONTROL_GRAPH.nodes) return;
+    const node = WB_CONTROL_GRAPH.nodes['req:' + reqId];
+    if (!node) return;
+    node.effective_state = recheck.ok
+        ? 'ok'
+        : (recheck.severity === 'required' ? 'unconfigured' : 'degraded');
+    node.status_reason = recheck.detail || '';
+    renderSettingsTree();
+    renderSettingsSummary();
+}
+
 async function _postFix(reqId, params, btnEl) {
     btnEl.disabled = true;
     const orig = btnEl.textContent;
@@ -807,12 +825,18 @@ async function _postFix(reqId, params, btnEl) {
         } else {
             settingsToast(`Fix did not apply: ${data.detail}`, 'error');
         }
-        // Re-fetch the graph regardless — even a failed fix may have
-        // moved partial state (and recheck data is fresh server-side).
-        await loadSettings(true);
-        // After re-render, briefly flash the requirement so the user
-        // sees that THIS row is the one that changed. Helps locate the
-        // result when a domain has many requirements.
+        // Update the fixed requirement in place from the endpoint's
+        // single-requirement `recheck`, then refresh the rest of the
+        // graph in the background (unforced — no panel blanking) so
+        // cascade roll-ups onto parent components/domains reconcile.
+        // Avoids blanking the whole panel behind a multi-second graph
+        // rebuild just to reflect one row's change.
+        if (data.recheck) {
+            _applyRecheck(reqId, data.recheck);
+        }
+        loadSettings(false);
+        // Briefly flash the requirement so the user sees THIS row is
+        // the one that changed.
         if (data.ok) {
             requestAnimationFrame(() => _flashNode('req:' + reqId));
         }

--- a/work_buddy/dashboard/frontend/scripts/tabs/settings.py
+++ b/work_buddy/dashboard/frontend/scripts/tabs/settings.py
@@ -149,7 +149,7 @@ async function reprobeAll(btnEl) {
         const resp = await fetch('/api/control/reprobe', {method: 'POST'});
         if (!resp.ok) {
             const errText = await resp.text();
-            showToast(`Reprobe failed: ${errText}`, 'error');
+            settingsToast(`Reprobe failed: ${errText}`, 'error');
             return;
         }
         const data = await resp.json();
@@ -157,9 +157,9 @@ async function reprobeAll(btnEl) {
         _rebuildComponentEventIndex();
         renderSettingsTree();
         renderSettingsSummary();
-        showToast('Probes refreshed.', 'success');
+        settingsToast('Probes refreshed.', 'success');
     } catch (exc) {
-        showToast(`Reprobe request failed: ${exc}`, 'error');
+        settingsToast(`Reprobe request failed: ${exc}`, 'error');
     } finally {
         btnEl.disabled = false;
         btnEl.textContent = orig;
@@ -316,7 +316,7 @@ function onBadgeDrilldown(ev) {
     }
 
     if (bad.length === 0) {
-        showToast(`${rootId} reports ${nodes[rootId].effective_state} but no bad descendant found — check the status reason directly.`, 'info');
+        settingsToast(`${rootId} reports ${nodes[rootId].effective_state} but no bad descendant found — check the status reason directly.`, 'info');
         return;
     }
 
@@ -375,7 +375,7 @@ function _flashNode(nodeId, siblingCount) {
     el.classList.add('wb-flash');
     setTimeout(() => el.classList.remove('wb-flash'), 1800);
     if (siblingCount > 1) {
-        showToast(`Showing worst of ${siblingCount} issues — badges above lead to others.`, 'info');
+        settingsToast(`Showing worst of ${siblingCount} issues — badges above lead to others.`, 'info');
     }
 }
 
@@ -465,7 +465,7 @@ async function onPreferenceClick(btnEl) {
         });
         if (!resp.ok) {
             const err = await resp.text();
-            showToast(`Preference update failed: ${err}`, 'error');
+            settingsToast(`Preference update failed: ${err}`, 'error');
             return;
         }
         const data = await resp.json();
@@ -473,9 +473,9 @@ async function onPreferenceClick(btnEl) {
         WB_MATCHED_SET = _computeMatchedSet();
         renderSettingsTree();
         renderSettingsSummary();
-        showToast(`Preference saved for ${componentId}`, 'success');
+        settingsToast(`Preference saved for ${componentId}`, 'success');
     } catch (exc) {
-        showToast(`Preference update failed: ${exc}`, 'error');
+        settingsToast(`Preference update failed: ${exc}`, 'error');
     } finally {
         // If render didn't run (error path), re-enable the buttons
         siblings.forEach(b => { b.disabled = false; });
@@ -483,8 +483,13 @@ async function onPreferenceClick(btnEl) {
     }
 }
 
-// Minimal toast fallback in case the shared one isn't loaded yet
-function showToast(msg, kind) {
+// Simple status toast for the Settings tab (fix results, reprobe,
+// preference saves). Deliberately NOT named `showToast`: core/
+// notifications.py owns `window.showToast(title, body, ..., view, ...)`
+// for notification cards, and all frontend scripts concatenate into one
+// scope — naming this `showToast` lets the notifications version shadow
+// it, and calling it with `(msg, kind)` then throws on `view.short_id`.
+function settingsToast(msg, kind) {
     const container = document.getElementById('toast-container');
     if (!container) { console.log('[toast]', kind, msg); return; }
     const el = document.createElement('div');
@@ -793,14 +798,14 @@ async function _postFix(reqId, params, btnEl) {
         });
         const data = await resp.json();
         if (data.spawned) {
-            showToast(`Help session launched (pid ${data.spawned.pid}).`, 'success');
+            settingsToast(`Help session launched (pid ${data.spawned.pid}).`, 'success');
         } else if (data.ok) {
             const eff = data.side_effects && data.side_effects.length
                 ? ` — ${data.side_effects.join('; ')}`
                 : '';
-            showToast(`Fixed: ${data.detail}${eff}`, 'success');
+            settingsToast(`Fixed: ${data.detail}${eff}`, 'success');
         } else {
-            showToast(`Fix did not apply: ${data.detail}`, 'error');
+            settingsToast(`Fix did not apply: ${data.detail}`, 'error');
         }
         // Re-fetch the graph regardless — even a failed fix may have
         // moved partial state (and recheck data is fresh server-side).
@@ -812,7 +817,7 @@ async function _postFix(reqId, params, btnEl) {
             requestAnimationFrame(() => _flashNode('req:' + reqId));
         }
     } catch (exc) {
-        showToast(`Fix request failed: ${exc}`, 'error');
+        settingsToast(`Fix request failed: ${exc}`, 'error');
         btnEl.disabled = false;
         btnEl.textContent = orig;
     }
@@ -882,13 +887,13 @@ async function onComponentReprobeClick(btnEl) {
         const resp = await fetch('/api/reprobe/' + encodeURIComponent(componentId), {method: 'POST'});
         if (!resp.ok) {
             const errText = await resp.text();
-            showToast(`Reprobe ${componentId} failed: ${errText}`, 'error');
+            settingsToast(`Reprobe ${componentId} failed: ${errText}`, 'error');
             return;
         }
         await loadSettings(true);  // force-refresh the graph (single probe is on disk now)
         requestAnimationFrame(() => _flashNode('component:' + componentId));
     } catch (exc) {
-        showToast(`Reprobe request failed: ${exc}`, 'error');
+        settingsToast(`Reprobe request failed: ${exc}`, 'error');
     } finally {
         // loadSettings re-renders so btnEl no longer exists if successful,
         // but restore state on error paths.
@@ -909,12 +914,12 @@ async function onHelpClick(btnEl) {
         const resp = await fetch('/api/control/help/' + encodeURI(nodeId), {method: 'POST'});
         const data = await resp.json();
         if (data.ok) {
-            showToast(`Help session launched (pid ${data.pid || '?'}).`, 'success');
+            settingsToast(`Help session launched (pid ${data.pid || '?'}).`, 'success');
         } else {
-            showToast(`Help launch failed: ${data.detail}`, 'error');
+            settingsToast(`Help launch failed: ${data.detail}`, 'error');
         }
     } catch (exc) {
-        showToast(`Help request failed: ${exc}`, 'error');
+        settingsToast(`Help request failed: ${exc}`, 'error');
     } finally {
         btnEl.disabled = false;
         btnEl.textContent = orig;
@@ -943,7 +948,7 @@ function onStateChipClick(state) {
         .filter(n => n.effective_state === state && n.kind !== 'capability')
         .sort((a, b) => (kindRank[a.kind] ?? 99) - (kindRank[b.kind] ?? 99));
     if (candidates.length === 0) {
-        showToast(`No ${state} nodes visible.`, 'info');
+        settingsToast(`No ${state} nodes visible.`, 'info');
         return;
     }
     const target = candidates[0];

--- a/work_buddy/dashboard/frontend/scripts/tabs/settings.py
+++ b/work_buddy/dashboard/frontend/scripts/tabs/settings.py
@@ -649,9 +649,34 @@ function renderSettingsSummary() {
 //   * ? — always present (when not ok). Spawns a help-agent session with
 //     a structured brief. Replaces the legacy Status-tab `🪄 /wb-setup
 //     diagnose` hint.
+// Shared data-* attributes for any button that opens the fix flow
+// (onFixClick reads them). data-fix-params is single-quoted because the
+// JSON value is full of double quotes; escapeHtml only covers < > & so
+// apostrophes inside fix_params text would close the attribute early —
+// hence the explicit ' -> &#39; pass.
+function _fixDataAttrs(r) {
+    return `data-req-id="${escapeHtml(r.id.replace(/^req:/, ''))}" ` +
+        `data-fix-kind="${escapeHtml(r.fix_kind)}" ` +
+        `data-fix-preview="${escapeHtml(r.fix_preview || '')}" ` +
+        `data-fix-params='${escapeHtml(JSON.stringify(r.fix_params || {})).replace(/'/g, '&#39;')}'`;
+}
+
 function _renderRequirementActions(r) {
-    if (r.effective_state === 'ok' || r.effective_state === 'disabled') {
+    if (r.effective_state === 'disabled') {
         return '';
+    }
+    // A satisfied (ok) requirement has no fix to apply — but an
+    // input_required one is still an editable setting (timezone, backup
+    // repo, …). Offer a subtle pencil to change its value; other ok
+    // requirements get no action.
+    if (r.effective_state === 'ok') {
+        if (r.fix_kind !== 'input_required') return '';
+        const roDisabled = WB_READ_ONLY_MODE
+            ? 'disabled title="Dashboard is in read-only mode"' : '';
+        return `<span class="settings-req-actions">` +
+            `<button class="settings-edit-btn" type="button" ` +
+            `onclick="onFixClick(this)" ${_fixDataAttrs(r)} ${roDisabled} ` +
+            `title="Change this setting">✎</button></span>`;
     }
     // Two user-facing verbs:
     //   * "Configure" covers BOTH programmatic and input_required.
@@ -678,17 +703,10 @@ function _renderRequirementActions(r) {
         fixClass += ' settings-fix-btn-agent';
         fixTitle = 'Opens a Claude Code session to walk you through this. ' + (r.fix_preview || '');
     }
-    // data-fix-params is single-quoted because the JSON value is full of
-    // double quotes; escapeHtml only covers < > & so apostrophes inside
-    // fix_params text (hints, labels) would close the attribute early —
-    // hence the explicit ' -> &#39; pass.
     const fixBtn = r.fix_kind && r.fix_kind !== 'none'
         ? `<button class="${fixClass}" type="button"
                    onclick="onFixClick(this)"
-                   data-req-id="${escapeHtml(r.id.replace(/^req:/, ''))}"
-                   data-fix-kind="${escapeHtml(r.fix_kind)}"
-                   data-fix-preview="${escapeHtml(r.fix_preview || '')}"
-                   data-fix-params='${escapeHtml(JSON.stringify(r.fix_params || {})).replace(/'/g, '&#39;')}'
+                   ${_fixDataAttrs(r)}
                    ${WB_READ_ONLY_MODE ? 'disabled title="Dashboard is in read-only mode"' : ''}
                    title="${escapeHtml(fixTitle.trim())}">${escapeHtml(fixLabel)}</button>`
         : '';
@@ -858,11 +876,16 @@ function _renderInputForm(btnEl, reqId, fixParams) {
         const inputType = spec.secret ? 'password' : (spec.type === 'path' ? 'text' : 'text');
         const required = spec.required ? 'required' : '';
         const placeholder = spec.hint ? `placeholder="${escapeHtml(spec.hint)}"` : '';
-        const defaultVal = spec.default != null ? `value="${escapeHtml(String(spec.default))}"` : '';
+        // Pre-fill with the requirement's current configured value when
+        // the server supplied one, else the declared default. This is
+        // what lets the form double as an "edit this setting" panel.
+        const prefill = spec.current_value != null ? spec.current_value
+                      : (spec.default != null ? spec.default : null);
+        const valueAttr = prefill != null ? `value="${escapeHtml(String(prefill))}"` : '';
         return `
             <label class="settings-fix-field">
                 <span class="settings-fix-field-label">${escapeHtml(spec.label || name)}${spec.required ? ' *' : ''}</span>
-                <input type="${inputType}" name="${escapeHtml(name)}" ${required} ${placeholder} ${defaultVal}
+                <input type="${inputType}" name="${escapeHtml(name)}" ${required} ${placeholder} ${valueAttr}
                        autocomplete="off" spellcheck="false" />
             </label>
         `;

--- a/work_buddy/dashboard/frontend/scripts/tabs/settings.py
+++ b/work_buddy/dashboard/frontend/scripts/tabs/settings.py
@@ -674,13 +674,17 @@ function _renderRequirementActions(r) {
         fixClass += ' settings-fix-btn-agent';
         fixTitle = 'Opens a Claude Code session to walk you through this. ' + (r.fix_preview || '');
     }
+    // data-fix-params is single-quoted because the JSON value is full of
+    // double quotes; escapeHtml only covers < > & so apostrophes inside
+    // fix_params text (hints, labels) would close the attribute early —
+    // hence the explicit ' -> &#39; pass.
     const fixBtn = r.fix_kind && r.fix_kind !== 'none'
         ? `<button class="${fixClass}" type="button"
                    onclick="onFixClick(this)"
                    data-req-id="${escapeHtml(r.id.replace(/^req:/, ''))}"
                    data-fix-kind="${escapeHtml(r.fix_kind)}"
                    data-fix-preview="${escapeHtml(r.fix_preview || '')}"
-                   data-fix-params='${escapeHtml(JSON.stringify(r.fix_params || {}))}'
+                   data-fix-params='${escapeHtml(JSON.stringify(r.fix_params || {})).replace(/'/g, '&#39;')}'
                    ${WB_READ_ONLY_MODE ? 'disabled title="Dashboard is in read-only mode"' : ''}
                    title="${escapeHtml(fixTitle.trim())}">${escapeHtml(fixLabel)}</button>`
         : '';
@@ -725,8 +729,16 @@ async function onFixClick(btnEl) {
     let params = {};
     try { params = JSON.parse(btnEl.dataset.fixParams || '{}'); } catch (e) { params = {}; }
 
-    if (fixKind === 'input_required' && Object.keys(params).length > 0) {
-        _renderInputForm(btnEl, reqId, params);
+    if (fixKind === 'input_required') {
+        // input_required must never fall through to the agent_handoff
+        // confirm dialog. With form fields, render the form; without
+        // (misconfigured fix_params, or a parse failure above), fall
+        // back to the programmatic confirm panel.
+        if (Object.keys(params).length > 0) {
+            _renderInputForm(btnEl, reqId, params);
+        } else {
+            _renderConfirmPanel(btnEl, reqId, preview);
+        }
         return;
     }
 

--- a/work_buddy/dashboard/frontend/scripts/tabs/settings.py
+++ b/work_buddy/dashboard/frontend/scripts/tabs/settings.py
@@ -94,11 +94,13 @@ async function loadSettings(force) {
         const url = '/api/control/graph' + (force ? '?force=1' : '');
         // Fetch the control graph and /api/state in parallel. The latter
         // feeds the per-component event chips and the at-a-glance status
-        // cards (both Status sub-view). A failed state fetch must not
-        // block the graph render — hence the catch.
-        const [resp, stateResp] = await Promise.all([
+        // cards (both Status sub-view) — optional decoration. fetchJSON's
+        // timeout abandons a slow or hung /api/state so it can never
+        // block the graph render (a plain .catch covers only rejection,
+        // not a request that hangs without ever resolving).
+        const [resp, state] = await Promise.all([
             fetch(url),
-            fetch('/api/state').catch(() => null),
+            fetchJSON('/api/state', null, 5000),
         ]);
         if (!resp.ok) {
             tree.innerHTML = `<div class="error-state">Failed to load (${resp.status}): ${await resp.text()}</div>`;
@@ -106,12 +108,9 @@ async function loadSettings(force) {
         }
         const data = await resp.json();
         WB_CONTROL_GRAPH = data;
-        if (stateResp && stateResp.ok) {
-            try {
-                const state = await stateResp.json();
-                window._WB_LAST_STATE = state;
-                window._WB_EVENT_COUNTS = state.event_counts_by_source || {};
-            } catch (e) { /* event chips are optional decoration */ }
+        if (state) {
+            window._WB_LAST_STATE = state;
+            window._WB_EVENT_COUNTS = state.event_counts_by_source || {};
         }
         _rebuildComponentEventIndex();
         renderStatusCards();
@@ -1275,7 +1274,7 @@ window.settingsSurface = {
 // so a preference toggle re-evaluates the gates with no page reload.
 async function loadActivity() {
     window._activityLoaded = true;
-    const data = await fetchJSON('/api/state');
+    const data = await fetchJSON('/api/state', null, 5000);
     if (!data) return;
     window._WB_LAST_STATE = data;
     const container = document.getElementById('activity-cards');

--- a/work_buddy/dashboard/frontend/styles.py
+++ b/work_buddy/dashboard/frontend/styles.py
@@ -232,7 +232,7 @@ body {
     font-weight: 600;
 }
 
-.badge-green { background: var(--green-subtle); color: var(--green); }
+.badge-green { background: #3fb9501a; color: var(--green); }
 .badge-yellow { background: #d299221a; color: var(--yellow); }
 .badge-red { background: #f851491a; color: var(--red); }
 .badge-blue { background: var(--accent-subtle); color: var(--accent); }
@@ -3311,7 +3311,7 @@ body {
     border: 1px solid var(--green);
     border-radius: 6px;
     color: var(--green);
-    background: var(--green-subtle);
+    background: #3fb9501a;
     font-size: 11px;
     font-weight: 600;
     cursor: help;

--- a/work_buddy/dashboard/frontend/styles.py
+++ b/work_buddy/dashboard/frontend/styles.py
@@ -3405,9 +3405,32 @@ body {
 }
 .settings-fix-btn:disabled,
 .settings-help-btn:disabled,
-.settings-fix-cancel-btn:disabled {
+.settings-fix-cancel-btn:disabled,
+.settings-edit-btn:disabled {
     cursor: not-allowed;
     opacity: 0.45;
+}
+
+/* Edit (pencil) button — appears on a satisfied input_required
+   requirement so a valid setting can still be changed. Deliberately
+   low-key (muted, icon-only): the requirement is fine, this is just
+   "change it if you want". Accent on hover, like the other actions. */
+.settings-edit-btn {
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text-muted);
+    border-radius: 4px;
+    width: 22px;
+    padding: 2px 0;
+    text-align: center;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.settings-edit-btn:hover:not(:disabled) {
+    background: var(--accent-subtle);
+    color: var(--accent);
+    border-color: var(--accent);
 }
 
 /* The component-header version sits to the right of the also-in pill */

--- a/work_buddy/health/requirements.py
+++ b/work_buddy/health/requirements.py
@@ -55,7 +55,11 @@ class RequirementDef:
                 side_effects?: list[str]}``. Required for programmatic / input_required.
         fix_params: For input_required, declares the form fields the user must fill.
             Shape: ``{field_name: {type: "str"|"path"|"secret", label: str,
-                                    default: Any, required: bool, hint: str}}``.
+                                    default: Any, required: bool, hint: str,
+                                    config_path: str}}``. ``config_path`` is
+            optional (non-secret fields only): a dotted path into the merged
+            config that ``fix_params_with_current_values`` reads so the
+            dashboard form can pre-fill the field's current value.
         fix_preview: One-line description of what the fix will do, shown in the
             confirm popover before the user commits. E.g. "Will create
             C:\\Vaults\\SecondBrain\\journal\\". Null = no preview shown.
@@ -118,6 +122,44 @@ def _check_fn_module(check_fn: str) -> str:
     return check_fn.rsplit(".", 1)[0]
 
 
+def _config_value_at(cfg: dict[str, Any], dotted_path: str) -> Any:
+    """Walk a dotted path into a config dict; return None if any hop is absent."""
+    node: Any = cfg
+    for key in dotted_path.split("."):
+        if not isinstance(node, dict) or key not in node:
+            return None
+        node = node[key]
+    return node
+
+
+def fix_params_with_current_values(
+    req: RequirementDef,
+) -> dict[str, dict[str, Any]]:
+    """Return ``req.fix_params`` with a ``current_value`` injected for each
+    field that declares a ``config_path``.
+
+    Lets the dashboard fix form double as an "edit this setting" panel —
+    the form pre-fills the live configured value. Secret fields never
+    declare a ``config_path``, so a token is never echoed back to the UI.
+    The input fix_params dict is not mutated (each field spec is copied).
+    """
+    params = {name: dict(spec) for name, spec in (req.fix_params or {}).items()}
+    if not params:
+        return params
+    cfg: dict[str, Any] | None = None
+    for spec in params.values():
+        path = spec.get("config_path")
+        if not path:
+            continue
+        if cfg is None:
+            from work_buddy.config import load_config
+            cfg = load_config()
+        value = _config_value_at(cfg, path)
+        if value is not None:
+            spec["current_value"] = value
+    return params
+
+
 # --- Bootstrap (core/) ---
 
 _register(RequirementDef(
@@ -174,6 +216,7 @@ _register(RequirementDef(
             "label": "Path to your repos directory",
             "hint": "Absolute path to the directory where your git repos live, e.g. C:\\repos or /home/you/code",
             "required": True,
+            "config_path": "repos_root",
         },
     },
     fix_preview="Validates the path exists, then sets repos_root in config.yaml.",
@@ -195,6 +238,7 @@ _register(RequirementDef(
             "label": "IANA timezone",
             "hint": "e.g. America/Toronto, Europe/London, Asia/Tokyo",
             "required": True,
+            "config_path": "timezone",
         },
     },
     fix_preview="Validates the timezone, then sets it in config.yaml.",
@@ -923,6 +967,7 @@ _register(RequirementDef(
             ),
             "default": "my-work-buddy-data",
             "required": True,
+            "config_path": "backups.github.repo",
         },
     },
     fix_preview=(

--- a/work_buddy/mcp_server/context_wrappers.py
+++ b/work_buddy/mcp_server/context_wrappers.py
@@ -763,9 +763,10 @@ def get_projects_context(*, statuses: list[str] | None = None) -> str:
     Also syncs results to the project store.
 
     ``statuses`` filters only the rendered markdown — every project still
-    gets scanned and synced. Default is active + inferred (past + future
-    are hidden to keep bundles uncluttered). Pass an explicit list to
-    widen.
+    gets scanned and synced. Default is active only (paused / future /
+    past are hidden to keep bundles uncluttered); valid values are
+    active, paused, future, past. Pass an explicit list to widen.
+    ``deleted`` is never rendered through this surface.
     """
     from work_buddy.projects.sync import sync_projects
 

--- a/work_buddy/mcp_server/registry.py
+++ b/work_buddy/mcp_server/registry.py
@@ -2425,7 +2425,7 @@ def _context_capabilities() -> list[Capability]:
         # ── Projects ──────────────────────────────────────────────
         Capability(
             name="context_projects",
-            description="Active projects with identity, state, and trajectory — synthesized from vault directories, STATE.md files in repos, task tags, git activity, and contracts. Filters the rendered output to active + inferred by default; pass ``statuses`` to widen.",
+            description="Active projects with identity, state, and trajectory — synthesized from vault directories, STATE.md files in repos, task tags, git activity, and contracts. Filters the rendered output to active projects by default; pass ``statuses`` to widen.",
             category="context",
             search_aliases=[
                 "projects",
@@ -2438,7 +2438,7 @@ def _context_capabilities() -> list[Capability]:
             parameters={
                 "statuses": {
                     "type": "list",
-                    "description": "Project statuses to include in the rendered bundle. Default: active + inferred. Pass [\"active\", \"inferred\", \"future\", \"past\"] to include everything. Filters only the rendered output — every project is still scanned and synced to the registry.",
+                    "description": "Project lifecycle statuses to include in the rendered bundle. Default: active only. Valid values: active, paused, future, past. Pass [\"active\", \"paused\", \"future\", \"past\"] to include everything (deleted is never rendered). Filters only the rendered output — every project is still scanned and synced to the registry.",
                     "required": False,
                 },
             },

--- a/work_buddy/sidecar/daemon.py
+++ b/work_buddy/sidecar/daemon.py
@@ -50,6 +50,68 @@ _REPO_ROOT = Path(__file__).parent.parent.parent
 # ---------------------------------------------------------------------------
 
 
+def safe_port(value: Any, *, service_name: str) -> int | None:
+    """Coerce a configured service port to a valid int, or None if invalid.
+
+    A bad ``sidecar.services.<svc>.port`` (non-numeric or out of range)
+    would otherwise crash service startup. Returning None lets the
+    caller skip the misconfigured service while the daemon keeps running.
+    """
+    try:
+        port = int(value)
+    except (TypeError, ValueError):
+        logger.error(
+            "Service %r has a non-numeric port %r; skipping it.",
+            service_name, value,
+        )
+        return None
+    if not (1 <= port <= 65535):
+        logger.error(
+            "Service %r has out-of-range port %d; skipping it.",
+            service_name, port,
+        )
+        return None
+    return port
+
+
+class TickFailureTracker:
+    """Tracks consecutive daemon-tick failures and decides when to escalate.
+
+    A tick that throws is caught as non-fatal and retried, so a persistent
+    fault (e.g. an invalid config value) would otherwise fail silently
+    forever — visible only as per-tick log noise. This surfaces a sustained
+    run of failures exactly once (a loud log line + a sidecar event) and
+    announces recovery exactly once.
+    """
+
+    def __init__(self, threshold: int = 3) -> None:
+        self._threshold = threshold
+        self._consecutive = 0
+        self._escalated = False
+
+    def record_success(self) -> str | None:
+        """Note a successful tick. Returns a recovery message if the
+        tracker had previously escalated, else None."""
+        recovered = self._escalated
+        self._consecutive = 0
+        self._escalated = False
+        if recovered:
+            return "Daemon tick recovered after sustained failures."
+        return None
+
+    def record_failure(self, exc: BaseException) -> str | None:
+        """Note a failed tick. Returns an escalation message the first
+        time the failure run crosses the threshold, else None."""
+        self._consecutive += 1
+        if self._consecutive >= self._threshold and not self._escalated:
+            self._escalated = True
+            return (
+                f"Daemon tick has failed {self._consecutive} consecutive "
+                f"times: {exc}"
+            )
+        return None
+
+
 @dataclass
 class ChildService:
     """A supervised child process (messaging, embedding, etc.)."""
@@ -711,10 +773,13 @@ def run(foreground: bool = True) -> None:
     for name, svc_cfg in services_cfg.items():
         if not svc_cfg.get("enabled", True):
             continue
+        port = safe_port(svc_cfg.get("port"), service_name=name)
+        if port is None:
+            continue
         children.append(ChildService(
             name=name,
             module=svc_cfg["module"],
-            port=svc_cfg["port"],
+            port=port,
             args=svc_cfg.get("args", []),
         ))
 
@@ -834,6 +899,7 @@ def run(foreground: bool = True) -> None:
     _print_startup_banner(children, cfg)
 
     # --- Main loop ---
+    tick_failures = TickFailureTracker()
     try:
         while not _shutdown_requested:
             tick_start = time.time()
@@ -864,6 +930,18 @@ def run(foreground: bool = True) -> None:
                 # Log but don't crash the daemon — individual tick failures
                 # are recoverable. The next tick will retry.
                 logger.error("Tick error (non-fatal): %s", exc, exc_info=True)
+                escalation = tick_failures.record_failure(exc)
+                if escalation:
+                    # Sustained failure — make it loud instead of silent.
+                    logger.critical("%s", escalation)
+                    event_log.emit(
+                        "tick_failures", "daemon", escalation, level="error",
+                    )
+            else:
+                recovery = tick_failures.record_success()
+                if recovery:
+                    logger.info("%s", recovery)
+                    event_log.emit("tick_recovered", "daemon", recovery)
 
             # 5. Persist event log snapshot + write state
             state.events = event_log.recent(50)

--- a/work_buddy/sidecar/scheduler/engine.py
+++ b/work_buddy/sidecar/scheduler/engine.py
@@ -114,7 +114,8 @@ class Scheduler:
 
     def __init__(self, config: dict[str, Any], event_log: Any | None = None) -> None:
         self._config = config
-        self._timezone: str = safe_timezone(config.get("timezone"))
+        self._raw_timezone = config.get("timezone")
+        self._timezone: str = safe_timezone(self._raw_timezone)
         self._event_log = event_log
 
         self._jobs_dirs: list[tuple[Path, str]] = self._resolve_jobs_dirs(config)
@@ -355,7 +356,13 @@ class Scheduler:
         new_windows = parse_exclusion_windows(sidecar_cfg.get("exclusion_windows", []))
         self._exclusion_windows = new_windows
         self._config = cfg
-        self._timezone = safe_timezone(cfg.get("timezone"))
+        # Re-validate the timezone only when the raw config value
+        # changed. Otherwise a persistently-invalid value would log a
+        # fallback warning on every 30s reload.
+        raw_tz = cfg.get("timezone")
+        if raw_tz != self._raw_timezone:
+            self._raw_timezone = raw_tz
+            self._timezone = safe_timezone(raw_tz)
         self._jobs_dirs = self._resolve_jobs_dirs(cfg)
 
         # Reload jobs from all configured directories

--- a/work_buddy/sidecar/scheduler/engine.py
+++ b/work_buddy/sidecar/scheduler/engine.py
@@ -31,6 +31,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from work_buddy.config import safe_timezone
 from work_buddy.logging_config import get_logger
 from work_buddy.paths import data_dir
 from work_buddy.sidecar.scheduler.cron import cron_matches, next_cron_match
@@ -113,7 +114,7 @@ class Scheduler:
 
     def __init__(self, config: dict[str, Any], event_log: Any | None = None) -> None:
         self._config = config
-        self._timezone: str = config.get("timezone", "America/New_York")
+        self._timezone: str = safe_timezone(config.get("timezone"))
         self._event_log = event_log
 
         self._jobs_dirs: list[tuple[Path, str]] = self._resolve_jobs_dirs(config)
@@ -354,7 +355,7 @@ class Scheduler:
         new_windows = parse_exclusion_windows(sidecar_cfg.get("exclusion_windows", []))
         self._exclusion_windows = new_windows
         self._config = cfg
-        self._timezone = cfg.get("timezone", "America/New_York")
+        self._timezone = safe_timezone(cfg.get("timezone"))
         self._jobs_dirs = self._resolve_jobs_dirs(cfg)
 
         # Reload jobs from all configured directories


### PR DESCRIPTION
## Summary

Started as a single Settings bug fix; testing it surfaced a cluster of related runtime-resilience gaps. All fixed here.

**1. Settings `input_required` Configure button** (`ba8e0954`)
The button showed the `agent_handoff` "open a new terminal?" dialog instead of the inline form. Root cause: `data-fix-params` is a single-quoted HTML attribute but `escapeHtml` doesn't escape apostrophes, so `fix_params` hint text with apostrophes broke the attribute → `JSON.parse` failed → `onFixClick` fell through to `agent_handoff`. Fixed the escaping and made `input_required` branch on its own.

**2. Translucent green status pills** (`2ba4c006`)
`.badge-green` and `.settings-pref-required` used a solid `--green-subtle` fill, unlike every other badge (hue at ~10% alpha). Both now use `#3fb9501a`.

**3. Runtime config hardening** (`f5d21f3e`)
An invalid `timezone` made `ZoneInfo()` throw on every scheduler tick — silently halting jobs. `safe_timezone()` (UTC fallback), `safe_port()` (skip a misconfigured service vs. crash the daemon), `TickFailureTracker` (surface a sustained tick-failure run once instead of silent-forever).

**4. `/api/state` + Settings frontend resilience** (`e37a2976`)
`GET /api/state` could take 20s+ with an optional dependency offline, and `loadSettings` blocked its render on it. `get_system_state()` now serves a background-refreshed cache; `fetchJSON` gained an optional timeout; the three `/api/state` callers bound it at 5s.

**5. Settings toasts shadowed by the notification `showToast`** (`90124a88`)
`core/notifications.py` defines `window.showToast(title, body, …, view, …)`; `tabs/settings.py` separately declared `function showToast(msg, kind)`. Concatenated into one scope, the notifications version shadowed the Settings one — every Settings toast actually invoked the notification renderer, which threw `TypeError` on `view.short_id` before creating any toast element. Result: clicking Configure/Apply produced **no visible feedback at all** (the fix applied server-side, but the toast crashed). Renamed the Settings-local helper to `settingsToast`.

_+ `7954710e` — `docs(context): correct context_projects status taxonomy`. Unrelated stale-docs fix folded in while auditing the project subsystem (docstrings only, no behavior change, no conflict risk). Rides along._

## Test plan
- [x] Unit tests: `test_timezone_safety.py`, `test_sidecar_daemon_helpers.py` (new) + regression suite — 90 passed
- [x] `/api/state`: cold build once, every later call <25ms (background-refreshed cache verified live)
- [x] Scheduler hardening verified live on a reset sidecar: invalid timezone → one `falling back to UTC` warning, zero `ZoneInfoNotFoundError`, jobs kept firing
- [x] `input_required` inline form renders; submitting an invalid value now shows one clean error toast (no `short_id` crash)
- [x] `.badge-green`/`.settings-pref-required` confirmed `rgba(63,185,80,0.1)`, matching `.badge-red`

Task: t-a268e2bb

🤖 Generated with [Claude Code](https://claude.com/claude-code)