### PR TITLE
feat(search): Phase 3a — drill-handler registry + structured find op

### DIFF
--- a/knowledge/store/search.md
+++ b/knowledge/store/search.md
@@ -1,0 +1,34 @@
+---
+name: Search
+kind: concept
+description: Universal IR search verb (`find`) plus the markdown-formatted twin (`context_search`). Search any indexed source — conversations, summaries, knowledge units, Chrome tabs, task notes, documents, projects — with optional per-source drill.
+scope: system
+tags:
+- search
+- ir
+- retrieval
+- find
+aliases:
+- universal search
+- find anything
+- ir surface
+parents: []
+---
+
+Search surface for work-buddy. Two ops at the agent-facing layer:
+
+- **`find`** — structured-returning universal verb. Returns a `list[dict]` for plain ranking, or the funnel shape (`stage1_hits` + `candidate_items` + `drilled`) when `drill=True`. Use when downstream code needs to *act on* the structured hits (chain into `drill_tree`, aggregate per-item, etc.).
+- **`context_search`** — markdown-formatted twin. Same underlying IR engine; emits human-readable markdown. Use for human-eyeball reads.
+
+Both delegate to `work_buddy.ir.search.search` for the actual ranking. Sources are pluggable: `conversation`, `summary`, `chrome`, `task_note`, `docs`, `projects`. A source with a registered drill handler (see `work_buddy.summarization.drill_registry`) participates in the `drill=True` per-item drill stage; sources without one get an empty `drilled` block.
+
+## Children
+
+- [find](search/find) — structured search op
+- [walk](search/walk) — universal tree navigation alias (see also [disclosure/drill_tree](disclosure/drill_tree))
+
+## Related
+
+- [context_search](context/context_search) — markdown twin
+- [summary_search](summarization/summary_search) — pre-find compatible alias, `find(source="summary", drill=True)` equivalent
+- [drill_tree](disclosure/drill_tree) — canonical tree navigation (walk's underlying op)

--- a/knowledge/store/search/find.md
+++ b/knowledge/store/search/find.md
@@ -1,0 +1,81 @@
+---
+name: Find
+kind: capability
+description: Structured IR search across any indexed source. Returns a plain list of hits, or — when `drill=True` — the funnel shape (`stage1_hits` + `candidate_items` + `drilled`). Subsumes `summary_search` (which remains as an alias).
+capability_name: find
+category: search
+parameters:
+  query:
+    type: str
+    description: Natural-language query string.
+    required: true
+  source:
+    type: str
+    description: 'Filter by source name: ''conversation'', ''summary'', ''chrome'', ''task_note'', ''docs'', ''projects''. Omit for cross-source search.'
+    required: false
+  scope:
+    type: str
+    description: 'Doc-id prefix filter (source-specific). conversation: a session_id. summary: a namespace (the funnel appends the trailing '':'' automatically).'
+    required: false
+  drill:
+    type: bool
+    description: When True, run a per-source drill handler against the top items. Returns the funnel shape `{stage1_hits, candidate_items, drilled}`. Default False (returns the plain IR hit list).
+    required: false
+  top_k:
+    type: int
+    description: Stage-1 result cap (default 10).
+    required: false
+  method:
+    type: str
+    description: '''keyword'', ''semantic'', ''keyword,semantic'' (default), or ''substring''. ''substring'' is solo-only.'
+    required: false
+  recency:
+    type: bool
+    description: Apply recency bias (default per config; pass False for time-insensitive ranking).
+    required: false
+  drill_top_k:
+    type: int
+    description: When drilling, how many distinct items to drill (default 5).
+    required: false
+  drill_per_item_top_k:
+    type: int
+    description: When drilling, how many raw-span hits per item (default 5).
+    required: false
+op: op.wb.find
+schema_version: wb-capability/v1
+tags:
+- search
+- ir
+- retrieval
+- find
+- progressive-disclosure
+aliases:
+- search anything
+- find content
+- universal search
+- ir search structured
+parents:
+- search
+---
+
+Universal structured IR search. Two return modes:
+
+- **`drill=False`** (default) — returns `list[dict]` mirroring `ir.search.search`'s raw output. Each hit has `doc_id`, `score`, `source`, `display_text`, `metadata`. Use this when you just want ranked hits.
+- **`drill=True`** — returns the funnel-shape dict: `{query, scope, stage1_hits, candidate_items, drilled, error?}`. `stage1_hits` are per-node hits with `drill_node_id` ready to hand to `walk` / `drill_tree`. `candidate_items` are per-item aggregates (best score across hits in the same item). `drilled` maps `item_id` to the per-source drill handler's output (e.g., for `source="summary"` and namespace `conversation_session`, this is a `session_search` result).
+
+## When to reach for this vs. related tools
+
+- Use **`find`** when downstream code needs the structured hits — chaining into `walk` / `drill_tree`, computing aggregates, building UI lists, etc.
+- Use **`context_search`** when you want markdown-formatted output for human eyeballs. Same underlying engine.
+- Use **`summary_search`** for back-compat code that depends on the funnel-shape return; it's now an alias for `find(source="summary", drill=True)`.
+- Use **`walk`** (or **`drill_tree`**) when you already have a node id and want to navigate by id, not by query.
+
+## Sources with drill handlers today
+
+- **`summary`** — drill dispatches by namespace (`conversation_session` → `session_search`). Other namespaces return `None`; the funnel still emits the coarse hits.
+
+Sources without a registered drill handler get an empty `drilled` block and a DEBUG log on `drill=True`. Register a new handler via `work_buddy.summarization.drill_registry.register_drill_handler(source, handler)`.
+
+## Requires the IR index
+
+Run `ir_index(action="build", source=...)` if a source's index is cold. The `summary`, `conversation`, and `task_note` sources are kept fresh by sidecar crons.

--- a/tests/unit/test_drill_registry.py
+++ b/tests/unit/test_drill_registry.py
@@ -1,0 +1,116 @@
+"""Tests for `work_buddy.summarization.drill_registry`.
+
+Registry-level behavior: register / lookup / reset / default registrations.
+The `summary` source handler's namespace-dispatch behavior is exercised by
+`test_summarization_funnel.py` since that's its concrete use-site.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from work_buddy.summarization.drill_registry import (
+    _register_defaults,
+    _reset_for_tests,
+    available_sources,
+    get_drill_handler,
+    register_drill_handler,
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_defaults_after_test():
+    """Every test that touches the registry must leave it in the
+    default-registered state so test order doesn't matter."""
+    yield
+    _reset_for_tests()
+    _register_defaults()
+
+
+def test_default_registry_contains_summary():
+    assert "summary" in available_sources()
+    handler = get_drill_handler("summary")
+    assert handler is not None
+    assert callable(handler)
+
+
+def test_unknown_source_returns_none():
+    assert get_drill_handler("nonsense_source_xyz") is None
+
+
+def test_register_drill_handler_stores_handler():
+    def _fake(ns, iid, query, method, top_k):
+        return {"called": True}
+
+    register_drill_handler("custom_source", _fake)
+    assert "custom_source" in available_sources()
+    assert get_drill_handler("custom_source") is _fake
+    out = get_drill_handler("custom_source")("ns", "id", "q", "k,s", 5)
+    assert out == {"called": True}
+
+
+def test_register_drill_handler_is_idempotent_by_name():
+    """Re-registering the same source overwrites the previous handler."""
+
+    def _first(ns, iid, query, method, top_k):
+        return "first"
+
+    def _second(ns, iid, query, method, top_k):
+        return "second"
+
+    register_drill_handler("rotating_source", _first)
+    register_drill_handler("rotating_source", _second)
+    result = get_drill_handler("rotating_source")("n", "i", "q", "k", 5)
+    assert result == "second"
+
+
+def test_reset_for_tests_clears_registry():
+    register_drill_handler("ephemeral", lambda *a, **k: None)
+    assert "ephemeral" in available_sources()
+    _reset_for_tests()
+    assert available_sources() == []
+
+
+def test_register_defaults_restores_summary_handler():
+    _reset_for_tests()
+    assert get_drill_handler("summary") is None
+    _register_defaults()
+    assert get_drill_handler("summary") is not None
+
+
+def test_summary_handler_dispatches_conversation_session(monkeypatch):
+    """The registered `summary`-source handler routes
+    conversation_session to session_search via the namespace dispatcher."""
+    from work_buddy.sessions import inspector
+
+    calls: list[dict] = []
+
+    def fake_session_search(
+        session_id, query, method="keyword,semantic", top_k=5,
+    ):
+        calls.append({
+            "session_id": session_id, "query": query,
+            "method": method, "top_k": top_k,
+        })
+        return {"hits": []}
+
+    monkeypatch.setattr(inspector, "session_search", fake_session_search)
+
+    handler = get_drill_handler("summary")
+    result = handler(
+        "conversation_session", "sess-x", "the query",
+        "keyword,semantic", 7,
+    )
+    assert calls == [{
+        "session_id": "sess-x", "query": "the query",
+        "method": "keyword,semantic", "top_k": 7,
+    }]
+    assert result == {"hits": []}
+
+
+def test_summary_handler_returns_none_for_unknown_namespace():
+    handler = get_drill_handler("summary")
+    result = handler(
+        "unknown_namespace", "id", "q", "keyword", 5,
+    )
+    assert result is None

--- a/tests/unit/test_find_op.py
+++ b/tests/unit/test_find_op.py
@@ -1,0 +1,269 @@
+"""Tests for `work_buddy.mcp_server.ops.search_ops.find_op`.
+
+The structured-returning universal search verb. Two return modes:
+- `drill=False` -> plain `list[dict]` from `ir.search.search`.
+- `drill=True` -> funnel-shape dict, with per-source drill handler lookup.
+
+Parity with `summary_search` is required for `source="summary"`,
+`drill=True` callers — that's how Phase 3a keeps the back-compat alias
+honest.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from work_buddy.mcp_server.ops.search_ops import find_op
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _hit(
+    source: str,
+    doc_id: str,
+    *,
+    namespace: str = "",
+    item_id: str = "",
+    score: float = 0.5,
+    title: str = "",
+    summary: str = "",
+    ordinal: int = 0,
+    level: int = 1,
+) -> dict[str, Any]:
+    """Build a fake ir.search.search result row."""
+    return {
+        "doc_id": doc_id,
+        "score": score,
+        "source": source,
+        "display_text": summary,
+        "metadata": {
+            "namespace": namespace,
+            "item_id": item_id,
+            "level": level,
+            "ordinal": ordinal,
+            "extra": {"title": title},
+        },
+    }
+
+
+@pytest.fixture
+def patch_ir_search(monkeypatch):
+    """Return a helper that installs a fake `ir.search.search` for the
+    duration of the test."""
+    def _install(fake):
+        import work_buddy.ir.search as ir_search_mod
+
+        monkeypatch.setattr(ir_search_mod, "search", fake)
+
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# drill=False — pass-through list shape
+# ---------------------------------------------------------------------------
+
+
+def test_find_drill_false_returns_raw_ir_list(patch_ir_search):
+    hits = [_hit("conversation", "c:1", score=0.9)]
+
+    def fake_ir(query, **kw):
+        return hits
+
+    patch_ir_search(fake_ir)
+    out = find_op("anything", source="conversation")
+    assert out == hits  # raw passthrough, no funnel reshaping
+
+
+def test_find_drill_false_forwards_all_args(patch_ir_search):
+    captured: dict[str, Any] = {}
+
+    def fake_ir(query, **kw):
+        captured["query"] = query
+        captured.update(kw)
+        return []
+
+    patch_ir_search(fake_ir)
+    find_op(
+        "q", source="docs", scope="x:", top_k=5,
+        method="semantic", recency=False,
+    )
+    assert captured["query"] == "q"
+    assert captured["source"] == "docs"
+    assert captured["scope"] == "x:"
+    assert captured["top_k"] == 5
+    assert captured["method"] == "semantic"
+    assert captured["recency"] is False
+
+
+def test_find_drill_false_propagates_error_string(patch_ir_search):
+    def fake_ir(query, **kw):
+        return "Embedding service unavailable."
+
+    patch_ir_search(fake_ir)
+    out = find_op("q", source="conversation")
+    assert isinstance(out, str)
+    assert "unavailable" in out
+
+
+# ---------------------------------------------------------------------------
+# drill=True, source="summary" — parity with summary_search
+# ---------------------------------------------------------------------------
+
+
+def test_find_drill_true_summary_returns_funnel_shape(patch_ir_search):
+    """source='summary' + drill=True should route through the funnel and
+    return the same dict shape as `summary_search` does directly."""
+    hits = [_hit(
+        "summary", "conversation_session:s1:n0",
+        namespace="conversation_session", item_id="s1",
+        score=0.8, title="root",
+    )]
+
+    def fake_ir(query, **kw):
+        return hits
+
+    patch_ir_search(fake_ir)
+    # Stub out the drill handler so we don't try to load real sessions.
+    from work_buddy.summarization import drill_registry
+
+    drill_registry.register_drill_handler(
+        "summary",
+        lambda ns, iid, q, m, k: {"stub": iid},
+    )
+    try:
+        out = find_op("q", source="summary", drill=True)
+    finally:
+        drill_registry._reset_for_tests()
+        drill_registry._register_defaults()
+
+    assert isinstance(out, dict)
+    assert set(out.keys()) >= {
+        "query", "scope", "stage1_hits", "candidate_items", "drilled",
+    }
+    assert len(out["stage1_hits"]) == 1
+    assert out["stage1_hits"][0]["item_id"] == "s1"
+    assert out["candidate_items"][0]["item_id"] == "s1"
+    assert out["drilled"] == {"s1": {"stub": "s1"}}
+
+
+def test_find_drill_true_source_none_routes_to_summary(patch_ir_search):
+    """source=None + drill=True falls through to the summary funnel for
+    back-compat with `summary_search` semantics (which has no source
+    arg)."""
+    def fake_ir(query, **kw):
+        # The funnel always sets source="summary" — verify.
+        assert kw.get("source") == "summary"
+        return []
+
+    patch_ir_search(fake_ir)
+    out = find_op("q", drill=True)
+    assert isinstance(out, dict)
+    assert out["stage1_hits"] == []
+
+
+# ---------------------------------------------------------------------------
+# drill=True, non-summary source
+# ---------------------------------------------------------------------------
+
+
+def test_find_drill_true_unregistered_source_silently_skips_drill(
+    patch_ir_search,
+):
+    """A source without a registered drill handler should produce stage1
+    hits + candidate items but an empty `drilled` map. No exception, no
+    surprise."""
+    hits = [
+        _hit("docs", "docs:a", namespace="docs", item_id="docs:a",
+             score=0.7, title="doc-a"),
+        _hit("docs", "docs:b", namespace="docs", item_id="docs:b",
+             score=0.4, title="doc-b"),
+    ]
+
+    def fake_ir(query, **kw):
+        return hits
+
+    patch_ir_search(fake_ir)
+    out = find_op("q", source="docs", drill=True)
+
+    assert isinstance(out, dict)
+    assert len(out["stage1_hits"]) == 2
+    assert len(out["candidate_items"]) == 2
+    assert out["candidate_items"][0]["best_score"] == 0.7  # ranked
+    assert out["drilled"] == {}  # no handler -> empty
+
+
+def test_find_drill_true_with_registered_non_summary_handler(patch_ir_search):
+    """A non-summary source with a registered handler should populate
+    `drilled`."""
+    from work_buddy.summarization import drill_registry
+
+    hits = [
+        _hit("chrome", "chrome:tab1", namespace="chrome", item_id="tab1",
+             score=0.6, title="Tab 1"),
+        _hit("chrome", "chrome:tab2", namespace="chrome", item_id="tab2",
+             score=0.5, title="Tab 2"),
+    ]
+
+    def fake_ir(query, **kw):
+        return hits
+
+    patch_ir_search(fake_ir)
+
+    calls: list[tuple] = []
+
+    def chrome_handler(ns, iid, query, method, top_k):
+        calls.append((ns, iid))
+        return {"drilled_content": iid}
+
+    drill_registry.register_drill_handler("chrome", chrome_handler)
+    try:
+        out = find_op("q", source="chrome", drill=True)
+    finally:
+        drill_registry._reset_for_tests()
+        drill_registry._register_defaults()
+
+    assert out["drilled"] == {
+        "tab1": {"drilled_content": "tab1"},
+        "tab2": {"drilled_content": "tab2"},
+    }
+    assert set(c[1] for c in calls) == {"tab1", "tab2"}
+
+
+def test_find_drill_true_error_string_from_ir_returns_error_dict(
+    patch_ir_search,
+):
+    def fake_ir(query, **kw):
+        return "Embedding service unavailable."
+
+    patch_ir_search(fake_ir)
+    out = find_op("q", source="docs", drill=True)
+    assert isinstance(out, dict)
+    assert out["stage1_hits"] == []
+    assert "unavailable" in out["error"]
+
+
+def test_find_drill_true_unexpected_ir_return_yields_error(patch_ir_search):
+    def fake_ir(query, **kw):
+        return {"unexpected": "shape"}
+
+    patch_ir_search(fake_ir)
+    out = find_op("q", source="docs", drill=True)
+    assert "error" in out
+    assert "unexpected" in out["error"]
+
+
+# ---------------------------------------------------------------------------
+# Op registration
+# ---------------------------------------------------------------------------
+
+
+def test_find_op_is_registered():
+    """The module-level _register() side effect should have bound the op."""
+    from work_buddy.mcp_server.op_registry import get_op
+
+    assert get_op("op.wb.find") is not None

--- a/work_buddy/mcp_server/ops/search_ops.py
+++ b/work_buddy/mcp_server/ops/search_ops.py
@@ -1,0 +1,208 @@
+"""Search-domain ops.
+
+`find` is the structured-returning universal IR search verb. Returns a
+plain `list[dict]` when `drill=False` (mirroring `ir.search.search`'s
+output) or the funnel-shaped dict (`stage1_hits` + `candidate_items` +
+`drilled`) when `drill=True`. Sources with a registered drill handler
+(see `work_buddy.summarization.drill_registry`) get per-hit drill; sources
+without one get an empty `drilled` block.
+
+`context_search` is the markdown-formatted twin (see
+`work_buddy.mcp_server.ops.context_ops`). The two ops share the same
+underlying IR engine but emit different return shapes for different
+consumers.
+
+Lazy imports inside the callables to avoid pulling backends into the
+gateway boot path.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from work_buddy.mcp_server.op_registry import register_op
+
+logger = logging.getLogger(__name__)
+
+
+def find_op(
+    query: str,
+    *,
+    source: str | None = None,
+    scope: str | None = None,
+    drill: bool = False,
+    top_k: int = 10,
+    method: str = "keyword,semantic",
+    recency: bool | None = None,
+    drill_top_k: int = 5,
+    drill_per_item_top_k: int = 5,
+) -> Any:
+    """Structured IR search across any indexed source.
+
+    Args:
+        query: Natural-language query string.
+        source: Filter by source name (``"conversation"``, ``"summary"``,
+            ``"chrome"``, ``"task_note"``, ``"docs"``, ``"projects"``).
+            Omit for cross-source search.
+        scope: Doc-id prefix filter (source-specific). For
+            ``source="conversation"``, a ``session_id``. For
+            ``source="summary"``, a ``namespace`` (the funnel appends
+            the trailing ``:`` automatically).
+        drill: When True, after stage-1 ranking, run a per-source drill
+            handler against the top items. Returns the funnel-shape dict
+            (``stage1_hits`` + ``candidate_items`` + ``drilled``).
+        top_k: Stage-1 cap (default 10).
+        method: ``"keyword"``, ``"semantic"``, ``"keyword,semantic"`` or
+            ``"substring"``. ``"substring"`` is solo-only.
+        recency: Apply recency bias (default per config; pass False for
+            time-insensitive ranking).
+        drill_top_k: When drilling, how many distinct items to drill
+            (default 5).
+        drill_per_item_top_k: When drilling, how many raw-span hits per
+            item (default 5).
+
+    Returns:
+        - ``list[dict]`` when ``drill=False`` — the raw IR hit list from
+          ``ir.search.search`` (each dict has ``doc_id``, ``score``,
+          ``source``, ``display_text``, ``metadata``).
+        - ``dict`` when ``drill=True`` — the funnel shape
+          (``{query, scope, stage1_hits, candidate_items, drilled}``).
+          On error, ``{stage1_hits: [], candidate_items: [], drilled: {},
+          error: "..."}``.
+        - ``str`` (error string) when ``drill=False`` and IR returns one
+          (e.g. embedding service unavailable).
+    """
+    from work_buddy.ir.search import search as ir_search
+
+    if not drill:
+        return ir_search(
+            query,
+            top_k=top_k,
+            source=source,
+            scope=scope,
+            method=method,
+            recency=recency,
+        )
+
+    # drill=True — route through the funnel shape with per-source drill
+    # handler lookup.
+    from work_buddy.summarization.drill_registry import get_drill_handler
+    from work_buddy.summarization.funnel import summary_search
+
+    # For the `summary` source, the existing funnel shape is exactly right.
+    # Funnel internally consults the registry for the `summary` handler.
+    if source == "summary" or source is None:
+        return summary_search(
+            query,
+            scope=scope,
+            top_k=top_k,
+            drill=True,
+            drill_top_k=drill_top_k,
+            drill_per_item_top_k=drill_per_item_top_k,
+            method=method,
+        )
+
+    # For non-summary sources, run a generic funnel-shape: stage-1 IR,
+    # aggregate, run drill handler if registered (else empty drilled).
+    out: dict[str, Any] = {
+        "query": query,
+        "scope": scope,
+        "stage1_hits": [],
+        "candidate_items": [],
+        "drilled": {},
+    }
+    raw = ir_search(
+        query,
+        top_k=top_k,
+        source=source,
+        scope=scope,
+        method=method,
+        recency=recency,
+    )
+    if isinstance(raw, str):
+        out["error"] = raw
+        return out
+    if not isinstance(raw, list):
+        out["error"] = f"unexpected ir.search return: {type(raw).__name__}"
+        return out
+
+    # The non-summary stage1 shape mirrors summary stage1 where applicable;
+    # fields not present in the source's metadata are simply omitted.
+    stage1: list[dict[str, Any]] = []
+    by_item: dict[tuple[str, str], dict[str, Any]] = {}
+    for r in raw:
+        meta = r.get("metadata") or {}
+        # Non-summary sources may not have `namespace` / `item_id`; fall
+        # back to the source name and `doc_id` so aggregation still works
+        # per-doc rather than crashing.
+        ns = meta.get("namespace") or source or ""
+        item_id = meta.get("item_id") or r.get("doc_id") or ""
+        if not item_id:
+            continue
+        entry = {
+            "doc_id": r.get("doc_id"),
+            "namespace": ns,
+            "item_id": item_id,
+            "title": meta.get("title") or "",
+            "summary": r.get("display_text") or "",
+            "score": r.get("score", 0.0),
+            "metadata": meta,
+        }
+        stage1.append(entry)
+        key = (ns, item_id)
+        agg = by_item.get(key)
+        if agg is None:
+            agg = {
+                "namespace": ns,
+                "item_id": item_id,
+                "best_score": entry["score"],
+                "n_hits": 0,
+                "top_titles": [],
+            }
+            by_item[key] = agg
+        agg["n_hits"] += 1
+        if entry["score"] > agg["best_score"]:
+            agg["best_score"] = entry["score"]
+        if entry["title"] and entry["title"] not in agg["top_titles"]:
+            if len(agg["top_titles"]) < 3:
+                agg["top_titles"].append(entry["title"])
+    out["stage1_hits"] = stage1
+    out["candidate_items"] = sorted(
+        by_item.values(), key=lambda a: a["best_score"], reverse=True,
+    )
+
+    handler = get_drill_handler(source) if source else None
+    if handler is not None:
+        drilled: dict[str, Any] = {}
+        for cand in out["candidate_items"][:drill_top_k]:
+            res = handler(
+                cand["namespace"],
+                cand["item_id"],
+                query,
+                method,
+                drill_per_item_top_k,
+            )
+            drilled[cand["item_id"]] = res
+        out["drilled"] = drilled
+    else:
+        logger.debug(
+            "find(drill=True) — no drill handler registered for source %r",
+            source,
+        )
+
+    return out
+
+
+def _register() -> None:
+    # ``replace=True`` so a registry reload (via the importlib.reload path
+    # in ``op_registry.load_builtin_ops``) re-binds the op cleanly rather
+    # than crashing on the already-registered name. Pytest's test
+    # collection triggers this path when one test directly imports an op
+    # module and a later test calls ``load_builtin_ops`` — without
+    # ``replace=True`` the reload re-runs this ``_register()`` and the
+    # duplicate-registration check fires.
+    register_op("op.wb.find", find_op, replace=True)
+
+
+_register()

--- a/work_buddy/summarization/drill_registry.py
+++ b/work_buddy/summarization/drill_registry.py
@@ -1,0 +1,84 @@
+"""Per-source drill-handler registry for the unified search funnel.
+
+Phase 2 (PR #131) shipped the `summary_search` funnel with a single
+`_default_drill_handler` hardcoded to the `summary` source. This registry
+generalizes that pattern: any IR source can register its own drill handler
+that takes a top-ranked hit and returns the source-specific raw content
+(e.g. for the `summary` source, the handler routes by `namespace` to
+`session_search` per-session for `conversation_session`).
+
+Pattern mirrors `work_buddy/disclosure/registry.py` — lazy factory under
+`_register_defaults()` so importing this module does not pull in heavy
+backends; the actual handler module is imported only on first use.
+
+The registry is keyed by **IR source name** (`"summary"`, `"conversation"`,
+`"chrome"`, ...), not by `namespace`. The `summary` source's handler
+performs its own namespace dispatch internally — that dispatch was the
+original `_default_drill_handler` and now lives at
+`work_buddy.summarization.funnel._summary_namespace_drill_dispatch`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+# Drill handler signature (legacy summary-funnel shape, preserved):
+#   (namespace, item_id, query, method, top_k) -> Any
+#
+# `namespace` is the summary namespace at call time (always equal to the
+# source name for non-`summary` sources, since they have no internal
+# namespace concept — for those, the handler can ignore it).
+DrillHandler = Callable[[str, str, str, str, int], Any]
+
+
+_HANDLERS: dict[str, DrillHandler] = {}
+
+
+def register_drill_handler(source: str, handler: DrillHandler) -> None:
+    """Register a drill handler for an IR source. Idempotent by name."""
+    _HANDLERS[source] = handler
+
+
+def get_drill_handler(source: str) -> DrillHandler | None:
+    """Return the handler for `source`, or `None` if unregistered."""
+    return _HANDLERS.get(source)
+
+
+def available_sources() -> list[str]:
+    """Return the list of sources with a registered drill handler, sorted."""
+    return sorted(_HANDLERS.keys())
+
+
+def _reset_for_tests() -> None:
+    """Clear the registry. Test-only — never call from production code."""
+    _HANDLERS.clear()
+
+
+# ---------------------------------------------------------------------------
+# Default registrations
+# ---------------------------------------------------------------------------
+
+
+def _register_defaults() -> None:
+    """Register the built-in drill handlers. Lazy-imported handler bodies
+    avoid pulling backends into the import path until first use."""
+
+    def _summary_handler(
+        namespace: str,
+        item_id: str,
+        query: str,
+        method: str,
+        top_k: int,
+    ) -> Any:
+        from work_buddy.summarization.funnel import (
+            _summary_namespace_drill_dispatch,
+        )
+
+        return _summary_namespace_drill_dispatch(
+            namespace, item_id, query, method, top_k,
+        )
+
+    register_drill_handler("summary", _summary_handler)
+
+
+_register_defaults()

--- a/work_buddy/summarization/funnel.py
+++ b/work_buddy/summarization/funnel.py
@@ -8,10 +8,11 @@ Two stages:
    `namespace` + `item_id` of its parent summarized item, so candidates can
    be ranked by best-summary-score per item.
 2. **Fine** (optional) — for each top candidate, drill into its raw source.
-   Today this dispatches to `session_search(session_id=item_id, query=...)`
-   for the `conversation_session` namespace. Other namespaces (Chrome page,
-   future doc/event-stream summarizers) can plug a custom drill handler in
-   later — the funnel itself stays the same shape.
+   The drill handler is resolved via `work_buddy.summarization.drill_registry`
+   (keyed by IR source name). The built-in `summary`-source handler
+   dispatches by `namespace` — `conversation_session` routes to
+   `session_search`, other namespaces have no drill (returns `None`),
+   the funnel still surfaces the coarse hits.
 
 The shape of the return preserves both views: per-node summary hits (useful
 for "find the topic about X") and per-item aggregates (useful for "which
@@ -31,18 +32,18 @@ logger = logging.getLogger(__name__)
 DrillHandler = Callable[[str, str, str, str, int], Any]
 
 
-def _default_drill_handler(
+def _summary_namespace_drill_dispatch(
     namespace: str,
     item_id: str,
     query: str,
     method: str,
     top_k: int,
 ) -> Any:
-    """Dispatch the drill stage based on namespace.
+    """Internal namespace dispatcher for the `summary` source's drill handler.
 
     `conversation_session` -> `session_search`. Other namespaces have no
-    registered drill today (returns `None` to indicate "no drill available
-    for this domain"); the funnel still surfaces the coarse hits.
+    registered drill (returns `None` to indicate "no drill available for
+    this domain"); the funnel still surfaces the coarse hits.
     """
     if namespace == "conversation_session":
         from work_buddy.sessions.inspector import session_search
@@ -62,6 +63,24 @@ def _default_drill_handler(
             return None
         return result
     return None
+
+
+def _default_drill_handler(
+    namespace: str,
+    item_id: str,
+    query: str,
+    method: str,
+    top_k: int,
+) -> Any:
+    """Back-compat shim — the original namespace dispatcher.
+
+    Preserved for tests and any out-of-tree consumer that imports it
+    directly. Routes through the new namespace dispatcher so behavior
+    is identical to the pre-registry version.
+    """
+    return _summary_namespace_drill_dispatch(
+        namespace, item_id, query, method, top_k,
+    )
 
 
 def summary_search(
@@ -94,7 +113,9 @@ def summary_search(
             (`"keyword"`, `"semantic"`, or `"keyword,semantic"`).
         ir_search_fn: Override for tests — defaults to `ir.search.search`.
         drill_handler: Override the per-namespace drill dispatcher; defaults
-            to one that routes `conversation_session` to `session_search`.
+            to the handler registered under the `summary` source in
+            `work_buddy.summarization.drill_registry`. Passing this
+            override bypasses the registry entirely (useful for tests).
 
     Returns a dict with three keys (always present, may be empty):
 
@@ -119,7 +140,15 @@ def summary_search(
 
         ir_search_fn = _ir_search
     if drill_handler is None:
-        drill_handler = _default_drill_handler
+        # Lazy resolve from the registry so tests that swap registry state
+        # see their override; falls back to the legacy namespace dispatcher
+        # if the registry is empty (e.g. after _reset_for_tests with no
+        # re-registration).
+        from work_buddy.summarization.drill_registry import get_drill_handler
+
+        drill_handler = (
+            get_drill_handler("summary") or _summary_namespace_drill_dispatch
+        )
 
     out: dict[str, Any] = {
         "query": query,


### PR DESCRIPTION
## Summary

Phase 3a of the search/navigate-surface cohesion refactor (task t-bbefceef). Generalizes the per-namespace drill handler that lived inside `summary_search` (PR #131) into a per-source registry, and introduces a new structured-returning `find` op that subsumes the funnel shape.

- **`work_buddy/summarization/drill_registry.py`** (new) — mirrors `disclosure/registry.py`. Lazy-import `_register_defaults()` registers the `summary` source's namespace dispatcher (`conversation_session` → `session_search`).
- **`work_buddy/summarization/funnel.py`** — funnel resolves its drill handler via the registry; the legacy `_default_drill_handler` is preserved as a back-compat shim. `drill_handler=` test override unchanged.
- **`work_buddy/mcp_server/ops/search_ops.py`** (new) — `find_op` registers `op.wb.find`. Returns `list[dict]` (raw IR hits) when `drill=False`, or the funnel shape (`stage1_hits` + `candidate_items` + `drilled`) when `drill=True`. Non-summary sources with a registered drill handler get per-item drill; sources without one get an empty `drilled` block.
- **`knowledge/store/search.md`** + **`knowledge/store/search/find.md`** (new) — capability declaration following PR #131's frontmatter pattern.
- **Tests** — `test_drill_registry.py` (registry semantics) + `test_find_op.py` (both return modes, error propagation, op registration).

**Non-breaking.** Every existing import path (`summary_search`, the funnel shape, `_default_drill_handler`) is preserved. The `context_search` markdown twin is untouched.

## Test plan

- [x] `conda run -n work-buddy python -m pytest tests/unit/test_drill_registry.py tests/unit/test_find_op.py tests/unit/test_summarization_funnel.py tests/unit/test_disclosure.py tests/unit/test_summarization_framework.py tests/unit/test_summarization_store.py tests/unit/test_conversation_observability_summaries.py tests/unit/test_ir_summary_source.py -q` — 116 tests pass clean.
- [x] `capability_loader.load_declared_capabilities()` returns the new `find` capability with its callable bound.
- [ ] **Restart MCP server** (or `Ctrl+R` / `/mcp`) so `op.wb.find` is registered — `mcp_registry_reload` does NOT pick up new op names.
- [ ] After restart: `mcp__work-buddy__wb_search("find")` returns the capability schema; `mcp__work-buddy__wb_run("find", {"query": "summarization framework", "source": "summary", "drill": true})` returns the funnel-shape dict.
- [ ] Verify `mcp__work-buddy__wb_run("summary_search", {"query": "..."})` still returns byte-equivalent output to pre-merge (registry-backed dispatcher now, but visible behavior unchanged).

## Context

This is the first of four stacked PRs implementing Phase 3 of the disclosure / search cohesion design ([PHASE-3-DISCLOSURE-COHESION.md from c456fb06](https://github.com/KadenMc/work-buddy/blob/c456fb06/PHASE-3-DISCLOSURE-COHESION.md)). Phase 3b will migrate `query_session_summary`'s consumers via a `legacy_row_adapter` + register `session_summary_get`. Phase 3c will introduce a `walk` alias for `drill_tree`. Phase 3d (optional/stretch) adds a `KnowledgeIRSource` so `find(source="knowledge")` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)