### PR TITLE
docs(dev): document the DCO commit sign-off requirement

### DIFF
--- a/knowledge/store/dev/dev-mode.md
+++ b/knowledge/store/dev/dev-mode.md
@@ -153,6 +153,9 @@ mcp__work-buddy__wb_run("service_restart", {"service": "dashboard"})
 - Production: `poetry add <package>`
 - Temporary/testing: `poetry add --group temp <package>` (cleanly removable)
 
+### Committing
+work-buddy enforces a Developer Certificate of Origin: **every commit must be signed off** with `git commit -s`, which appends a `Signed-off-by` trailer. The `DCO` status check is required on `main` — a pull request with any unsigned commit cannot merge. `/wb-dev-pr` signs off in its commit step; if you commit by hand, always pass `-s`.
+
 ## What NOT to do
 
 - **Don't skip the orientation workflow.** Every documented failure to orient has produced wrong code. You are the next data point if you skip.
@@ -162,4 +165,5 @@ mcp__work-buddy__wb_run("service_restart", {"service": "dashboard"})
 - **Don't forget doc hygiene** — run `/wb-dev-document` before `/wb-dev-pr`.
 - **Don't hand-edit `knowledge/store/*.json`** — use `docs_*` / `workflow_*` / the auto-generator for capability units.
 - **Don't commit unrelated files** — stage only what you changed.
+- **Don't commit without `-s`** — work-buddy enforces a DCO; an unsigned commit fails the required `DCO` check and blocks the PR.
 - **Don't ship transient narrative in durable surfaces.** See `<<wb:dev/durable-surfaces>>`.

--- a/knowledge/store/dev/dev-pr-directions.md
+++ b/knowledge/store/dev/dev-pr-directions.md
@@ -29,6 +29,10 @@ Run `/wb-dev-pr` to commit work-buddy code changes. The workflow enforces branch
 
 At the end of every dev session, once your changes are ready to ship. Run `/wb-dev-document` standalone first if you want to preview doc edits outside the commit flow.
 
+## Sign-off is mandatory (DCO)
+
+work-buddy enforces a Developer Certificate of Origin: every commit must be signed off with `git commit -s`, which appends a `Signed-off-by` trailer. The `DCO` status check is required on `main`, so a pull request with any unsigned commit cannot merge. The `commit` step's instructions sign off for you; if a commit still lands unsigned, run `git rebase --signoff origin/main` and force-push before the PR can pass.
+
 ## Doc update is the teeth
 
 `dev-document` runs as a mandatory step. The skip path requires a specific rationale that gets recorded in the commit body. Do not treat skipping as normal — the default is to run dev-document, even when you expect it will propose nothing.

--- a/knowledge/store/dev/dev-pr.md
+++ b/knowledge/store/dev/dev-pr.md
@@ -282,6 +282,10 @@ Advance with `{"ready": true}` when clean. If you find and fix issues, mention t
 
 Reasoning step. Stage and commit.
 
+## Sign off every commit (DCO)
+
+work-buddy enforces a Developer Certificate of Origin: every commit must be signed off with the `-s` flag (`git commit -s ...`), which appends a `Signed-off-by` trailer. The `DCO` status check is required on `main` — a pull request with any unsigned commit cannot merge. Commit with `-s` from the start; to repair commits already made without it, run `git rebase --signoff origin/main` and force-push.
+
 ## Stage precisely
 
 Do NOT use `git add -A` or `git add .`.
@@ -297,10 +301,10 @@ Follow the repo's conventional-commit style (check `git log --oneline -5`). Keep
 
 If the `document` step was skipped, paste the `skip_rationale` into the commit body under a `Doc-update skipped:` line so the skip is visible in history.
 
-Use a HEREDOC for multi-line commit messages:
+Use a HEREDOC for multi-line commit messages, and keep the `-s`:
 
 ```bash
-git commit -m "$(cat <<'EOF'
+git commit -s -m "$(cat <<'EOF'
 <subject>
 
 <body>


### PR DESCRIPTION
## Summary

Follow-up to the GPL-3.0-only relicense (#123). That PR adopted a Developer Certificate of Origin with an enforced `DCO` status check on `main`, but the agent-facing development surfaces didn't mention `git commit -s` — so an agent running `/wb-dev-pr` would produce unsigned commits and fail the required check.

This adds the sign-off requirement to the three surfaces an agent reads when committing:
- `dev/dev-mode` (loaded by `/wb-dev`) — a "Committing" subsection plus a "What NOT to do" entry.
- `dev/dev-pr-directions` (loaded by `/wb-dev-pr`) — a "Sign-off is mandatory" section.
- the `dev-pr` workflow's `commit` step instruction — the text read at the moment of committing now leads with the DCO requirement and uses `git commit -s` in its example.

Knowledge-store content only; no code change.

## Test plan

- [x] `/wb-dev-document` validation passed — store integrity intact after the three edits (383 units, 0 failures).
- [ ] The `DCO` check passes on this PR (the commit is signed off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)