### PR TITLE
Workflow run lifecycle: cancel, idle sweep, restart recovery

### DIFF
--- a/.claude/commands/wb-workflow-cancel.md
+++ b/.claude/commands/wb-workflow-cancel.md
@@ -1,0 +1,4 @@
+---
+short: Cancel a workflow run
+---
+Load directions via `mcp__work-buddy__wb_run("agent_docs", {"path": "architecture/wb-workflow-cancel-directions", "depth": "full"})`, then call the capability.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -43,6 +43,18 @@ tasks:
   db_path: "tasks/task_metadata.db"
   event_lookback_hours: 48
 
+workflows:
+  run_lifecycle:
+    # Auto-cancel a workflow run with no step progress for this long. An
+    # orphaned run (agent stopped calling wb_advance) is reclaimed by the
+    # in-process idle sweep once it crosses this threshold.
+    idle_timeout_hours: 24
+    # How often the in-process idle sweep runs (MCP gateway process).
+    sweep_interval_minutes: 60
+    # Reload incomplete runs from disk into the active-runs map when the
+    # MCP gateway starts. Set false to disable restart recovery.
+    recovery_enabled: true
+
 embedding:
   service_port: 5124
   device: "auto"           # "auto" (GPU if available, else CPU), "cpu", or "cuda"

--- a/knowledge/store/architecture/wb-workflow-cancel-directions.md
+++ b/knowledge/store/architecture/wb-workflow-cancel-directions.md
@@ -1,0 +1,47 @@
+---
+name: Workflow Cancel Directions
+kind: directions
+description: How to cancel a workflow run — finding the run id, the reason argument, and how cancel relates to the automatic idle sweep.
+trigger: User or agent wants to cancel, abort, or clean up a workflow run that is stuck, abandoned mid-run, or no longer wanted.
+command: wb-workflow-cancel
+capabilities:
+- context/workflow_cancel
+tags:
+- workflow
+- cancel
+- lifecycle
+- directions
+- slash-command
+aliases:
+- wb-workflow-cancel
+- cancel workflow
+- abort workflow run
+- stop a workflow
+parents:
+- architecture/workflows
+---
+
+Cancel a running workflow run — drop it from the conductor's in-memory active-runs map, mark its on-disk DAG cancelled (kept for audit), and revoke its workflow consent blanket.
+
+## When to use
+
+- An agent abandoned a workflow mid-run (stopped calling `wb_advance`) and the stale run is cluttering `wb_status` / the active-runs list.
+- A workflow is stuck or broke mid-run (e.g. the Obsidian bridge failed) and you want to clear it so a fresh run can start.
+- The user changed their mind about a workflow that is still in progress.
+
+## How
+
+1. Find the run id. In-flight runs are surfaced by `wb_status` and by the conductor's active-runs list as `workflow_run_id` values like `wf_7040ee31`.
+2. Cancel it:
+
+   ```
+   mcp__work-buddy__wb_run("workflow_cancel", {"workflow_run_id": "wf_...", "reason": "..."})
+   ```
+
+`reason` is optional free text recorded for the audit trail; it defaults to `user_requested`.
+
+## Notes
+
+- **Idempotent.** Cancelling an already-cancelled run is a no-op; a run that has already completed is left untouched (nothing to cancel).
+- The run is **not deleted** — its DAG file on disk is marked cancelled, so the run's history stays auditable.
+- Orphaned runs are also reclaimed without you: an in-process sweep auto-cancels any run idle past the configured threshold (default 24h, reason `idle_timeout`). Manual cancel is for when you don't want to wait, or want a specific reason on the record.

--- a/knowledge/store/architecture/workflow-run-lifecycle.md
+++ b/knowledge/store/architecture/workflow-run-lifecycle.md
@@ -1,0 +1,49 @@
+---
+name: Workflow Run Lifecycle
+kind: concept
+description: 'How in-flight workflow runs are bounded and recovered: cancel, the idle-timeout sweep, and restart recovery of the conductor''s in-memory active-runs map.'
+summary: 'The conductor''s in-memory _ACTIVE_RUNS map is kept bounded and recoverable by three mechanisms: cancel_workflow (manual), an idle-timeout sweep thread, and recover_active_runs at gateway startup.'
+tags:
+- workflows
+- conductor
+- lifecycle
+- cancel
+- idle-sweep
+- restart-recovery
+- active-runs
+aliases:
+- workflow cancel
+- idle sweep
+- restart recovery
+- active runs map
+- orphaned workflow run
+- workflow run TTL
+parents:
+- architecture/workflows
+---
+
+The conductor holds in-flight runs in an in-memory map — `_ACTIVE_RUNS` in `work_buddy/mcp_server/conductor.py`, keyed by `workflow_run_id`. A run is added at `start_workflow` and, left alone, removed only when it completes. Three mechanisms keep that map bounded and recoverable.
+
+## Cancel
+
+`cancel_workflow(run_id, reason)` — capability `workflow_cancel`, slash command `/wb-workflow-cancel` — drops a run from `_ACTIVE_RUNS`, marks its on-disk DAG cancelled (the file is kept, not deleted, for audit), and revokes the workflow consent blanket. It is idempotent: cancelling an already-cancelled run is a no-op, and a run that has already completed is left untouched. A run not in `_ACTIVE_RUNS` is still cancellable — the lookup falls back to the on-disk DAG.
+
+## Idle sweep
+
+`sweep_idle_runs()` — capability `workflow_sweep_idle` — cancels runs with no step progress past the idle threshold (`workflows.run_lifecycle.idle_timeout_hours`, default 24h), with reason `idle_timeout`. An orphaned run — one whose agent stopped calling `wb_advance` — never leaves `_ACTIVE_RUNS` on its own; the sweep reclaims it.
+
+The sweep runs on an interval (`sweep_interval_minutes`, default 60) in a daemon thread inside the MCP gateway process. It must run there, not as a sidecar cron job: `_ACTIVE_RUNS` is in-process state and the sidecar is a separate process that cannot mutate it.
+
+## Restart recovery
+
+`recover_active_runs()` runs once at gateway startup (`main_http`) and reloads incomplete runs from disk back into `_ACTIVE_RUNS`. Without it, a restart silently abandons every in-flight workflow — an agent's next `wb_advance` would get "unknown run". Runs idle past the threshold are expired (marked cancelled) rather than recovered. Gated by `workflows.run_lifecycle.recovery_enabled`.
+
+Recovery interacts with `reconcile_workflow_consent`: once `_ACTIVE_RUNS` is repopulated, a re-registering session finds its recovered run and correctly keeps the consent blanket instead of revoking it as orphaned.
+
+## How idleness is measured
+
+From the freshest `started_at` / `completed_at` across the DAG's nodes — genuine step progress — not the file's `saved_at` (which also advances on non-progress writes). A `WorkflowDAG` persists its `agent_session_id` and a cancellation record (`cancelled` / `cancelled_reason` / `cancelled_at`) so a recovered or cancelled run round-trips intact.
+
+## Thread safety
+
+`_ACTIVE_RUNS` is mutated by gateway request workers and by the sweep thread. Mutations are guarded by `_ACTIVE_RUNS_LOCK`; the sweep and `list_active_runs` iterate a snapshot taken under the lock. The lock is held only for the dict op — never across disk I/O or subprocess calls.

--- a/knowledge/store/context/workflow_cancel.md
+++ b/knowledge/store/context/workflow_cancel.md
@@ -1,0 +1,33 @@
+---
+name: Workflow Cancel
+kind: capability
+description: Cancel a running workflow run — drop it from the in-memory active-runs map, mark its on-disk DAG cancelled (kept for audit), and revoke its consent blanket. Idempotent; a completed run is left untouched.
+capability_name: workflow_cancel
+category: context
+parameters:
+  workflow_run_id:
+    type: str
+    description: Run id of the workflow to cancel (e.g. 'wf_7040ee31'). Find it via wb_status or the conductor's active-runs list.
+    required: true
+  reason:
+    type: str
+    description: Free-text reason recorded on the cancelled DAG for the audit trail. Defaults to 'user_requested'.
+    required: false
+mutates_state: true
+retry_policy: manual
+op: op.wb.workflow_cancel
+schema_version: wb-capability/v1
+tags:
+- context
+- workflow
+- cancel
+- lifecycle
+aliases:
+- cancel workflow
+- abort workflow
+- stop workflow run
+- kill workflow
+- abandon workflow run
+parents:
+- context
+---

--- a/knowledge/store/context/workflow_sweep_idle.md
+++ b/knowledge/store/context/workflow_sweep_idle.md
@@ -1,0 +1,33 @@
+---
+name: Workflow Sweep Idle
+kind: capability
+description: Cancel active workflow runs that have had no step progress past the idle threshold. Runs automatically on an interval in the MCP gateway; also callable manually (with dry_run) for observability.
+capability_name: workflow_sweep_idle
+category: context
+parameters:
+  idle_threshold_hours:
+    type: float
+    description: Override the idle threshold in hours. Omit to use the configured default (workflows.run_lifecycle.idle_timeout_hours).
+    required: false
+  dry_run:
+    type: bool
+    description: List the runs that would be cancelled without cancelling them.
+    required: false
+mutates_state: true
+retry_policy: manual
+op: op.wb.workflow_sweep_idle
+schema_version: wb-capability/v1
+tags:
+- context
+- workflow
+- sweep
+- idle
+- lifecycle
+aliases:
+- sweep idle workflows
+- reclaim orphaned workflows
+- cancel stale workflow runs
+- idle workflow timeout
+parents:
+- context
+---

--- a/tests/unit/test_conductor_response_invariants.py
+++ b/tests/unit/test_conductor_response_invariants.py
@@ -32,6 +32,18 @@ from work_buddy.mcp_server._response_audit import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_agents_dir(tmp_agents_dir):
+    """Redirect agent-session writes to a temp dir for every test here.
+
+    The integration tests call ``start_workflow``, which persists a DAG
+    via ``_save()``. Without isolation those files land in the live
+    ``.data/agents/<session>/workflows/`` and the conductor's restart
+    recovery later loads them as bogus active runs.
+    """
+    yield
+
+
 def assert_no_duplicated_subtrees(
     resp: Any,
     *,

--- a/tests/unit/test_workflow_dag.py
+++ b/tests/unit/test_workflow_dag.py
@@ -214,7 +214,7 @@ class TestDAGSafeName:
     A run's name is ``"<workflow>:<run_id>"``. On Windows/NTFS a ``:`` in a
     path opens an alternate data stream, so a save would silently divert the
     JSON into a stream of a 0-byte base file and ``glob("*.json")`` would
-    never see it. (BUG 2 in the lifecycle plan.)
+    never see it.
     """
 
     def test_safe_name_strips_colon(self):
@@ -227,8 +227,9 @@ class TestDAGSafeName:
 
     @freeze_time("2026-04-12 10:00:00")
     def test_save_produces_real_nonempty_json(self, tmp_agents_dir, monkeypatch):
-        """Regression for BUG 2: the saved file must be a real, non-empty
-        ``.json`` — not the 0-byte ADS husk produced by an unsanitized name."""
+        """The saved file must be a real, non-empty ``.json`` — not the
+        0-byte NTFS alternate-data-stream husk an unsanitized colon in the
+        name would produce."""
         monkeypatch.setenv("WORK_BUDDY_SESSION_ID", "test-colon")
         import work_buddy.agent_session as asmod
         monkeypatch.setattr(asmod, "_cached_session_dir", None)

--- a/tests/unit/test_workflow_dag.py
+++ b/tests/unit/test_workflow_dag.py
@@ -8,6 +8,17 @@ from freezegun import freeze_time
 from work_buddy.workflow import WorkflowDAG, TaskStatus
 
 
+@pytest.fixture(autouse=True)
+def _isolate_agents_dir(tmp_agents_dir):
+    """Redirect agent-session writes to a temp dir for every test here.
+
+    DAG transitions call ``_save()``; without isolation those writes land
+    in the live ``.data/agents/<session>/workflows/`` and are then picked
+    up by the conductor's restart recovery as bogus active runs.
+    """
+    yield
+
+
 class TestDAGConstruction:
     def test_add_single_task(self):
         dag = WorkflowDAG(name="test:t1", description="test")

--- a/tests/unit/test_workflow_dag.py
+++ b/tests/unit/test_workflow_dag.py
@@ -195,3 +195,91 @@ class TestDAGSummary:
         assert "Step A" in summary
         assert "Step B" in summary
         assert "0/2 tasks completed" in summary
+
+
+class TestDAGSafeName:
+    """The save filename must be filesystem-safe — notably colon-free.
+
+    A run's name is ``"<workflow>:<run_id>"``. On Windows/NTFS a ``:`` in a
+    path opens an alternate data stream, so a save would silently divert the
+    JSON into a stream of a 0-byte base file and ``glob("*.json")`` would
+    never see it. (BUG 2 in the lifecycle plan.)
+    """
+
+    def test_safe_name_strips_colon(self):
+        assert ":" not in WorkflowDAG._safe_name("update-journal:wf_abc123")
+
+    def test_safe_name_strips_spaces_and_slashes(self):
+        out = WorkflowDAG._safe_name("My Workflow/sub:wf_1")
+        assert " " not in out and "/" not in out and ":" not in out
+        assert out == "my_workflow_sub_wf_1"
+
+    @freeze_time("2026-04-12 10:00:00")
+    def test_save_produces_real_nonempty_json(self, tmp_agents_dir, monkeypatch):
+        """Regression for BUG 2: the saved file must be a real, non-empty
+        ``.json`` — not the 0-byte ADS husk produced by an unsanitized name."""
+        monkeypatch.setenv("WORK_BUDDY_SESSION_ID", "test-colon")
+        import work_buddy.agent_session as asmod
+        monkeypatch.setattr(asmod, "_cached_session_dir", None)
+
+        dag = WorkflowDAG(name="update-journal:wf_abc123", description="x")
+        dag.add_task("a", name="A")
+        save_path = dag.save()
+
+        assert save_path.exists()
+        assert save_path.suffix == ".json"
+        assert ":" not in save_path.name
+        assert save_path.stat().st_size > 0
+        # The directory listing should show the real file (glob must match).
+        assert list(save_path.parent.glob("*.json")) == [save_path]
+
+
+class TestDAGLifecyclePersistence:
+    """Round-trip of the run-level lifecycle fields added for cancel/recovery."""
+
+    @freeze_time("2026-04-12 10:00:00")
+    def test_persists_agent_session_id(self, tmp_agents_dir, monkeypatch):
+        monkeypatch.setenv("WORK_BUDDY_SESSION_ID", "test-sess-persist")
+        import work_buddy.agent_session as asmod
+        monkeypatch.setattr(asmod, "_cached_session_dir", None)
+
+        dag = WorkflowDAG(name="recover-test:wf_sess", description="x")
+        dag.add_task("a", name="A")
+        dag.agent_session_id = "agent-12345678"
+        save_path = dag.save()
+
+        loaded = WorkflowDAG.load(save_path)
+        assert loaded.agent_session_id == "agent-12345678"
+
+    @freeze_time("2026-04-12 10:00:00")
+    def test_mark_cancelled_persists(self, tmp_agents_dir, monkeypatch):
+        monkeypatch.setenv("WORK_BUDDY_SESSION_ID", "test-cancel-persist")
+        import work_buddy.agent_session as asmod
+        monkeypatch.setattr(asmod, "_cached_session_dir", None)
+
+        dag = WorkflowDAG(name="cancel-test:wf_c1", description="x")
+        dag.add_task("a", name="A")
+        dag.mark_cancelled("idle_timeout")
+
+        loaded = WorkflowDAG.load(dag._get_save_path())
+        assert loaded.cancelled is True
+        assert loaded.cancelled_reason == "idle_timeout"
+        assert loaded.cancelled_at == "2026-04-12T10:00:00+00:00"
+
+    def test_load_tolerates_file_without_lifecycle_fields(self, tmp_path):
+        """An older DAG file (pre-lifecycle) loads with safe defaults."""
+        old = {
+            "name": "legacy:wf_old",
+            "description": "old",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "saved_at": "2026-01-01T00:00:00+00:00",
+            "nodes": {},
+            "edges": [],
+        }
+        path = tmp_path / "legacy_wf_old.json"
+        path.write_text(json.dumps(old), encoding="utf-8")
+
+        loaded = WorkflowDAG.load(path)
+        assert loaded.cancelled is False
+        assert loaded.cancelled_reason is None
+        assert loaded.agent_session_id is None

--- a/tests/unit/test_workflow_lifecycle.py
+++ b/tests/unit/test_workflow_lifecycle.py
@@ -179,6 +179,30 @@ class TestSweepIdleRuns:
         result = conductor.sweep_idle_runs()
         assert result["threshold_hours"] == 99.0
 
+    def test_sweep_survives_concurrent_mutation(self, tmp_agents_dir):
+        """The sweep snapshots _ACTIVE_RUNS under a lock — a concurrent
+        insert/remove must never raise 'dict changed size during iteration'."""
+        import threading
+
+        stop = threading.Event()
+
+        def _churn() -> None:
+            i = 0
+            while not stop.is_set():
+                key = f"wf_churn{i}"
+                conductor._ACTIVE_RUNS[key] = _make_dag(f"t:{key}", started=False)
+                conductor._ACTIVE_RUNS.pop(key, None)
+                i += 1
+
+        churner = threading.Thread(target=_churn, daemon=True)
+        churner.start()
+        try:
+            for _ in range(50):
+                conductor.sweep_idle_runs(idle_threshold_hours=24)  # must not raise
+        finally:
+            stop.set()
+            churner.join(timeout=2)
+
 
 # ---------------------------------------------------------------------------
 # recover_active_runs

--- a/tests/unit/test_workflow_lifecycle.py
+++ b/tests/unit/test_workflow_lifecycle.py
@@ -281,12 +281,12 @@ class TestRecoverActiveRuns:
 
 
 # ---------------------------------------------------------------------------
-# _load_dag_from_disk — BUG 1 (get_agent_dir ImportError) regression
+# _load_dag_from_disk — get_agent_dir ImportError regression
 # ---------------------------------------------------------------------------
 
 class TestLoadDagFromDisk:
     def test_load_dag_from_disk_does_not_raise_importerror(self, tmp_agents_dir):
-        """Regression: the old code imported a non-existent get_agent_dir."""
+        """_load_dag_from_disk must not import a non-existent get_agent_dir."""
         result = conductor._load_dag_from_disk("wf_whatever")
         assert result is None  # nothing on disk — but no ImportError
 
@@ -420,8 +420,8 @@ class TestEndToEnd:
         run_id = start["workflow_run_id"]
         assert run_id in conductor._ACTIVE_RUNS
 
-        # BUG 2 end-to-end: the persisted DAG is a real, non-empty .json,
-        # not a 0-byte colon-mangled husk.
+        # End-to-end: the persisted DAG is a real, non-empty .json, not a
+        # 0-byte colon-mangled NTFS alternate-data-stream husk.
         dag = conductor._ACTIVE_RUNS[run_id]
         path = dag._get_save_path()
         assert path.exists() and path.suffix == ".json"

--- a/tests/unit/test_workflow_lifecycle.py
+++ b/tests/unit/test_workflow_lifecycle.py
@@ -357,3 +357,71 @@ class TestServerStartupWiring:
         monkeypatch.setattr(conductor, "recover_active_runs", _boom)
         # Must not raise.
         server._recover_workflow_runs()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end — start a real run through the conductor, then cancel / recover
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def _minimal_workflow():
+    """Register a one-step reasoning workflow for end-to-end exercises."""
+    from work_buddy.mcp_server.registry import (
+        WorkflowDefinition, WorkflowStep, get_registry,
+    )
+
+    name = "test_lifecycle_e2e"
+    wf = WorkflowDefinition(
+        name=name,
+        description="End-to-end lifecycle fixture.",
+        workflow_file="test:in-memory",
+        execution="main",
+        steps=[
+            WorkflowStep(
+                id="only", name="Only step", step_type="reasoning",
+                depends_on=[], instruction="Do the thing.",
+            ),
+        ],
+    )
+    registry = get_registry()
+    registry[name] = wf
+    yield name
+    registry.pop(name, None)
+
+
+class TestEndToEnd:
+    def test_start_persists_real_json_then_cancel(self, tmp_agents_dir,
+                                                  _minimal_workflow):
+        start = conductor.start_workflow(_minimal_workflow)
+        run_id = start["workflow_run_id"]
+        assert run_id in conductor._ACTIVE_RUNS
+
+        # BUG 2 end-to-end: the persisted DAG is a real, non-empty .json,
+        # not a 0-byte colon-mangled husk.
+        dag = conductor._ACTIVE_RUNS[run_id]
+        path = dag._get_save_path()
+        assert path.exists() and path.suffix == ".json"
+        assert path.stat().st_size > 0
+        assert ":" not in path.name
+
+        result = conductor.cancel_workflow(run_id, reason="user_requested")
+        assert result["cancelled"] is True
+        assert run_id not in conductor._ACTIVE_RUNS
+
+        # A cancelled run is not resurrected by restart recovery.
+        conductor._ACTIVE_RUNS.clear()
+        conductor.recover_active_runs(idle_threshold_hours=24)
+        assert run_id not in conductor._ACTIVE_RUNS
+
+    def test_start_then_restart_recovery_repopulates(self, tmp_agents_dir,
+                                                     _minimal_workflow):
+        start = conductor.start_workflow(_minimal_workflow)
+        run_id = start["workflow_run_id"]
+
+        # Simulate an MCP-server restart: the in-memory map is wiped.
+        conductor._ACTIVE_RUNS.clear()
+        assert run_id not in conductor._ACTIVE_RUNS
+
+        rec = conductor.recover_active_runs(idle_threshold_hours=24)
+        assert run_id in rec["recovered"]
+        assert run_id in conductor._ACTIVE_RUNS

--- a/tests/unit/test_workflow_lifecycle.py
+++ b/tests/unit/test_workflow_lifecycle.py
@@ -1,0 +1,298 @@
+"""Unit tests for workflow run lifecycle — cancel, idle sweep, restart recovery.
+
+Covers ``conductor.cancel_workflow`` / ``sweep_idle_runs`` /
+``recover_active_runs`` and the ``_load_dag_from_disk`` import-bug fix.
+The ``_ACTIVE_RUNS`` module global is cleared around every test; the
+workflow-consent revoke is stubbed so no real consent DB is touched.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from freezegun import freeze_time
+
+from work_buddy.mcp_server import conductor
+from work_buddy.workflow import WorkflowDAG
+
+
+@pytest.fixture(autouse=True)
+def _clean_active_runs():
+    """Each test starts and ends with an empty _ACTIVE_RUNS map."""
+    conductor._ACTIVE_RUNS.clear()
+    yield
+    conductor._ACTIVE_RUNS.clear()
+
+
+@pytest.fixture(autouse=True)
+def _no_consent_db(monkeypatch):
+    """Stub the workflow-consent revoke so tests never touch a real DB."""
+    calls: list[dict] = []
+
+    def _fake_revoke(workflow_run_id="", *, session_id=None):
+        calls.append({"workflow_run_id": workflow_run_id, "session_id": session_id})
+
+    import work_buddy.consent as consent_mod
+    monkeypatch.setattr(consent_mod, "revoke_workflow_consent", _fake_revoke)
+    return calls
+
+
+def _make_dag(name: str, *, session_id: str = "agent-sess-1",
+              started: bool = True, complete: bool = False) -> WorkflowDAG:
+    """Build a minimal one-task DAG for lifecycle tests."""
+    dag = WorkflowDAG(name=name, description="test")
+    dag.agent_session_id = session_id
+    dag.add_task("a", name="Step A")
+    if started or complete:
+        dag.start_task("a")
+    if complete:
+        dag.complete_task("a", result="done")
+    return dag
+
+
+# ---------------------------------------------------------------------------
+# cancel_workflow
+# ---------------------------------------------------------------------------
+
+class TestCancelWorkflow:
+    def test_cancel_active_run(self, tmp_agents_dir):
+        dag = _make_dag("triage:wf_active1")
+        conductor._ACTIVE_RUNS["wf_active1"] = dag
+
+        result = conductor.cancel_workflow("wf_active1", reason="user_requested")
+
+        assert result["cancelled"] is True
+        assert result["was_active"] is True
+        assert result["reason"] == "user_requested"
+        assert "wf_active1" not in conductor._ACTIVE_RUNS
+        # On-disk DAG records the cancellation.
+        reloaded = WorkflowDAG.load(dag._get_save_path())
+        assert reloaded.cancelled is True
+        assert reloaded.cancelled_reason == "user_requested"
+
+    def test_cancel_revokes_consent_with_pinned_session(self, tmp_agents_dir,
+                                                        _no_consent_db):
+        dag = _make_dag("triage:wf_consent1", session_id="agent-XYZ")
+        conductor._ACTIVE_RUNS["wf_consent1"] = dag
+
+        conductor.cancel_workflow("wf_consent1")
+
+        assert _no_consent_db == [
+            {"workflow_run_id": "wf_consent1", "session_id": "agent-XYZ"}
+        ]
+
+    def test_cancel_disk_only_run(self, tmp_agents_dir):
+        """A run not in _ACTIVE_RUNS is still cancellable via its disk DAG."""
+        dag = _make_dag("triage:wf_disk1")
+        dag.save()  # on disk, but NOT registered in _ACTIVE_RUNS
+
+        result = conductor.cancel_workflow("wf_disk1", reason="cleanup")
+
+        assert result["cancelled"] is True
+        assert result["was_active"] is False
+        reloaded = WorkflowDAG.load(dag._get_save_path())
+        assert reloaded.cancelled is True
+
+    def test_cancel_unknown_run(self, tmp_agents_dir):
+        result = conductor.cancel_workflow("wf_nonexistent")
+        assert result["cancelled"] is False
+        assert "error" in result
+
+    def test_cancel_complete_run_refused(self, tmp_agents_dir):
+        dag = _make_dag("triage:wf_done1", complete=True)
+        conductor._ACTIVE_RUNS["wf_done1"] = dag
+
+        result = conductor.cancel_workflow("wf_done1")
+
+        assert result["cancelled"] is False
+        assert "complete" in result["detail"].lower()
+        # A refused cancel leaves the run in place.
+        assert "wf_done1" in conductor._ACTIVE_RUNS
+
+    def test_cancel_is_idempotent(self, tmp_agents_dir):
+        dag = _make_dag("triage:wf_idem1")
+        conductor._ACTIVE_RUNS["wf_idem1"] = dag
+
+        first = conductor.cancel_workflow("wf_idem1")
+        second = conductor.cancel_workflow("wf_idem1")
+
+        assert first["cancelled"] is True
+        assert second["cancelled"] is True
+        assert second.get("already_cancelled") is True
+
+
+# ---------------------------------------------------------------------------
+# sweep_idle_runs
+# ---------------------------------------------------------------------------
+
+class TestSweepIdleRuns:
+    def test_sweep_cancels_idle_run(self, tmp_agents_dir):
+        with freeze_time("2026-05-01 12:00:00"):
+            dag = _make_dag("triage:wf_idle1")
+            conductor._ACTIVE_RUNS["wf_idle1"] = dag
+        # 48h later — past the 24h threshold.
+        with freeze_time("2026-05-03 12:00:00"):
+            result = conductor.sweep_idle_runs(idle_threshold_hours=24)
+
+        assert "wf_idle1" in result["cancelled"]
+        assert "wf_idle1" not in conductor._ACTIVE_RUNS
+
+    def test_sweep_spares_fresh_run(self, tmp_agents_dir):
+        with freeze_time("2026-05-03 11:00:00"):
+            dag = _make_dag("triage:wf_fresh1")
+            conductor._ACTIVE_RUNS["wf_fresh1"] = dag
+        # Only 1h later — well under threshold.
+        with freeze_time("2026-05-03 12:00:00"):
+            result = conductor.sweep_idle_runs(idle_threshold_hours=24)
+
+        assert result["cancelled"] == []
+        assert "wf_fresh1" in conductor._ACTIVE_RUNS
+
+    def test_sweep_dry_run_lists_but_does_not_cancel(self, tmp_agents_dir):
+        with freeze_time("2026-05-01 12:00:00"):
+            dag = _make_dag("triage:wf_dry1")
+            conductor._ACTIVE_RUNS["wf_dry1"] = dag
+        with freeze_time("2026-05-03 12:00:00"):
+            result = conductor.sweep_idle_runs(idle_threshold_hours=24, dry_run=True)
+
+        assert result["dry_run"] is True
+        assert any(c["workflow_run_id"] == "wf_dry1" for c in result["candidates"])
+        assert result["cancelled"] == []
+        assert "wf_dry1" in conductor._ACTIVE_RUNS  # untouched
+
+    def test_sweep_skips_complete_run(self, tmp_agents_dir):
+        with freeze_time("2026-05-01 12:00:00"):
+            dag = _make_dag("triage:wf_cmpl1", complete=True)
+            conductor._ACTIVE_RUNS["wf_cmpl1"] = dag
+        with freeze_time("2026-05-03 12:00:00"):
+            result = conductor.sweep_idle_runs(idle_threshold_hours=24)
+
+        # A complete run is not "idle" — it's done; leave it for advance_workflow.
+        assert result["cancelled"] == []
+
+    def test_sweep_threshold_defaults_from_config(self, tmp_agents_dir, monkeypatch):
+        monkeypatch.setattr(
+            conductor, "_idle_threshold_hours",
+            lambda override=None: 99.0 if override is None else float(override),
+        )
+        result = conductor.sweep_idle_runs()
+        assert result["threshold_hours"] == 99.0
+
+
+# ---------------------------------------------------------------------------
+# recover_active_runs
+# ---------------------------------------------------------------------------
+
+class TestRecoverActiveRuns:
+    def test_recovery_repopulates_incomplete_run(self, tmp_agents_dir):
+        with freeze_time("2026-05-20 12:00:00"):
+            dag = _make_dag("triage:wf_recov1", started=False)
+            dag.save()
+            result = conductor.recover_active_runs(idle_threshold_hours=24)
+
+        assert "wf_recov1" in result["recovered"]
+        assert "wf_recov1" in conductor._ACTIVE_RUNS
+
+    def test_recovery_skips_complete_run(self, tmp_agents_dir):
+        with freeze_time("2026-05-20 12:00:00"):
+            dag = _make_dag("triage:wf_recovdone", complete=True)
+            dag.save()
+            result = conductor.recover_active_runs(idle_threshold_hours=24)
+
+        assert "wf_recovdone" not in conductor._ACTIVE_RUNS
+        assert result["skipped"] >= 1
+
+    def test_recovery_skips_cancelled_run(self, tmp_agents_dir):
+        with freeze_time("2026-05-20 12:00:00"):
+            dag = _make_dag("triage:wf_recovcanc", started=False)
+            dag.mark_cancelled("user_requested")
+            result = conductor.recover_active_runs(idle_threshold_hours=24)
+
+        assert "wf_recovcanc" not in conductor._ACTIVE_RUNS
+
+    def test_recovery_expires_idle_run(self, tmp_agents_dir):
+        # Created 3 days ago, never advanced — idle past the 24h threshold.
+        with freeze_time("2026-05-17 12:00:00"):
+            dag = _make_dag("triage:wf_recovidle", started=False)
+            dag.save()
+        with freeze_time("2026-05-20 12:00:00"):
+            result = conductor.recover_active_runs(idle_threshold_hours=24)
+
+        assert "wf_recovidle" in result["expired"]
+        assert "wf_recovidle" not in conductor._ACTIVE_RUNS
+        # Expired runs are marked cancelled on disk so they don't resurface.
+        reloaded = WorkflowDAG.load(dag._get_save_path())
+        assert reloaded.cancelled is True
+        assert reloaded.cancelled_reason == "idle_timeout"
+
+    def test_recovery_restores_agent_session_id(self, tmp_agents_dir):
+        with freeze_time("2026-05-20 12:00:00"):
+            dag = _make_dag("triage:wf_recovsess", session_id="agent-PINNED",
+                            started=False)
+            dag.save()
+            conductor.recover_active_runs(idle_threshold_hours=24)
+
+        assert conductor._ACTIVE_RUNS["wf_recovsess"].agent_session_id == "agent-PINNED"
+
+    def test_recovery_tolerates_corrupt_file(self, tmp_agents_dir):
+        wf_dir = tmp_agents_dir / "2026-05-20T00-00-00_corrupt0" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "broken.json").write_text("{not valid json", encoding="utf-8")
+
+        # Must not raise — corrupt files are counted and skipped.
+        result = conductor.recover_active_runs(idle_threshold_hours=24)
+        assert result["errors"] >= 1
+
+    def test_recovery_skips_unkeyable_name(self, tmp_agents_dir):
+        """A DAG whose name has no ':' yields no parseable run id."""
+        with freeze_time("2026-05-20 12:00:00"):
+            dag = WorkflowDAG(name="noколон", description="x")
+            dag.add_task("a", name="A")
+            dag.save()
+            result = conductor.recover_active_runs(idle_threshold_hours=24)
+
+        assert result["recovered"] == []
+        assert result["skipped"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# _load_dag_from_disk — BUG 1 (get_agent_dir ImportError) regression
+# ---------------------------------------------------------------------------
+
+class TestLoadDagFromDisk:
+    def test_load_dag_from_disk_does_not_raise_importerror(self, tmp_agents_dir):
+        """Regression: the old code imported a non-existent get_agent_dir."""
+        result = conductor._load_dag_from_disk("wf_whatever")
+        assert result is None  # nothing on disk — but no ImportError
+
+    def test_load_dag_from_disk_finds_run_by_id(self, tmp_agents_dir):
+        dag = _make_dag("triage:wf_findme01")
+        dag.save()
+        found = conductor._load_dag_from_disk("wf_findme01")
+        assert found is not None
+        assert found.name == "triage:wf_findme01"
+
+
+# ---------------------------------------------------------------------------
+# _run_last_activity
+# ---------------------------------------------------------------------------
+
+class TestRunLastActivity:
+    def test_uses_freshest_node_timestamp(self, tmp_agents_dir):
+        with freeze_time("2026-05-01 09:00:00"):
+            dag = WorkflowDAG(name="t:wf_la1", description="x")
+            dag.add_task("a", name="A")
+        with freeze_time("2026-05-01 15:00:00"):
+            dag.start_task("a")  # started_at = 15:00
+
+        last = conductor._run_last_activity(dag)
+        assert last.hour == 15
+
+    def test_falls_back_to_created_at(self, tmp_agents_dir):
+        with freeze_time("2026-05-01 08:00:00"):
+            dag = WorkflowDAG(name="t:wf_la2", description="x")
+            dag.add_task("a", name="A")  # no task started
+
+        last = conductor._run_last_activity(dag)
+        assert last.hour == 8

--- a/tests/unit/test_workflow_lifecycle.py
+++ b/tests/unit/test_workflow_lifecycle.py
@@ -296,3 +296,64 @@ class TestRunLastActivity:
 
         last = conductor._run_last_activity(dag)
         assert last.hour == 8
+
+
+# ---------------------------------------------------------------------------
+# Gateway startup wiring (server._recover_workflow_runs)
+# ---------------------------------------------------------------------------
+
+class TestServerStartupWiring:
+    def test_recovery_skipped_when_disabled(self, monkeypatch):
+        from work_buddy.mcp_server import server
+        import work_buddy.config as config_mod
+
+        called: list[bool] = []
+        monkeypatch.setattr(
+            config_mod, "load_config",
+            lambda *a, **k: {
+                "workflows": {"run_lifecycle": {"recovery_enabled": False}}
+            },
+        )
+        monkeypatch.setattr(
+            conductor, "recover_active_runs",
+            lambda *a, **k: called.append(True) or {},
+        )
+        server._recover_workflow_runs()
+        assert called == []  # the config kill-switch was honored
+
+    def test_recovery_runs_when_enabled(self, monkeypatch):
+        from work_buddy.mcp_server import server
+        import work_buddy.config as config_mod
+
+        called: list[bool] = []
+        monkeypatch.setattr(
+            config_mod, "load_config",
+            lambda *a, **k: {
+                "workflows": {"run_lifecycle": {"recovery_enabled": True}}
+            },
+        )
+        monkeypatch.setattr(
+            conductor, "recover_active_runs",
+            lambda *a, **k: called.append(True) or {"recovered": [], "expired": []},
+        )
+        server._recover_workflow_runs()
+        assert called == [True]
+
+    def test_recovery_swallows_errors(self, monkeypatch):
+        """A recovery failure must never block the gateway from booting."""
+        from work_buddy.mcp_server import server
+        import work_buddy.config as config_mod
+
+        monkeypatch.setattr(
+            config_mod, "load_config",
+            lambda *a, **k: {
+                "workflows": {"run_lifecycle": {"recovery_enabled": True}}
+            },
+        )
+
+        def _boom(*a, **k):
+            raise RuntimeError("disk on fire")
+
+        monkeypatch.setattr(conductor, "recover_active_runs", _boom)
+        # Must not raise.
+        server._recover_workflow_runs()

--- a/work_buddy/config.py
+++ b/work_buddy/config.py
@@ -129,6 +129,15 @@ DEFAULTS = {
         # Repository-Setup requirement so it is user-configurable.
         "markdown_dir": "work-buddy/projects",
     },
+    "workflows": {
+        # Lifecycle of in-flight workflow runs in the MCP gateway's
+        # in-memory active-runs map. See work_buddy/mcp_server/conductor.py.
+        "run_lifecycle": {
+            "idle_timeout_hours": 24,
+            "sweep_interval_minutes": 60,
+            "recovery_enabled": True,
+        },
+    },
 }
 
 

--- a/work_buddy/mcp_server/conductor.py
+++ b/work_buddy/mcp_server/conductor.py
@@ -25,8 +25,10 @@ import logging
 import os
 import subprocess
 import sys
+import threading
 import uuid
-from datetime import date, datetime, timezone
+from collections.abc import Iterator
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -46,6 +48,18 @@ logger = logging.getLogger(__name__)
 # In-memory map of active workflow runs.
 # Key: workflow_run_id, Value: WorkflowDAG instance
 _ACTIVE_RUNS: dict[str, WorkflowDAG] = {}
+
+# Guards compound mutations of _ACTIVE_RUNS. The dict is touched both by
+# gateway request workers (start/advance run on asyncio.to_thread threads)
+# and by the idle-sweep daemon thread. Single dict ops are GIL-atomic, but
+# this lock makes snapshot-then-iterate and check-then-delete sequences
+# safe. It is held only for microsecond dict ops — never across _save()
+# (disk I/O) or subprocess calls — so it cannot serialize real work.
+_ACTIVE_RUNS_LOCK = threading.Lock()
+
+# Fallback idle timeout when config is unavailable. The config surface is
+# workflows.run_lifecycle.idle_timeout_hours (see config.yaml).
+_DEFAULT_IDLE_TIMEOUT_HOURS = 24.0
 
 
 def _validate_workflow_params(
@@ -179,16 +193,18 @@ def start_workflow(
             metadata=meta,
         )
 
-    dag.save()
-    _ACTIVE_RUNS[run_id] = dag
+    # Pin the caller's session to the DAG *before* the first save, so the
+    # persisted file — and any run recovered from it after an MCP-server
+    # restart — can resolve consent against the right session. Every
+    # auto_run subprocess started from this workflow also uses the agent's
+    # consent.db via this pin; without it the subprocess reads
+    # WORK_BUDDY_SESSION_ID from its parent (the MCP server's own session)
+    # and consent grants land in a different DB.
+    dag.agent_session_id = agent_session_id
 
-    # Pin the caller's session to the DAG so every auto_run subprocess
-    # started from this workflow uses the agent's consent.db (not the
-    # MCP server's bootstrap sidecar session). Without this the
-    # subprocess reads WORK_BUDDY_SESSION_ID from its parent process,
-    # which is the MCP server's own session — and consent grants issued
-    # by the agent land in a different DB.
-    dag.agent_session_id = agent_session_id  # type: ignore[attr-defined]
+    dag.save()
+    with _ACTIVE_RUNS_LOCK:
+        _ACTIVE_RUNS[run_id] = dag
 
     # Grant blanket consent for the workflow's lifetime.  Accepting a
     # workflow implies consent for all its operations unless a step
@@ -320,7 +336,8 @@ def advance_workflow(
     # Check if workflow is now complete
     if dag.is_complete():
         result = _build_complete_response(workflow_run_id, dag)
-        del _ACTIVE_RUNS[workflow_run_id]
+        with _ACTIVE_RUNS_LOCK:
+            _ACTIVE_RUNS.pop(workflow_run_id, None)
         return result
 
     # Build response — auto_run steps are consumed transparently inside.
@@ -332,7 +349,8 @@ def advance_workflow(
 
     if response.get("type") == "workflow_complete":
         # Auto-run chain finished the workflow — clean up
-        _ACTIVE_RUNS.pop(workflow_run_id, None)
+        with _ACTIVE_RUNS_LOCK:
+            _ACTIVE_RUNS.pop(workflow_run_id, None)
         return response
 
     # ``prior_step`` is a pointer; the just-completed step's result lives
@@ -357,13 +375,16 @@ def get_workflow_status(workflow_run_id: str) -> dict[str, Any]:
 
 def list_active_runs() -> list[dict[str, Any]]:
     """List all active workflow runs."""
+    with _ACTIVE_RUNS_LOCK:
+        snapshot = list(_ACTIVE_RUNS.items())
     return [
         {
             "workflow_run_id": run_id,
             "name": dag.name,
             "is_complete": dag.is_complete(),
+            "cancelled": getattr(dag, "cancelled", False),
         }
-        for run_id, dag in _ACTIVE_RUNS.items()
+        for run_id, dag in snapshot
     ]
 
 
@@ -394,7 +415,9 @@ def reconcile_workflow_consent(session_id: str) -> dict[str, Any]:
         )
         if not is_workflow_consent_active(session_id=session_id):
             return {"swept": False, "reason": "no_blanket"}
-        for dag in _ACTIVE_RUNS.values():
+        with _ACTIVE_RUNS_LOCK:
+            dags = list(_ACTIVE_RUNS.values())
+        for dag in dags:
             if getattr(dag, "agent_session_id", None) == session_id:
                 return {"swept": False, "reason": "active_run_present"}
         revoke_workflow_consent(session_id=session_id)
@@ -479,26 +502,56 @@ def get_step_result(
     return {"step_id": step_id, "result": result}
 
 
-def _load_dag_from_disk(workflow_run_id: str) -> WorkflowDAG | None:
-    """Try to load a DAG from persisted state files.
+def _iter_dag_files() -> Iterator[Path]:
+    """Yield every persisted workflow-DAG JSON file across all agent sessions.
 
-    Searches the current session's workflow directory for a DAG whose
-    name contains the ``workflow_run_id``.
+    A DAG is saved under the ``workflows/`` directory of whichever session
+    the saving process belonged to. After an MCP-server restart there is
+    no meaningful "current session", and the persistent gateway runs under
+    its own synthetic session — so any code that needs to find a run by id
+    (the disk fallback, restart recovery) must scan every session.
+
+    Scans ``agents/*/workflows/`` directly rather than via ``list_sessions``
+    so a session directory missing its ``manifest.json`` is still covered.
     """
-    from work_buddy.agent_session import get_agent_dir
+    from work_buddy.agent_session import get_agents_dir
 
-    wf_dir = get_agent_dir() / "workflows"
-    if not wf_dir.is_dir():
-        return None
+    try:
+        agents_dir = get_agents_dir()
+    except Exception:  # pragma: no cover — defensive
+        return
+    if not agents_dir.is_dir():
+        return
+    for session_dir in sorted(agents_dir.iterdir()):
+        wf_dir = session_dir / "workflows"
+        if not wf_dir.is_dir():
+            continue
+        for path in sorted(wf_dir.glob("*.json")):
+            try:
+                if path.stat().st_size == 0:
+                    continue  # empty file — never a valid DAG
+            except OSError:  # pragma: no cover — defensive
+                continue
+            yield path
 
-    for path in wf_dir.glob("*.json"):
+
+def _load_dag_from_disk(workflow_run_id: str) -> WorkflowDAG | None:
+    """Find a persisted DAG by run id, scanning every agent session.
+
+    The run id is matched against the DAG ``name`` (format
+    ``"<workflow>:<run_id>"``), not the filename — filenames are
+    lower-cased and colon-sanitized, so the id may not survive verbatim.
+    """
+    for path in _iter_dag_files():
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
-            dag_name = data.get("name", "")
-            if workflow_run_id in dag_name:
-                return WorkflowDAG.load(path)
-        except Exception:
+        except (json.JSONDecodeError, OSError):
             continue
+        if workflow_run_id in data.get("name", ""):
+            try:
+                return WorkflowDAG.load(path)
+            except Exception:  # pragma: no cover — defensive
+                continue
     return None
 
 
@@ -581,6 +634,274 @@ def fail_after_retry_exhaustion(
         "workflow_run_id": workflow_run_id,
         "step_id": step_id,
         "error": error,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Run lifecycle — cancel, idle sweep, restart recovery
+# ---------------------------------------------------------------------------
+
+
+def _idle_threshold_hours(override: float | None = None) -> float:
+    """Resolve the idle-timeout threshold in hours.
+
+    An explicit ``override`` wins; otherwise read
+    ``workflows.run_lifecycle.idle_timeout_hours`` from config, falling
+    back to the module default.
+    """
+    if override is not None:
+        return float(override)
+    try:
+        from work_buddy.config import load_config
+        cfg = load_config().get("workflows", {}).get("run_lifecycle", {})
+        return float(cfg.get("idle_timeout_hours", _DEFAULT_IDLE_TIMEOUT_HOURS))
+    except Exception:  # pragma: no cover — defensive
+        return _DEFAULT_IDLE_TIMEOUT_HOURS
+
+
+def _parse_ts(raw: Any) -> datetime | None:
+    """Parse an ISO-8601 string to an aware UTC datetime, or None."""
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        ts = datetime.fromisoformat(raw)
+    except (ValueError, TypeError):
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts
+
+
+def _run_last_activity(dag: WorkflowDAG) -> datetime:
+    """Return the timestamp of the run's most recent step progress.
+
+    Idleness is measured from genuine workflow progress — the freshest
+    ``started_at`` / ``completed_at`` across all DAG nodes — not from the
+    file's ``saved_at`` (which also advances on non-progress writes).
+    Falls back to the run's ``created_at`` when no task has run yet, and
+    to "now" if even that is unparseable (a malformed run is treated as
+    fresh rather than swept on sight).
+    """
+    latest: datetime | None = None
+    for _, data in dag._graph.nodes(data=True):
+        for field in ("completed_at", "started_at"):
+            ts = _parse_ts(data.get(field))
+            if ts is not None and (latest is None or ts > latest):
+                latest = ts
+    if latest is None:
+        latest = _parse_ts(getattr(dag, "_created_at", "")) or datetime.now(timezone.utc)
+    return latest
+
+
+def cancel_workflow(
+    workflow_run_id: str,
+    reason: str | None = None,
+) -> dict[str, Any]:
+    """Cancel a workflow run.
+
+    Marks the on-disk DAG cancelled (kept for audit), drops the run from
+    the in-memory active-runs map, and revokes the workflow consent
+    blanket. Looks the run up in ``_ACTIVE_RUNS`` first; if it is not
+    active (e.g. only on disk after a restart) it falls back to the
+    persisted DAG so a stale run can still be cleaned.
+
+    Idempotent: cancelling an already-cancelled run is a no-op, and a run
+    that has already completed is left untouched.
+    """
+    reason = reason or "user_requested"
+
+    with _ACTIVE_RUNS_LOCK:
+        dag = _ACTIVE_RUNS.get(workflow_run_id)
+    was_active = dag is not None
+
+    if dag is None:
+        dag = _load_dag_from_disk(workflow_run_id)
+
+    if dag is None:
+        return {
+            "cancelled": False,
+            "workflow_run_id": workflow_run_id,
+            "error": (
+                f"Unknown workflow run: {workflow_run_id!r} "
+                f"(not active and not found on disk)."
+            ),
+        }
+
+    if getattr(dag, "cancelled", False):
+        # Already cancelled — ensure it isn't lingering in the map; no-op.
+        with _ACTIVE_RUNS_LOCK:
+            _ACTIVE_RUNS.pop(workflow_run_id, None)
+        return {
+            "cancelled": True,
+            "already_cancelled": True,
+            "workflow_run_id": workflow_run_id,
+            "reason": getattr(dag, "cancelled_reason", None),
+        }
+
+    if dag.is_complete():
+        return {
+            "cancelled": False,
+            "workflow_run_id": workflow_run_id,
+            "detail": "Workflow run already complete — nothing to cancel.",
+        }
+
+    # Mark cancelled on disk first (the audit trail survives even if the
+    # process dies right here), then drop from the active map.
+    dag.mark_cancelled(reason)
+    with _ACTIVE_RUNS_LOCK:
+        _ACTIVE_RUNS.pop(workflow_run_id, None)
+
+    # Revoke the workflow consent blanket via the DAG-pinned session, so a
+    # cancelled run never leaves a live blanket behind in the agent's DB.
+    try:
+        from work_buddy.consent import revoke_workflow_consent
+        revoke_workflow_consent(
+            workflow_run_id,
+            session_id=getattr(dag, "agent_session_id", None),
+        )
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning(
+            "cancel_workflow: consent revoke failed for %s: %s",
+            workflow_run_id, exc,
+        )
+
+    logger.info(
+        "Workflow run %s cancelled (reason=%s, was_active=%s)",
+        workflow_run_id, reason, was_active,
+    )
+    return {
+        "cancelled": True,
+        "workflow_run_id": workflow_run_id,
+        "reason": reason,
+        "was_active": was_active,
+    }
+
+
+def sweep_idle_runs(
+    idle_threshold_hours: float | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Cancel active workflow runs idle past the timeout.
+
+    An orphaned run — one whose agent stopped calling ``wb_advance`` —
+    never leaves ``_ACTIVE_RUNS`` on its own; this sweep reclaims it. It
+    runs in the same process as ``_ACTIVE_RUNS`` (the MCP gateway), so it
+    works whether invoked by the background sweep thread or manually via
+    ``wb_run``. Complete and already-cancelled runs are skipped.
+    """
+    threshold = _idle_threshold_hours(idle_threshold_hours)
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=threshold)
+
+    with _ACTIVE_RUNS_LOCK:
+        snapshot = list(_ACTIVE_RUNS.items())
+
+    candidates: list[dict[str, Any]] = []
+    cancelled: list[str] = []
+
+    for run_id, dag in snapshot:
+        if dag.is_complete() or getattr(dag, "cancelled", False):
+            continue
+        last = _run_last_activity(dag)
+        if last >= cutoff:
+            continue
+        candidates.append({
+            "workflow_run_id": run_id,
+            "name": dag.name,
+            "idle_hours": round((now - last).total_seconds() / 3600.0, 2),
+        })
+        if not dry_run:
+            result = cancel_workflow(run_id, reason="idle_timeout")
+            if result.get("cancelled"):
+                cancelled.append(run_id)
+
+    if candidates:
+        logger.info(
+            "Idle-run sweep: %d candidate(s), %d cancelled "
+            "(threshold=%.1fh, dry_run=%s)",
+            len(candidates), len(cancelled), threshold, dry_run,
+        )
+    return {
+        "checked": len(snapshot),
+        "candidates": candidates,
+        "cancelled": cancelled,
+        "dry_run": dry_run,
+        "threshold_hours": threshold,
+    }
+
+
+def recover_active_runs(
+    idle_threshold_hours: float | None = None,
+) -> dict[str, Any]:
+    """Reload incomplete workflow runs from disk into ``_ACTIVE_RUNS``.
+
+    The in-memory active-runs map does not survive an MCP-server restart,
+    but the DAG state on disk does. Without this, a restart silently
+    abandons every in-flight workflow — an agent's next ``wb_advance``
+    would get "unknown run". Called once at gateway startup.
+
+    Runs that are complete or already cancelled are not recovered. Runs
+    idle past the timeout are not recovered either — they are marked
+    cancelled on disk so they don't resurface on the next boot.
+    """
+    threshold = _idle_threshold_hours(idle_threshold_hours)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=threshold)
+
+    recovered: list[str] = []
+    expired: list[str] = []
+    skipped = 0
+    errors = 0
+
+    for path in _iter_dag_files():
+        try:
+            dag = WorkflowDAG.load(path)
+        except Exception:
+            # Corrupt or unreadable file — skip it, don't fail the boot.
+            errors += 1
+            continue
+
+        # run_id is the segment after the last ':' in "<workflow>:<run_id>".
+        name = dag.name or ""
+        if ":" not in name:
+            logger.warning(
+                "recover_active_runs: DAG at %s has un-keyable name %r — "
+                "skipping", path, name,
+            )
+            skipped += 1
+            continue
+        run_id = name.rsplit(":", 1)[1]
+
+        if dag.is_complete() or getattr(dag, "cancelled", False):
+            skipped += 1
+            continue
+
+        if _run_last_activity(dag) < cutoff:
+            # Idle past the timeout — don't repopulate a dead run; mark it
+            # cancelled on disk so it doesn't resurface on the next boot.
+            try:
+                dag.mark_cancelled("idle_timeout")
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.warning(
+                    "recover_active_runs: failed to expire %s: %s",
+                    run_id, exc,
+                )
+            expired.append(run_id)
+            continue
+
+        with _ACTIVE_RUNS_LOCK:
+            _ACTIVE_RUNS[run_id] = dag
+        recovered.append(run_id)
+
+    logger.info(
+        "Workflow run recovery: %d recovered, %d expired (idle), "
+        "%d skipped, %d errors",
+        len(recovered), len(expired), skipped, errors,
+    )
+    return {
+        "recovered": recovered,
+        "expired": expired,
+        "skipped": skipped,
+        "errors": errors,
     }
 
 

--- a/work_buddy/mcp_server/ops/workflow_ops.py
+++ b/work_buddy/mcp_server/ops/workflow_ops.py
@@ -1,0 +1,23 @@
+"""Workflow run lifecycle ops — cancel a run, sweep idle runs.
+
+Each op here is referenced by a capability declaration (a ``kind:
+"capability"`` knowledge-store unit carrying a matching ``op`` field).
+The callables live in :mod:`work_buddy.mcp_server.conductor`, which owns
+the in-memory active-runs map these operate on — registering them as ops
+exposes that lifecycle control over the MCP gateway (``wb_run``) and to
+the user-facing ``/wb-workflow-cancel`` slash command.
+"""
+
+from __future__ import annotations
+
+from work_buddy.mcp_server.op_registry import register_op
+
+
+def _register() -> None:
+    from work_buddy.mcp_server.conductor import cancel_workflow, sweep_idle_runs
+
+    register_op("op.wb.workflow_cancel", cancel_workflow)
+    register_op("op.wb.workflow_sweep_idle", sweep_idle_runs)
+
+
+_register()

--- a/work_buddy/mcp_server/server.py
+++ b/work_buddy/mcp_server/server.py
@@ -122,6 +122,77 @@ def _warm_registry_in_background() -> None:
     t.start()
 
 
+def _recover_workflow_runs() -> None:
+    """Reload incomplete workflow runs from disk at gateway startup.
+
+    The conductor's in-memory active-runs map does not survive a restart;
+    without this, every in-flight workflow is silently abandoned and an
+    agent's next ``wb_advance`` gets "unknown run". Runs idle past the
+    timeout are expired rather than recovered.
+
+    Gated on ``workflows.run_lifecycle.recovery_enabled``. Never raises —
+    a recovery failure must not stop the gateway from booting.
+    """
+    logger = logging.getLogger("work_buddy.mcp_server")
+    try:
+        from work_buddy.config import load_config
+        rl = load_config().get("workflows", {}).get("run_lifecycle", {})
+        if not rl.get("recovery_enabled", True):
+            logger.info("Workflow run recovery disabled by config — skipping")
+            return
+        from work_buddy.mcp_server.conductor import recover_active_runs
+        result = recover_active_runs()
+        logger.info(
+            "Workflow run recovery: %d recovered, %d expired",
+            len(result.get("recovered", [])),
+            len(result.get("expired", [])),
+        )
+    except Exception as exc:
+        logger.warning("Workflow run recovery failed (continuing): %s", exc)
+
+
+def _start_idle_sweep_in_background() -> None:
+    """Periodically sweep idle workflow runs in a daemon thread.
+
+    ``_ACTIVE_RUNS`` lives in this process and an orphaned run never
+    leaves it on its own — this sweep reclaims runs idle past the
+    configured threshold. Interval and threshold come from
+    ``workflows.run_lifecycle`` in config.
+
+    Daemon thread so it never blocks shutdown; each tick is wrapped so a
+    failure logs and the loop continues rather than killing the sweep.
+    """
+    import threading
+    import time
+
+    logger = logging.getLogger("work_buddy.mcp_server")
+
+    try:
+        from work_buddy.config import load_config
+        rl = load_config().get("workflows", {}).get("run_lifecycle", {})
+        interval_minutes = float(rl.get("sweep_interval_minutes", 60))
+    except Exception:
+        interval_minutes = 60.0
+    # Clamp to a sane floor — a sub-minute sweep would just churn.
+    interval_seconds = max(60.0, interval_minutes * 60.0)
+
+    def _loop() -> None:
+        from work_buddy.mcp_server.conductor import sweep_idle_runs
+        while True:
+            time.sleep(interval_seconds)
+            try:
+                sweep_idle_runs()
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.warning("Idle-run sweep tick failed: %s", exc)
+
+    t = threading.Thread(target=_loop, name="workflow-idle-sweep", daemon=True)
+    t.start()
+    logger.info(
+        "Workflow idle-run sweep started (every %.0f min)",
+        interval_seconds / 60.0,
+    )
+
+
 def main_http() -> None:
     """Entry point — run as a persistent streamable-http service."""
     port = _get_port()
@@ -139,5 +210,10 @@ def main_http() -> None:
     # shared helper centralizes the boilerplate.
     from work_buddy.threads.bootstrap import bootstrap_for_subprocess
     bootstrap_for_subprocess(subprocess_name="mcp-gateway")
+    # Reload in-flight workflow runs from disk before serving requests, so
+    # a wb_advance for a pre-restart run resolves instead of dead-ending.
+    _recover_workflow_runs()
     _warm_registry_in_background()
+    # Background reclaimer for orphaned (idle) workflow runs.
+    _start_idle_sweep_in_background()
     server.run(transport="streamable-http")

--- a/work_buddy/workflow.py
+++ b/work_buddy/workflow.py
@@ -80,6 +80,17 @@ class WorkflowDAG:
         self._graph = nx.DiGraph()
         self._created_at = datetime.now(timezone.utc).isoformat()
 
+        # Run-level lifecycle state. ``agent_session_id`` pins the run to the
+        # agent session that started it (assigned by the conductor); it is
+        # persisted so a run recovered after an MCP-server restart can still
+        # resolve consent against the right session.  The cancellation fields
+        # record an explicit cancel — manual or by the idle-timeout sweep —
+        # which is a run-level property, distinct from per-task status.
+        self.agent_session_id: str | None = None
+        self.cancelled: bool = False
+        self.cancelled_reason: str | None = None
+        self.cancelled_at: str | None = None
+
     @staticmethod
     def _read_workflow_policy(workflow_file: str) -> tuple[str, bool]:
         """Read execution policy from a workflow file's YAML frontmatter.
@@ -262,6 +273,20 @@ class WorkflowDAG:
         logger.info(f"Task completed: {task_id}")
         self._save()
 
+    def mark_cancelled(self, reason: str) -> None:
+        """Mark the whole run as cancelled and persist.
+
+        Cancellation is a run-level property, not a per-task status: a
+        cancelled run may still have pending or running tasks. The conductor
+        removes the run from its active-runs map after calling this; the
+        persisted flag keeps restart-recovery from re-importing the run.
+        """
+        self.cancelled = True
+        self.cancelled_reason = reason
+        self.cancelled_at = datetime.now(timezone.utc).isoformat()
+        logger.info(f"Workflow cancelled: {self.name} — {reason}")
+        self._save()
+
     def fail_task(self, task_id: str, error: str = "") -> None:
         """Mark a task as failed."""
         if task_id not in self._graph:
@@ -376,20 +401,49 @@ class WorkflowDAG:
 
     # --- Persistence ---
 
+    @staticmethod
+    def _safe_name(name: str) -> str:
+        """Turn a DAG name into a filesystem-safe stem.
+
+        A run's name is ``"<workflow>:<run_id>"``. The ``:`` is **not**
+        merely cosmetic to strip — on Windows/NTFS a ``:`` in a path opens
+        an alternate data stream, so ``write_text`` on ``wf:run.json`` would
+        silently divert the content into a stream of a 0-byte base file and
+        ``glob("*.json")`` would never see it. Replacing it is what makes
+        on-disk workflow state real on Windows.
+        """
+        return (
+            name.replace(" ", "_")
+            .replace("/", "_")
+            .replace(":", "_")
+            .lower()
+        )
+
     def _get_save_path(self) -> Path:
         """Get the save path for this workflow's state."""
         wf_dir = get_session_dir() / "workflows"
         wf_dir.mkdir(exist_ok=True)
-        safe_name = self.name.replace(" ", "_").replace("/", "_").lower()
-        return wf_dir / f"{safe_name}.json"
+        return wf_dir / f"{self._safe_name(self.name)}.json"
 
     def _save(self) -> None:
-        """Persist the DAG state to disk."""
+        """Persist the DAG state to disk.
+
+        The write is atomic (write to a temp file, then ``replace``) so a
+        crash mid-write can never leave a half-written DAG file — important
+        now that restart-recovery reads every DAG file on boot.
+        """
         data = {
             "name": self.name,
             "description": self.description,
             "created_at": self._created_at,
             "saved_at": datetime.now(timezone.utc).isoformat(),
+            # Agent session that owns this run — needed to resolve consent
+            # for a run recovered after an MCP-server restart.
+            "agent_session_id": getattr(self, "agent_session_id", None),
+            # Run-level cancellation record (manual or idle-timeout sweep).
+            "cancelled": getattr(self, "cancelled", False),
+            "cancelled_reason": getattr(self, "cancelled_reason", None),
+            "cancelled_at": getattr(self, "cancelled_at", None),
             "nodes": {},
             "edges": [],
             # Caller-provided initial params (set by start_workflow when the
@@ -403,7 +457,9 @@ class WorkflowDAG:
             data["edges"].append([u, v])
 
         path = self._get_save_path()
-        path.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+        tmp.replace(path)
 
     def save(self) -> Path:
         """Explicitly save and return the save path."""
@@ -418,6 +474,11 @@ class WorkflowDAG:
         dag._created_at = raw.get("created_at", "")
         # Restore initial_params if persisted (None for older save files).
         dag.initial_params = raw.get("initial_params")  # type: ignore[attr-defined]
+        # Restore run-level lifecycle state (safe defaults for older files).
+        dag.agent_session_id = raw.get("agent_session_id")
+        dag.cancelled = raw.get("cancelled", False)
+        dag.cancelled_reason = raw.get("cancelled_reason")
+        dag.cancelled_at = raw.get("cancelled_at")
 
         # Rebuild graph
         for node_id, node_data in raw["nodes"].items():
@@ -431,8 +492,7 @@ class WorkflowDAG:
     def load_by_name(cls, name: str) -> "WorkflowDAG":
         """Load a DAG by workflow name from the current session."""
         wf_dir = get_session_dir() / "workflows"
-        safe_name = name.replace(" ", "_").replace("/", "_").lower()
-        path = wf_dir / f"{safe_name}.json"
+        path = wf_dir / f"{cls._safe_name(name)}.json"
         if not path.exists():
             raise FileNotFoundError(f"No saved workflow '{name}' in current session.")
         return cls.load(path)

--- a/work_buddy/workflow.py
+++ b/work_buddy/workflow.py
@@ -91,6 +91,12 @@ class WorkflowDAG:
         self.cancelled_reason: str | None = None
         self.cancelled_at: str | None = None
 
+        # When this DAG was loaded from disk, the file it came from. A
+        # subsequent _save() writes back there rather than recomputing a
+        # path under the *current* process's session directory — see
+        # _get_save_path.
+        self._loaded_from: Path | None = None
+
     @staticmethod
     def _read_workflow_policy(workflow_file: str) -> tuple[str, bool]:
         """Read execution policy from a workflow file's YAML frontmatter.
@@ -420,7 +426,17 @@ class WorkflowDAG:
         )
 
     def _get_save_path(self) -> Path:
-        """Get the save path for this workflow's state."""
+        """Get the save path for this workflow's state.
+
+        A DAG loaded from disk re-saves to the file it came from
+        (``_loaded_from``). Otherwise — for a run recovered after a restart,
+        or a disk-only run being cancelled — ``_save()`` would write a
+        duplicate under the *current* process's session directory instead
+        of updating the original file.
+        """
+        if self._loaded_from is not None:
+            self._loaded_from.parent.mkdir(parents=True, exist_ok=True)
+            return self._loaded_from
         wf_dir = get_session_dir() / "workflows"
         wf_dir.mkdir(exist_ok=True)
         return wf_dir / f"{self._safe_name(self.name)}.json"
@@ -472,6 +488,7 @@ class WorkflowDAG:
         raw = json.loads(path.read_text(encoding="utf-8"))
         dag = cls(name=raw["name"], description=raw.get("description", ""))
         dag._created_at = raw.get("created_at", "")
+        dag._loaded_from = Path(path)
         # Restore initial_params if persisted (None for older save files).
         dag.initial_params = raw.get("initial_params")  # type: ignore[attr-defined]
         # Restore run-level lifecycle state (safe defaults for older files).

--- a/work_buddy/workflow.py
+++ b/work_buddy/workflow.py
@@ -446,7 +446,7 @@ class WorkflowDAG:
 
         The write is atomic (write to a temp file, then ``replace``) so a
         crash mid-write can never leave a half-written DAG file — important
-        now that restart-recovery reads every DAG file on boot.
+        because restart-recovery reads every DAG file on boot.
         """
         data = {
             "name": self.name,


### PR DESCRIPTION
## Summary
- Adds lifecycle management for the conductor's in-memory `_ACTIVE_RUNS`
  map: a `workflow_cancel` capability + `/wb-workflow-cancel` slash
  command, an in-process idle-timeout sweep (24h threshold, hourly,
  config-driven), and restart recovery that reloads incomplete runs from
  disk at gateway startup. Orphaned workflow runs no longer accumulate
  forever, and a restart no longer silently abandons in-flight work.
- Fixes two latent bugs that blocked the feature: `_load_dag_from_disk`
  imported a non-existent `get_agent_dir` (raised `ImportError` on every
  call); and DAG run names embed a `:` that on NTFS diverted persisted
  state into a 0-byte alternate-data-stream husk — workflow persistence
  was silently broken on Windows.
- Hardens supporting code: atomic DAG saves, a lock + snapshot iteration
  around `_ACTIVE_RUNS` (closes a latent `dict changed size during
  iteration` crash in `list_active_runs`), and test isolation so DAG
  tests no longer write into the live data directory.

## Test plan
- [x] Full `tests/unit/` suite green
- [x] 52 workflow/conductor lifecycle tests — cancel, idle sweep,
      recovery, end-to-end, thread-safety, both bug regressions
- [x] Capability declarations resolve against the op registry
- [x] Live-verified after a gateway restart: `workflow_cancel` /
      `workflow_sweep_idle` callable via `wb_run`; recovery ran at startup

Task: t-3badb8ca

🤖 Generated with [Claude Code](https://claude.com/claude-code)