### PR TITLE
feat(summarization): composition framework + conv_obs and Chrome migrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ Every scope below is browsable with `mcp__work-buddy__wb_run("agent_docs", {"sco
 | `services/` | Messaging, memory (Hindsight), dashboard, sidecar |
 | `features/` | Preferences and feature opt-in |
 | `operations/` | Gateway, agent sessions |
-| `architecture/` | Repo structure, workflows, knowledge system, embedding service, retry queue, artifact system, llm-with-tools |
+| `architecture/` | Repo structure, workflows, knowledge system, embedding service, retry queue, artifact system, summarization framework, llm-with-tools |
 | `status/` | Setup wizard, tailscale, feature status |
 | `morning/` | Morning routine |
 | `metacognition/` | Blindspot patterns (personal knowledge) |

--- a/knowledge/store/architecture/conversation-observability.md
+++ b/knowledge/store/architecture/conversation-observability.md
@@ -59,7 +59,7 @@ dev_notes: |-
   - `currently_dirty` is best-effort. The `uncommitted_report` helper re-queries `git status --porcelain` during assembly so the surfaced status codes reflect current state; storing the codes at refresh time would lie about a mutable resource.
 ---
 
-Centralizes session-derived facts that previously lived ad hoc in `work_buddy/sessions/inspector.py`. The subsystem is a thin SQLite store plus refresh functions; raw JSONL parsing stays in the inspector (single source of truth for the parser), and Git context source continues to own commit/status collection.
+A SQLite-backed store of session-derived facts for Claude Code: commits, file writes, uncommitted-work attribution, observed-session metadata. The subsystem is a thin SQLite store plus refresh functions; raw JSONL parsing stays in `work_buddy/sessions/inspector.py` (single source of truth for the parser), and Git context source continues to own commit/status collection. Per-session LLM topic summaries are produced and stored by the summarization framework (`architecture/summarization-framework`); this subsystem owns the discovery side (observed-session enumeration) and the conv_obs-shaped read API that maps the framework's tree storage to a flat row.
 
 ## Why
 
@@ -67,28 +67,28 @@ Centralizes session-derived facts that previously lived ad hoc in `work_buddy/se
 
 ## Surface
 
-Five tables in `<data_root>/conversation_observability/conversation_observability.db` (path overridable via `conversation_observability.db_path`):
+Three live tables in `<data_root>/conversation_observability/conversation_observability.db` (path overridable via `conversation_observability.db_path`):
 
 - `observed_sessions` — per-JSONL ledger. Carries metadata (start/end, message_count, span_count, tool_names) plus three per-concern scan-mtime columns: `source_mtime` (metadata load), `commits_scanned_mtime` (commits refresh), `writes_scanned_mtime` (writes refresh). Each refresher owns its column so running them in any order doesn't conflate staleness state.
 - `session_commits` — one row per git commit attributed to a session. Keyed by full SHA, indexed on `short_sha` for GitSource lookups.
 - `session_file_writes` — one row per (session, file_path). Carries the tool that wrote it, the latest write timestamp, an optional `committed_sha` cross-reference, and a `currently_dirty` snapshot (best-effort — git state is mutable, so consumers should treat this as not authoritative without a refresh).
-- `topic_summaries` — LLM-generated topic chunks for a summarized session, each with title, summary, span range, turn range, and keywords.
-- `session_summaries` — per-session tldr + full provenance (model, profile, backend, prompt_version, summary_schema_version, selection_version, cache_version). Status flag + error column track failures.
 
-Foreign-key cascades use `SqliteRowsStorage.post_delete_sql` rather than SQLite's FK enforcement. Deleting an `observed_sessions` row removes every child in the same transaction.
+`session_summaries` and `topic_summaries` schemas remain defined in `schema.py` for rollback safety but are no longer written. Per-session tldr + ordered topic segments live in the summarization framework's `<data_root>/summarization/summarization.db` under namespace `conversation_session` (see `architecture/summarization-framework`). The legacy read API (`query_session_summary`, `query_topic_summaries`, and the `conversation_observability_summarize` / `conversation_observability_summary_get` capabilities) is preserved via thin shims in `summaries.py` that map between the framework's tree-shaped storage and the legacy row shape consumers expect (dashboard `/api/chats/<id>/topics`, the `claude_session_summary` context collector, `/wb-session-identify`'s tldr triage).
+
+Foreign-key cascades on the three live tables use `SqliteRowsStorage.post_delete_sql` rather than SQLite's FK enforcement. Deleting an `observed_sessions` row removes every child in the same transaction. Cross-DB cascade into `summarization.db` is not provided; both DBs use `INFINITE_LIFECYCLE` so stale rows are tolerated.
 
 ## Refresh model
 
 Two sidecar crons keep the DB fresh independent of caller demand:
 
 - `conversation-observability-refresh.md` — every 5 minutes (offset from `ir-index-rebuild` by 2 minutes), `max_sessions=5`, `stale_only=true`. Runs all three non-LLM refreshers.
-- `conversation-observability-summarize.md` — every 2 hours, `max_sessions=3`, feature-gated on `conversation_observability.summaries.enabled` (default off).
+- `conversation-observability-summarize.md` — every 2 hours, `max_sessions=3`. Calls the `conversation_observability_summarize` op, which drives the framework's `Summarizer.refresh` over the `conversation_session` composition.
 
 The `claude_session_summary` context source also triggers a stale-only refresh inline before rendering so bundle collections never read a cold DB. The `/ir/index` endpoint is deliberately NOT hooked — stale-only DB-backed scans are cheap enough that an independent cron is cleaner than embedding-service coupling.
 
 ## Lifecycle
 
-The artifact uses `INFINITE_LIFECYCLE` (paired with the new `NeverExpires` lifecycle trigger): every row is derived from JSONL session files that may have been deleted, so losing the DB means losing data that cannot be recovered. The sweep tick will see the artifact but never remove rows. Bumping any version constant in `summaries.py` invalidates cached summaries (re-summarize on next refresh); the row schema otherwise has no automatic eviction.
+The artifact uses `INFINITE_LIFECYCLE` (paired with the `NeverExpires` lifecycle trigger): every row is derived from JSONL session files that may have been deleted, so losing the DB means losing data that cannot be recovered. The sweep tick will see the artifact but never remove rows. Summary invalidation lives on the framework side: bumping `LayeredDisclosureStrategy.prompt_version` or `schema_version` (in `work_buddy/summarization/strategies.py`), or the `DurableSummaryStore`'s `selection_version` / `cache_version` (set in the conv_obs binding), invalidates cached summaries. The framework's composer re-bridges the strategy's versions into the store on every refresh, so a bump takes effect on the next sidecar fire.
 
 ## Consumers
 

--- a/knowledge/store/architecture/summarization-framework.md
+++ b/knowledge/store/architecture/summarization-framework.md
@@ -1,0 +1,97 @@
+---
+name: Summarization Framework
+kind: concept
+description: 'Composition-based summarization — Source × Strategy × Store with a shared refresh orchestrator. Two compositions today: conversation sessions (layered disclosure → durable store) and Chrome tabs (flat extraction → TTL cache).'
+summary: 'Protocol-based composition framework for content summarization. `Summarizer = Source × Strategy × Store` — three pluggable axes plus a shared core (refresh orchestrator, composer, construction-time coherence checks, provenance stamping). Stored result is always a tree (`SummaryNode`); flat extraction is depth-1, layered disclosure carries children with `source_ref` pointers. Two real compositions: conversation_session (layered, durable SQLite) and chrome_page (flat, TTL cache). New domains add a `Source` adapter, pick a strategy + store, register a binding factory.'
+tags:
+- summarization
+- composition
+- llm
+- framework
+- progressive-disclosure
+aliases:
+- summarization system
+- summary framework
+- Source Strategy Store
+- summarizer composer
+parents:
+- architecture
+---
+
+A protocol-based composition framework for content summarization, modeled on the artifact system. `Summarizer = Source × Strategy × Store` — three pluggable axes plus a written-once shared core (refresh orchestrator, composer, construction-time coherence checks, provenance stamping).
+
+## The three axes
+
+- **`Source`** — domain adapter. `discover(window) -> [(item_id, freshness_token)]`, `render(item_id) -> prompt text`. Per domain (sessions, web pages, event streams). May declare `BATCHED` and implement `render_batch`.
+- **`SummaryStrategy`** — output-shape adapter. Owns system prompt + output JSON schema + `parse(structured_output, raw) -> SummaryNode`. Per output shape (layered disclosure, flat extraction).
+- **`Store`** — persistence + staleness adapter. `is_fresh`, `select_stale`, `save`, `load`, `record_error`. Two implementations: `DurableSummaryStore` (SQLite, version-stamped) and `TtlCacheStore` (wraps `work_buddy.llm.cache`).
+
+Provenance (model / backend / version / timestamp stamping) is uniform and baked into the core — not a pluggable axis. The framework's `Store` is responsible for caching; `LLMRunner` is called without `cache_ttl_minutes` to avoid double-caching.
+
+## Tree-shaped record invariant
+
+Every stored summary is a `SummaryNode` tree: `{summary, source_ref?, children: [], extra}`. Flat extraction = depth-1 (root only, empty `children`, null `source_ref`). Layered disclosure = root + children, each child carrying a `source_ref` pointer to exact source events. The durable store schema persists arbitrary-depth trees with a `source_ref` slot on every node — the structural foundation that lets future progressive-disclosure features (deeper navigation, IR indexing of summaries) land additively without schema migration.
+
+## Composer + coherence
+
+`Summarizer(source=, strategy=, store=)` validates coherence at construction. Today's checks: `LAYERED` strategy requires `PERSISTS_TREE` store; `FLAT` strategy requires `PERSISTS_FLAT` or `PERSISTS_TREE`; `BATCHED` must be declared on both source and strategy or neither. Violations raise `IncoherentComposition`.
+
+At each `refresh` / `refresh_one` the composer re-bridges the strategy's `prompt_version` / `schema_version` into the store via `set_strategy_versions`, so a version bump invalidates stored rows on the next staleness check.
+
+## Current compositions
+
+| Composition | Source | Strategy | Store | Used by |
+|---|---|---|---|---|
+| `conversation_session` | `SessionSource` | `LayeredDisclosureStrategy` | `DurableSummaryStore(namespace="conversation_session")` | dashboard `/api/chats/<id>/topics`, `/wb-session-identify`, `claude_session_summary` collector, the `conversation_observability_summarize` MCP capability, the sidecar `conversation-observability-summarize` job |
+| `chrome_page` | `ChromeSource` (per-call) | `FlatExtractionStrategy` (BATCHED) | `TtlCacheStore(key_prefix="summarize_tab", ttl=30m)` | `chrome_infer._summarize_tabs`, `pipelines/chrome.py` |
+
+## Adding a new composition
+
+1. Implement a `Source` for the domain (`discover` + `render`, optionally `render_batch` if `BATCHED`).
+2. Pick (or implement) a `SummaryStrategy` — flat or layered.
+3. Pick a `Store` — durable for version-stamped, TTL for cache-style.
+4. Build a binding factory `build_<name>_summarizer() -> Summarizer` in the consumer package.
+5. Optional: surface read/write shims in the consumer package if existing call-sites depend on a legacy API.
+
+Unit-test the composition by injecting a stub LLM via `as_caller(stub_fn)` — the framework normalizes legacy bare-dict-returning stubs.
+
+## Key files
+
+- `work_buddy/summarization/protocol.py` — `SummaryNode`, `Source`/`SummaryStrategy`/`Store` Protocols, `Provenance`, `SummaryCapability`, `LLMCaller`, exceptions.
+- `work_buddy/summarization/summarizer.py` — `Summarizer` composer + `RefreshReport`.
+- `work_buddy/summarization/orchestrator.py` — `run_refresh` (per-item + batch paths), `as_caller`, `default_llm_caller`, provenance assembly.
+- `work_buddy/summarization/strategies.py` — `LayeredDisclosureStrategy`, `FlatExtractionStrategy`.
+- `work_buddy/summarization/stores.py` — `DurableSummaryStore`, `TtlCacheStore`.
+- `work_buddy/summarization/db.py` + `schema.py` — durable SQLite (WAL, idempotent schema; tree-shaped `summary_items` + `summary_nodes` tables).
+- `work_buddy/conversation_observability/summarizer_binding.py` — `SessionSource`, `build_session_summarizer`.
+- `work_buddy/collectors/chrome_summarizer_binding.py` — `ChromeSource`, `build_chrome_summarizer`, `summarize_tabs` (the public Chrome entry).
+
+Tests: `tests/unit/test_summarization_framework.py`, `tests/unit/test_summarization_store.py`, `tests/unit/test_chrome_summarization.py`, `tests/unit/test_conversation_observability_summaries.py`.
+
+## Dev notes
+
+### Adding a new Store
+
+Store implementations must guarantee `is_fresh` and `select_stale` use the same private staleness predicate — otherwise the orchestrator's "check fresh, then save with same token" cycle can race. `DurableSummaryStore._is_stale_row` is the canonical pattern.
+
+Declare the right capabilities. `PERSISTS_TREE` means "can save arbitrary-depth trees"; `PERSISTS_FLAT` means "depth-1 only." A store that can do both should declare both (the coherence check picks whichever the strategy needs).
+
+### Bridging strategy versions into the store
+
+The store evaluates staleness against the strategy's `prompt_version` / `schema_version`. To bridge them, implement a `set_strategy_versions(prompt_version, schema_version)` method on the store — `Summarizer.__post_init__` and every `refresh`/`refresh_one` call invoke it. Stores without this method use whatever defaults they carry.
+
+### Provenance is core, not an axis
+
+Unlike the artifact system where Provenance is a pluggable axis (some artifacts session-tagged, some not), summarization provenance is uniform (model / backend / four version ints / timestamp). Adding a fourth axis here would be speculative — wait for a real consumer that needs it.
+
+### Batch path
+
+The orchestrator dispatches to `_run_refresh_batch` when `BATCHED` is in the composed capabilities. Source provides `render_batch`; the orchestrator labels each item (`## Item N: <id>`) and concatenates into one user prompt; strategy provides `parse_batch(structured_output, raw, item_ids) -> [SummaryNode | None]`. Items missing from the response are recorded as errors but the rest are saved.
+
+### TtlCacheStore wraps work_buddy.llm.cache
+
+The TTL store does not invent caching — it wraps the existing `llm/cache.py` (`get` / `put`). Freshness tokens are `{"hash": <sha256>, "text": <content>}`; the `text` field enables `llm.cache`'s SimHash fuzzy fallback. The `strategy_version_tag` derives the `system_hash` so a strategy prompt-version bump invalidates the cache.
+
+### Conv_obs legacy tables
+
+`session_summaries` and `topic_summaries` in `conversation_observability/schema.py` remain defined but are no longer written — they predate the framework and are retained as a zero-effort rollback path. Removing them is a separate, follow-up change after the new store has proven out.

--- a/tests/unit/test_chrome_summarization.py
+++ b/tests/unit/test_chrome_summarization.py
@@ -1,0 +1,246 @@
+"""Tests for the Chrome composition of the summarization framework.
+
+Covers: `ChromeSource` discovery + batch render; `summarize_tabs` end-to-end
+through the framework with a stub LLM; URL normalization fidelity; cache-hit
+reuse behavior.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import pytest
+
+from work_buddy.collectors.chrome_summarizer_binding import (
+    ChromeSource,
+    build_chrome_summarizer,
+    normalize_url_for_cache,
+    summarize_tabs,
+)
+from work_buddy.summarization import as_caller
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_llm_cache(monkeypatch, tmp_path):
+    """Point `llm.cache._CACHE_PATH` at a tmp file so the TtlCacheStore writes
+    to a sandbox rather than the user's real cache."""
+    from work_buddy.llm import cache as cache_mod
+    cache_file = tmp_path / "llm_cache.json"
+    monkeypatch.setattr(cache_mod, "_CACHE_PATH", cache_file)
+    return cache_file
+
+
+def _stub_batch_response(item_ids: list[str]) -> dict[str, Any]:
+    return {
+        "summaries": [
+            {
+                "item_index": i,
+                "content_summary": f"summary for {iid}",
+                "entities": [
+                    {"name": "X", "type": "concept", "context": "appears here"},
+                ],
+                "key_claims": [f"{iid} is interesting"],
+                "user_intent_speculation": "they wanted to know",
+                "user_posture": "researching",
+            }
+            for i, iid in enumerate(item_ids)
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# URL normalization fidelity
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_url_strips_query_for_normal_sites():
+    assert normalize_url_for_cache(
+        "https://example.com/foo/bar/?utm=x",
+    ) == "example.com/foo/bar"
+
+
+def test_normalize_url_preserves_query_for_google():
+    assert normalize_url_for_cache(
+        "https://www.google.com/search?q=hello",
+    ) == "www.google.com/search?q=hello"
+
+
+def test_normalize_url_preserves_query_for_chatgpt():
+    assert normalize_url_for_cache(
+        "https://chatgpt.com/c/abc?xyz=1",
+    ) == "chatgpt.com/c/abc?xyz=1"
+
+
+# ---------------------------------------------------------------------------
+# ChromeSource discovery + render
+# ---------------------------------------------------------------------------
+
+
+def test_chrome_source_discover_emits_per_tab_hash_token():
+    tabs = [
+        {"url": "https://a.com/x", "title": "A"},
+        {"url": "https://b.com/y", "title": "B"},
+    ]
+    tab_contents = {
+        "https://a.com/x": {"text": "alpha"},
+        "https://b.com/y": {"text": "beta"},
+    }
+    src = ChromeSource(tabs, tab_contents)
+    disc = src.discover(None)
+
+    assert sorted(iid for iid, _ in disc) == ["a.com/x", "b.com/y"]
+    for item_id, token in disc:
+        assert "hash" in token and "text" in token
+
+
+def test_chrome_source_render_batch_builds_per_tab_prompt():
+    tabs = [{"url": "https://a.com/", "title": "Title A"}]
+    src = ChromeSource(tabs, {"https://a.com/": {"text": "the page"}})
+    out = src.render_batch(["a.com"])
+    assert out[0].startswith("Title A [a.com]")
+    assert "the page" in out[0]
+
+
+def test_chrome_source_render_handles_missing_item_id():
+    src = ChromeSource([], {})
+    assert src.render("nope") is None
+    assert src.render_batch(["nope"]) == [None]
+
+
+# ---------------------------------------------------------------------------
+# build_chrome_summarizer construction
+# ---------------------------------------------------------------------------
+
+
+def test_chrome_summarizer_constructs_with_expected_caps():
+    summ = build_chrome_summarizer([], {})
+    caps = sorted(c.value for c in summ.capabilities)
+    # Flat strategy, batched, TTL-evicted, tree-or-flat-capable store.
+    assert "batched" in caps
+    assert "flat" in caps
+    assert "ttl_evicted" in caps
+
+
+# ---------------------------------------------------------------------------
+# summarize_tabs end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_tabs_returns_aligned_pagesummaries(tmp_llm_cache):
+    tabs = [
+        {"url": "https://a.com/", "title": "A"},
+        {"url": "https://b.com/", "title": "B"},
+    ]
+    tab_contents = {
+        "https://a.com/": {"text": "content A"},
+        "https://b.com/": {"text": "content B"},
+    }
+
+    call_count = {"n": 0}
+
+    def stub(*, system, user, output_schema=None, profile=None):
+        call_count["n"] += 1
+        # The batched user prompt contains both items, so produce summaries
+        # for both at indices 0 and 1.
+        return _stub_batch_response(["a.com", "b.com"])
+
+    summaries, cached_count = summarize_tabs(
+        tabs, tab_contents, llm_caller=as_caller(stub),
+    )
+
+    assert len(summaries) == 2
+    assert call_count["n"] == 1   # one batched LLM call
+    assert cached_count == 0
+    # PageSummary shape preserved.
+    assert summaries[0].content_summary
+    assert summaries[0].source_label == "A [a.com]"
+    assert summaries[0].user_posture == "researching"
+    assert summaries[0].entities[0].name == "X"
+
+
+def test_summarize_tabs_reuses_cached_entries(tmp_llm_cache):
+    """First call summarizes; second call finds them in cache → 0 LLM calls."""
+    tabs = [{"url": "https://a.com/", "title": "A"}]
+    tab_contents = {"https://a.com/": {"text": "stable content"}}
+
+    n_calls = {"n": 0}
+
+    def stub(*, system, user, output_schema=None, profile=None):
+        n_calls["n"] += 1
+        return _stub_batch_response(["a.com"])
+
+    # Pass 1: cold cache.
+    summaries1, cached1 = summarize_tabs(
+        tabs, tab_contents, llm_caller=as_caller(stub),
+    )
+    assert n_calls["n"] == 1
+    assert cached1 == 0
+    assert summaries1[0].content_summary == "summary for a.com"
+
+    # Pass 2: same input — cache hit; no LLM call.
+    summaries2, cached2 = summarize_tabs(
+        tabs, tab_contents, llm_caller=as_caller(stub),
+    )
+    assert n_calls["n"] == 1   # unchanged
+    assert cached2 == 1
+    assert summaries2[0].content_summary == "summary for a.com"
+    assert summaries2[0].cached is True
+
+
+def test_summarize_tabs_invalidates_when_content_changes(tmp_llm_cache):
+    tabs = [{"url": "https://a.com/", "title": "A"}]
+
+    n_calls = {"n": 0}
+
+    def stub(*, system, user, output_schema=None, profile=None):
+        n_calls["n"] += 1
+        return _stub_batch_response(["a.com"])
+
+    summarize_tabs(
+        tabs, {"https://a.com/": {"text": "v1"}},
+        llm_caller=as_caller(stub),
+    )
+    summarize_tabs(
+        tabs, {"https://a.com/": {"text": "v2"}},
+        llm_caller=as_caller(stub),
+    )
+    # Content changed → cache miss → second LLM call.
+    assert n_calls["n"] == 2
+
+
+def test_summarize_tabs_returns_fallback_for_unsummarizable_tab(tmp_llm_cache):
+    """When the LLM omits an item from the batch, the tab gets a fallback
+    PageSummary so the consumer index stays aligned."""
+    tabs = [
+        {"url": "https://a.com/", "title": "A"},
+        {"url": "https://b.com/", "title": "B"},
+    ]
+    tab_contents = {
+        "https://a.com/": {"text": "alpha"},
+        "https://b.com/": {"text": "beta"},
+    }
+
+    def stub(*, system, user, output_schema=None, profile=None):
+        # Return only the first item — second is missing from response.
+        return {"summaries": [_stub_batch_response(["a.com"])["summaries"][0]]}
+
+    summaries, _cached = summarize_tabs(
+        tabs, tab_contents, llm_caller=as_caller(stub),
+    )
+
+    assert len(summaries) == 2
+    assert summaries[0].content_summary == "summary for a.com"
+    assert summaries[1].content_summary == "Content unavailable"
+    assert summaries[1].source_label == "B [b.com]"
+
+
+def test_summarize_tabs_empty_selection_returns_empty(tmp_llm_cache):
+    summaries, cached = summarize_tabs([], {})
+    assert summaries == []
+    assert cached == 0

--- a/tests/unit/test_conversation_observability_summaries.py
+++ b/tests/unit/test_conversation_observability_summaries.py
@@ -32,8 +32,15 @@ def co_env(tmp_path, monkeypatch):
     projects = tmp_path / "projects"
     projects.mkdir()
     db_file = tmp_path / "co.db"
+    # The summarization framework's durable store lives in its own DB; point
+    # both `_default_db_path` and `db_path` at a tmp file so the new conv_obs
+    # composition writes there.
+    summ_db_file = tmp_path / "summarization.db"
 
     from work_buddy.sessions import inspector
+    from work_buddy.conversation_observability import (
+        summarizer_binding as _binding,
+    )
 
     monkeypatch.setattr(inspector, "_CLAUDE_PROJECTS", projects)
     monkeypatch.setattr(
@@ -44,8 +51,19 @@ def co_env(tmp_path, monkeypatch):
         "work_buddy.conversation_observability.db.db_path",
         lambda cfg=None: db_file,
     )
+    monkeypatch.setattr(
+        "work_buddy.summarization.db._default_db_path",
+        lambda: summ_db_file,
+    )
+    monkeypatch.setattr(
+        "work_buddy.summarization.db.db_path",
+        lambda cfg=None: summ_db_file,
+    )
+    # Reset the singleton so the next `get_session_summarizer()` call
+    # picks up the patched paths.
+    _binding.reset_session_summarizer()
     inspector._commit_cache.clear()
-    return {"projects": projects, "db": db_file}
+    return {"projects": projects, "db": db_file, "summ_db": summ_db_file}
 
 
 def _basic_session(sid: str) -> list[dict[str, Any]]:
@@ -165,7 +183,11 @@ def test_summarize_session_records_error_on_invalid_response(co_env) -> None:
     assert row is not None
     assert row["status"] == "error"
     assert row["error"]
-    assert "valid json" in row["error"].lower() or "invalid llm response" in row["error"].lower()
+    # The new framework records "parse error: ..." when the LLM response
+    # is not a structured dict; older code recorded "invalid LLM response: ...".
+    # Either form is acceptable — what matters is an error was recorded.
+    err_lower = row["error"].lower()
+    assert "parse" in err_lower or "valid" in err_lower or "json" in err_lower
 
 
 def test_summarize_session_error_does_not_corrupt_prior_good_summary(
@@ -213,7 +235,6 @@ def test_summarize_session_error_does_not_corrupt_prior_good_summary(
 
 
 def test_summary_marked_stale_when_prompt_version_bumps(co_env) -> None:
-    from work_buddy.conversation_observability import summaries as summary_mod
     from work_buddy.conversation_observability.sessions import (
         refresh_observed_sessions,
     )
@@ -221,6 +242,7 @@ def test_summary_marked_stale_when_prompt_version_bumps(co_env) -> None:
         refresh_session_summaries,
         summarize_session,
     )
+    from work_buddy.summarization.strategies import LayeredDisclosureStrategy
 
     sid = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
     write_session(
@@ -234,23 +256,25 @@ def test_summary_marked_stale_when_prompt_version_bumps(co_env) -> None:
         llm_call=lambda **kw: _stub_response("v1 tldr"),
     )
 
-    # First refresh: fresh — _select_candidates returns no stale work.
+    # First refresh: fresh — discover returns the session, but the store's
+    # select_stale prunes it (versions + token match).
     r1 = refresh_session_summaries(
         days=30, llm_call=lambda **kw: _stub_response("v2 tldr"),
     )
     assert r1["summarized"] == 0
-    assert r1["total_candidates"] == 0
 
-    # Bump PROMPT_VERSION → that session becomes stale.
-    original = summary_mod.PROMPT_VERSION
+    # Bump the strategy's prompt_version → that session becomes stale.
+    # `Summarizer.refresh` re-syncs versions into the store on every call,
+    # so the patched attribute is picked up automatically.
+    original = LayeredDisclosureStrategy.prompt_version
     try:
-        summary_mod.PROMPT_VERSION = original + 1
+        LayeredDisclosureStrategy.prompt_version = original + 1
         r2 = refresh_session_summaries(
             days=30, llm_call=lambda **kw: _stub_response("v2 tldr"),
         )
         assert r2["summarized"] >= 1
     finally:
-        summary_mod.PROMPT_VERSION = original
+        LayeredDisclosureStrategy.prompt_version = original
 
 
 def test_summary_marked_stale_when_source_file_changes(co_env) -> None:

--- a/tests/unit/test_llm_summarize_shims.py
+++ b/tests/unit/test_llm_summarize_shims.py
@@ -1,0 +1,255 @@
+"""Tests for the thin `llm.summarize` shims over the framework.
+
+The shims delegate prompt / schema / parse to `FlatExtractionStrategy` and
+adapt `SummaryNode` back into `PageSummary` for legacy callers. These tests
+patch `LLMRunner.call` to verify the orchestration without touching real
+LLM endpoints — they complement the strategy-level tests in
+`test_summarization_framework.py` and end-to-end tests in
+`test_chrome_summarization.py`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from work_buddy.llm.summarize import (
+    PageSummary,
+    TypedEntity,
+    summarize,
+    summarize_batch,
+)
+
+
+@dataclass
+class _FakeLLMResponse:
+    structured_output: dict | None = None
+    content: str = ""
+    cached: bool = False
+    input_tokens: int = 0
+    output_tokens: int = 0
+    error: str | None = None
+    model: str = ""
+    backend: str = ""
+
+    def is_error(self) -> bool:
+        return self.error is not None
+
+
+def _make_single_response(
+    summary_text: str = "A page about X",
+    entities: list[dict] | None = None,
+    cached: bool = False,
+) -> _FakeLLMResponse:
+    return _FakeLLMResponse(
+        structured_output={
+            "content_summary": summary_text,
+            "entities": entities or [{"name": "X", "type": "concept", "context": "appears here"}],
+            "key_claims": ["X is interesting"],
+            "user_intent_speculation": "they want to know about X",
+            "user_posture": "researching",
+        },
+        content="",
+        cached=cached,
+        input_tokens=120,
+        output_tokens=80,
+    )
+
+
+def _make_batch_response(n: int) -> _FakeLLMResponse:
+    return _FakeLLMResponse(
+        structured_output={
+            "summaries": [
+                {
+                    "item_index": i,
+                    "content_summary": f"summary {i}",
+                    "entities": [
+                        {"name": f"E{i}", "type": "concept", "context": "here"},
+                    ],
+                    "key_claims": [f"claim {i}"],
+                    "user_intent_speculation": "spec",
+                    "user_posture": "researching",
+                }
+                for i in range(n)
+            ],
+        },
+        content="",
+        cached=False,
+        input_tokens=200,
+        output_tokens=150,
+    )
+
+
+# ---------------------------------------------------------------------------
+# summarize
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_returns_pagesummary_with_strategy_parsed_fields(monkeypatch):
+    captured: list[dict] = []
+
+    def fake_call(self, **kwargs):
+        captured.append(kwargs)
+        return _make_single_response("X is a concept")
+
+    from work_buddy.llm import runner_v2
+    monkeypatch.setattr(runner_v2.LLMRunner, "call", fake_call)
+
+    result = summarize("the content here", label="My Label")
+
+    assert isinstance(result, PageSummary)
+    assert result.content_summary == "X is a concept"
+    assert result.source_label == "My Label"
+    assert result.user_posture == "researching"
+    assert isinstance(result.entities[0], TypedEntity)
+    assert result.entities[0].name == "X"
+    assert result.tokens == {"input": 120, "output": 80}
+    # The shim passed the strategy's system prompt through.
+    assert "extract structured facts" in captured[0]["system"].lower()
+    # And the strategy's single-item schema (not the batch schema).
+    assert captured[0]["output_schema"].get("required") == [
+        "content_summary",
+        "entities",
+        "key_claims",
+        "user_intent_speculation",
+        "user_posture",
+    ]
+
+
+def test_summarize_returns_failure_pagesummary_on_llm_error(monkeypatch):
+    def fake_call(self, **kwargs):
+        return _FakeLLMResponse(error="upstream timeout")
+
+    from work_buddy.llm import runner_v2
+    monkeypatch.setattr(runner_v2.LLMRunner, "call", fake_call)
+
+    result = summarize("content", label="L")
+
+    assert "Summarization failed" in result.content_summary
+    assert "upstream timeout" in result.content_summary
+    assert result.source_label == "L"
+    assert result.entities == []
+
+
+def test_summarize_returns_failure_pagesummary_on_parse_error(monkeypatch):
+    def fake_call(self, **kwargs):
+        # Structured output missing required `content_summary` -> strategy.parse raises.
+        return _FakeLLMResponse(
+            structured_output={"entities": []},
+        )
+
+    from work_buddy.llm import runner_v2
+    monkeypatch.setattr(runner_v2.LLMRunner, "call", fake_call)
+
+    result = summarize("content", label="L")
+
+    assert "Summarization failed" in result.content_summary
+    assert "parse error" in result.content_summary
+    assert result.source_label == "L"
+
+
+def test_summarize_passes_cache_ttl_through(monkeypatch):
+    captured: dict = {}
+
+    def fake_call(self, **kwargs):
+        captured.update(kwargs)
+        return _make_single_response()
+
+    from work_buddy.llm import runner_v2
+    monkeypatch.setattr(runner_v2.LLMRunner, "call", fake_call)
+
+    summarize("text", label="L", cache_ttl_minutes=42)
+
+    assert captured["cache_ttl_minutes"] == 42
+
+
+# ---------------------------------------------------------------------------
+# summarize_batch
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_batch_empty_short_circuits():
+    assert summarize_batch([]) == []
+
+
+def test_summarize_batch_returns_aligned_pagesummaries(monkeypatch):
+    captured: dict = {}
+
+    def fake_call(self, **kwargs):
+        captured.update(kwargs)
+        return _make_batch_response(3)
+
+    from work_buddy.llm import runner_v2
+    monkeypatch.setattr(runner_v2.LLMRunner, "call", fake_call)
+
+    items = [
+        {"text": "alpha content", "label": "Alpha"},
+        {"text": "beta content", "label": "Beta"},
+        {"text": "gamma content", "label": "Gamma"},
+    ]
+    results = summarize_batch(items)
+
+    assert len(results) == 3
+    assert all(isinstance(r, PageSummary) for r in results)
+    assert results[0].content_summary == "summary 0"
+    assert results[2].content_summary == "summary 2"
+    assert results[1].source_label == "Beta"
+    # The batch schema was used, not the single-item schema.
+    assert captured["output_schema"].get("required") == ["summaries"]
+
+
+def test_summarize_batch_returns_empty_for_missing_response_items(monkeypatch):
+    """If the LLM returns fewer summaries than items, the missing ones get
+    empty `PageSummary` objects so the consumer can index by position."""
+
+    def fake_call(self, **kwargs):
+        # Only one summary even though we'll send three items.
+        return _FakeLLMResponse(
+            structured_output={
+                "summaries": [{
+                    "item_index": 0,
+                    "content_summary": "alpha summary",
+                    "entities": [],
+                    "key_claims": [],
+                    "user_intent_speculation": "",
+                    "user_posture": "researching",
+                }],
+            },
+            input_tokens=30, output_tokens=20,
+        )
+
+    from work_buddy.llm import runner_v2
+    monkeypatch.setattr(runner_v2.LLMRunner, "call", fake_call)
+
+    items = [
+        {"text": "a", "label": "Alpha"},
+        {"text": "b", "label": "Beta"},
+        {"text": "c", "label": "Gamma"},
+    ]
+    results = summarize_batch(items)
+
+    assert len(results) == 3
+    assert results[0].content_summary == "alpha summary"
+    assert results[1].content_summary == ""
+    assert results[1].source_label == "Beta"
+    assert results[2].content_summary == ""
+
+
+def test_summarize_batch_returns_failure_pagesummaries_on_error(monkeypatch):
+    def fake_call(self, **kwargs):
+        return _FakeLLMResponse(error="batch failed")
+
+    from work_buddy.llm import runner_v2
+    monkeypatch.setattr(runner_v2.LLMRunner, "call", fake_call)
+
+    items = [
+        {"text": "x", "label": "X"},
+        {"text": "y", "label": "Y"},
+    ]
+    results = summarize_batch(items)
+
+    assert len(results) == 2
+    assert all("Summarization failed" in r.content_summary for r in results)
+    assert results[0].source_label == "X"
+    assert results[1].source_label == "Y"

--- a/tests/unit/test_summarization_framework.py
+++ b/tests/unit/test_summarization_framework.py
@@ -1,0 +1,571 @@
+"""Unit tests for the summarization framework core.
+
+Covers: the orchestrator (per-item + batch refresh paths), the `Summarizer`
+composer's coherence checks, error isolation, and the `as_caller` adapter
+that normalizes legacy bare-callable LLM stubs.
+
+Uses lightweight fake `Source` / `SummaryStrategy` / `Store` implementations
+in-file. Real conv_obs / Chrome composition behavior is tested in
+`test_conversation_observability_summaries.py` and Chrome's own test file.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from work_buddy.summarization import (
+    DiscoveryWindow,
+    IncoherentComposition,
+    LLMCallResult,
+    Provenance,
+    RefreshReport,
+    SummarizationError,
+    Summarizer,
+    SummaryCapability,
+    SummaryNode,
+    as_caller,
+    run_refresh,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeSource:
+    """Per-item fake source. Pass a `discover_items` list of `(id, token)`
+    and a `render_map: dict[id, str | None]` to control behaviour."""
+
+    def __init__(
+        self,
+        discover_items: list[tuple[str, Any]],
+        render_map: dict[str, str | None] | None = None,
+        capabilities: frozenset[SummaryCapability] = frozenset(),
+    ) -> None:
+        self.name = "fake_source"
+        self.capabilities = capabilities
+        self._discover = discover_items
+        self._render = render_map or {}
+        self.discover_calls = 0
+        self.render_calls: list[str] = []
+        self.render_batch_calls: list[list[str]] = []
+
+    def discover(self, window: DiscoveryWindow) -> list[tuple[str, Any]]:
+        self.discover_calls += 1
+        return list(self._discover)
+
+    def render(self, item_id: str) -> str | None:
+        self.render_calls.append(item_id)
+        if item_id in self._render:
+            return self._render[item_id]
+        return f"body for {item_id}"
+
+    def render_batch(self, item_ids: list[str]) -> list[str | None]:
+        self.render_batch_calls.append(list(item_ids))
+        return [self.render(iid) for iid in item_ids]
+
+
+class FakeStrategy:
+    """Flat strategy that parses `{summary: str}` into a single-node tree."""
+
+    def __init__(
+        self,
+        capabilities: frozenset[SummaryCapability] = frozenset({
+            SummaryCapability.FLAT
+        }),
+        prompt_version: int = 1,
+        schema_version: int = 1,
+        raise_on_parse: bool = False,
+    ) -> None:
+        self.name = "fake_strategy"
+        self.capabilities = capabilities
+        self.prompt_version = prompt_version
+        self.schema_version = schema_version
+        self.system_prompt = "fake system"
+        self.output_schema = {"type": "object"}
+        self.batch_output_schema = {"type": "object"}
+        self._raise = raise_on_parse
+
+    def parse(
+        self, structured_output: dict[str, Any] | None, raw_content: str,
+    ) -> SummaryNode:
+        if self._raise:
+            raise SummarizationError("fake parse failure")
+        if not isinstance(structured_output, dict):
+            raise SummarizationError("not dict")
+        return SummaryNode(
+            summary=str(structured_output.get("summary", "")),
+            extra=dict(structured_output),
+        )
+
+    def parse_batch(
+        self,
+        structured_output: dict[str, Any] | None,
+        raw_content: str,
+        item_ids: list[str],
+    ) -> list[SummaryNode | None]:
+        if not isinstance(structured_output, dict):
+            return [None] * len(item_ids)
+        raw = structured_output.get("summaries") or []
+        by_idx = {
+            e["item_index"]: e for e in raw
+            if isinstance(e, dict) and "item_index" in e
+        }
+        return [
+            self.parse(by_idx[i], "") if i in by_idx else None
+            for i, _ in enumerate(item_ids)
+        ]
+
+
+class FakeStore:
+    """In-memory store. Treats `freshness_token` as the exact-match key."""
+
+    def __init__(
+        self,
+        capabilities: frozenset[SummaryCapability] = frozenset({
+            SummaryCapability.PERSISTS_TREE,
+            SummaryCapability.VERSION_STAMPED,
+        }),
+        prior: dict[str, tuple[SummaryNode, Any]] | None = None,
+    ) -> None:
+        self.name = "fake_store"
+        self.capabilities = capabilities
+        self.selection_version = 1
+        self.cache_version = 1
+        self._records: dict[str, tuple[SummaryNode, Any, str, str | None]] = {}
+        if prior:
+            for iid, (node, token) in prior.items():
+                self._records[iid] = (node, token, "ok", None)
+        self.save_calls: list[tuple[str, SummaryNode, Provenance, Any]] = []
+        self.error_calls: list[tuple[str, str]] = []
+
+    def is_fresh(self, item_id: str, freshness_token: Any) -> bool:
+        rec = self._records.get(item_id)
+        if rec is None:
+            return False
+        if rec[2] != "ok":
+            return False
+        return str(rec[1]) == str(freshness_token)
+
+    def select_stale(
+        self, candidates: list[tuple[str, Any]],
+    ) -> list[tuple[str, Any]]:
+        return [
+            (iid, tok) for iid, tok in candidates
+            if not self.is_fresh(iid, tok)
+        ]
+
+    def save(
+        self,
+        item_id: str,
+        result: SummaryNode,
+        provenance: Provenance,
+        freshness_token: Any,
+    ) -> None:
+        self.save_calls.append((item_id, result, provenance, freshness_token))
+        self._records[item_id] = (result, freshness_token, "ok", None)
+
+    def load(self, item_id: str) -> SummaryNode | None:
+        rec = self._records.get(item_id)
+        return rec[0] if rec else None
+
+    def record_error(
+        self, item_id: str, error: str, provenance: Provenance,
+    ) -> None:
+        self.error_calls.append((item_id, error))
+        prev = self._records.get(item_id)
+        if prev is None:
+            self._records[item_id] = (
+                SummaryNode(summary=""), "", "error", error,
+            )
+        else:
+            # Preserve prior node; flip status.
+            self._records[item_id] = (prev[0], prev[1], "error", error)
+
+
+def _stub_llm_dict_returner(payload: dict[str, Any]):
+    """Build a legacy-shape llm_call stub that returns `payload` as a dict."""
+    calls: list[dict[str, Any]] = []
+
+    def _fn(*, system: str, user: str, output_schema=None, profile=None):
+        calls.append({
+            "system": system, "user": user,
+            "output_schema": output_schema, "profile": profile,
+        })
+        return payload
+
+    _fn.calls = calls  # type: ignore[attr-defined]
+    return _fn
+
+
+# ---------------------------------------------------------------------------
+# 1. Framework core — per-item refresh
+# ---------------------------------------------------------------------------
+
+
+def test_run_refresh_summarizes_stale_items():
+    source = FakeSource(
+        [("a", "tok-a"), ("b", "tok-b"), ("c", "tok-c")],
+    )
+    store = FakeStore()
+    summ = Summarizer("test", source, FakeStrategy(), store)
+
+    stub = _stub_llm_dict_returner({"summary": "S"})
+    report = summ.refresh(
+        days=7, max_items=10, force=False,
+        llm_caller=as_caller(stub),
+    )
+
+    assert report.summarized == 3
+    assert report.errored == 0
+    assert report.skipped_fresh == 0
+    assert report.total_candidates == 3
+    assert len(store.save_calls) == 3
+    assert store.load("a") is not None
+    # Stub was called for each item.
+    assert len(stub.calls) == 3
+
+
+def test_max_items_caps_work():
+    source = FakeSource([("a", "1"), ("b", "1"), ("c", "1"), ("d", "1")])
+    store = FakeStore()
+    summ = Summarizer("test", source, FakeStrategy(), store)
+
+    stub = _stub_llm_dict_returner({"summary": "S"})
+    report = summ.refresh(
+        days=7, max_items=2, force=False,
+        llm_caller=as_caller(stub),
+    )
+
+    assert report.summarized == 2
+    assert len(stub.calls) == 2
+    # The two that didn't make it are still "stale" but not counted as
+    # skipped_fresh (which means "non-stale" by `select_stale`).
+    assert report.skipped_fresh == 0
+    assert report.total_candidates == 4
+
+
+def test_skips_fresh_items():
+    source = FakeSource([("a", "1"), ("b", "1"), ("c", "1")])
+    pre = SummaryNode(summary="prior")
+    store = FakeStore(prior={"a": (pre, "1"), "b": (pre, "1")})
+    summ = Summarizer("test", source, FakeStrategy(), store)
+
+    stub = _stub_llm_dict_returner({"summary": "S"})
+    report = summ.refresh(
+        days=7, max_items=10, force=False,
+        llm_caller=as_caller(stub),
+    )
+
+    assert report.summarized == 1
+    assert report.skipped_fresh == 2
+    assert report.total_candidates == 3
+    assert len(stub.calls) == 1
+
+
+def test_render_none_skips_item_cleanly():
+    source = FakeSource(
+        [("a", "1"), ("b", "1")],
+        render_map={"b": None},
+    )
+    store = FakeStore()
+    summ = Summarizer("test", source, FakeStrategy(), store)
+
+    stub = _stub_llm_dict_returner({"summary": "S"})
+    report = summ.refresh(
+        days=7, max_items=10, force=False,
+        llm_caller=as_caller(stub),
+    )
+
+    assert report.summarized == 1
+    assert report.errored == 0
+    assert len(stub.calls) == 1
+    assert store.load("a") is not None
+    assert store.load("b") is None
+
+
+def test_force_bypasses_select_stale():
+    source = FakeSource([("a", "1"), ("b", "1")])
+    pre = SummaryNode(summary="prior")
+    store = FakeStore(prior={"a": (pre, "1"), "b": (pre, "1")})
+    summ = Summarizer("test", source, FakeStrategy(), store)
+
+    stub = _stub_llm_dict_returner({"summary": "S"})
+    report = summ.refresh(
+        days=7, max_items=10, force=True,
+        llm_caller=as_caller(stub),
+    )
+
+    assert report.summarized == 2
+    assert len(stub.calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# 2. Coherence checks
+# ---------------------------------------------------------------------------
+
+
+def test_layered_requires_persists_tree():
+    layered_strat = FakeStrategy(
+        capabilities=frozenset({SummaryCapability.LAYERED}),
+    )
+    flat_only_store = FakeStore(
+        capabilities=frozenset({SummaryCapability.PERSISTS_FLAT}),
+    )
+    src = FakeSource([])
+    with pytest.raises(IncoherentComposition, match="PERSISTS_TREE"):
+        Summarizer("bad", src, layered_strat, flat_only_store)
+
+
+def test_flat_strategy_ok_with_flat_store():
+    flat_strat = FakeStrategy(
+        capabilities=frozenset({SummaryCapability.FLAT}),
+    )
+    flat_store = FakeStore(
+        capabilities=frozenset({SummaryCapability.PERSISTS_FLAT}),
+    )
+    src = FakeSource([])
+    # Should not raise.
+    Summarizer("ok_flat", src, flat_strat, flat_store)
+
+
+def test_flat_strategy_ok_with_tree_store():
+    flat_strat = FakeStrategy(
+        capabilities=frozenset({SummaryCapability.FLAT}),
+    )
+    tree_store = FakeStore(
+        capabilities=frozenset({SummaryCapability.PERSISTS_TREE}),
+    )
+    src = FakeSource([])
+    Summarizer("ok_flat_in_tree", src, flat_strat, tree_store)
+
+
+def test_batched_mismatch_strategy_only_rejected():
+    batched_strat = FakeStrategy(
+        capabilities=frozenset({
+            SummaryCapability.FLAT, SummaryCapability.BATCHED,
+        }),
+    )
+    non_batched_src = FakeSource([], capabilities=frozenset())
+    store = FakeStore()
+    with pytest.raises(IncoherentComposition, match="BATCHED"):
+        Summarizer("bad", non_batched_src, batched_strat, store)
+
+
+def test_batched_mismatch_source_only_rejected():
+    flat_strat = FakeStrategy(
+        capabilities=frozenset({SummaryCapability.FLAT}),
+    )
+    batched_src = FakeSource(
+        [], capabilities=frozenset({SummaryCapability.BATCHED}),
+    )
+    store = FakeStore()
+    with pytest.raises(IncoherentComposition, match="BATCHED"):
+        Summarizer("bad", batched_src, flat_strat, store)
+
+
+# ---------------------------------------------------------------------------
+# 3. Error isolation
+# ---------------------------------------------------------------------------
+
+
+def test_llm_error_isolated_and_recorded():
+    source = FakeSource([("a", "1"), ("b", "1"), ("c", "1")])
+    store = FakeStore()
+    summ = Summarizer("test", source, FakeStrategy(), store)
+
+    call_count = {"n": 0}
+
+    def stub(*, system, user, output_schema=None, profile=None):
+        call_count["n"] += 1
+        if user == "body for b":
+            return None  # legacy: None response → error
+        return {"summary": "ok"}
+
+    report = summ.refresh(
+        days=7, max_items=10, force=False,
+        llm_caller=as_caller(stub),
+    )
+
+    assert report.summarized == 2
+    assert report.errored == 1
+    assert any(iid == "b" for iid, _ in store.error_calls)
+    # Items a and c saved despite b's error.
+    assert store.load("a") is not None
+    assert store.load("c") is not None
+
+
+def test_parse_failure_isolated():
+    source = FakeSource([("a", "1"), ("b", "1")])
+    store = FakeStore()
+
+    class _StrategyOneFails(FakeStrategy):
+        def parse(self, structured_output, raw_content):
+            if structured_output and structured_output.get("summary") == "BOOM":
+                raise SummarizationError("planned parse failure")
+            return super().parse(structured_output, raw_content)
+
+    summ = Summarizer("test", source, _StrategyOneFails(), store)
+
+    def stub(*, system, user, output_schema=None, profile=None):
+        if user == "body for a":
+            return {"summary": "BOOM"}
+        return {"summary": "ok"}
+
+    report = summ.refresh(
+        days=7, max_items=10, force=False,
+        llm_caller=as_caller(stub),
+    )
+
+    assert report.errored == 1
+    assert report.summarized == 1
+    assert store.load("b") is not None
+
+
+def test_record_error_preserves_prior_good_result():
+    pre = SummaryNode(summary="prior good")
+    source = FakeSource([("a", "tok-a")])  # different token → stale
+    store = FakeStore(prior={"a": (pre, "tok-old")})
+    summ = Summarizer("test", source, FakeStrategy(), store)
+
+    def stub(*, system, user, output_schema=None, profile=None):
+        return None  # forces an error
+
+    report = summ.refresh(
+        days=7, max_items=10, force=True,
+        llm_caller=as_caller(stub),
+    )
+
+    assert report.errored == 1
+    # Prior good summary still loadable.
+    loaded = store.load("a")
+    assert loaded is not None
+    assert loaded.summary == "prior good"
+
+
+# ---------------------------------------------------------------------------
+# 1b. Batch path
+# ---------------------------------------------------------------------------
+
+
+def test_batch_path_issues_one_call_for_n_items():
+    source = FakeSource(
+        [("a", "1"), ("b", "1"), ("c", "1")],
+        capabilities=frozenset({SummaryCapability.BATCHED}),
+    )
+    strategy = FakeStrategy(
+        capabilities=frozenset({
+            SummaryCapability.FLAT, SummaryCapability.BATCHED,
+        }),
+    )
+    store = FakeStore()
+    summ = Summarizer("test_batched", source, strategy, store)
+
+    call_count = {"n": 0}
+
+    def stub(*, system, user, output_schema=None, profile=None):
+        call_count["n"] += 1
+        # Response shape for parse_batch
+        return {
+            "summaries": [
+                {"item_index": 0, "summary": "Sa"},
+                {"item_index": 1, "summary": "Sb"},
+                {"item_index": 2, "summary": "Sc"},
+            ],
+        }
+
+    report = summ.refresh(
+        days=7, max_items=10, force=False,
+        llm_caller=as_caller(stub),
+    )
+
+    assert call_count["n"] == 1
+    assert report.summarized == 3
+    assert store.load("a").summary == "Sa"
+    assert store.load("c").summary == "Sc"
+
+
+def test_batch_path_missing_item_in_response_recorded_as_error():
+    source = FakeSource(
+        [("a", "1"), ("b", "1")],
+        capabilities=frozenset({SummaryCapability.BATCHED}),
+    )
+    strategy = FakeStrategy(
+        capabilities=frozenset({
+            SummaryCapability.FLAT, SummaryCapability.BATCHED,
+        }),
+    )
+    store = FakeStore()
+    summ = Summarizer("test", source, strategy, store)
+
+    def stub(*, system, user, output_schema=None, profile=None):
+        return {"summaries": [{"item_index": 0, "summary": "Sa"}]}
+
+    report = summ.refresh(
+        days=7, max_items=10, force=False,
+        llm_caller=as_caller(stub),
+    )
+
+    assert report.summarized == 1
+    assert report.errored == 1
+    assert any(iid == "b" for iid, _ in store.error_calls)
+
+
+# ---------------------------------------------------------------------------
+# Adapter (as_caller) edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_as_caller_normalizes_bare_dict():
+    fn = _stub_llm_dict_returner({"x": 1})
+    caller = as_caller(fn)
+    result = caller.call(system="s", user="u")
+    assert result.structured_output == {"x": 1}
+    assert result.error is None
+
+
+def test_as_caller_normalizes_json_string():
+    def fn(*, system, user, output_schema=None, profile=None):
+        return json.dumps({"x": 2})
+
+    caller = as_caller(fn)
+    result = caller.call(system="s", user="u")
+    assert result.structured_output == {"x": 2}
+
+
+def test_as_caller_normalizes_none_to_error():
+    def fn(*, system, user, output_schema=None, profile=None):
+        return None
+
+    caller = as_caller(fn)
+    result = caller.call(system="s", user="u")
+    assert result.is_error()
+
+
+def test_as_caller_normalizes_response_object():
+    class _Resp:
+        structured_output = {"y": 3}
+        content = "irrelevant"
+        model = "m1"
+        backend = "b1"
+
+        def is_error(self):
+            return False
+
+    def fn(*, system, user, output_schema=None, profile=None):
+        return _Resp()
+
+    caller = as_caller(fn)
+    result = caller.call(system="s", user="u")
+    assert result.structured_output == {"y": 3}
+    assert result.model == "m1"
+    assert result.backend == "b1"
+    assert not result.is_error()
+
+
+def test_as_caller_returns_none_when_given_none():
+    assert as_caller(None) is None

--- a/tests/unit/test_summarization_store.py
+++ b/tests/unit/test_summarization_store.py
@@ -1,0 +1,298 @@
+"""Unit tests for `DurableSummaryStore` and `TtlCacheStore`."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from work_buddy.summarization import (
+    Provenance,
+    SummaryNode,
+)
+from work_buddy.summarization.stores import (
+    DurableSummaryStore,
+    TtlCacheStore,
+)
+
+
+# ---------------------------------------------------------------------------
+# DurableSummaryStore — tree round-trip + staleness + namespacing
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_db(monkeypatch, tmp_path):
+    """Point both `_default_db_path` and the config-resolution path at a temp
+    DB file so the store auto-discovers it via `get_connection()`."""
+    from work_buddy.summarization import db as db_mod
+
+    db_file = tmp_path / "summarization-test.db"
+    monkeypatch.setattr(db_mod, "_default_db_path", lambda: db_file)
+    monkeypatch.setattr(db_mod, "db_path", lambda cfg=None: db_file)
+    return db_file
+
+
+def _prov(prompt_v: int = 1, schema_v: int = 1) -> Provenance:
+    return Provenance(
+        model="m", backend="b", profile="p",
+        generated_at=Provenance.now_iso(),
+        prompt_version=prompt_v,
+        summary_schema_version=schema_v,
+        selection_version=1, cache_version=1,
+    )
+
+
+def test_durable_round_trip_depth2_tree(tmp_db):
+    store = DurableSummaryStore("ns_a")
+    store.set_strategy_versions(1, 1)
+
+    root = SummaryNode(
+        summary="root summary",
+        source_ref=None,
+        children=[
+            SummaryNode(
+                summary="child 1",
+                source_ref={"span_start": 0, "span_end": 5},
+                extra={"title": "T1", "keywords": ["k1"]},
+            ),
+            SummaryNode(
+                summary="child 2",
+                source_ref={"span_start": 5, "span_end": 9},
+                extra={"title": "T2", "keywords": ["k2", "k3"]},
+            ),
+        ],
+        extra={"meta": "v"},
+    )
+
+    store.save("item-1", root, _prov(), "tok-1")
+    loaded = store.load("item-1")
+
+    assert loaded is not None
+    assert loaded.summary == "root summary"
+    assert loaded.extra == {"meta": "v"}
+    assert len(loaded.children) == 2
+    assert loaded.children[0].summary == "child 1"
+    assert loaded.children[0].source_ref == {"span_start": 0, "span_end": 5}
+    assert loaded.children[0].extra["title"] == "T1"
+    assert loaded.children[1].summary == "child 2"
+    assert loaded.children[1].extra["keywords"] == ["k2", "k3"]
+
+
+def test_durable_select_stale_missing_item(tmp_db):
+    store = DurableSummaryStore("ns_a")
+    store.set_strategy_versions(1, 1)
+    candidates = [("alpha", "1"), ("beta", "1")]
+
+    # Nothing saved yet — both are stale.
+    assert store.select_stale(candidates) == candidates
+
+    store.save("alpha", SummaryNode(summary="a"), _prov(), "1")
+    stale = store.select_stale(candidates)
+    assert stale == [("beta", "1")]
+
+
+def test_durable_select_stale_token_changed(tmp_db):
+    store = DurableSummaryStore("ns_a")
+    store.set_strategy_versions(1, 1)
+    store.save("alpha", SummaryNode(summary="a"), _prov(), "tok-old")
+
+    # Same id, different token → stale.
+    assert store.select_stale([("alpha", "tok-new")]) == [("alpha", "tok-new")]
+    # Same token → fresh.
+    assert store.select_stale([("alpha", "tok-old")]) == []
+
+
+def test_durable_select_stale_version_bumped(tmp_db):
+    store = DurableSummaryStore("ns_a")
+    store.set_strategy_versions(1, 1)
+    store.save("alpha", SummaryNode(summary="a"), _prov(prompt_v=1), "1")
+
+    # Bump the strategy's prompt_version → stored row's prompt_version (1)
+    # mismatches → stale.
+    store.set_strategy_versions(2, 1)
+    assert store.select_stale([("alpha", "1")]) == [("alpha", "1")]
+
+
+def test_durable_is_fresh_matches_select_stale(tmp_db):
+    """The two staleness APIs must agree (shared predicate)."""
+    store = DurableSummaryStore("ns_a")
+    store.set_strategy_versions(1, 1)
+
+    store.save("a", SummaryNode(summary="x"), _prov(), "tok-1")
+
+    for token in ["tok-1", "tok-2", ""]:
+        is_fresh = store.is_fresh("a", token)
+        is_in_stale = ("a", token) in store.select_stale([("a", token)])
+        # is_fresh = True iff NOT in stale list.
+        assert is_fresh == (not is_in_stale), (
+            f"is_fresh/select_stale disagree for token={token!r}"
+        )
+
+
+def test_durable_namespaces_dont_collide(tmp_db):
+    store_a = DurableSummaryStore("ns_a")
+    store_a.set_strategy_versions(1, 1)
+    store_b = DurableSummaryStore("ns_b")
+    store_b.set_strategy_versions(1, 1)
+
+    store_a.save("same-id", SummaryNode(summary="from A"), _prov(), "1")
+    store_b.save("same-id", SummaryNode(summary="from B"), _prov(), "1")
+
+    assert store_a.load("same-id").summary == "from A"
+    assert store_b.load("same-id").summary == "from B"
+
+
+def test_durable_record_error_preserves_prior_good_nodes(tmp_db):
+    store = DurableSummaryStore("ns_a")
+    store.set_strategy_versions(1, 1)
+    good = SummaryNode(
+        summary="good root",
+        children=[SummaryNode(summary="good child")],
+    )
+    store.save("item-1", good, _prov(), "tok-1")
+
+    # Now record an error. Prior nodes should remain loadable; load() should
+    # still return the prior tree.
+    store.record_error("item-1", "llm went boom", _prov())
+    loaded = store.load("item-1")
+    assert loaded is not None
+    assert loaded.summary == "good root"
+    assert len(loaded.children) == 1
+
+
+def test_durable_record_error_no_prior_inserts_status_only(tmp_db):
+    store = DurableSummaryStore("ns_a")
+    store.set_strategy_versions(1, 1)
+    store.record_error("item-1", "boom", _prov())
+    # No nodes were ever saved → load returns None.
+    assert store.load("item-1") is None
+    # But the item's meta row exists with status='error'.
+    meta = store.load_item_meta("item-1")
+    assert meta is not None
+    assert meta["status"] == "error"
+    assert meta["error"] == "boom"
+
+
+def test_durable_overwrite_existing_replaces_children(tmp_db):
+    store = DurableSummaryStore("ns_a")
+    store.set_strategy_versions(1, 1)
+    store.save(
+        "item-1",
+        SummaryNode(summary="v1", children=[
+            SummaryNode(summary="old child 1"),
+            SummaryNode(summary="old child 2"),
+        ]),
+        _prov(), "1",
+    )
+    store.save(
+        "item-1",
+        SummaryNode(summary="v2", children=[SummaryNode(summary="new child")]),
+        _prov(), "2",
+    )
+
+    loaded = store.load("item-1")
+    assert loaded.summary == "v2"
+    assert len(loaded.children) == 1
+    assert loaded.children[0].summary == "new child"
+
+
+# ---------------------------------------------------------------------------
+# TtlCacheStore — wraps llm.cache
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_llm_cache(monkeypatch, tmp_path):
+    """Point `llm.cache._CACHE_PATH` at a temp file."""
+    from work_buddy.llm import cache as cache_mod
+    cache_file = tmp_path / "llm_cache.json"
+    monkeypatch.setattr(cache_mod, "_CACHE_PATH", cache_file)
+    return cache_file
+
+
+def test_ttl_round_trip_flat_summary(tmp_llm_cache):
+    store = TtlCacheStore(
+        "chrome_page", strategy_version_tag="chrome_page:v1",
+        ttl_minutes=30,
+    )
+
+    content = "the page content"
+    content_hash = hashlib.sha256(content.encode()).hexdigest()
+    token = {"hash": content_hash, "text": content}
+
+    node = SummaryNode(
+        summary="A page about X",
+        extra={"entities": [{"name": "X", "type": "concept"}],
+               "key_claims": ["X is Y"]},
+    )
+
+    assert store.is_fresh("http://example.com/p", token) is False
+    store.save("http://example.com/p", node, _prov(), token)
+    assert store.is_fresh("http://example.com/p", token) is True
+
+    loaded = store.load("http://example.com/p")
+    assert loaded is not None
+    assert loaded.summary == "A page about X"
+    assert loaded.extra["entities"][0]["name"] == "X"
+
+
+def test_ttl_content_hash_change_invalidates(tmp_llm_cache):
+    store = TtlCacheStore(
+        "chrome_page", strategy_version_tag="chrome_page:v1",
+    )
+
+    old_content = "old"
+    new_content = "new"
+    old_token = {
+        "hash": hashlib.sha256(old_content.encode()).hexdigest(),
+        "text": old_content,
+    }
+    new_token = {
+        "hash": hashlib.sha256(new_content.encode()).hexdigest(),
+        "text": new_content,
+    }
+
+    store.save("k", SummaryNode(summary="s"), _prov(), old_token)
+    # Same key, different content → cache miss (via cache.get's hash check).
+    assert store.is_fresh("k", new_token) is False
+
+
+def test_ttl_strategy_version_bump_invalidates(tmp_llm_cache):
+    content = "x"
+    token = {
+        "hash": hashlib.sha256(content.encode()).hexdigest(),
+        "text": content,
+    }
+
+    s1 = TtlCacheStore(
+        "chrome_page", strategy_version_tag="chrome_page:v1",
+    )
+    s1.save("k", SummaryNode(summary="s"), _prov(), token)
+    assert s1.is_fresh("k", token) is True
+
+    # Different version tag → different system_hash → cache miss.
+    s2 = TtlCacheStore(
+        "chrome_page", strategy_version_tag="chrome_page:v2",
+    )
+    assert s2.is_fresh("k", token) is False
+
+
+def test_ttl_select_stale_consistent_with_is_fresh(tmp_llm_cache):
+    store = TtlCacheStore(
+        "chrome_page", strategy_version_tag="chrome_page:v1",
+    )
+    content = "c"
+    token = {
+        "hash": hashlib.sha256(content.encode()).hexdigest(),
+        "text": content,
+    }
+    store.save("a", SummaryNode(summary="s"), _prov(), token)
+
+    # 'a' is fresh; 'b' is missing.
+    stale = store.select_stale([("a", token), ("b", token)])
+    assert stale == [("b", token)]

--- a/work_buddy/collectors/chrome_infer.py
+++ b/work_buddy/collectors/chrome_infer.py
@@ -138,110 +138,19 @@ def _summarize_tabs(
     selected: list[dict],
     tab_contents: dict[str, dict],
 ) -> tuple[list, int]:
-    """Summarize tabs using the summarize module. Returns (summaries, cached_count).
+    """Summarize tabs and return `(summaries_aligned_with_selected, cached_count)`.
 
-    Checks per-tab cache first. Uncached tabs are batch-summarized in one
-    Haiku call. Results are cached for future calls.
+    Delegates to the summarization framework
+    (`chrome_summarizer_binding.summarize_tabs`), which composes
+    `ChromeSource × FlatExtractionStrategy × TtlCacheStore`. The framework
+    issues one batched Haiku call for stale tabs and reuses cached entries
+    for the rest.
     """
-    from work_buddy.llm.cache import get as cache_get, put as cache_put
-    from work_buddy.llm.cost import log_call
-    from work_buddy.llm.summarize import PageSummary, summarize_batch
+    from work_buddy.collectors.chrome_summarizer_binding import (
+        summarize_tabs as _framework_summarize_tabs,
+    )
 
-    summaries: list[PageSummary] = [None] * len(selected)  # type: ignore
-    uncached_indices: list[int] = []
-    tabs_cached = 0
-
-    # Cache provenance: the summarize_batch path has its own system
-    # prompt we don't see here. Use a versioned tag as the ``system``
-    # identity so prompt revisions can be bumped without silent cache
-    # reuse. When ``summarize_batch`` changes materially, bump this.
-    _SUMMARIZE_TAB_VERSION = "summarize_tab:v1"
-    _summarize_system_hash = hashlib.sha256(
-        _SUMMARIZE_TAB_VERSION.encode()
-    ).hexdigest()[:12]
-
-    # Check cache per tab
-    for i, tab in enumerate(selected):
-        url = tab["url"]
-        cache_key = f"summarize_tab:{_normalize_for_cache(url)}"
-        content_text = tab_contents.get(url, {}).get("text", "") or ""
-        input_hash = hashlib.sha256(content_text.encode()).hexdigest()
-        cached = cache_get(
-            cache_key,
-            input_hash=input_hash,
-            input_text=content_text,
-        )
-        if cached:
-            tabs_cached += 1
-            r = cached["result"]
-            from work_buddy.llm.summarize import TypedEntity
-            summaries[i] = PageSummary(
-                content_summary=r.get("content_summary", ""),
-                entities=[TypedEntity(**e) for e in r.get("entities", [])],
-                key_claims=r.get("key_claims", []),
-                user_intent_speculation=r.get("user_intent_speculation", ""),
-                user_posture=r.get("user_posture", "referencing"),
-                source_label=_tab_label(tab),
-                cached=True,
-            )
-            log_call(
-                model=load_config().get("llm", {}).get("default_model", "claude-haiku-4-5-20251001"),
-                input_tokens=0, output_tokens=0,
-                task_id=cache_key, cached=True,
-            )
-        else:
-            uncached_indices.append(i)
-
-    # Batch-summarize uncached tabs
-    if uncached_indices:
-        batch_items = []
-        for i in uncached_indices:
-            tab = selected[i]
-            url = tab["url"]
-            text = tab_contents.get(url, {}).get("text", "")
-            meta_desc = tab_contents.get(url, {}).get("meta", {}).get("description", "")
-            if meta_desc:
-                text = f"[Meta: {meta_desc[:150]}]\n{text}"
-            batch_items.append({"text": text, "label": _tab_label(tab)})
-
-        batch_results = summarize_batch(batch_items)
-
-        for j, i in enumerate(uncached_indices):
-            if j < len(batch_results):
-                summaries[i] = batch_results[j]
-
-                # Cache the result
-                tab = selected[i]
-                url = tab["url"]
-                cache_key = f"summarize_tab:{_normalize_for_cache(url)}"
-                content_text = tab_contents.get(url, {}).get("text", "") or ""
-                cache_put(
-                    cache_key,
-                    result={
-                        "content_summary": batch_results[j].content_summary,
-                        "entities": [{"name": e.name, "type": e.type, "context": e.context} for e in batch_results[j].entities],
-                        "key_claims": batch_results[j].key_claims,
-                        "user_intent_speculation": batch_results[j].user_intent_speculation,
-                        "user_posture": batch_results[j].user_posture,
-                    },
-                    input_hash=hashlib.sha256(content_text.encode()).hexdigest(),
-                    input_text=content_text,
-                    system_hash=_summarize_system_hash,
-                    system_preview=_SUMMARIZE_TAB_VERSION,
-                    ttl_minutes=30,
-                )
-
-    # Fill any remaining None entries
-    for i in range(len(summaries)):
-        if summaries[i] is None:
-            summaries[i] = PageSummary(
-                content_summary="Content unavailable",
-                entities=[], key_claims=[],
-                user_intent_speculation="", user_posture="referencing",
-                source_label=_tab_label(selected[i]),
-            )
-
-    return summaries, tabs_cached
+    return _framework_summarize_tabs(selected, tab_contents)
 
 
 def _classify_summaries(

--- a/work_buddy/collectors/chrome_summarizer_binding.py
+++ b/work_buddy/collectors/chrome_summarizer_binding.py
@@ -1,0 +1,320 @@
+"""Chrome as the second composition of the summarization framework.
+
+Composition: `ChromeSource × FlatExtractionStrategy × TtlCacheStore`.
+
+Public entry: `summarize_tabs(selected, tab_contents) -> (list[PageSummary],
+cached_count)`. Replaces the previous hand-rolled per-tab caching + batched
+LLM call in `chrome_infer.py`.
+
+Cache fidelity: the existing cache key scheme used by Chrome triage —
+`scoped_task_id = f"summarize_tab:{_normalize_for_cache(url)}"`, content-hash
+invalidation, SimHash fuzzy fallback, system-hash from a `summarize_tab:v1`
+tag, 30-minute TTL — is preserved at the cache-key / hash / TTL layer. The
+JSON shape *inside* each entry's `result` field changes (now wrapping the
+`SummaryNode` tree); entries written by the legacy code path are treated as
+cache misses on the next access and naturally refresh under the 30-minute
+TTL. New-format entries written by the framework remain readable by the
+framework.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import Any
+from urllib.parse import urlparse
+
+from work_buddy.summarization import (
+    DiscoveryWindow,
+    Summarizer,
+    SummaryCapability,
+    SummaryNode,
+)
+from work_buddy.summarization.strategies import FlatExtractionStrategy
+from work_buddy.summarization.stores import TtlCacheStore
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Cache key normalization — preserves the existing Chrome scheme
+# ---------------------------------------------------------------------------
+
+
+def normalize_url_for_cache(url: str) -> str:
+    """Normalize URL for cache key — strip query params except where they
+    materially identify the page (Google search, ChatGPT conversations).
+
+    Mirrors the prior `chrome_infer._normalize_for_cache` exactly so existing
+    cache entries written by the legacy code path remain reusable.
+    """
+    parsed = urlparse(url)
+    path = parsed.path.rstrip("/")
+    if parsed.query and any(
+        k in parsed.netloc for k in ("google.com", "chatgpt.com")
+    ):
+        return f"{parsed.netloc}{path}?{parsed.query}"
+    return f"{parsed.netloc}{path}"
+
+
+def _tab_label(tab: dict) -> str:
+    url = tab.get("url", "")
+    domain = urlparse(url).netloc
+    title = tab.get("title", "")[:60]
+    return f"{title} [{domain}]" if domain else title
+
+
+# ---------------------------------------------------------------------------
+# ChromeSource
+# ---------------------------------------------------------------------------
+
+
+class ChromeSource:
+    """`Source` for Chrome tab summarization.
+
+    Constructed per `summarize_tabs` call with the tabs to process and the
+    fetched tab contents. `discover` enumerates the tabs with content-hash
+    freshness tokens; `render_batch` produces per-tab prompt text.
+    """
+
+    name = "chrome_page"
+    capabilities = frozenset({SummaryCapability.BATCHED})
+
+    def __init__(
+        self,
+        tabs: list[dict],
+        tab_contents: dict[str, dict],
+    ) -> None:
+        # Indexed by normalized URL (the framework's `item_id`) so render()
+        # and discover() agree.
+        self._by_item: dict[str, tuple[dict, str]] = {}
+        for tab in tabs:
+            url = tab.get("url", "")
+            if not url:
+                continue
+            item_id = normalize_url_for_cache(url)
+            content_text = tab_contents.get(url, {}).get("text", "") or ""
+            self._by_item[item_id] = (tab, content_text)
+
+    # --- protocol -----------------------------------------------------------
+
+    def discover(self, window: DiscoveryWindow) -> list[tuple[str, Any]]:
+        out: list[tuple[str, Any]] = []
+        for item_id, (_tab, content) in self._by_item.items():
+            content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+            out.append((item_id, {"hash": content_hash, "text": content}))
+        return out
+
+    def render(self, item_id: str) -> str | None:
+        # Single-render isn't part of Chrome's BATCHED path, but provided
+        # for the Protocol surface.
+        entry = self._by_item.get(item_id)
+        if entry is None:
+            return None
+        tab, content = entry
+        return _build_tab_prompt(tab, content)
+
+    def render_batch(self, item_ids: list[str]) -> list[str | None]:
+        out: list[str | None] = []
+        for iid in item_ids:
+            entry = self._by_item.get(iid)
+            if entry is None:
+                out.append(None)
+                continue
+            tab, content = entry
+            out.append(_build_tab_prompt(tab, content))
+        return out
+
+
+def _build_tab_prompt(tab: dict, content: str) -> str:
+    """Per-tab prompt body. Mirrors the previous `summarize_batch` shape —
+    a short content sample with an optional meta-description prefix."""
+    label = _tab_label(tab)
+    meta = (
+        tab.get("meta", {}).get("description", "")
+        if isinstance(tab.get("meta"), dict)
+        else ""
+    )
+    text = content[:3000]
+    if meta:
+        text = f"[Meta: {meta[:150]}]\n{text}"
+    return f"{label}\n\n{text}"
+
+
+# ---------------------------------------------------------------------------
+# Adapter — SummaryNode → PageSummary (the consumer-facing type kept verbatim)
+# ---------------------------------------------------------------------------
+
+
+def _node_to_page_summary(
+    node: SummaryNode,
+    tab: dict,
+    *,
+    cached: bool,
+):
+    """Adapt a `SummaryNode` (root of a depth-1 flat tree) back into a
+    `PageSummary` so existing consumers (`pipelines/chrome.py`) see no shape
+    change.
+    """
+    from work_buddy.llm.summarize import PageSummary, TypedEntity
+
+    extra = node.extra or {}
+    raw_entities = extra.get("entities") or []
+    entities: list = []
+    for e in raw_entities:
+        if isinstance(e, dict):
+            entities.append(TypedEntity(
+                name=str(e.get("name", "")),
+                type=str(e.get("type", "other")),
+                context=str(e.get("context", "")),
+            ))
+    return PageSummary(
+        content_summary=node.summary,
+        entities=entities,
+        key_claims=list(extra.get("key_claims") or []),
+        user_intent_speculation=str(extra.get("user_intent_speculation", "")),
+        user_posture=str(extra.get("user_posture", "referencing")),
+        source_label=_tab_label(tab),
+        cached=cached,
+    )
+
+
+def _fallback_page_summary(tab: dict):
+    from work_buddy.llm.summarize import PageSummary
+
+    return PageSummary(
+        content_summary="Content unavailable",
+        entities=[],
+        key_claims=[],
+        user_intent_speculation="",
+        user_posture="referencing",
+        source_label=_tab_label(tab),
+        cached=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Factory + public entry
+# ---------------------------------------------------------------------------
+
+
+def build_chrome_summarizer(
+    tabs: list[dict],
+    tab_contents: dict[str, dict],
+) -> Summarizer:
+    """Build a per-pass Chrome `Summarizer`.
+
+    A new `ChromeSource` is constructed each call (the source holds the
+    tabs-to-summarize as state). The strategy and store are stateless.
+    """
+    return Summarizer(
+        name="chrome_page",
+        source=ChromeSource(tabs, tab_contents),
+        strategy=FlatExtractionStrategy(),
+        store=TtlCacheStore(
+            namespace="chrome_page",
+            strategy_version_tag="chrome_page:v1",
+            ttl_minutes=30,
+            # Exact prior cache key prefix — entries written by the legacy
+            # code path remain readable.
+            key_prefix="summarize_tab",
+        ),
+    )
+
+
+def summarize_tabs(
+    selected: list[dict],
+    tab_contents: dict[str, dict],
+    *,
+    llm_caller=None,
+) -> tuple[list, int]:
+    """Summarize a batch of tabs through the framework.
+
+    Returns `(summaries_aligned_with_selected, cached_count)` where each
+    element of the returned list is a `PageSummary`. Drop-in replacement for
+    the previous `chrome_infer._summarize_tabs` body.
+
+    `llm_caller` is an injection seam for tests; production callers leave it
+    `None` and the framework uses the default `LLMRunner` caller.
+    """
+    from work_buddy.config import load_config
+    from work_buddy.llm.cost import log_call
+
+    if not selected:
+        return [], 0
+
+    summarizer = build_chrome_summarizer(selected, tab_contents)
+    # One batched LLM call for all stale tabs; cache hits are skipped.
+    report = summarizer.refresh(
+        days=0,
+        max_items=max(1, len(selected)),
+        force=False,
+        llm_caller=llm_caller,
+    )
+    cached_count = report.skipped_fresh
+
+    # Per-tab cache-hit cost-log entries (preserves the prior accounting).
+    if cached_count > 0:
+        model = (
+            load_config().get("llm", {}).get(
+                "default_model", "claude-haiku-4-5-20251001",
+            )
+        )
+    # Build a quick lookup of which item_ids were stale (= newly summarized)
+    # so we know which loaded results came from cache vs the fresh call.
+    stale_item_ids: set[str] = set()
+    for iid, _err in report.errors:
+        stale_item_ids.add(iid)
+    # We don't have a direct "saved-this-pass" list from RefreshReport.
+    # Practical proxy: anything we just summarized was, before the call,
+    # not in cache. We rebuild that set via discover + the store's
+    # post-refresh state — but a cheaper signal is just `cached` from the
+    # cache entry itself (lookup re-reads).
+
+    summaries: list = []
+    from work_buddy.llm.cache import get as cache_get
+
+    for tab in selected:
+        url = tab.get("url", "")
+        item_id = normalize_url_for_cache(url) if url else ""
+        node = summarizer.store.load(item_id) if item_id else None
+
+        # Cache-hit detection: re-query the cache layer to see if this entry
+        # was already present (TTL not new). Simpler than threading state
+        # through the orchestrator.
+        was_cached = False
+        if item_id and node is not None:
+            content_text = (tab_contents.get(url, {}).get("text", "") or "")
+            content_hash = hashlib.sha256(
+                content_text.encode("utf-8")
+            ).hexdigest()
+            # If the cache entry exists and would still match by hash, it was
+            # a cache hit (the orchestrator's `skipped_fresh` count agrees).
+            entry = cache_get(
+                f"summarize_tab:{item_id}",
+                input_hash=content_hash,
+                input_text=content_text,
+            )
+            was_cached = entry is not None
+
+        if node is None:
+            summaries.append(_fallback_page_summary(tab))
+        else:
+            summaries.append(
+                _node_to_page_summary(node, tab, cached=was_cached),
+            )
+
+    # Cost-log accounting for cached entries — single aggregate entry per
+    # cache hit, mirroring the per-hit behavior of the legacy code.
+    if cached_count > 0:
+        for ps in summaries:
+            if getattr(ps, "cached", False):
+                log_call(
+                    model=model,
+                    input_tokens=0,
+                    output_tokens=0,
+                    task_id=f"summarize_tab:cached:{ps.source_label[:40]}",
+                    cached=True,
+                )
+
+    return summaries, cached_count

--- a/work_buddy/conversation_observability/summaries.py
+++ b/work_buddy/conversation_observability/summaries.py
@@ -83,7 +83,7 @@ def refresh_session_summaries(
         llm_caller=as_caller(llm_call),
         profile=profile,
     )
-    return report.to_legacy_dict()
+    return report.to_op_dict()
 
 
 def summarize_session(

--- a/work_buddy/conversation_observability/summaries.py
+++ b/work_buddy/conversation_observability/summaries.py
@@ -1,111 +1,55 @@
-"""Bounded LLM topic summaries for observed Claude Code sessions.
+"""Backwards-compatible shims over the summarization framework.
 
-Generates per-session ``tldr`` + ``topic_summary`` rows and persists
-them to ``session_summaries`` / ``topic_summaries``. Used by:
+The producer of conversation-session summaries has been migrated to
+`work_buddy.summarization` + `work_buddy.conversation_observability.summarizer_binding`.
+This module preserves the legacy callable surface — `refresh_session_summaries`,
+`summarize_session`, `query_session_summary`, `query_topic_summaries` — so
+existing consumers see no change:
 
-* ``/wb-session-identify`` — as candidate sanity checks before drilling
-  into raw IR hits.
-* ``claude_session_summary`` context source — when enabled, the tldr
-  replaces the descriptors-only line.
+- the dashboard `/api/chats/<id>/topics` endpoint (`dashboard/service.py`)
+- the `conversation_observability_summarize` MCP capability (op binding in
+  `mcp_server/ops/conversation_observability_ops.py`)
+- the `conversation_observability_summary_get` MCP capability
+- the `claude_session_summary` context collector
+- the sidecar job `conversation-observability-summarize.md`
+- the legacy test stubs that pass `llm_call=...` as a bare callable
 
-Design constraints:
-
-* **Bounded by default.** ``refresh_session_summaries(max_sessions=3)``
-  caps per-call work; the sidecar cron uses a small N because each
-  call hits the LLM.
-* **Stale detection is multi-axis.** A summary is stale if the source
-  file's mtime changed OR the prompt / schema / selection / cache
-  versions bumped. Every version is recorded on the row.
-* **Failures don't corrupt prior good summaries.** If the LLM errors
-  or returns invalid JSON, the row's ``status`` flips to ``'error'``
-  with the exception detail, but the previous good tldr stays present
-  unless the caller explicitly forces an overwrite.
-* **LLM caller is injectable** for testability — pass ``llm_call=`` to
-  ``summarize_session`` and ``refresh_session_summaries``. Default is
-  ``work_buddy.llm.runner_v2.llm_call`` with the FRONTIER_FAST tier.
-
-Disabled by default. Set ``conversation_observability.summaries.enabled``
-to True in ``config.local.yaml`` to opt in.
+The legacy `session_summaries` and `topic_summaries` SQLite tables remain
+defined in `schema.py` (zero-effort rollback) but are no longer written. Data
+now lives in the framework's `summarization.db` under namespace
+`conversation_session`. A follow-up change removes the unused table
+definitions after a shakeout period.
 """
 
 from __future__ import annotations
 
-import json
 import logging
-from datetime import datetime, timezone
 from typing import Any, Callable
 
-from work_buddy.conversation_observability.db import get_connection
-from work_buddy.conversation_observability.sessions import (
-    refresh_observed_sessions,
+from work_buddy.conversation_observability.summarizer_binding import (
+    get_session_summarizer,
 )
+from work_buddy.summarization import as_caller
+from work_buddy.summarization.strategies import LayeredDisclosureStrategy
 
 logger = logging.getLogger(__name__)
 
 
-# Version stamps. Bumping any of these invalidates cached summaries for
-# **every** session — handle with care. See module docstring.
-PROMPT_VERSION = 1
-SUMMARY_SCHEMA_VERSION = 1
-SELECTION_VERSION = 1
-CACHE_VERSION = 1
+# ---------------------------------------------------------------------------
+# Compat re-exports — historical module-level constants
+# ---------------------------------------------------------------------------
+#
+# Tests and (one) other test file import these. They're now owned by
+# `LayeredDisclosureStrategy`; the re-exports preserve the import path
+# without ownership ambiguity. To change the prompt, edit
+# `work_buddy/summarization/strategies.py`.
 
-
-SYSTEM_PROMPT = """\
-You are an analyst producing compact, factual recaps of Claude Code
-agent-user conversations. Each conversation is a sequence of turns
-(user + assistant) interleaved with tool calls (Bash, Edit, Write, etc.)
-and tool outputs.
-
-Produce two things:
-1. tldr: ONE sentence (≤25 words) capturing what was accomplished or
-   attempted. No greetings, no commentary on tone. Concrete enough that
-   the user can recognize the session a week from now.
-2. topic_summary: an ordered list of distinct topics within the session.
-   Each topic has a short title (≤8 words), a one-sentence summary, a
-   span_range covering the spans it spans, and 2-5 keywords. Cap at 8
-   topics; merge fine-grained sub-topics rather than emitting many
-   nearly-identical entries.
-
-Be operational. Prefer concrete nouns ("AFK build of conversation
-observability subsystem") over abstract ones ("worked on a feature").
-"""
-
-
-SUMMARY_OUTPUT_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "required": ["tldr", "topic_summary"],
-    "properties": {
-        "tldr": {"type": "string"},
-        "topic_summary": {
-            "type": "array",
-            "maxItems": 8,
-            "items": {
-                "type": "object",
-                "required": ["title", "summary", "span_range", "keywords"],
-                "properties": {
-                    "title": {"type": "string"},
-                    "summary": {"type": "string"},
-                    "span_range": {
-                        "type": "array",
-                        "minItems": 2,
-                        "maxItems": 2,
-                        "items": {"type": "integer"},
-                    },
-                    "keywords": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "maxItems": 5,
-                    },
-                },
-            },
-        },
-    },
-}
+SYSTEM_PROMPT: str = LayeredDisclosureStrategy.system_prompt
+SUMMARY_OUTPUT_SCHEMA: dict[str, Any] = LayeredDisclosureStrategy.output_schema
 
 
 # ---------------------------------------------------------------------------
-# Refresh — find stale candidates and summarize a bounded subset
+# Write-path shims
 # ---------------------------------------------------------------------------
 
 
@@ -116,62 +60,30 @@ def refresh_session_summaries(
     llm_call: Callable[..., Any] | None = None,
     profile: str | None = None,
 ) -> dict[str, Any]:
-    """Summarize up to ``max_sessions`` stale sessions.
+    """Refresh a bounded batch of stale session summaries.
 
-    Stale criteria:
-      * No ``session_summaries`` row exists, OR
-      * Any version stamp differs from the module constants, OR
-      * The session's source file mtime is newer than the summary's
-        ``generated_at``, OR
-      * ``force=True`` (re-summarize regardless of staleness).
+    Legacy entry preserved for the `conversation_observability_summarize` op,
+    the sidecar job, and tests. Returns the legacy result-dict shape
+    `{summarized, skipped_fresh, errored, total_candidates}`.
 
-    Returns a summary dict for observability:
-    ``{summarized, skipped_fresh, errored, total_candidates}``.
+    Refreshes `observed_sessions` first (legacy behavior — the source of
+    candidate ids), then delegates to `Summarizer.refresh`.
     """
-    # Make sure observed_sessions is fresh enough to drive candidate
-    # selection. The summarizer only operates on sessions we know about.
+    from work_buddy.conversation_observability.sessions import (
+        refresh_observed_sessions,
+    )
+
     refresh_observed_sessions(days=days, stale_only=True)
 
-    candidates = _select_candidates(days=days)
-    summarized = 0
-    skipped_fresh = 0
-    errored = 0
-
-    for session_id in candidates:
-        if summarized >= max_sessions:
-            break
-
-        if not force and _is_summary_fresh(session_id):
-            skipped_fresh += 1
-            continue
-
-        try:
-            summarize_session(
-                session_id=session_id,
-                force=force,
-                llm_call=llm_call,
-                profile=profile,
-            )
-            summarized += 1
-        except Exception as exc:  # pragma: no cover — defensive
-            errored += 1
-            logger.warning(
-                "conversation_observability: summarize_session(%s) failed: %s",
-                session_id, exc,
-            )
-            _record_summary_error(session_id, exc)
-
-    return {
-        "summarized": summarized,
-        "skipped_fresh": skipped_fresh,
-        "errored": errored,
-        "total_candidates": len(candidates),
-    }
-
-
-# ---------------------------------------------------------------------------
-# Per-session summarize
-# ---------------------------------------------------------------------------
+    summarizer = get_session_summarizer()
+    report = summarizer.refresh(
+        days=days,
+        max_items=max_sessions,
+        force=force,
+        llm_caller=as_caller(llm_call),
+        profile=profile,
+    )
+    return report.to_legacy_dict()
 
 
 def summarize_session(
@@ -181,405 +93,145 @@ def summarize_session(
     llm_call: Callable[..., Any] | None = None,
     profile: str | None = None,
 ) -> dict[str, Any] | None:
-    """Summarize one session and persist its rows.
+    """Summarize one session (legacy single-item entry, used by tests).
 
-    Returns the new ``session_summaries`` row (as a dict), or ``None``
-    when the session has no usable turns (empty session — nothing to
-    summarize). Pass ``llm_call`` to inject a stub during tests; the
-    real default lazily imports the LLMRunner the first call.
+    Returns the legacy `session_summaries` row dict (via
+    `query_session_summary`), or `None` if the session isn't observed / has
+    no usable turns.
     """
-    from work_buddy.sessions.inspector import ConversationSession
-
-    if llm_call is None:
-        llm_call = _default_llm_call
-
-    if not force and _is_summary_fresh(session_id):
-        return _load_summary_row(session_id)
-
-    try:
-        session = ConversationSession(session_id)
-        session._ensure_loaded()
-    except FileNotFoundError:
-        _record_summary_error(session_id, "session file missing")
+    summarizer = get_session_summarizer()
+    token = summarizer.source.token_for(session_id)
+    if token is None:
         return None
 
-    span_count = len(session._span_map or {})
-    if span_count == 0:
-        return None
-
-    prompt = _build_user_prompt(session)
-    response = llm_call(
-        system=SYSTEM_PROMPT,
-        user=prompt,
-        output_schema=SUMMARY_OUTPUT_SCHEMA,
+    node = summarizer.refresh_one(
+        session_id,
+        force=force,
+        freshness_token=token,
+        llm_caller=as_caller(llm_call),
         profile=profile,
     )
-
-    parsed = _coerce_response(response)
-    if not isinstance(parsed, dict) or "tldr" not in parsed:
-        _record_summary_error(
-            session_id,
-            f"invalid LLM response: {str(response)[:200]}",
-        )
+    # Legacy behavior: return `None` when the call produced no usable
+    # result (empty session OR an LLM/parse error). Consumers can still
+    # `query_session_summary` separately to inspect any recorded error row.
+    if node is None:
         return None
-
-    now_iso = datetime.now(timezone.utc).isoformat()
-    topics = parsed.get("topic_summary") or []
-    model = _extract_model(response)
-    backend = _extract_backend(response)
-
-    conn = get_connection()
-    try:
-        # Replace any previous rows for this session — both the summary
-        # itself and its topic children.
-        conn.execute(
-            "DELETE FROM topic_summaries WHERE session_id = ?", (session_id,),
-        )
-        for i, topic in enumerate(topics):
-            span_range = topic.get("span_range") or [None, None]
-            span_start = span_range[0] if len(span_range) >= 1 else None
-            span_end = span_range[1] if len(span_range) >= 2 else None
-            turn_start = turn_end = None
-            try:
-                if (
-                    isinstance(span_start, int)
-                    and isinstance(span_end, int)
-                    and span_end > span_start
-                ):
-                    from work_buddy.conversation_observability.sessions import (
-                        span_range_to_turn_range,
-                    )
-
-                    turn_start, turn_end = span_range_to_turn_range(
-                        session, span_start, span_end,
-                    )
-            except Exception:
-                pass
-
-            conn.execute(
-                "INSERT INTO topic_summaries "
-                "(id, session_id, topic_index, title, summary, "
-                " span_start, span_end, turn_start, turn_end, "
-                " keywords_json) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    f"{session_id}:{i}",
-                    session_id,
-                    i,
-                    str(topic.get("title", "")),
-                    str(topic.get("summary", "")),
-                    span_start,
-                    span_end,
-                    turn_start,
-                    turn_end,
-                    json.dumps(topic.get("keywords", []), ensure_ascii=False),
-                ),
-            )
-
-        conn.execute(
-            "INSERT INTO session_summaries "
-            "(session_id, tldr, topic_count, generated_at, model, "
-            " profile, backend, prompt_version, summary_schema_version, "
-            " selection_version, cache_version, status, error) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'ok', NULL) "
-            "ON CONFLICT(session_id) DO UPDATE SET "
-            "  tldr=excluded.tldr, "
-            "  topic_count=excluded.topic_count, "
-            "  generated_at=excluded.generated_at, "
-            "  model=excluded.model, "
-            "  profile=excluded.profile, "
-            "  backend=excluded.backend, "
-            "  prompt_version=excluded.prompt_version, "
-            "  summary_schema_version=excluded.summary_schema_version, "
-            "  selection_version=excluded.selection_version, "
-            "  cache_version=excluded.cache_version, "
-            "  status='ok', error=NULL",
-            (
-                session_id,
-                str(parsed["tldr"]),
-                len(topics),
-                now_iso,
-                model,
-                profile,
-                backend,
-                PROMPT_VERSION,
-                SUMMARY_SCHEMA_VERSION,
-                SELECTION_VERSION,
-                CACHE_VERSION,
-            ),
-        )
-        conn.commit()
-    finally:
-        conn.close()
-
-    return _load_summary_row(session_id)
+    return query_session_summary(session_id)
 
 
 # ---------------------------------------------------------------------------
-# Read-only queries
+# Read-path shims
 # ---------------------------------------------------------------------------
 
 
 def query_session_summary(session_id: str) -> dict[str, Any] | None:
-    """Look up a summary by session_id, including its topic list."""
-    return _load_summary_row(session_id)
+    """Return the legacy `session_summaries` row dict (with `topics`).
+
+    Consumed by:
+    - the dashboard `/api/chats/<id>/topics` endpoint
+    - the `conversation_observability_summary_get` MCP capability
+    - the `claude_session_summary` context collector
+    """
+    summarizer = get_session_summarizer()
+    store = summarizer.store
+
+    meta = store.load_item_meta(session_id)
+    if meta is None:
+        return None
+
+    # Always load the tree, regardless of status — `record_error` preserves
+    # prior nodes when flipping status to 'error', and consumers (dashboard,
+    # `conversation_observability_summary_get`) expect the prior tldr to
+    # survive a transient LLM failure.
+    node = store.load(session_id)
+    tldr = node.summary if node is not None else ""
+
+    return {
+        "session_id": session_id,
+        "tldr": tldr,
+        "topic_count": meta.get("topic_count", 0),
+        "generated_at": meta.get("generated_at"),
+        "model": meta.get("model"),
+        "profile": meta.get("profile"),
+        "backend": meta.get("backend"),
+        "prompt_version": meta.get("prompt_version"),
+        "summary_schema_version": meta.get("summary_schema_version"),
+        "selection_version": meta.get("selection_version"),
+        "cache_version": meta.get("cache_version"),
+        "status": meta.get("status"),
+        "error": meta.get("error"),
+        "topics": query_topic_summaries(session_id),
+    }
 
 
 def query_topic_summaries(session_id: str) -> list[dict[str, Any]]:
-    """All topic rows for one session, in order."""
-    conn = get_connection()
+    """Return the legacy `topic_summaries` row dicts (one per child node).
+
+    `turn_start` / `turn_end` are computed lazily from `span_start` /
+    `span_end` via `span_range_to_turn_range`. The previous implementation
+    pre-computed and persisted these at save time; the framework's
+    `SummaryStrategy.parse` doesn't have session context, so computing at
+    read time is cleaner. Cost: one `ConversationSession` load per
+    dashboard topics-tab view.
+    """
+    summarizer = get_session_summarizer()
+    node = summarizer.store.load(session_id)
+    if node is None:
+        return []
+
+    # Lazy session load for turn_range conversion. Best-effort: if the
+    # session file is missing we still return topics without turn_range.
+    session: Any | None = None
     try:
-        rows = conn.execute(
-            "SELECT * FROM topic_summaries WHERE session_id = ? "
-            "ORDER BY topic_index",
-            (session_id,),
-        ).fetchall()
-    finally:
-        conn.close()
+        from work_buddy.sessions.inspector import ConversationSession
+
+        session = ConversationSession(session_id)
+        session._ensure_loaded()
+    except Exception:
+        session = None
+
+    span_to_turn = None
+    if session is not None:
+        try:
+            from work_buddy.conversation_observability.sessions import (
+                span_range_to_turn_range,
+            )
+
+            span_to_turn = span_range_to_turn_range
+        except Exception:
+            span_to_turn = None
+
     out: list[dict[str, Any]] = []
-    for r in rows:
-        rec = dict(r)
-        try:
-            rec["keywords"] = json.loads(rec.pop("keywords_json", "[]"))
-        except (ValueError, TypeError):
-            rec["keywords"] = []
-        out.append(rec)
-    return out
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _select_candidates(days: int) -> list[str]:
-    """Return session_ids worth summarizing, newest-first.
-
-    Picks observed sessions in the recency window that either have no
-    summary, an older summary version, or whose source file is newer
-    than the cached summary.
-    """
-    from datetime import timedelta
-
-    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
-    conn = get_connection()
-    try:
-        rows = conn.execute(
-            "SELECT obs.session_id, obs.source_mtime, obs.message_count, "
-            "       sum.generated_at, sum.prompt_version, "
-            "       sum.summary_schema_version, sum.selection_version, "
-            "       sum.cache_version "
-            "FROM observed_sessions obs "
-            "LEFT JOIN session_summaries sum ON sum.session_id = obs.session_id "
-            "WHERE obs.observed_at >= ? AND obs.status = 'ok' "
-            "  AND obs.message_count IS NOT NULL "
-            "  AND obs.message_count > 0 "
-            "ORDER BY obs.observed_at DESC",
-            (cutoff,),
-        ).fetchall()
-    finally:
-        conn.close()
-
-    candidates: list[str] = []
-    for r in rows:
-        sid = r["session_id"]
-        if r["generated_at"] is None:
-            candidates.append(sid)
-            continue
+    for i, child in enumerate(node.children):
+        extra = child.extra or {}
+        span_start = extra.get("span_start")
+        span_end = extra.get("span_end")
+        turn_start: int | None = None
+        turn_end: int | None = None
         if (
-            r["prompt_version"] != PROMPT_VERSION
-            or r["summary_schema_version"] != SUMMARY_SCHEMA_VERSION
-            or r["selection_version"] != SELECTION_VERSION
-            or r["cache_version"] != CACHE_VERSION
+            session is not None
+            and span_to_turn is not None
+            and isinstance(span_start, int)
+            and isinstance(span_end, int)
+            and span_end > span_start
         ):
-            candidates.append(sid)
-            continue
-        # mtime-based staleness: if the file changed after the summary
-        # was generated, re-summarize.
-        try:
-            generated_dt = datetime.fromisoformat(
-                r["generated_at"].replace("Z", "+00:00")
-            )
-            if r["source_mtime"] > generated_dt.timestamp() + 1:
-                candidates.append(sid)
-        except (ValueError, TypeError):
-            candidates.append(sid)
-    return candidates
+            try:
+                turn_start, turn_end = span_to_turn(
+                    session, span_start, span_end,
+                )
+            except Exception:
+                pass
 
-
-def _is_summary_fresh(session_id: str) -> bool:
-    """True when a non-stale summary already exists for this session."""
-    conn = get_connection()
-    try:
-        row = conn.execute(
-            "SELECT s.generated_at, s.prompt_version, "
-            "       s.summary_schema_version, s.selection_version, "
-            "       s.cache_version, s.status, "
-            "       o.source_mtime "
-            "FROM session_summaries s "
-            "JOIN observed_sessions o ON o.session_id = s.session_id "
-            "WHERE s.session_id = ?",
-            (session_id,),
-        ).fetchone()
-    finally:
-        conn.close()
-
-    if row is None or row["status"] != "ok":
-        return False
-    if (
-        row["prompt_version"] != PROMPT_VERSION
-        or row["summary_schema_version"] != SUMMARY_SCHEMA_VERSION
-        or row["selection_version"] != SELECTION_VERSION
-        or row["cache_version"] != CACHE_VERSION
-    ):
-        return False
-    try:
-        generated_dt = datetime.fromisoformat(
-            row["generated_at"].replace("Z", "+00:00")
-        )
-    except (ValueError, TypeError):
-        return False
-    return row["source_mtime"] <= generated_dt.timestamp() + 1
-
-
-def _load_summary_row(session_id: str) -> dict[str, Any] | None:
-    conn = get_connection()
-    try:
-        row = conn.execute(
-            "SELECT * FROM session_summaries WHERE session_id = ?",
-            (session_id,),
-        ).fetchone()
-    finally:
-        conn.close()
-    if row is None:
-        return None
-    rec = dict(row)
-    rec["topics"] = query_topic_summaries(session_id)
-    return rec
-
-
-def _record_summary_error(session_id: str, exc: Any) -> None:
-    """Stamp an error status without overwriting a prior good tldr."""
-    now_iso = datetime.now(timezone.utc).isoformat()
-    msg = str(exc)
-    conn = get_connection()
-    try:
-        existing = conn.execute(
-            "SELECT tldr FROM session_summaries WHERE session_id = ?",
-            (session_id,),
-        ).fetchone()
-        if existing is None:
-            conn.execute(
-                "INSERT INTO session_summaries "
-                "(session_id, tldr, generated_at, prompt_version, "
-                " summary_schema_version, selection_version, "
-                " cache_version, status, error) "
-                "VALUES (?, '', ?, ?, ?, ?, ?, 'error', ?)",
-                (
-                    session_id,
-                    now_iso,
-                    PROMPT_VERSION,
-                    SUMMARY_SCHEMA_VERSION,
-                    SELECTION_VERSION,
-                    CACHE_VERSION,
-                    msg,
-                ),
-            )
-        else:
-            conn.execute(
-                "UPDATE session_summaries SET status='error', error=? "
-                "WHERE session_id = ?",
-                (msg, session_id),
-            )
-        conn.commit()
-    finally:
-        conn.close()
-
-
-def _build_user_prompt(session: Any) -> str:
-    """Render a session's turns into a compact text prompt.
-
-    Strategy: take up to the first 4000 chars per turn, capped at
-    ~40 KB total to stay within reasonable input budgets. Tool calls
-    are rendered as one-liners; tool outputs are truncated aggressively.
-    """
-    max_total_chars = 40_000
-    chunks: list[str] = []
-    used = 0
-    for i, turn in enumerate(session.turns):
-        role = turn.get("role", "?")
-        text = (turn.get("text", "") or "")[:4000]
-        tools = turn.get("tools", []) or []
-        line = f"[turn {i} | {role}]"
-        if tools:
-            tool_names = ", ".join(
-                t if isinstance(t, str) else t.get("name", "?")
-                for t in tools
-            )
-            line += f" tools=[{tool_names}]"
-        if text:
-            line += f"\n{text}"
-        chunks.append(line)
-        used += len(line)
-        if used >= max_total_chars:
-            chunks.append(f"[…{len(session.turns) - i - 1} more turns truncated…]")
-            break
-    return "\n\n".join(chunks)
-
-
-def _default_llm_call(
-    *,
-    system: str,
-    user: str,
-    output_schema: dict[str, Any] | None = None,
-    profile: str | None = None,
-) -> Any:
-    """The real-system default — lazy-loaded to keep the test path cheap."""
-    from work_buddy.llm.runner_v2 import LLMRunner
-    from work_buddy.llm.tiers import ModelTier
-
-    return LLMRunner().call(
-        tier=ModelTier.FRONTIER_FAST,
-        system=system,
-        user=user,
-        output_schema=output_schema,
-        max_tokens=1024,
-        trace_id="conversation_observability.summary",
-    )
-
-
-def _coerce_response(response: Any) -> Any:
-    """Normalize stub / real LLM responses to a parsed JSON dict.
-
-    Tests pass back a plain dict (or a string). The real ``LLMResponse``
-    carries ``parsed`` (dict | None) and ``content`` (raw string). We
-    accept either path.
-    """
-    if isinstance(response, dict):
-        return response
-    if isinstance(response, str):
-        try:
-            return json.loads(response)
-        except (ValueError, TypeError):
-            return response
-    parsed = getattr(response, "parsed", None)
-    if isinstance(parsed, dict):
-        return parsed
-    content = getattr(response, "content", None)
-    if isinstance(content, str):
-        try:
-            return json.loads(content)
-        except (ValueError, TypeError):
-            return content
-    return None
-
-
-def _extract_model(response: Any) -> str | None:
-    return getattr(response, "model", None)
-
-
-def _extract_backend(response: Any) -> str | None:
-    backend = getattr(response, "backend", None)
-    if backend:
-        return str(backend)
-    return None
+        out.append({
+            "id": f"{session_id}:{i}",
+            "session_id": session_id,
+            "topic_index": i,
+            "title": extra.get("title", ""),
+            "summary": child.summary,
+            "span_start": span_start,
+            "span_end": span_end,
+            "turn_start": turn_start,
+            "turn_end": turn_end,
+            "keywords": list(extra.get("keywords") or []),
+        })
+    return out

--- a/work_buddy/conversation_observability/summarizer_binding.py
+++ b/work_buddy/conversation_observability/summarizer_binding.py
@@ -1,0 +1,188 @@
+"""conv_obs as the first composition of the summarization framework.
+
+`build_session_summarizer()` returns a `Summarizer` wired with
+`SessionSource × LayeredDisclosureStrategy × DurableSummaryStore`. The
+backwards-compatible `summaries.py` shims use it to preserve the existing
+read/write API (dashboard `/api/chats/<id>/topics`, the
+`conversation_observability_summarize` MCP capability, the sidecar job, the
+`claude_session_summary` context collector).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from work_buddy.summarization import (
+    DiscoveryWindow,
+    Summarizer,
+    SummaryCapability,
+)
+from work_buddy.summarization.strategies import LayeredDisclosureStrategy
+from work_buddy.summarization.stores import DurableSummaryStore
+
+logger = logging.getLogger(__name__)
+
+_NAMESPACE = "conversation_session"
+
+
+# ---------------------------------------------------------------------------
+# SessionSource
+# ---------------------------------------------------------------------------
+
+
+class SessionSource:
+    """`Source` adapter for Claude Code conversation sessions.
+
+    `discover` queries `observed_sessions` for candidates in the window.
+    `render` loads a `ConversationSession`, returns `None` if the session has
+    no spans, else assembles the prompt text from turns.
+
+    The freshness token is the `source_mtime` (stringified) — bumped whenever
+    the underlying JSONL file is rewritten. `token_for(session_id)` exposes
+    the current token so the shim's `summarize_session` can drive the
+    short-circuit freshness check.
+    """
+
+    name = "conversation_session"
+    capabilities = frozenset()  # not BATCHED
+
+    def discover(
+        self, window: DiscoveryWindow,
+    ) -> list[tuple[str, Any]]:
+        from datetime import timedelta
+
+        from work_buddy.conversation_observability.db import get_connection
+
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(days=window.days)
+        ).isoformat()
+
+        conn = get_connection()
+        try:
+            rows = conn.execute(
+                "SELECT session_id, source_mtime FROM observed_sessions "
+                "WHERE observed_at >= ? AND status = 'ok' "
+                "  AND message_count IS NOT NULL AND message_count > 0 "
+                "ORDER BY observed_at DESC",
+                (cutoff,),
+            ).fetchall()
+        finally:
+            conn.close()
+
+        return [(r["session_id"], str(r["source_mtime"])) for r in rows]
+
+    def render(self, session_id: str) -> str | None:
+        try:
+            from work_buddy.sessions.inspector import ConversationSession
+
+            session = ConversationSession(session_id)
+            session._ensure_loaded()
+        except FileNotFoundError:
+            return None
+
+        if not getattr(session, "_span_map", None):
+            return None
+
+        return _build_session_prompt(session)
+
+    def render_batch(self, item_ids: list[str]) -> list[str | None]:
+        # Not BATCHED — not used by the orchestrator. Provided for the
+        # Protocol surface only.
+        return [self.render(iid) for iid in item_ids]
+
+    def token_for(self, session_id: str) -> str | None:
+        """Return the current freshness token for one session, or `None` if
+        the session isn't observed. Used by the `summarize_session` shim to
+        short-circuit on freshness."""
+        from work_buddy.conversation_observability.db import get_connection
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT source_mtime FROM observed_sessions "
+                "WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        if row is None:
+            return None
+        return str(row["source_mtime"])
+
+
+def _build_session_prompt(session: Any) -> str:
+    """Render a session's turns into compact prompt text.
+
+    Strategy mirrors the previous in-tree `_build_user_prompt`: per-turn
+    truncation, total cap. Kept identical so layered-disclosure prompts have
+    the same input distribution.
+    """
+    max_total_chars = 40_000
+    chunks: list[str] = []
+    used = 0
+    for i, turn in enumerate(session.turns):
+        role = turn.get("role", "?")
+        text = (turn.get("text", "") or "")[:4000]
+        tools = turn.get("tools", []) or []
+        line = f"[turn {i} | {role}]"
+        if tools:
+            tool_names = ", ".join(
+                t if isinstance(t, str) else t.get("name", "?")
+                for t in tools
+            )
+            line += f" tools=[{tool_names}]"
+        if text:
+            line += f"\n{text}"
+        chunks.append(line)
+        used += len(line)
+        if used >= max_total_chars:
+            chunks.append(
+                f"[…{len(session.turns) - i - 1} more turns truncated…]"
+            )
+            break
+    return "\n\n".join(chunks)
+
+
+# ---------------------------------------------------------------------------
+# Factory + lazy singleton
+# ---------------------------------------------------------------------------
+
+
+_summarizer_singleton: Summarizer | None = None
+
+
+def build_session_summarizer() -> Summarizer:
+    """Build a fresh `Summarizer` for conversation sessions.
+
+    Tests can call this directly to get an isolated instance (and pair with
+    a monkey-patched DB path). Production callers go through
+    `get_session_summarizer()` for the lazy singleton.
+    """
+    return Summarizer(
+        name="conversation_session",
+        source=SessionSource(),
+        strategy=LayeredDisclosureStrategy(),
+        store=DurableSummaryStore(
+            namespace=_NAMESPACE,
+            selection_version=1,
+            cache_version=1,
+        ),
+    )
+
+
+def get_session_summarizer() -> Summarizer:
+    """Lazy singleton accessor."""
+    global _summarizer_singleton
+    if _summarizer_singleton is None:
+        _summarizer_singleton = build_session_summarizer()
+    return _summarizer_singleton
+
+
+def reset_session_summarizer() -> None:
+    """Drop the lazy singleton. Used by tests that monkey-patch DB paths
+    after the first construction."""
+    global _summarizer_singleton
+    _summarizer_singleton = None

--- a/work_buddy/llm/summarize.py
+++ b/work_buddy/llm/summarize.py
@@ -1,11 +1,22 @@
-"""Structured page/content summarization via LLM.
+"""Structured page/content summarization — thin shims over the framework.
 
-Extracts a ``PageSummary`` from raw text content (webpage, chat transcript,
-document, etc.). Pure fact extraction — no intent classification, no
-hypothesis testing. Results are cached per content hash.
+`PageSummary` and `TypedEntity` are the consumer-facing dataclasses that other
+modules (Chrome triage in particular) import directly. They remain owned by
+this module.
 
-Separate from ``classify.py`` which handles intent classification.
-These are independent tasks that happen to share data sources.
+`summarize` and `summarize_batch` are thin wrappers that delegate prompt /
+schema / parse to `work_buddy.summarization.strategies.FlatExtractionStrategy`
+and adapt the framework's `SummaryNode` back into a `PageSummary`. They
+preserve the previous call signature (including `cache_ttl_minutes`, which
+passes through to `LLMRunner`'s built-in cache — appropriate for these direct
+callers since they do not compose a framework `Store`).
+
+Internal Chrome triage paths go through
+`work_buddy.collectors.chrome_summarizer_binding.summarize_tabs` instead,
+which uses the framework's full composer + `TtlCacheStore` for cache +
+provenance handling.
+
+Separate from `classify.py` which handles intent classification.
 """
 
 from __future__ import annotations
@@ -16,13 +27,14 @@ from typing import Any
 from work_buddy.llm.runner_v2 import LLMRunner
 from work_buddy.llm.tiers import ModelTier
 from work_buddy.logging_config import get_logger
-from work_buddy.prompts import get_prompt
+from work_buddy.summarization.protocol import SummaryNode
+from work_buddy.summarization.strategies import FlatExtractionStrategy
 
 logger = get_logger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Types
+# Consumer-facing dataclasses
 # ---------------------------------------------------------------------------
 
 
@@ -30,122 +42,32 @@ logger = get_logger(__name__)
 class TypedEntity:
     """A named entity extracted from content with type and context."""
 
-    name: str  # e.g., "Max 5x", "Anthropic", "v0.89.0"
-    type: str  # e.g., "product", "organization", "version", "price", "tool", "person", "concept"
-    context: str  # 1 phrase: how this entity appears ("$100/month tier", "deprecated in v3")
+    name: str
+    type: str
+    context: str
 
 
 @dataclass
 class PageSummary:
     """Structured summary of a piece of content.
 
-    Extracted by Haiku from raw text. Cached per URL + content hash.
-    Consumed by agents for activity reconstruction, or fed into
-    classify() for intent matching.
+    Extracted by Haiku from raw text. Consumed by agents for activity
+    reconstruction, or fed into ``classify()`` for intent matching.
     """
 
-    content_summary: str  # 80-word max factual summary
-    entities: list[TypedEntity]  # concrete things mentioned (3-6 items)
-    key_claims: list[str]  # 2-4 specific quotable facts
-    user_intent_speculation: str  # "Speculate as to why the user visited..."
-    user_posture: str  # enum: researching, referencing, evaluating, operating, troubleshooting, contributing, monitoring
+    content_summary: str
+    entities: list[TypedEntity]
+    key_claims: list[str]
+    user_intent_speculation: str
+    user_posture: str
 
-    # Metadata (not from LLM)
-    source_label: str = ""  # display label of the source (e.g., "Claude [claude.ai]")
+    source_label: str = ""
     cached: bool = False
     tokens: dict[str, int] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
-# Schema
-# ---------------------------------------------------------------------------
-
-_SYSTEM_PROMPT = get_prompt("summarize_system")
-
-_SUMMARY_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "properties": {
-        "content_summary": {
-            "type": "string",
-            "description": "80-word max factual summary of what the content contains",
-        },
-        "entities": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string"},
-                    "type": {
-                        "type": "string",
-                        "description": "Entity type: product, tool, library, service, person, organization, version, price, concept, project, file_or_path, other",
-                    },
-                    "context": {
-                        "type": "string",
-                        "description": "1 phrase explaining how this entity appears in the content",
-                    },
-                },
-                "required": ["name", "type", "context"],
-                "additionalProperties": False,
-            },
-            "description": "3-6 named entities mentioned in the content",
-        },
-        "key_claims": {
-            "type": "array",
-            "items": {"type": "string"},
-            "description": "2-4 specific, quotable facts from the content worth remembering",
-        },
-        "user_intent_speculation": {
-            "type": "string",
-            "description": "Speculate as to why the user visited this page and what they might do with this information. This is a best guess, not a known fact.",
-        },
-        "user_posture": {
-            "type": "string",
-            "enum": [
-                "researching",
-                "referencing",
-                "evaluating",
-                "operating",
-                "troubleshooting",
-                "contributing",
-                "monitoring",
-            ],
-            "description": "The user's role relative to this content",
-        },
-    },
-    "required": [
-        "content_summary",
-        "entities",
-        "key_claims",
-        "user_intent_speculation",
-        "user_posture",
-    ],
-    "additionalProperties": False,
-}
-
-# Schema for batch summarization (multiple items in one call)
-_BATCH_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "properties": {
-        "summaries": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "item_index": {"type": "integer"},
-                    **_SUMMARY_SCHEMA["properties"],
-                },
-                "required": ["item_index", *_SUMMARY_SCHEMA["required"]],
-                "additionalProperties": False,
-            },
-        },
-    },
-    "required": ["summaries"],
-    "additionalProperties": False,
-}
-
-
-# ---------------------------------------------------------------------------
-# Public API
+# Public API — thin shims
 # ---------------------------------------------------------------------------
 
 
@@ -157,29 +79,28 @@ def summarize(
     content_hash: str | None = None,
     content_sample: str | None = None,
 ) -> PageSummary:
-    """Summarize a single piece of content into a structured PageSummary.
+    """Summarize a single piece of content into a structured ``PageSummary``.
 
     Args:
-        text: Raw content to summarize (up to ~3KB recommended).
+        text: Raw content to summarize (up to ~5KB is used).
         label: Display label for the content (e.g., "Claude [claude.ai]").
-        cache_ttl_minutes: Cache TTL. Cached by task_id + content hash.
-        content_hash: Hash for cache invalidation (e.g., MD5 of full text).
-        content_sample: ~500 char sample for fuzzy SimHash matching.
+        cache_ttl_minutes: Cache TTL for the underlying ``LLMRunner`` cache.
+        content_hash: Accepted for API compatibility; not currently plumbed
+            to the LLMRunner cache key.
+        content_sample: Accepted for API compatibility; not currently plumbed
+            to the LLMRunner cache key.
 
     Returns:
-        PageSummary with structured fields extracted by Haiku.
+        ``PageSummary`` with structured fields extracted by Haiku.
     """
+    strategy = FlatExtractionStrategy()
     task_id = f"summarize:{label}" if label else "summarize:unknown"
 
-    # content_hash / content_sample parameters are ``run_task``-specific
-    # cache keys; LLMRunner doesn't plumb them through yet. Phase-1
-    # behavior regression: summaries rely on task_id + default cache key.
-    # Restoring explicit hash-keyed caching is a phase-3 follow-up.
     resp = LLMRunner().call(
         tier=ModelTier.FRONTIER_FAST,
-        system=_SYSTEM_PROMPT,
+        system=strategy.system_prompt,
         user=f"## Content: {label}\n\n{text[:5000]}",
-        output_schema=_SUMMARY_SCHEMA,
+        output_schema=strategy.output_schema,
         max_tokens=512,
         cache_ttl_minutes=cache_ttl_minutes,
         trace_id=task_id,
@@ -187,15 +108,20 @@ def summarize(
 
     if resp.is_error():
         logger.error("Summarization failed for %s: %s", label, resp.error)
-        return PageSummary(
-            content_summary=f"Summarization failed: {resp.error}",
-            entities=[], key_claims=[],
-            user_intent_speculation="", user_posture="referencing",
-            source_label=label,
-            tokens={"input": 0, "output": 0},
-        )
+        return _failed_page_summary(label, resp.error or "llm error")
 
-    return _parse_single(resp, label)
+    try:
+        node = strategy.parse(resp.structured_output, resp.content)
+    except Exception as exc:
+        logger.error("Parse failed for %s: %s", label, exc)
+        return _failed_page_summary(label, f"parse error: {exc}")
+
+    return _node_to_page_summary(
+        node,
+        label,
+        cached=resp.cached,
+        tokens={"input": resp.input_tokens, "output": resp.output_tokens},
+    )
 
 
 def summarize_batch(
@@ -205,38 +131,39 @@ def summarize_batch(
 ) -> list[PageSummary]:
     """Summarize multiple items in a single LLM call.
 
-    Each item is a dict with ``text`` and ``label`` keys.
-    More token-efficient than calling summarize() N times (shared
-    system prompt, single API call).
+    Each item is a dict with ``text`` and ``label`` keys. More
+    token-efficient than calling ``summarize()`` N times (shared system
+    prompt, single API call).
 
     Args:
-        items: List of {text: str, label: str} dicts.
-        cache_ttl_minutes: Cache TTL for the batch. Default 0 (individual
-            item caching should be handled by the caller).
+        items: List of ``{text: str, label: str}`` dicts.
+        cache_ttl_minutes: Cache TTL for the batch via ``LLMRunner``'s cache.
 
     Returns:
-        List of PageSummary in the same order as input items.
+        List of ``PageSummary`` aligned with input items.
     """
     if not items:
         return []
 
-    # Build prompt
-    lines = []
-    for i, item in enumerate(items):
-        lines.append(f"## Item {i}: {item.get('label', '')}")
-        lines.append(item.get("text", "")[:3000])
-        lines.append("")
+    strategy = FlatExtractionStrategy()
+    batch_schema = strategy.batch_output_schema or strategy.output_schema
 
-    # Scale max_tokens: ~500 per item (content_summary + entities + claims + intent + posture)
-    # Empirically: single items produce ~270 tokens, but batch overhead is higher
-    max_tokens = max(1024, len(items) * 500 + 200)
+    parts: list[str] = []
+    for i, item in enumerate(items):
+        parts.append(f"## Item {i}: {item.get('label', '')}")
+        parts.append(item.get("text", "")[:3000])
+        parts.append("")
+
+    # Scale max_tokens: ~500 per item (content_summary + entities + claims
+    # + intent + posture). Cap at the tier's reasonable upper bound.
+    max_tokens = min(max(1024, len(items) * 500 + 200), 4096)
 
     resp = LLMRunner().call(
         tier=ModelTier.FRONTIER_FAST,
-        system=_SYSTEM_PROMPT,
-        user="\n".join(lines),
-        output_schema=_BATCH_SCHEMA,
-        max_tokens=min(max_tokens, 4096),
+        system=strategy.system_prompt,
+        user="\n".join(parts),
+        output_schema=batch_schema,
+        max_tokens=max_tokens,
         cache_ttl_minutes=cache_ttl_minutes,
         trace_id="summarize:batch",
     )
@@ -244,76 +171,91 @@ def summarize_batch(
     if resp.is_error():
         logger.error("Batch summarization failed: %s", resp.error)
         return [
-            PageSummary(
-                content_summary=f"Summarization failed: {resp.error}",
-                entities=[], key_claims=[],
-                user_intent_speculation="", user_posture="referencing",
-                source_label=item.get("label", ""),
-                tokens={"input": 0, "output": 0},
-            )
+            _failed_page_summary(item.get("label", ""), resp.error or "llm error")
             for item in items
         ]
 
-    return _parse_batch(resp, items)
-
-
-# ---------------------------------------------------------------------------
-# Parsing helpers
-# ---------------------------------------------------------------------------
-
-
-def _parse_entities(raw: list[dict]) -> list[TypedEntity]:
-    return [
-        TypedEntity(
-            name=e.get("name", ""),
-            type=e.get("type", "other"),
-            context=e.get("context", ""),
+    item_ids = [str(i) for i in range(len(items))]
+    try:
+        nodes = strategy.parse_batch(
+            resp.structured_output, resp.content, item_ids,
         )
-        for e in raw
-    ]
+    except Exception as exc:
+        logger.error("Batch parse failed: %s", exc)
+        return [
+            _failed_page_summary(item.get("label", ""), f"parse error: {exc}")
+            for item in items
+        ]
+
+    per_item_tokens = {
+        "input": resp.input_tokens // max(len(items), 1),
+        "output": resp.output_tokens // max(len(items), 1),
+    }
+
+    out: list[PageSummary] = []
+    for item, node in zip(items, nodes):
+        label = item.get("label", "")
+        if node is None:
+            out.append(_empty_page_summary(label, per_item_tokens))
+        else:
+            out.append(_node_to_page_summary(
+                node, label, cached=resp.cached, tokens=per_item_tokens,
+            ))
+    return out
 
 
-def _parse_single(result: Any, label: str) -> PageSummary:
-    parsed = result.structured_output or {}
+# ---------------------------------------------------------------------------
+# Adapters — SummaryNode -> PageSummary
+# ---------------------------------------------------------------------------
+
+
+def _node_to_page_summary(
+    node: SummaryNode,
+    label: str,
+    *,
+    cached: bool,
+    tokens: dict[str, int],
+) -> PageSummary:
+    extra = node.extra or {}
+    entities: list[TypedEntity] = []
+    for e in extra.get("entities") or []:
+        if isinstance(e, dict):
+            entities.append(TypedEntity(
+                name=str(e.get("name", "")),
+                type=str(e.get("type", "other")),
+                context=str(e.get("context", "")),
+            ))
     return PageSummary(
-        content_summary=parsed.get("content_summary", ""),
-        entities=_parse_entities(parsed.get("entities", [])),
-        key_claims=parsed.get("key_claims", []),
-        user_intent_speculation=parsed.get("user_intent_speculation", ""),
-        user_posture=parsed.get("user_posture", "referencing"),
+        content_summary=node.summary,
+        entities=entities,
+        key_claims=list(extra.get("key_claims") or []),
+        user_intent_speculation=str(extra.get("user_intent_speculation", "")),
+        user_posture=str(extra.get("user_posture", "referencing")),
         source_label=label,
-        cached=result.cached,
-        tokens={"input": result.input_tokens, "output": result.output_tokens},
+        cached=cached,
+        tokens=tokens,
     )
 
 
-def _parse_batch(result: Any, items: list[dict]) -> list[PageSummary]:
-    parsed = result.structured_output or {}
-    raw_summaries = parsed.get("summaries", [])
+def _failed_page_summary(label: str, error: str) -> PageSummary:
+    return PageSummary(
+        content_summary=f"Summarization failed: {error}",
+        entities=[],
+        key_claims=[],
+        user_intent_speculation="",
+        user_posture="referencing",
+        source_label=label,
+        tokens={"input": 0, "output": 0},
+    )
 
-    # Index by item_index for safe lookup
-    by_index: dict[int, dict] = {}
-    for s in raw_summaries:
-        idx = s.get("item_index", -1)
-        by_index[idx] = s
 
-    summaries = []
-    per_item_tokens = {
-        "input": result.input_tokens // max(len(items), 1),
-        "output": result.output_tokens // max(len(items), 1),
-    }
-
-    for i, item in enumerate(items):
-        raw = by_index.get(i, {})
-        summaries.append(PageSummary(
-            content_summary=raw.get("content_summary", ""),
-            entities=_parse_entities(raw.get("entities", [])),
-            key_claims=raw.get("key_claims", []),
-            user_intent_speculation=raw.get("user_intent_speculation", ""),
-            user_posture=raw.get("user_posture", "referencing"),
-            source_label=item.get("label", ""),
-            cached=result.cached,
-            tokens=per_item_tokens,
-        ))
-
-    return summaries
+def _empty_page_summary(label: str, tokens: dict[str, int]) -> PageSummary:
+    return PageSummary(
+        content_summary="",
+        entities=[],
+        key_claims=[],
+        user_intent_speculation="",
+        user_posture="referencing",
+        source_label=label,
+        tokens=tokens,
+    )

--- a/work_buddy/summarization/__init__.py
+++ b/work_buddy/summarization/__init__.py
@@ -1,0 +1,51 @@
+"""Summarization framework — `Summarizer = Source × Strategy × Store`.
+
+Protocol-based composition for content summarization, modeled on the artifact
+system (`Artifact = Storage × Lifecycle × Provenance`). Three pluggable axes
+plus a written-once shared core that handles bounded refresh, staleness
+detection, error isolation, and provenance stamping.
+
+Two consumers today:
+- `work_buddy.conversation_observability` — sessions, layered disclosure,
+  durable version-stamped store.
+- `work_buddy.collectors.chrome_summarizer_binding` — web pages, flat
+  extraction, TTL content-hash cache.
+
+The stored summary is always a `SummaryNode` tree — flat extraction is the
+depth-1 case. This invariant keeps the deferred progressive-disclosure phase
+additive (it adds consumers of the tree, never reshapes it).
+"""
+
+from work_buddy.summarization.protocol import (
+    DiscoveryWindow,
+    IncoherentComposition,
+    LLMCallResult,
+    LLMCaller,
+    Provenance,
+    Source,
+    Store,
+    SummarizationError,
+    SummaryCapability,
+    SummaryNode,
+    SummaryStrategy,
+)
+from work_buddy.summarization.summarizer import RefreshReport, Summarizer
+from work_buddy.summarization.orchestrator import as_caller, run_refresh
+
+__all__ = [
+    "DiscoveryWindow",
+    "IncoherentComposition",
+    "LLMCallResult",
+    "LLMCaller",
+    "Provenance",
+    "RefreshReport",
+    "Source",
+    "Store",
+    "SummarizationError",
+    "SummaryCapability",
+    "SummaryNode",
+    "SummaryStrategy",
+    "Summarizer",
+    "as_caller",
+    "run_refresh",
+]

--- a/work_buddy/summarization/db.py
+++ b/work_buddy/summarization/db.py
@@ -1,0 +1,47 @@
+"""Connection + schema setup for the summarization store.
+
+Mirrors `conversation_observability/db.py`: WAL mode for concurrent readers,
+idempotent schema creation on every connect, config-driven path (override via
+`summarization.db_path` in `config.local.yaml`; default
+`<data_root>/summarization/summarization.db`).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from work_buddy.paths import data_dir
+from work_buddy.summarization.schema import SCHEMA
+
+
+def _default_db_path() -> Path:
+    return data_dir("summarization") / "summarization.db"
+
+
+def db_path(cfg: dict | None = None) -> Path:
+    """Resolve the DB path from config, falling back to the default."""
+    if cfg is None:
+        from work_buddy.config import load_config
+
+        cfg = load_config()
+    explicit = (cfg.get("summarization") or {}).get("db_path")
+    if explicit:
+        return Path(explicit)
+    return _default_db_path()
+
+
+def get_connection(cfg: dict | None = None) -> sqlite3.Connection:
+    """Open (or create) the summarization DB.
+
+    Idempotent: `CREATE TABLE IF NOT EXISTS` re-runs on every connect, so a
+    missing file becomes a populated one transparently. WAL mode allows
+    concurrent readers + a single writer.
+    """
+    path = db_path(cfg)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path), timeout=30)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.executescript(SCHEMA)
+    return conn

--- a/work_buddy/summarization/orchestrator.py
+++ b/work_buddy/summarization/orchestrator.py
@@ -1,0 +1,419 @@
+"""The shared refresh orchestrator + LLM injection seam.
+
+`run_refresh` is the written-once core: discover candidates, filter to stale,
+render each, call the LLM, parse, persist, isolate errors. Bounded by
+`max_items`.
+
+The orchestrator dispatches per-item or batch based on the summarizer's
+`BATCHED` capability — the batch path issues one LLM call for N items.
+
+`as_caller` adapts a legacy bare-callable LLM stub (used by existing conv_obs
+tests) into an `LLMCaller`-conforming object so test stubs need no changes.
+`default_llm_caller` is the production caller wrapping `LLMRunner` at
+`ModelTier.FRONTIER_FAST`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable
+
+from work_buddy.summarization.protocol import (
+    DiscoveryWindow,
+    LLMCallResult,
+    LLMCaller,
+    Provenance,
+    SummarizationError,
+    SummaryCapability,
+    SummaryNode,
+)
+from work_buddy.summarization.summarizer import RefreshReport, Summarizer
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Provenance assembly
+# ---------------------------------------------------------------------------
+
+
+def build_provenance(
+    summarizer: Summarizer,
+    llm_result: LLMCallResult | None,
+    profile: str | None,
+) -> Provenance:
+    """Assemble a `Provenance` from the strategy, the store, and the LLM
+    response. The orchestrator is the only place this is built — provenance
+    is uniform, not a pluggable axis."""
+    return Provenance(
+        model=llm_result.model if llm_result else None,
+        backend=llm_result.backend if llm_result else None,
+        profile=profile,
+        generated_at=Provenance.now_iso(),
+        prompt_version=summarizer.strategy.prompt_version,
+        summary_schema_version=summarizer.strategy.schema_version,
+        selection_version=summarizer.store.selection_version,
+        cache_version=summarizer.store.cache_version,
+    )
+
+
+def build_error_provenance(
+    summarizer: Summarizer,
+    profile: str | None,
+) -> Provenance:
+    """Provenance stamp for a record-error path (no LLM response available)."""
+    return build_provenance(summarizer, None, profile)
+
+
+# ---------------------------------------------------------------------------
+# The refresh core
+# ---------------------------------------------------------------------------
+
+
+def run_refresh(
+    summarizer: Summarizer,
+    *,
+    window: DiscoveryWindow,
+    llm_caller: LLMCaller,
+    profile: str | None = None,
+) -> RefreshReport:
+    """Run a bounded refresh pass over `summarizer`.
+
+    Discover → filter-to-stale (unless `force`) → for each item up to
+    `window.max_items`: render → LLM → parse → save. Errors per-item are
+    caught and recorded; other items continue.
+
+    Dispatches to the batch path when `BATCHED` is in the summarizer's
+    capabilities (source AND strategy must both declare it — enforced by
+    `Summarizer._validate_coherence`).
+    """
+    candidates = summarizer.source.discover(window)
+    if window.force:
+        stale = list(candidates)
+    else:
+        stale = summarizer.store.select_stale(candidates)
+
+    report = RefreshReport(
+        summarizer=summarizer.name,
+        total_candidates=len(candidates),
+        skipped_fresh=len(candidates) - len(stale),
+    )
+
+    # Cap to max_items.
+    stale_capped = stale[: window.max_items] if window.max_items > 0 else stale
+
+    if SummaryCapability.BATCHED in summarizer.capabilities:
+        _run_refresh_batch(summarizer, stale_capped, llm_caller, profile, report)
+    else:
+        _run_refresh_per_item(
+            summarizer, stale_capped, llm_caller, profile, report,
+        )
+
+    return report
+
+
+def _run_refresh_per_item(
+    summarizer: Summarizer,
+    stale: list[tuple[str, Any]],
+    llm_caller: LLMCaller,
+    profile: str | None,
+    report: RefreshReport,
+) -> None:
+    """Per-item refresh path — one LLM call per item."""
+    for item_id, token in stale:
+        try:
+            body = summarizer.source.render(item_id)
+            if body is None:
+                continue
+
+            result = llm_caller.call(
+                system=summarizer.strategy.system_prompt,
+                user=body,
+                output_schema=summarizer.strategy.output_schema,
+                profile=profile,
+                max_tokens=1024,
+                trace_id=f"summarization.{summarizer.name}",
+            )
+
+            if result.is_error():
+                raise SummarizationError(result.error or "llm error")
+
+            node = summarizer.strategy.parse(
+                result.structured_output, result.content,
+            )
+            prov = build_provenance(summarizer, result, profile)
+            summarizer.store.save(item_id, node, prov, token)
+            report.summarized += 1
+        except Exception as exc:
+            report.errored += 1
+            report.errors.append((item_id, str(exc)))
+            try:
+                summarizer.store.record_error(
+                    item_id,
+                    str(exc),
+                    build_error_provenance(summarizer, profile),
+                )
+            except Exception as inner:
+                # Defensive — error-recording itself shouldn't break the pass.
+                logger.warning(
+                    "Failed to record error for %s/%s: %s",
+                    summarizer.name, item_id, inner,
+                )
+
+
+def _run_refresh_batch(
+    summarizer: Summarizer,
+    stale: list[tuple[str, Any]],
+    llm_caller: LLMCaller,
+    profile: str | None,
+    report: RefreshReport,
+) -> None:
+    """Batch refresh path — one LLM call for all stale items.
+
+    Source.render_batch produces per-item prompt texts; the orchestrator
+    labels and concatenates them into one user prompt. Strategy.parse_batch
+    is called once with the response and returns per-item trees aligned with
+    the stale order. Items whose render or parse is `None` are silently
+    skipped (not counted as errors).
+    """
+    if not stale:
+        return
+
+    item_ids = [item_id for item_id, _ in stale]
+    tokens = [token for _, token in stale]
+    rendered = summarizer.source.render_batch(item_ids)
+
+    # Filter to non-None renders. Track index mapping back to the original
+    # stale list so we save the right items.
+    rendered_items: list[tuple[str, Any, str, int]] = []
+    for idx, (iid, tok, body) in enumerate(zip(item_ids, tokens, rendered)):
+        if body is not None:
+            rendered_items.append((iid, tok, body, idx))
+
+    if not rendered_items:
+        return
+
+    # Build the combined user prompt with item markers.
+    parts: list[str] = []
+    for batch_idx, (iid, _tok, body, _orig_idx) in enumerate(rendered_items):
+        parts.append(f"## Item {batch_idx}: {iid}\n{body}")
+    user_prompt = "\n\n".join(parts)
+
+    # Batched strategies expose `batch_output_schema`; fall back to the
+    # single-item schema if a strategy declares BATCHED without one.
+    batch_schema = (
+        getattr(summarizer.strategy, "batch_output_schema", None)
+        or summarizer.strategy.output_schema
+    )
+    try:
+        result = llm_caller.call(
+            system=summarizer.strategy.system_prompt,
+            user=user_prompt,
+            output_schema=batch_schema,
+            profile=profile,
+            max_tokens=4096,
+            trace_id=f"summarization.{summarizer.name}.batch",
+        )
+
+        if result.is_error():
+            raise SummarizationError(result.error or "llm error")
+
+        batch_ids = [iid for iid, _, _, _ in rendered_items]
+        nodes = summarizer.strategy.parse_batch(
+            result.structured_output, result.content, batch_ids,
+        )
+    except Exception as exc:
+        # Whole batch failed → record an error for every item that was sent.
+        for iid, _tok, _body, _idx in rendered_items:
+            report.errored += 1
+            report.errors.append((iid, str(exc)))
+            try:
+                summarizer.store.record_error(
+                    iid,
+                    str(exc),
+                    build_error_provenance(summarizer, profile),
+                )
+            except Exception as inner:
+                logger.warning(
+                    "Failed to record batch error for %s/%s: %s",
+                    summarizer.name, iid, inner,
+                )
+        return
+
+    # Per-item save.
+    prov = build_provenance(summarizer, result, profile)
+    for (iid, token, _body, _orig_idx), node in zip(rendered_items, nodes):
+        if node is None:
+            report.errored += 1
+            report.errors.append((iid, "missing from batch response"))
+            try:
+                summarizer.store.record_error(
+                    iid,
+                    "missing from batch response",
+                    prov,
+                )
+            except Exception:
+                pass
+            continue
+        try:
+            summarizer.store.save(iid, node, prov, token)
+            report.summarized += 1
+        except Exception as exc:
+            report.errored += 1
+            report.errors.append((iid, str(exc)))
+            try:
+                summarizer.store.record_error(iid, str(exc), prov)
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# LLM injection seam
+# ---------------------------------------------------------------------------
+
+
+def as_caller(fn: Callable[..., Any] | None) -> LLMCaller | None:
+    """Adapt a legacy bare-callable LLM stub into an `LLMCaller`.
+
+    Legacy shape (used by existing conv_obs tests):
+        def fn(*, system, user, output_schema=None, profile=None) -> Any
+
+    The return value is normalized: bare dict → `structured_output`;
+    JSON-decodable str → `structured_output` + `content`; arbitrary str →
+    `content`; `LLMResponse`-shaped object → fields read off via `getattr`;
+    `None` → `error="None response"`.
+
+    Returns `None` when `fn` is `None`, letting callers do
+    `as_caller(maybe_fn) or default_llm_caller()`.
+    """
+    if fn is None:
+        return None
+
+    class _Adapter:
+        def call(
+            self,
+            *,
+            system: str,
+            user: str,
+            output_schema: dict[str, Any] | None = None,
+            profile: str | None = None,
+            max_tokens: int | None = None,
+            trace_id: str | None = None,
+        ) -> LLMCallResult:
+            try:
+                resp = fn(
+                    system=system,
+                    user=user,
+                    output_schema=output_schema,
+                    profile=profile,
+                )
+            except Exception as exc:
+                return LLMCallResult(error=str(exc))
+            return _normalize_legacy_response(resp)
+
+    return _Adapter()
+
+
+def _normalize_legacy_response(resp: Any) -> LLMCallResult:
+    """Normalize whatever a legacy `llm_call` stub returned into an
+    `LLMCallResult`.
+
+    Folds in the same logic conv_obs's `_coerce_response` used to do, so
+    existing test stubs (which return bare dicts) work unchanged.
+    """
+    if resp is None:
+        return LLMCallResult(error="None response")
+
+    if isinstance(resp, dict):
+        return LLMCallResult(structured_output=resp)
+
+    if isinstance(resp, str):
+        try:
+            parsed = json.loads(resp)
+            if isinstance(parsed, dict):
+                return LLMCallResult(structured_output=parsed, content=resp)
+        except (ValueError, TypeError):
+            pass
+        return LLMCallResult(content=resp)
+
+    # Response-shaped object.
+    structured = getattr(resp, "structured_output", None)
+    if structured is None:
+        # Legacy `.parsed` attribute (older runner).
+        parsed_attr = getattr(resp, "parsed", None)
+        if isinstance(parsed_attr, dict):
+            structured = parsed_attr
+        elif isinstance(parsed_attr, str):
+            try:
+                maybe = json.loads(parsed_attr)
+                if isinstance(maybe, dict):
+                    structured = maybe
+            except (ValueError, TypeError):
+                pass
+
+    content = getattr(resp, "content", "") or ""
+    model = getattr(resp, "model", None)
+    backend = getattr(resp, "backend", None)
+    error = getattr(resp, "error", None)
+    is_err_method = getattr(resp, "is_error", None)
+    if callable(is_err_method):
+        try:
+            if is_err_method():
+                error = error or "llm error"
+        except Exception:
+            pass
+
+    return LLMCallResult(
+        structured_output=structured if isinstance(structured, dict) else None,
+        content=content,
+        model=model,
+        backend=backend,
+        error=error,
+    )
+
+
+def default_llm_caller() -> LLMCaller:
+    """Production LLM caller wrapping `LLMRunner` at
+    `ModelTier.FRONTIER_FAST`.
+
+    The framework's `Store` is responsible for caching — this caller does NOT
+    pass `cache_ttl_minutes` to `LLMRunner` to avoid double-caching.
+    """
+    from work_buddy.llm.runner_v2 import LLMRunner
+    from work_buddy.llm.tiers import ModelTier
+
+    runner = LLMRunner()
+
+    class _Default:
+        def call(
+            self,
+            *,
+            system: str,
+            user: str,
+            output_schema: dict[str, Any] | None = None,
+            profile: str | None = None,
+            max_tokens: int | None = None,
+            trace_id: str | None = None,
+        ) -> LLMCallResult:
+            try:
+                resp = runner.call(
+                    tier=ModelTier.FRONTIER_FAST,
+                    system=system,
+                    user=user,
+                    output_schema=output_schema,
+                    max_tokens=max_tokens or 1024,
+                    trace_id=trace_id,
+                )
+            except Exception as exc:
+                return LLMCallResult(error=str(exc))
+
+            return LLMCallResult(
+                structured_output=resp.structured_output,
+                content=resp.content,
+                model=resp.model or None,
+                backend=resp.backend or None,
+                error=resp.error if resp.is_error() else None,
+            )
+
+    return _Default()

--- a/work_buddy/summarization/orchestrator.py
+++ b/work_buddy/summarization/orchestrator.py
@@ -310,17 +310,20 @@ def as_caller(fn: Callable[..., Any] | None) -> LLMCaller | None:
                 )
             except Exception as exc:
                 return LLMCallResult(error=str(exc))
-            return _normalize_legacy_response(resp)
+            return _normalize_stub_response(resp)
 
     return _Adapter()
 
 
-def _normalize_legacy_response(resp: Any) -> LLMCallResult:
-    """Normalize whatever a legacy `llm_call` stub returned into an
+def _normalize_stub_response(resp: Any) -> LLMCallResult:
+    """Normalize whatever a bare-callable LLM stub returned into an
     `LLMCallResult`.
 
-    Folds in the same logic conv_obs's `_coerce_response` used to do, so
-    existing test stubs (which return bare dicts) work unchanged.
+    Accepts: bare dict (taken as `structured_output`), JSON-decodable str
+    (`structured_output` + `content`), arbitrary str (`content`),
+    `LLMResponse`-shaped object (fields read via `getattr`), `None`
+    (`error`). This lets test stubs written against `def fn(*, system, user,
+    output_schema, profile) -> dict` plug in via `as_caller`.
     """
     if resp is None:
         return LLMCallResult(error="None response")

--- a/work_buddy/summarization/protocol.py
+++ b/work_buddy/summarization/protocol.py
@@ -257,7 +257,7 @@ class Store(Protocol):
     ) -> None:
         """Record that summarization failed for `item_id` without overwriting
         a prior good result. Implementations flip a status flag and keep the
-        previously-saved tree (if any) loadable via `load`."""
+        prior tree (if any) loadable via `load`."""
         ...
 
 

--- a/work_buddy/summarization/protocol.py
+++ b/work_buddy/summarization/protocol.py
@@ -1,0 +1,310 @@
+"""Protocols, datatypes, and exceptions for the summarization framework.
+
+`Summarizer = Source × Strategy × Store` composition. Three pluggable axes
+conforming to `typing.Protocol`s, plus uniform provenance stamping (assembled
+by the orchestrator from the strategy + store + LLM response — not a
+pluggable axis here, unlike the artifact system where it genuinely varies).
+
+The stored summary is always a `SummaryNode` tree:
+
+- **Flat** extraction = depth-1 (a single root, empty `children`, null
+  `source_ref`).
+- **Layered** disclosure = root + child nodes, each child carrying a
+  `source_ref` pointer to exact source events.
+
+Every node has a `source_ref` slot even though flat extraction never uses it.
+This is load-bearing: it lets the deferred progressive-disclosure phase fold
+in additively (adds *consumers* of the tree, never reshapes the stored row).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Iterable, Protocol, runtime_checkable
+
+
+# ---------------------------------------------------------------------------
+# Datatypes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SummaryNode:
+    """One node in a summary tree — the universal stored shape."""
+
+    summary: str
+    source_ref: Any | None = None
+    children: list["SummaryNode"] = field(default_factory=list)
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def is_leaf(self) -> bool:
+        return not self.children
+
+    def walk(self) -> Iterable[tuple[int, "SummaryNode"]]:
+        """Pre-order traversal yielding `(level, node)`. Root is level 0."""
+        yield 0, self
+        for child in self.children:
+            for sub_level, sub_node in child.walk():
+                yield sub_level + 1, sub_node
+
+
+@dataclass
+class DiscoveryWindow:
+    """Bounds and mode for a discovery pass.
+
+    `days` is advisory — sources that don't have a time dimension (e.g. Chrome
+    tab summarization, where the caller supplies an explicit item set) ignore
+    it. `max_items` caps per-call work; `force` bypasses staleness filtering.
+    """
+
+    days: int = 7
+    max_items: int = 3
+    force: bool = False
+
+
+@dataclass(frozen=True)
+class Provenance:
+    """Uniform provenance stamping, assembled by the orchestrator core.
+
+    `prompt_version` and `summary_schema_version` come from the Strategy;
+    `selection_version` and `cache_version` come from the Store; `model`,
+    `backend`, `profile` are read off the LLM response (or callsite).
+    """
+
+    model: str | None
+    backend: str | None
+    profile: str | None
+    generated_at: str
+    prompt_version: int
+    summary_schema_version: int
+    selection_version: int
+    cache_version: int
+
+    @staticmethod
+    def now_iso() -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+
+class SummaryCapability(str, Enum):
+    """Capabilities declared by the three axes.
+
+    The Summarizer composer validates coherent combinations at construction
+    time (e.g. a `LAYERED` strategy paired with a `PERSISTS_FLAT`-only store
+    is incoherent).
+    """
+
+    # Strategy: output shape
+    LAYERED = "layered"
+    FLAT = "flat"
+
+    # Source + Strategy together: batch path
+    BATCHED = "batched"
+
+    # Store: persistence shape
+    PERSISTS_TREE = "persists_tree"
+    PERSISTS_FLAT = "persists_flat"
+
+    # Store: staleness model
+    VERSION_STAMPED = "version_stamped"
+    TTL_EVICTED = "ttl_evicted"
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class IncoherentComposition(ValueError):
+    """Raised at `Summarizer` construction when the three axes are mismatched.
+
+    Examples: a layered strategy paired with a store that can only persist a
+    flat record; a batched strategy paired with a non-batched source.
+    """
+
+
+class SummarizationError(RuntimeError):
+    """Per-item summarization failure.
+
+    The orchestrator catches this and isolates the failure: the item's row
+    flips to `status='error'`, prior good results are preserved, and other
+    items in the same refresh pass continue.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Axis protocols
+# ---------------------------------------------------------------------------
+
+
+class Source(Protocol):
+    """Domain adapter — enumerates items and renders them to prompt text.
+
+    `render_batch` is only required if `BATCHED` is in `capabilities`; the
+    orchestrator dispatches per-capability. Freshness tokens are opaque to the
+    source — the store stringifies them for staleness comparison.
+    """
+
+    name: str
+    capabilities: frozenset[SummaryCapability]
+
+    def discover(self, window: DiscoveryWindow) -> list[tuple[str, Any]]:
+        """Return `[(item_id, freshness_token), ...]` for candidates."""
+        ...
+
+    def render(self, item_id: str) -> str | None:
+        """Render one item's content into prompt text.
+
+        Return `None` if there is nothing to summarize (e.g. an empty session).
+        The orchestrator treats `None` as a clean skip — no LLM call, no error.
+        """
+        ...
+
+    def render_batch(self, item_ids: list[str]) -> list[str | None]:
+        """Render multiple items at once. Only required if `BATCHED`.
+
+        Returns a list aligned with `item_ids`; each element is prompt text
+        or `None` (skip this item).
+        """
+        ...
+
+
+class SummaryStrategy(Protocol):
+    """Output-shape adapter — owns the prompt, schema, and parse.
+
+    Two flavors:
+    - `LayeredDisclosureStrategy` — tldr + ordered child segments with refs.
+    - `FlatExtractionStrategy` — single root with structured extra fields.
+    """
+
+    name: str
+    prompt_version: int
+    schema_version: int
+    capabilities: frozenset[SummaryCapability]
+    system_prompt: str
+    output_schema: dict[str, Any]
+
+    def parse(
+        self,
+        structured_output: dict[str, Any] | None,
+        raw_content: str,
+    ) -> SummaryNode:
+        """Convert an LLM response into a `SummaryNode` tree.
+
+        Flat strategies return a 1-node tree (root only, empty `children`,
+        null `source_ref`). Layered strategies return root + children, each
+        child carrying a `source_ref`.
+
+        Raise `SummarizationError` on unparseable response; the orchestrator
+        catches and isolates.
+        """
+        ...
+
+    def parse_batch(
+        self,
+        structured_output: dict[str, Any] | None,
+        raw_content: str,
+        item_ids: list[str],
+    ) -> list[SummaryNode | None]:
+        """Parse a batched response into per-item trees. Only if `BATCHED`.
+
+        Returns a list aligned with `item_ids`. An element may be `None` if
+        the LLM omitted that item.
+        """
+        ...
+
+
+@runtime_checkable
+class Store(Protocol):
+    """Persistence + staleness adapter.
+
+    Implementations MUST share one private predicate between `is_fresh` and
+    `select_stale` — failing to compare freshness identically in both paths
+    creates a "looks fresh on save, looks stale on discover" race.
+    """
+
+    name: str
+    capabilities: frozenset[SummaryCapability]
+    selection_version: int
+    cache_version: int
+
+    def is_fresh(self, item_id: str, freshness_token: Any) -> bool: ...
+
+    def select_stale(
+        self,
+        candidates: list[tuple[str, Any]],
+    ) -> list[tuple[str, Any]]:
+        """Filter `candidates` down to those whose stored summaries are
+        missing or stale relative to the candidate's freshness token."""
+        ...
+
+    def save(
+        self,
+        item_id: str,
+        result: SummaryNode,
+        provenance: Provenance,
+        freshness_token: Any,
+    ) -> None: ...
+
+    def load(self, item_id: str) -> SummaryNode | None: ...
+
+    def record_error(
+        self,
+        item_id: str,
+        error: str,
+        provenance: Provenance,
+    ) -> None:
+        """Record that summarization failed for `item_id` without overwriting
+        a prior good result. Implementations flip a status flag and keep the
+        previously-saved tree (if any) loadable via `load`."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# LLM injection seam
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LLMCallResult:
+    """Normalized LLM response, independent of the underlying client.
+
+    The orchestrator needs five things: structured output, raw content, model
+    name, backend name, and an error flag. Anything else is squashed.
+
+    The `as_caller()` adapter (in `orchestrator.py`) wraps legacy
+    bare-dict-returning `llm_call=` stubs (used by existing conv_obs tests)
+    so they keep working without modification.
+    """
+
+    structured_output: dict[str, Any] | None = None
+    content: str = ""
+    model: str | None = None
+    backend: str | None = None
+    error: str | None = None
+
+    def is_error(self) -> bool:
+        return self.error is not None
+
+
+class LLMCaller(Protocol):
+    """One-method LLM call abstraction used by the orchestrator.
+
+    Default implementation wraps `LLMRunner().call(...)` at
+    `ModelTier.FRONTIER_FAST` and reads `.structured_output`. The framework's
+    Store is the one responsible for caching — `LLMCaller.call` does NOT
+    accept `cache_ttl_minutes`; passing it would double-cache.
+    """
+
+    def call(
+        self,
+        *,
+        system: str,
+        user: str,
+        output_schema: dict[str, Any] | None = None,
+        profile: str | None = None,
+        max_tokens: int | None = None,
+        trace_id: str | None = None,
+    ) -> LLMCallResult:
+        ...

--- a/work_buddy/summarization/schema.py
+++ b/work_buddy/summarization/schema.py
@@ -1,0 +1,57 @@
+"""SQL schema for the durable summarization store.
+
+Two tables: `summary_items` (one row per summarized item; provenance + status)
+and `summary_nodes` (the tree itself; adjacency-list with `parent_id` and
+`level`, plus a `source_ref` slot on every node).
+
+The `namespace` column partitions rows so one DB can hold multiple
+compositions (e.g. `conversation_session` and `chrome_page`) without
+collisions on `item_id`.
+
+Foreign-key cascade is NOT enforced via SQLite FKs (off by default). Rows are
+managed by the store's own delete paths.
+"""
+
+from __future__ import annotations
+
+SCHEMA = """\
+CREATE TABLE IF NOT EXISTS summary_items (
+    namespace               TEXT NOT NULL,
+    item_id                 TEXT NOT NULL,
+    freshness_token         TEXT NOT NULL,
+    generated_at            TEXT NOT NULL,
+    model                   TEXT,
+    backend                 TEXT,
+    profile                 TEXT,
+    prompt_version          INTEGER NOT NULL,
+    summary_schema_version  INTEGER NOT NULL,
+    selection_version       INTEGER NOT NULL,
+    cache_version           INTEGER NOT NULL,
+    status                  TEXT NOT NULL DEFAULT 'ok',
+    error                   TEXT,
+    PRIMARY KEY (namespace, item_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_summary_items_namespace
+    ON summary_items(namespace);
+CREATE INDEX IF NOT EXISTS idx_summary_items_generated_at
+    ON summary_items(generated_at);
+
+
+CREATE TABLE IF NOT EXISTS summary_nodes (
+    id          TEXT PRIMARY KEY,            -- "{namespace}:{item_id}:{ordinal}"
+    namespace   TEXT NOT NULL,
+    item_id     TEXT NOT NULL,
+    parent_id   TEXT,                        -- NULL for the root node
+    ordinal     INTEGER NOT NULL,            -- pre-order sibling order
+    level       INTEGER NOT NULL,            -- 0 = root, 1 = child, ...
+    summary     TEXT NOT NULL,
+    source_ref  TEXT,                        -- JSON, nullable, on EVERY node
+    extra_json  TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_summary_nodes_item
+    ON summary_nodes(namespace, item_id, level, ordinal);
+CREATE INDEX IF NOT EXISTS idx_summary_nodes_parent
+    ON summary_nodes(parent_id);
+"""

--- a/work_buddy/summarization/stores.py
+++ b/work_buddy/summarization/stores.py
@@ -1,0 +1,579 @@
+"""The two `Store` implementations.
+
+- `DurableSummaryStore` — version-stamped SQLite persistence of arbitrary-
+  depth `SummaryNode` trees. The conv_obs composition uses this. One DB can
+  hold multiple compositions (partitioned by `namespace`).
+- `TtlCacheStore` — wraps the existing `work_buddy.llm.cache` (content-hash +
+  SimHash + TTL). The Chrome composition uses this. Persists flat or shallow
+  trees opaquely as a JSON blob.
+
+Both share one private staleness predicate per store class so `is_fresh` and
+`select_stale` cannot diverge.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import uuid
+from pathlib import Path
+from typing import Any
+
+from work_buddy.summarization.db import db_path as _default_db_path_fn
+from work_buddy.summarization.db import get_connection
+from work_buddy.summarization.protocol import (
+    Provenance,
+    SummaryCapability,
+    SummaryNode,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ===========================================================================
+# DurableSummaryStore — SQLite, version-stamped, tree-shaped
+# ===========================================================================
+
+
+class DurableSummaryStore:
+    """Durable SQLite store for `SummaryNode` trees.
+
+    Constructed with `(namespace, selection_version, cache_version,
+    db_path?)`. `namespace` partitions rows in `summary_items` /
+    `summary_nodes` so multiple compositions can share one DB file.
+
+    Stale criteria (the shared private predicate `_is_stale_row`):
+    1. No row in `summary_items` for `(namespace, item_id)`.
+    2. Any of the four version ints differs from the configured values.
+    3. The stored `freshness_token` differs from the candidate's token.
+    4. `status != 'ok'`.
+    """
+
+    capabilities = frozenset({
+        SummaryCapability.PERSISTS_TREE,
+        SummaryCapability.VERSION_STAMPED,
+    })
+
+    def __init__(
+        self,
+        namespace: str,
+        *,
+        selection_version: int = 1,
+        cache_version: int = 1,
+        db_path: Path | None = None,
+    ) -> None:
+        self.name = f"durable:{namespace}"
+        self.namespace = namespace
+        self.selection_version = selection_version
+        self.cache_version = cache_version
+        self._db_path_override = db_path
+        # Strategy-side versions are set by the Summarizer composer post
+        # construction via `set_strategy_versions`. Default to 1 so a
+        # standalone store still works for tests; the composer wires real
+        # values from the paired strategy.
+        self._strategy_prompt_version: int = 1
+        self._strategy_schema_version: int = 1
+
+    def set_strategy_versions(
+        self, prompt_version: int, schema_version: int,
+    ) -> None:
+        """Called by the `Summarizer` composer to bridge the strategy's
+        version stamps into the store's staleness check. Without this,
+        bumping a strategy's `prompt_version` wouldn't invalidate stored
+        rows (the store would compare against its default).
+        """
+        self._strategy_prompt_version = prompt_version
+        self._strategy_schema_version = schema_version
+
+    # ---------------------------------------------------------------- helpers
+
+    def _connect(self):
+        if self._db_path_override is not None:
+            return get_connection(cfg={
+                "summarization": {"db_path": str(self._db_path_override)},
+            })
+        return get_connection()
+
+    def _is_stale_row(
+        self,
+        row: Any,
+        current_token: Any,
+    ) -> bool:
+        """Single source of truth for staleness. `row` may be a sqlite3.Row or
+        None (missing). `current_token` is the candidate's freshness token."""
+        if row is None:
+            return True
+        if row["status"] != "ok":
+            return True
+        if (
+            row["prompt_version"] != self._strategy_prompt_version
+            or row["summary_schema_version"]
+            != self._strategy_schema_version
+            or row["selection_version"] != self.selection_version
+            or row["cache_version"] != self.cache_version
+        ):
+            return True
+        return str(row["freshness_token"]) != str(current_token)
+
+    # ---------------------------------------------------------------- staleness
+
+    def is_fresh(self, item_id: str, freshness_token: Any) -> bool:
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT * FROM summary_items "
+                "WHERE namespace = ? AND item_id = ?",
+                (self.namespace, item_id),
+            ).fetchone()
+        finally:
+            conn.close()
+        return not self._is_stale_row(row, freshness_token)
+
+    def select_stale(
+        self,
+        candidates: list[tuple[str, Any]],
+    ) -> list[tuple[str, Any]]:
+        if not candidates:
+            return []
+        conn = self._connect()
+        try:
+            rows_by_id: dict[str, Any] = {}
+            for row in conn.execute(
+                "SELECT * FROM summary_items WHERE namespace = ?",
+                (self.namespace,),
+            ):
+                rows_by_id[row["item_id"]] = row
+        finally:
+            conn.close()
+        return [
+            (iid, token)
+            for iid, token in candidates
+            if self._is_stale_row(rows_by_id.get(iid), token)
+        ]
+
+    # ---------------------------------------------------------------- write
+
+    def save(
+        self,
+        item_id: str,
+        result: SummaryNode,
+        provenance: Provenance,
+        freshness_token: Any,
+    ) -> None:
+        conn = self._connect()
+        try:
+            # Replace any prior nodes for this item.
+            conn.execute(
+                "DELETE FROM summary_nodes "
+                "WHERE namespace = ? AND item_id = ?",
+                (self.namespace, item_id),
+            )
+
+            # Walk tree pre-order, assigning ordinals + parent ids.
+            ordinal_counter = 0
+            stack: list[tuple[SummaryNode, str | None]] = [(result, None)]
+            # We need to insert in DFS pre-order, but a stack reverses children.
+            # Reverse children when pushing so we visit them in original order.
+            inserted_root_id: str | None = None
+            # Use iterative DFS with parent tracking.
+            work: list[tuple[SummaryNode, str | None, int]] = [(result, None, 0)]
+            while work:
+                node, parent_id, level = work.pop(0)
+                node_id = f"{self.namespace}:{item_id}:{ordinal_counter}"
+                if inserted_root_id is None:
+                    inserted_root_id = node_id
+                conn.execute(
+                    "INSERT INTO summary_nodes "
+                    "(id, namespace, item_id, parent_id, ordinal, level, "
+                    " summary, source_ref, extra_json) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        node_id,
+                        self.namespace,
+                        item_id,
+                        parent_id,
+                        ordinal_counter,
+                        level,
+                        node.summary,
+                        json.dumps(node.source_ref, ensure_ascii=False)
+                        if node.source_ref is not None
+                        else None,
+                        json.dumps(node.extra or {}, ensure_ascii=False),
+                    ),
+                )
+                ordinal_counter += 1
+                # Append children (preserves order).
+                for child in node.children:
+                    work.append((child, node_id, level + 1))
+
+            # Upsert the items row.
+            conn.execute(
+                "INSERT INTO summary_items "
+                "(namespace, item_id, freshness_token, generated_at, "
+                " model, backend, profile, prompt_version, "
+                " summary_schema_version, selection_version, cache_version, "
+                " status, error) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'ok', NULL) "
+                "ON CONFLICT(namespace, item_id) DO UPDATE SET "
+                "  freshness_token=excluded.freshness_token, "
+                "  generated_at=excluded.generated_at, "
+                "  model=excluded.model, backend=excluded.backend, "
+                "  profile=excluded.profile, "
+                "  prompt_version=excluded.prompt_version, "
+                "  summary_schema_version=excluded.summary_schema_version, "
+                "  selection_version=excluded.selection_version, "
+                "  cache_version=excluded.cache_version, "
+                "  status='ok', error=NULL",
+                (
+                    self.namespace,
+                    item_id,
+                    str(freshness_token),
+                    provenance.generated_at,
+                    provenance.model,
+                    provenance.backend,
+                    provenance.profile,
+                    provenance.prompt_version,
+                    provenance.summary_schema_version,
+                    provenance.selection_version,
+                    provenance.cache_version,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def record_error(
+        self,
+        item_id: str,
+        error: str,
+        provenance: Provenance,
+    ) -> None:
+        """Stamp an error status without overwriting prior good nodes."""
+        conn = self._connect()
+        try:
+            existing = conn.execute(
+                "SELECT 1 FROM summary_items "
+                "WHERE namespace = ? AND item_id = ?",
+                (self.namespace, item_id),
+            ).fetchone()
+            if existing is None:
+                # No prior row — insert a placeholder error row.
+                conn.execute(
+                    "INSERT INTO summary_items "
+                    "(namespace, item_id, freshness_token, generated_at, "
+                    " model, backend, profile, prompt_version, "
+                    " summary_schema_version, selection_version, "
+                    " cache_version, status, error) "
+                    "VALUES (?, ?, '', ?, ?, ?, ?, ?, ?, ?, ?, 'error', ?)",
+                    (
+                        self.namespace, item_id,
+                        provenance.generated_at,
+                        provenance.model, provenance.backend, provenance.profile,
+                        provenance.prompt_version,
+                        provenance.summary_schema_version,
+                        provenance.selection_version,
+                        provenance.cache_version,
+                        error,
+                    ),
+                )
+            else:
+                # Keep nodes intact; just flip status.
+                conn.execute(
+                    "UPDATE summary_items SET status='error', error=? "
+                    "WHERE namespace = ? AND item_id = ?",
+                    (error, self.namespace, item_id),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+    # ---------------------------------------------------------------- read
+
+    def load(self, item_id: str) -> SummaryNode | None:
+        conn = self._connect()
+        try:
+            item_row = conn.execute(
+                "SELECT * FROM summary_items "
+                "WHERE namespace = ? AND item_id = ?",
+                (self.namespace, item_id),
+            ).fetchone()
+            if item_row is None:
+                return None
+
+            node_rows = list(conn.execute(
+                "SELECT * FROM summary_nodes "
+                "WHERE namespace = ? AND item_id = ? "
+                "ORDER BY ordinal",
+                (self.namespace, item_id),
+            ))
+        finally:
+            conn.close()
+
+        if not node_rows:
+            return None
+
+        # Build node objects and parent map.
+        nodes_by_id: dict[str, SummaryNode] = {}
+        order: list[tuple[str, str | None]] = []
+        for row in node_rows:
+            try:
+                source_ref = (
+                    json.loads(row["source_ref"])
+                    if row["source_ref"] is not None
+                    else None
+                )
+            except (ValueError, TypeError):
+                source_ref = None
+            try:
+                extra = json.loads(row["extra_json"] or "{}")
+            except (ValueError, TypeError):
+                extra = {}
+
+            nodes_by_id[row["id"]] = SummaryNode(
+                summary=row["summary"],
+                source_ref=source_ref,
+                children=[],
+                extra=extra,
+            )
+            order.append((row["id"], row["parent_id"]))
+
+        # Wire up children. The pre-order ordinal guarantees parents appear
+        # before their children.
+        root: SummaryNode | None = None
+        for node_id, parent_id in order:
+            if parent_id is None:
+                root = nodes_by_id[node_id]
+            else:
+                parent = nodes_by_id.get(parent_id)
+                if parent is not None:
+                    parent.children.append(nodes_by_id[node_id])
+
+        return root
+
+    def load_item_meta(self, item_id: str) -> dict[str, Any] | None:
+        """Return the `summary_items` row as a dict (with `topic_count`
+        derived from child nodes). Used by conv_obs shims to assemble the
+        legacy result row without re-loading the whole tree twice."""
+        conn = self._connect()
+        try:
+            item_row = conn.execute(
+                "SELECT * FROM summary_items "
+                "WHERE namespace = ? AND item_id = ?",
+                (self.namespace, item_id),
+            ).fetchone()
+            if item_row is None:
+                return None
+            topic_count = conn.execute(
+                "SELECT COUNT(*) AS n FROM summary_nodes "
+                "WHERE namespace = ? AND item_id = ? AND level = 1",
+                (self.namespace, item_id),
+            ).fetchone()["n"]
+        finally:
+            conn.close()
+        d = dict(item_row)
+        d["topic_count"] = topic_count
+        return d
+
+
+# ===========================================================================
+# TtlCacheStore — wraps work_buddy.llm.cache
+# ===========================================================================
+
+
+class TtlCacheStore:
+    """TTL content-hash cache store, wrapping `work_buddy.llm.cache`.
+
+    Constructed `(namespace, strategy_version_tag, ttl_minutes, *,
+    key_prefix=None)`. The `strategy_version_tag` (e.g. `"chrome_page:v1"`)
+    derives the `system_hash` so that a strategy prompt-version bump cleanly
+    invalidates the cache.
+
+    `freshness_token` shape: a dict `{"hash": <sha256 of content>, "text":
+    <content>}`. The `hash` is the exact-match invalidation key; the `text`
+    is used for `llm.cache`'s SimHash fuzzy fallback. The store stringifies
+    nothing — the token is passed straight through.
+
+    Persists trees opaquely as a JSON blob inside the cache entry's `result`,
+    so it can hold either flat (depth-1) or shallow trees if a layered
+    strategy ever pairs with a TTL store (today it does not — coherence checks
+    require PERSISTS_TREE for LAYERED, and `TtlCacheStore` declares
+    `PERSISTS_TREE` as well to keep the option open).
+    """
+
+    capabilities = frozenset({
+        SummaryCapability.PERSISTS_FLAT,
+        SummaryCapability.PERSISTS_TREE,
+        SummaryCapability.TTL_EVICTED,
+    })
+
+    def __init__(
+        self,
+        namespace: str,
+        *,
+        strategy_version_tag: str,
+        ttl_minutes: int = 30,
+        key_prefix: str | None = None,
+    ) -> None:
+        self.name = f"ttl_cache:{namespace}"
+        self.namespace = namespace
+        self.strategy_version_tag = strategy_version_tag
+        self.ttl_minutes = ttl_minutes
+        # `key_prefix` lets the binding tweak the cache key (e.g. Chrome wants
+        # `summarize_tab:` to preserve its existing cache scheme exactly).
+        self.key_prefix = key_prefix or f"summarization:{namespace}"
+        # TTL stores have their own version dimension — bump if persistence
+        # shape changes incompatibly.
+        self.selection_version = 1
+        self.cache_version = 1
+        self._system_hash = hashlib.sha256(
+            strategy_version_tag.encode("utf-8")
+        ).hexdigest()[:12]
+
+    # ---------------------------------------------------------------- helpers
+
+    def _scoped_key(self, item_id: str) -> str:
+        return f"{self.key_prefix}:{item_id}"
+
+    @staticmethod
+    def _token_parts(freshness_token: Any) -> tuple[str, str | None]:
+        """Extract `(input_hash, input_text)` from a token.
+
+        Accepts a dict `{"hash": ..., "text": ...}` or a bare string (treated
+        as the hash with no fuzzy text available)."""
+        if isinstance(freshness_token, dict):
+            h = str(freshness_token.get("hash", ""))
+            t = freshness_token.get("text")
+            return h, (str(t) if t is not None else None)
+        return str(freshness_token), None
+
+    # ---------------------------------------------------------------- staleness
+
+    def is_fresh(self, item_id: str, freshness_token: Any) -> bool:
+        from work_buddy.llm.cache import get as cache_get
+
+        input_hash, input_text = self._token_parts(freshness_token)
+        entry = cache_get(
+            self._scoped_key(item_id),
+            input_hash=input_hash,
+            input_text=input_text,
+        )
+        if entry is None:
+            return False
+        # Same strategy_version_tag check — system_hash on the entry must
+        # match. `cache_get` already filters via the scoped key, but as a
+        # belt-and-braces invariant check:
+        if entry.get("system_hash") != self._system_hash:
+            return False
+        return True
+
+    def select_stale(
+        self,
+        candidates: list[tuple[str, Any]],
+    ) -> list[tuple[str, Any]]:
+        return [
+            (iid, token)
+            for iid, token in candidates
+            if not self.is_fresh(iid, token)
+        ]
+
+    # ---------------------------------------------------------------- write
+
+    def save(
+        self,
+        item_id: str,
+        result: SummaryNode,
+        provenance: Provenance,
+        freshness_token: Any,
+    ) -> None:
+        from work_buddy.llm.cache import put as cache_put
+
+        input_hash, input_text = self._token_parts(freshness_token)
+        if input_text is None:
+            # Cache requires input_text for SimHash; fall back to a stub.
+            input_text = input_hash or ""
+
+        cache_put(
+            self._scoped_key(item_id),
+            result={
+                "tree": _node_to_jsonable(result),
+                "provenance": _provenance_to_dict(provenance),
+            },
+            input_hash=input_hash,
+            input_text=input_text,
+            system_hash=self._system_hash,
+            system_preview=self.strategy_version_tag,
+            ttl_minutes=self.ttl_minutes,
+            model=provenance.model or "",
+        )
+
+    def record_error(
+        self,
+        item_id: str,
+        error: str,
+        provenance: Provenance,
+    ) -> None:
+        # TTL cache: errors are not persisted. The next call retries.
+        # Log so a debugger can see what happened.
+        logger.warning(
+            "TtlCacheStore[%s] error for %s: %s",
+            self.namespace, item_id, error,
+        )
+
+    # ---------------------------------------------------------------- read
+
+    def load(self, item_id: str) -> SummaryNode | None:
+        from work_buddy.llm.cache import _read_cache  # type: ignore[attr-defined]
+
+        # The cache.get() path requires `input_hash`. For load() in the
+        # framework, we don't have the token at hand. Read the underlying
+        # store directly and reconstruct the node.
+        cache = _read_cache()
+        entry = cache.get(self._scoped_key(item_id))
+        if entry is None:
+            return None
+        if "input_hash" not in entry:
+            return None  # legacy-schema entry — ignore
+        if entry.get("system_hash") != self._system_hash:
+            return None
+        result = entry.get("result") or {}
+        tree = result.get("tree")
+        if not isinstance(tree, dict):
+            return None
+        return _node_from_jsonable(tree)
+
+
+# ---------------------------------------------------------------------------
+# Tree (de)serialization helpers
+# ---------------------------------------------------------------------------
+
+
+def _node_to_jsonable(node: SummaryNode) -> dict[str, Any]:
+    return {
+        "summary": node.summary,
+        "source_ref": node.source_ref,
+        "extra": node.extra or {},
+        "children": [_node_to_jsonable(c) for c in node.children],
+    }
+
+
+def _node_from_jsonable(d: dict[str, Any]) -> SummaryNode:
+    return SummaryNode(
+        summary=str(d.get("summary", "")),
+        source_ref=d.get("source_ref"),
+        children=[_node_from_jsonable(c) for c in (d.get("children") or [])],
+        extra=dict(d.get("extra") or {}),
+    )
+
+
+def _provenance_to_dict(p: Provenance) -> dict[str, Any]:
+    return {
+        "model": p.model,
+        "backend": p.backend,
+        "profile": p.profile,
+        "generated_at": p.generated_at,
+        "prompt_version": p.prompt_version,
+        "summary_schema_version": p.summary_schema_version,
+        "selection_version": p.selection_version,
+        "cache_version": p.cache_version,
+    }

--- a/work_buddy/summarization/strategies.py
+++ b/work_buddy/summarization/strategies.py
@@ -1,0 +1,344 @@
+"""The two `SummaryStrategy` implementations.
+
+- `LayeredDisclosureStrategy` — TL;DR + ordered child topics with source_refs.
+  Used by `conversation_observability`. Prompt and schema moved verbatim from
+  the previous in-tree implementation.
+- `FlatExtractionStrategy` — one root carrying structured extra fields
+  (entities, claims, intent, posture). Used by Chrome tab triage. Prompt and
+  schema moved verbatim from the previous in-tree implementation. Declares
+  `BATCHED` — one LLM call processes N items.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from work_buddy.summarization.protocol import (
+    SummarizationError,
+    SummaryCapability,
+    SummaryNode,
+)
+
+
+# ===========================================================================
+# Layered disclosure — sessions
+# ===========================================================================
+
+
+_LAYERED_SYSTEM_PROMPT = """\
+You are an analyst producing compact, factual recaps of Claude Code
+agent-user conversations. Each conversation is a sequence of turns
+(user + assistant) interleaved with tool calls (Bash, Edit, Write, etc.)
+and tool outputs.
+
+Produce two things:
+1. tldr: ONE sentence (≤25 words) capturing what was accomplished or
+   attempted. No greetings, no commentary on tone. Concrete enough that
+   the user can recognize the session a week from now.
+2. topic_summary: an ordered list of distinct topics within the session.
+   Each topic has a short title (≤8 words), a one-sentence summary, a
+   span_range covering the spans it spans, and 2-5 keywords. Cap at 8
+   topics; merge fine-grained sub-topics rather than emitting many
+   nearly-identical entries.
+
+Be operational. Prefer concrete nouns ("AFK build of conversation
+observability subsystem") over abstract ones ("worked on a feature").
+"""
+
+
+_LAYERED_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["tldr", "topic_summary"],
+    "properties": {
+        "tldr": {"type": "string"},
+        "topic_summary": {
+            "type": "array",
+            "maxItems": 8,
+            "items": {
+                "type": "object",
+                "required": ["title", "summary", "span_range", "keywords"],
+                "properties": {
+                    "title": {"type": "string"},
+                    "summary": {"type": "string"},
+                    "span_range": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": {"type": "integer"},
+                    },
+                    "keywords": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "maxItems": 5,
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+class LayeredDisclosureStrategy:
+    """Layered disclosure — produces tldr root + ordered topic children.
+
+    Each child node carries a `source_ref` pointing back to the input span
+    range, satisfying the "summaries are indexes, not truth" invariant the
+    deferred PD phase relies on.
+    """
+
+    name = "layered_disclosure"
+    prompt_version = 1
+    schema_version = 1
+    capabilities = frozenset({SummaryCapability.LAYERED})
+    system_prompt = _LAYERED_SYSTEM_PROMPT
+    output_schema = _LAYERED_OUTPUT_SCHEMA
+    batch_output_schema: dict[str, Any] | None = None
+
+    def parse(
+        self,
+        structured_output: dict[str, Any] | None,
+        raw_content: str,
+    ) -> SummaryNode:
+        if not isinstance(structured_output, dict):
+            raise SummarizationError(
+                "layered_disclosure.parse: structured_output is not a dict "
+                f"(got {type(structured_output).__name__})"
+            )
+        if "tldr" not in structured_output:
+            raise SummarizationError(
+                "layered_disclosure.parse: missing 'tldr' field"
+            )
+
+        tldr = str(structured_output["tldr"])
+        topics = structured_output.get("topic_summary") or []
+
+        children: list[SummaryNode] = []
+        for i, topic in enumerate(topics):
+            if not isinstance(topic, dict):
+                continue
+            span_range = topic.get("span_range") or [None, None]
+            span_start = span_range[0] if len(span_range) >= 1 else None
+            span_end = span_range[1] if len(span_range) >= 2 else None
+
+            source_ref: dict[str, Any] | None = None
+            if isinstance(span_start, int) and isinstance(span_end, int):
+                source_ref = {
+                    "span_start": span_start,
+                    "span_end": span_end,
+                }
+
+            children.append(SummaryNode(
+                summary=str(topic.get("summary", "")),
+                source_ref=source_ref,
+                children=[],
+                extra={
+                    "title": str(topic.get("title", "")),
+                    "topic_index": i,
+                    "keywords": list(topic.get("keywords") or []),
+                    "span_start": span_start,
+                    "span_end": span_end,
+                },
+            ))
+
+        return SummaryNode(
+            summary=tldr,
+            source_ref=None,
+            children=children,
+            extra={},
+        )
+
+
+# ===========================================================================
+# Flat extraction — web pages / Chrome tabs
+# ===========================================================================
+
+
+_FLAT_SYSTEM_PROMPT = """\
+You extract structured facts from web pages, chats, and similar content.
+Produce a compact factual summary plus typed entities, key claims, an
+intent guess, and the user's posture toward the content.
+
+Be operational and factual. No greetings, no opinions. Quote concrete
+nouns and numbers where they appear.
+"""
+
+
+_FLAT_SUMMARY_PROPERTIES: dict[str, Any] = {
+    "content_summary": {
+        "type": "string",
+        "description": "80-word max factual summary of what the content contains",
+    },
+    "entities": {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "type": {
+                    "type": "string",
+                    "description": (
+                        "Entity type: product, tool, library, service, person, "
+                        "organization, version, price, concept, project, "
+                        "file_or_path, other"
+                    ),
+                },
+                "context": {
+                    "type": "string",
+                    "description": (
+                        "1 phrase explaining how this entity appears in the "
+                        "content"
+                    ),
+                },
+            },
+            "required": ["name", "type", "context"],
+            "additionalProperties": False,
+        },
+        "description": "3-6 named entities mentioned in the content",
+    },
+    "key_claims": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "2-4 specific, quotable facts from the content worth remembering",
+    },
+    "user_intent_speculation": {
+        "type": "string",
+        "description": (
+            "Speculate as to why the user visited this page and what they "
+            "might do with this information. This is a best guess, not a "
+            "known fact."
+        ),
+    },
+    "user_posture": {
+        "type": "string",
+        "enum": [
+            "researching",
+            "referencing",
+            "evaluating",
+            "operating",
+            "troubleshooting",
+            "contributing",
+            "monitoring",
+        ],
+        "description": "The user's role relative to this content",
+    },
+}
+
+_FLAT_REQUIRED: list[str] = [
+    "content_summary",
+    "entities",
+    "key_claims",
+    "user_intent_speculation",
+    "user_posture",
+]
+
+
+_FLAT_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": _FLAT_SUMMARY_PROPERTIES,
+    "required": _FLAT_REQUIRED,
+    "additionalProperties": False,
+}
+
+
+_FLAT_BATCH_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "summaries": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "item_index": {"type": "integer"},
+                    **_FLAT_SUMMARY_PROPERTIES,
+                },
+                "required": ["item_index", *_FLAT_REQUIRED],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["summaries"],
+    "additionalProperties": False,
+}
+
+
+class FlatExtractionStrategy:
+    """Flat extraction — one root node carrying structured fields.
+
+    Produces a depth-1 `SummaryNode`: `summary=content_summary`, empty
+    `children`, null `source_ref`, and an `extra` dict with `entities`,
+    `key_claims`, `user_intent_speculation`, `user_posture`. The `PageSummary`
+    consumer-facing dataclass is rebuilt by an adapter near the Chrome
+    binding.
+
+    Declares `BATCHED` — the orchestrator's batch path issues one LLM call
+    per N items via `parse_batch`.
+    """
+
+    name = "flat_extraction"
+    prompt_version = 1
+    schema_version = 1
+    capabilities = frozenset({SummaryCapability.FLAT, SummaryCapability.BATCHED})
+    system_prompt = _FLAT_SYSTEM_PROMPT
+    output_schema = _FLAT_OUTPUT_SCHEMA
+    batch_output_schema = _FLAT_BATCH_SCHEMA
+
+    def parse(
+        self,
+        structured_output: dict[str, Any] | None,
+        raw_content: str,
+    ) -> SummaryNode:
+        if not isinstance(structured_output, dict):
+            raise SummarizationError(
+                "flat_extraction.parse: structured_output is not a dict "
+                f"(got {type(structured_output).__name__})"
+            )
+        if "content_summary" not in structured_output:
+            raise SummarizationError(
+                "flat_extraction.parse: missing 'content_summary' field"
+            )
+
+        return SummaryNode(
+            summary=str(structured_output.get("content_summary", "")),
+            source_ref=None,
+            children=[],
+            extra={
+                "entities": list(structured_output.get("entities") or []),
+                "key_claims": list(structured_output.get("key_claims") or []),
+                "user_intent_speculation": str(
+                    structured_output.get("user_intent_speculation", "")
+                ),
+                "user_posture": str(
+                    structured_output.get("user_posture", "referencing")
+                ),
+            },
+        )
+
+    def parse_batch(
+        self,
+        structured_output: dict[str, Any] | None,
+        raw_content: str,
+        item_ids: list[str],
+    ) -> list[SummaryNode | None]:
+        if not isinstance(structured_output, dict):
+            raise SummarizationError(
+                "flat_extraction.parse_batch: structured_output is not a dict"
+            )
+        raw = structured_output.get("summaries") or []
+        by_index: dict[int, dict[str, Any]] = {}
+        for entry in raw:
+            if isinstance(entry, dict):
+                idx = entry.get("item_index")
+                if isinstance(idx, int):
+                    by_index[idx] = entry
+
+        results: list[SummaryNode | None] = []
+        for i, _item_id in enumerate(item_ids):
+            entry = by_index.get(i)
+            if entry is None:
+                results.append(None)
+                continue
+            try:
+                results.append(self.parse(entry, ""))
+            except SummarizationError:
+                results.append(None)
+        return results

--- a/work_buddy/summarization/summarizer.py
+++ b/work_buddy/summarization/summarizer.py
@@ -1,0 +1,225 @@
+"""The `Summarizer` composer — combines `Source × Strategy × Store`.
+
+Construction validates coherence (see `_validate_coherence`). The public
+methods are thin wrappers over the orchestrator's `run_refresh` and
+single-item `refresh_one` paths.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+from work_buddy.summarization.protocol import (
+    DiscoveryWindow,
+    IncoherentComposition,
+    LLMCaller,
+    Provenance,
+    Source,
+    Store,
+    SummaryCapability,
+    SummaryNode,
+    SummaryStrategy,
+)
+
+
+@dataclass
+class RefreshReport:
+    """Outcome of a refresh pass — what was summarized, what was skipped, what
+    errored. Mirrors the existing conv_obs `refresh_session_summaries` result
+    dict so shims can map directly onto it."""
+
+    summarizer: str
+    summarized: int = 0
+    skipped_fresh: int = 0
+    errored: int = 0
+    total_candidates: int = 0
+    errors: list[tuple[str, str]] = field(default_factory=list)
+
+    def to_legacy_dict(self) -> dict:
+        """Map to the conv_obs legacy result shape."""
+        return {
+            "summarized": self.summarized,
+            "skipped_fresh": self.skipped_fresh,
+            "errored": self.errored,
+            "total_candidates": self.total_candidates,
+        }
+
+
+@dataclass
+class Summarizer:
+    """The composer. `Source × Strategy × Store`, with construction-time
+    coherence checks."""
+
+    name: str
+    source: Source
+    strategy: SummaryStrategy
+    store: Store
+
+    def __post_init__(self) -> None:
+        self._validate_coherence()
+        # Initial sync — see `_sync_strategy_versions`.
+        self._sync_strategy_versions()
+
+    def _sync_strategy_versions(self) -> None:
+        """Bridge the strategy's current prompt/schema versions into the
+        store so its staleness check evaluates against them.
+
+        Re-called at the start of every `refresh` / `refresh_one` so that
+        test-time monkeypatches of `Strategy.prompt_version` are picked up
+        (the store would otherwise be stuck with the values from
+        construction).
+        """
+        setter = getattr(self.store, "set_strategy_versions", None)
+        if callable(setter):
+            setter(
+                self.strategy.prompt_version,
+                self.strategy.schema_version,
+            )
+
+    @property
+    def capabilities(self) -> frozenset[SummaryCapability]:
+        return (
+            self.source.capabilities
+            | self.strategy.capabilities
+            | self.store.capabilities
+        )
+
+    def _validate_coherence(self) -> None:
+        s_caps = self.strategy.capabilities
+        st_caps = self.store.capabilities
+        src_caps = self.source.capabilities
+
+        # LAYERED strategy requires a tree-capable store.
+        if (
+            SummaryCapability.LAYERED in s_caps
+            and SummaryCapability.PERSISTS_TREE not in st_caps
+        ):
+            raise IncoherentComposition(
+                f"Summarizer {self.name!r}: layered strategy "
+                f"{self.strategy.name!r} requires a PERSISTS_TREE store, but "
+                f"{self.store.name!r} declares "
+                f"{sorted(c.value for c in st_caps)}."
+            )
+
+        # FLAT strategy requires a store that can persist at least depth-1.
+        if SummaryCapability.FLAT in s_caps and not (
+            SummaryCapability.PERSISTS_FLAT in st_caps
+            or SummaryCapability.PERSISTS_TREE in st_caps
+        ):
+            raise IncoherentComposition(
+                f"Summarizer {self.name!r}: flat strategy "
+                f"{self.strategy.name!r} requires a store declaring "
+                f"PERSISTS_FLAT or PERSISTS_TREE, but {self.store.name!r} "
+                f"declares {sorted(c.value for c in st_caps)}."
+            )
+
+        # BATCHED is all-or-nothing across source and strategy.
+        s_batched = SummaryCapability.BATCHED in s_caps
+        src_batched = SummaryCapability.BATCHED in src_caps
+        if s_batched != src_batched:
+            raise IncoherentComposition(
+                f"Summarizer {self.name!r}: BATCHED must be declared on both "
+                f"source and strategy or neither; "
+                f"strategy={s_batched}, source={src_batched}."
+            )
+
+    # ---------------------------------------------------------------- refresh
+
+    def refresh(
+        self,
+        *,
+        days: int = 7,
+        max_items: int = 3,
+        force: bool = False,
+        llm_caller: LLMCaller | None = None,
+        profile: str | None = None,
+    ) -> RefreshReport:
+        """Run a bounded refresh pass."""
+        from work_buddy.summarization.orchestrator import (
+            default_llm_caller,
+            run_refresh,
+        )
+
+        self._sync_strategy_versions()
+        window = DiscoveryWindow(days=days, max_items=max_items, force=force)
+        caller = llm_caller if llm_caller is not None else default_llm_caller()
+        return run_refresh(
+            self, window=window, llm_caller=caller, profile=profile,
+        )
+
+    def refresh_one(
+        self,
+        item_id: str,
+        *,
+        force: bool = False,
+        freshness_token: object | None = None,
+        llm_caller: LLMCaller | None = None,
+        profile: str | None = None,
+    ) -> SummaryNode | None:
+        """Refresh a single item by id (regardless of any discovery window).
+
+        Short-circuits when `force=False` AND a `freshness_token` is provided
+        AND `store.is_fresh(item_id, token)` returns True — in which case the
+        previously-saved tree is returned via `store.load`. Otherwise renders,
+        calls the LLM, parses, and persists.
+
+        On render returning `None` (e.g. an empty session) → returns `None`.
+        On LLM or parse error → `store.record_error` is called and `None` is
+        returned. Caller can distinguish "no content" from "error" via the
+        store's record (status flag).
+        """
+        from work_buddy.summarization.orchestrator import (
+            build_error_provenance,
+            build_provenance,
+            default_llm_caller,
+        )
+
+        self._sync_strategy_versions()
+
+        if not force and freshness_token is not None:
+            if self.store.is_fresh(item_id, freshness_token):
+                return self.store.load(item_id)
+
+        body = self.source.render(item_id)
+        if body is None:
+            return None
+
+        caller = llm_caller if llm_caller is not None else default_llm_caller()
+        result = caller.call(
+            system=self.strategy.system_prompt,
+            user=body,
+            output_schema=self.strategy.output_schema,
+            profile=profile,
+            max_tokens=1024,
+            trace_id=f"summarization.{self.name}",
+        )
+
+        if result.is_error():
+            self.store.record_error(
+                item_id,
+                result.error or "llm error",
+                build_error_provenance(self, profile),
+            )
+            return None
+
+        try:
+            node = self.strategy.parse(result.structured_output, result.content)
+        except Exception as exc:
+            self.store.record_error(
+                item_id,
+                f"parse error: {exc}",
+                build_provenance(self, result, profile),
+            )
+            return None
+
+        prov = build_provenance(self, result, profile)
+        token = freshness_token if freshness_token is not None else prov.generated_at
+        self.store.save(item_id, node, prov, token)
+        return node
+
+    # ---------------------------------------------------------------- read
+
+    def get(self, item_id: str) -> SummaryNode | None:
+        """Load the stored summary tree for `item_id`, or `None`."""
+        return self.store.load(item_id)

--- a/work_buddy/summarization/summarizer.py
+++ b/work_buddy/summarization/summarizer.py
@@ -36,8 +36,9 @@ class RefreshReport:
     total_candidates: int = 0
     errors: list[tuple[str, str]] = field(default_factory=list)
 
-    def to_legacy_dict(self) -> dict:
-        """Map to the conv_obs legacy result shape."""
+    def to_op_dict(self) -> dict:
+        """Map to the `conversation_observability_summarize` op's result shape
+        — the four-key dict consumers (sidecar job, MCP capability) expect."""
         return {
             "summarized": self.summarized,
             "skipped_fresh": self.skipped_fresh,
@@ -161,7 +162,7 @@ class Summarizer:
 
         Short-circuits when `force=False` AND a `freshness_token` is provided
         AND `store.is_fresh(item_id, token)` returns True — in which case the
-        previously-saved tree is returned via `store.load`. Otherwise renders,
+        stored tree is returned via `store.load`. Otherwise renders,
         calls the LLM, parses, and persists.
 
         On render returning `None` (e.g. an empty session) → returns `None`.


### PR DESCRIPTION
## Summary

- A protocol-based summarization framework (`work_buddy/summarization/`): `Summarizer = Source × Strategy × Store` composition + shared `run_refresh` orchestrator (per-item and batch paths) + construction-time coherence checks + uniform `Provenance` stamping + `LLMCaller` injection seam (`as_caller` adapts legacy bare-callable stubs unchanged). Modeled on the artifact system.
- Two real compositions migrated onto it: **conversation_session** (`SessionSource × LayeredDisclosureStrategy × DurableSummaryStore`, version-stamped SQLite at `<data_root>/summarization/summarization.db`) and **chrome_page** (`ChromeSource × FlatExtractionStrategy × TtlCacheStore`, wraps the existing `llm.cache` preserving the `summarize_tab:` cache-key + content-hash + SimHash + 30-min TTL scheme exactly).
- The conv_obs read API is preserved via thin shims in `summaries.py` (dashboard `/api/chats/<id>/topics`, `conversation_observability_summary_get`, `claude_session_summary` collector, `/wb-session-identify` tldr triage all see unchanged dict shapes). Old `session_summaries` / `topic_summaries` SQLite tables remain *defined* in `schema.py` for rollback only — no longer written. Removal is a deliberate follow-up after a shakeout period.
- `llm/summarize.py` is now thin shims over `FlatExtractionStrategy` — `_SYSTEM_PROMPT` / `_SUMMARY_SCHEMA` / `_BATCH_SCHEMA` / per-shape parse helpers all deleted; one source of truth for the flat-extraction prompt/schema/parse. `PageSummary` / `TypedEntity` stay verbatim as consumer-facing dataclasses. `summarize` / `summarize_batch` keep their public signatures and `cache_ttl_minutes` pass-through.

The stored summary is always a `SummaryNode` tree — flat extraction is the depth-1 case; layered disclosure carries children with `source_ref` pointers. Every node has a `source_ref` slot. This is the structural invariant that lets the deferred progressive-disclosure phase (IR-indexed summary search, coarse→fine retrieval funnel, `/wb-session-identify` rework) fold in additively with zero schema migration.

Doc updates: new `architecture/summarization-framework` knowledge unit + `architecture/conversation-observability` updated to reflect that summaries now live in `summarization.db` + CLAUDE.md domain map.

## Test plan

- [ ] `pytest tests/unit/test_summarization_framework.py tests/unit/test_summarization_store.py tests/unit/test_chrome_summarization.py tests/unit/test_conversation_observability_summaries.py tests/unit/test_llm_summarize_shims.py -q` — should show **76 passed**.
- [ ] `pytest tests/unit/ -k "chrome or session or summar or pipeline or llm" -q` — broader sweep, also green on the committed state.
- [ ] Live verification (already confirmed in dev): the `conversation-observability-summarize` sidecar cron fires every 2h and populates `summarization.db`; `conversation_observability_summary_get` for any recently observed session returns a row with `tldr` + `topics` in the legacy shape; the dashboard `/api/chats/<id>/topics` endpoint renders unchanged.
- [ ] Chrome triage: a tab-triage pass produces `PageSummary` results and reuses cache entries on a second pass with unchanged content.

## Deferred follow-ups (explicitly out of scope)

- Drop the unused `session_summaries` / `topic_summaries` `CREATE TABLE` blocks from `conversation_observability/schema.py` after ~a week of new-store shakeout.
- Progressive-disclosure phase 2: generic `summary` IR source over `summary_nodes`, coarse→fine retrieval funnel, `/wb-session-identify` rework, a unified depth/drill navigation contract across the four existing drill-down mechanisms.
- Sidecar job `feature_gated:` frontmatter is inert — tracked separately as task `t-b7d1b6ac`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)