### PR TITLE
chore: durable-surfaces cleanup — stage labels + legacy_* renames

### DIFF
--- a/knowledge/store/conversation_observability/conversation_observability_summary_get.md
+++ b/knowledge/store/conversation_observability/conversation_observability_summary_get.md
@@ -26,6 +26,6 @@ parents:
 - conversation_observability
 ---
 
-**Deprecated alias of [`session_summary_get`](../observability/session_summary_get).** Both names currently bind to the same Python callable (`legacy_row_from_session_id`); the long namespace prefix is preserved as a back-compat alias. Reach for `session_summary_get` in new code.
+**Alias of [`session_summary_get`](session_summary_get).** Both names bind to the same Python callable (`session_summary_row`); the long namespace prefix is preserved for back-compat. Reach for `session_summary_get` in new code.
 
-Returns the legacy row dict: `{session_id, tldr, topic_count, generated_at, model, profile, backend, prompt_version, summary_schema_version, selection_version, cache_version, status, error, topics: [...]}`. For the topic-tree alone, an agent can also use `drill_tree(domain="summary", node_id=f"conversation_session:{sid}", depth="summary")` — that's the canonical agent-facing path for navigating summary trees.
+Returns the row dict: `{session_id, tldr, topic_count, generated_at, model, profile, backend, prompt_version, summary_schema_version, selection_version, cache_version, status, error, topics: [...]}`. For the topic-tree alone, an agent can also use `drill_tree(domain="summary", node_id=f"conversation_session:{sid}", depth="summary")` — that's the canonical agent-facing path for navigating summary trees.

--- a/tests/unit/test_dashboard_chat_topics_endpoint.py
+++ b/tests/unit/test_dashboard_chat_topics_endpoint.py
@@ -1,13 +1,13 @@
 """Snapshot regression tests for `GET /api/chats/<sid>/topics`.
 
-Added as a gating test for Phase 3b's consumer migration: locks the JSON
-shape of the topics endpoint so the dashboard cannot silently drift when
-the underlying call path changes from `query_session_summary` to
-`legacy_row_from_session_id`.
+Locks the JSON shape the dashboard's topics endpoint emits. The
+endpoint composes its response from a Python adapter; this test
+asserts the response keys + value types so a refactor of the adapter
+cannot silently change what the frontend sees.
 
 The test seeds a deterministic fixture summary directly into a tmp
 `summarization.db`, monkey-patches `db_path()`, and verifies the
-endpoint emits a byte-equivalent JSON response.
+endpoint emits the expected JSON shape.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_find_op.py
+++ b/tests/unit/test_find_op.py
@@ -4,9 +4,9 @@ The structured-returning universal search verb. Two return modes:
 - `drill=False` -> plain `list[dict]` from `ir.search.search`.
 - `drill=True` -> funnel-shape dict, with per-source drill handler lookup.
 
-Parity with `summary_search` is required for `source="summary"`,
-`drill=True` callers — that's how Phase 3a keeps the back-compat alias
-honest.
+`summary_search` is the existing alias for the funnel shape; these
+tests assert parity when callers pass `source="summary"`, `drill=True`
+so the two ops stay byte-equivalent.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_ir_source_factory.py
+++ b/tests/unit/test_ir_source_factory.py
@@ -1,9 +1,11 @@
 """Tests for `work_buddy.ir.store._get_source` factory dispatch.
 
-Phase 3d refactored the if/elif chain to a small factory dict. These
-tests verify each source name resolves to the expected adapter class,
-unknown sources raise a clear error, and the docs source remains
-intact as the knowledge-store search path.
+`_get_source` resolves an IR source name (``"conversation"``, ``"docs"``,
+etc.) to a concrete adapter instance. These tests verify each known
+source name resolves to the expected adapter class, unknown sources
+raise a clear error with the available list, and the docs source's
+``name`` property is preserved (load-bearing for the IR DB's ``source``
+filter on knowledge-store reads).
 """
 
 from __future__ import annotations

--- a/tests/unit/test_session_summary_row.py
+++ b/tests/unit/test_session_summary_row.py
@@ -1,12 +1,10 @@
-"""Tests for `work_buddy.conversation_observability.legacy_row_adapter`.
+"""Tests for `work_buddy.conversation_observability.session_summary_row`.
 
-Equivalence with the pre-Phase-3 `query_session_summary` / `query_topic_summaries`
-shape: the adapter must produce a dict byte-equivalent to what the legacy
-function produced from the same database state.
-
-The legacy `summaries.query_session_summary` is itself unchanged in this
-phase — both functions read the same store. The test proves they produce
-the same dict so the consumer migration (dashboard, collector) is safe.
+The module owns the canonical `session_summaries` + `topic_summaries`
+row shape. The shim `summaries.query_session_summary` produces the same
+dict from the same store. These tests assert the two paths stay
+byte-equivalent and verify the row's invariants (key set, missing-session
+handling, error-status preservation, topics without span metadata).
 """
 
 from __future__ import annotations
@@ -74,11 +72,11 @@ def _seed(session_id: str, tldr: str, topics):
 
 
 # ---------------------------------------------------------------------------
-# Equivalence: row matches legacy query_session_summary
+# Equivalence with the compatibility shim
 # ---------------------------------------------------------------------------
 
 
-def test_legacy_row_matches_query_session_summary_happy_path(
+def test_session_summary_row_matches_query_session_summary_happy_path(
     tmp_summarization_db,
 ):
     _seed(
@@ -90,62 +88,64 @@ def test_legacy_row_matches_query_session_summary_happy_path(
         ],
     )
 
-    from work_buddy.conversation_observability.legacy_row_adapter import (
-        legacy_row_from_session_id,
+    from work_buddy.conversation_observability.session_summary_row import (
+        session_summary_row,
     )
     from work_buddy.conversation_observability.summaries import (
         query_session_summary,
     )
 
-    legacy = query_session_summary("sess-eq-1")
-    new = legacy_row_from_session_id("sess-eq-1")
+    shim = query_session_summary("sess-eq-1")
+    canonical = session_summary_row("sess-eq-1")
 
-    assert legacy == new
+    assert shim == canonical
 
 
-def test_legacy_row_matches_for_missing_session(tmp_summarization_db):
-    from work_buddy.conversation_observability.legacy_row_adapter import (
-        legacy_row_from_session_id,
+def test_session_summary_row_returns_none_for_missing_session(
+    tmp_summarization_db,
+):
+    from work_buddy.conversation_observability.session_summary_row import (
+        session_summary_row,
     )
     from work_buddy.conversation_observability.summaries import (
         query_session_summary,
     )
 
-    legacy = query_session_summary("never-existed")
-    new = legacy_row_from_session_id("never-existed")
-    assert legacy is None
-    assert new is None
-    assert legacy == new
+    shim = query_session_summary("never-existed")
+    canonical = session_summary_row("never-existed")
+    assert shim is None
+    assert canonical is None
+    assert shim == canonical
 
 
-def test_legacy_row_matches_for_error_status(tmp_summarization_db):
-    """When `record_error` overlays an existing session, the adapter
+def test_session_summary_row_matches_for_error_status(tmp_summarization_db):
+    """When `record_error` overlays an existing session, the row helper
     should still surface the prior tldr+topics (not the error)."""
     _seed("sess-err", "Original TLDR.", [("T", "S", (0, 1), [])])
     store = DurableSummaryStore("conversation_session")
     store.set_strategy_versions(1, 1)
     store.record_error("sess-err", "boom", _prov())
 
-    from work_buddy.conversation_observability.legacy_row_adapter import (
-        legacy_row_from_session_id,
+    from work_buddy.conversation_observability.session_summary_row import (
+        session_summary_row,
     )
     from work_buddy.conversation_observability.summaries import (
         query_session_summary,
     )
 
-    assert query_session_summary("sess-err") == legacy_row_from_session_id(
-        "sess-err",
-    )
+    assert query_session_summary("sess-err") == session_summary_row("sess-err")
 
 
-def test_legacy_row_includes_all_thirteen_fields(tmp_summarization_db):
+def test_session_summary_row_includes_all_thirteen_fields(
+    tmp_summarization_db,
+):
     _seed("sess-13", "tldr", [("T", "S", (0, 1), [])])
 
-    from work_buddy.conversation_observability.legacy_row_adapter import (
-        legacy_row_from_session_id,
+    from work_buddy.conversation_observability.session_summary_row import (
+        session_summary_row,
     )
 
-    row = legacy_row_from_session_id("sess-13")
+    row = session_summary_row("sess-13")
     assert set(row.keys()) == {
         "session_id", "tldr", "topic_count", "generated_at", "model",
         "profile", "backend", "prompt_version", "summary_schema_version",
@@ -153,30 +153,30 @@ def test_legacy_row_includes_all_thirteen_fields(tmp_summarization_db):
     }
 
 
-def test_legacy_topics_only_helper_matches_topic_list(tmp_summarization_db):
+def test_session_topics_helper_matches_topic_list(tmp_summarization_db):
     _seed(
         "sess-topics", "tldr",
         [("T1", "S1", (0, 3), ["x"]), ("T2", "S2", (3, 6), ["y"])],
     )
 
-    from work_buddy.conversation_observability.legacy_row_adapter import (
-        legacy_row_from_session_id,
-        legacy_topics_from_session_id,
+    from work_buddy.conversation_observability.session_summary_row import (
+        session_summary_row,
+        session_topics,
     )
 
-    row = legacy_row_from_session_id("sess-topics")
-    topics_only = legacy_topics_from_session_id("sess-topics")
+    row = session_summary_row("sess-topics")
+    topics_only = session_topics("sess-topics")
     assert topics_only == row["topics"]
 
 
-def test_legacy_topics_only_helper_returns_empty_for_missing(
+def test_session_topics_helper_returns_empty_for_missing(
     tmp_summarization_db,
 ):
-    from work_buddy.conversation_observability.legacy_row_adapter import (
-        legacy_topics_from_session_id,
+    from work_buddy.conversation_observability.session_summary_row import (
+        session_topics,
     )
 
-    assert legacy_topics_from_session_id("does-not-exist") == []
+    assert session_topics("does-not-exist") == []
 
 
 # ---------------------------------------------------------------------------
@@ -184,7 +184,7 @@ def test_legacy_topics_only_helper_returns_empty_for_missing(
 # ---------------------------------------------------------------------------
 
 
-def test_legacy_topics_without_span_metadata_returns_none_turn_range(
+def test_topics_without_span_metadata_returns_none_turn_range(
     tmp_summarization_db,
 ):
     """A topic node missing span metadata should still appear in the
@@ -203,11 +203,11 @@ def test_legacy_topics_without_span_metadata_returns_none_turn_range(
     )
     store.save("sess-no-span", root, _prov(), str(time.time()))
 
-    from work_buddy.conversation_observability.legacy_row_adapter import (
-        legacy_topics_from_session_id,
+    from work_buddy.conversation_observability.session_summary_row import (
+        session_topics,
     )
 
-    topics = legacy_topics_from_session_id("sess-no-span")
+    topics = session_topics("sess-no-span")
     assert len(topics) == 1
     assert topics[0]["span_start"] is None
     assert topics[0]["span_end"] is None

--- a/work_buddy/collectors/claude_session_summary_collector.py
+++ b/work_buddy/collectors/claude_session_summary_collector.py
@@ -60,8 +60,8 @@ def collect(cfg: dict[str, Any]) -> str:
             query_session_commits,
             refresh_session_commits,
         )
-        from work_buddy.conversation_observability.legacy_row_adapter import (
-            legacy_row_from_session_id,
+        from work_buddy.conversation_observability.session_summary_row import (
+            session_summary_row,
         )
         from work_buddy.conversation_observability.sessions import (
             list_observed_sessions,
@@ -142,7 +142,7 @@ def collect(cfg: dict[str, Any]) -> str:
 
             if include_tldr:
                 try:
-                    summary_row = legacy_row_from_session_id(sid)
+                    summary_row = session_summary_row(sid)
                 except Exception:
                     summary_row = None
                 if (

--- a/work_buddy/conversation_observability/session_summary_row.py
+++ b/work_buddy/conversation_observability/session_summary_row.py
@@ -1,27 +1,28 @@
-"""Adapter from the summarization framework's per-node store to the
-legacy `session_summaries` + `topic_summaries` row shape consumed by:
+"""Canonical accessor for the `session_summaries` + `topic_summaries`
+row shape.
+
+Returns one Python dict per session, assembled from the summarization
+framework's per-node store. Consumed by:
 
 - The dashboard `GET /api/chats/<sid>/topics` endpoint.
 - The `claude_session_summary` context collector's `include_tldr` branch.
-- The MCP op `session_summary_get` (and its deprecated alias
+- The MCP op `session_summary_get` (and its alias
   `conversation_observability_summary_get`).
 
-This module is the canonical Python entry point for the legacy row shape.
-The pre-Phase-3 `work_buddy.conversation_observability.summaries.query_session_summary`
-function still exists as a compat shim and delegates here.
+The compatibility shims in `summaries.py` (`query_session_summary`,
+`query_topic_summaries`) wrap the same logic and delegate here for new
+code.
 
-**Why not `drill_tree`?** The agent-facing
-`drill_tree(domain="summary", ...)` carries `TreeView.ChildRef` with only
-`node_id` / `title` / `summary_text` — child `extra` (where `span_start`,
-`span_end`, `keywords` live) is intentionally stripped to keep the
-tree-navigation contract narrow. The legacy row needs all three of those
-per-topic fields, so this adapter reads `summarization` storage directly
-via `store.load` + `store.load_item_meta`. Callers reaching for *agent*
-tree navigation use `drill_tree`; this adapter is a Python-internal
-shape transform that needs more than the tree view exposes.
-
-The returned dict is byte-equivalent (keys and value types) to what the
-legacy `query_session_summary` produced.
+**Why this reads `summarization` storage directly, not `drill_tree`:**
+the agent-facing `drill_tree(domain="summary", ...)` returns
+`TreeView.ChildRef` carrying only `node_id` / `title` / `summary_text` —
+each child's `extra` dict (which holds `span_start`, `span_end`,
+`keywords`) is intentionally stripped to keep the tree-navigation
+contract narrow. The row shape these consumers expect needs all three
+per-topic fields, so this module reads `store.load` + `store.load_item_meta`
+directly. Callers reaching for *agent* tree navigation use `drill_tree`;
+this module is a Python-internal shape transform that needs more than
+the tree view exposes.
 """
 
 from __future__ import annotations
@@ -32,12 +33,11 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-def legacy_row_from_session_id(session_id: str) -> dict[str, Any] | None:
-    """Return the legacy `session_summaries` row dict (with embedded
+def session_summary_row(session_id: str) -> dict[str, Any] | None:
+    """Return the full `session_summaries` row dict (with embedded
     `topics`) for one session, or `None` if the session has no summary.
 
-    The shape mirrors what `conversation_observability.summaries.query_session_summary`
-    has produced since PR #130:
+    Shape:
 
         {
           "session_id": str,
@@ -93,7 +93,7 @@ def legacy_row_from_session_id(session_id: str) -> dict[str, Any] | None:
     node = store.load(session_id)
     tldr = node.summary if node is not None else ""
 
-    topics = _legacy_topics_from_node(session_id, node)
+    topics = _topics_from_node(session_id, node)
 
     return {
         "session_id": session_id,
@@ -113,12 +113,11 @@ def legacy_row_from_session_id(session_id: str) -> dict[str, Any] | None:
     }
 
 
-def legacy_topics_from_session_id(session_id: str) -> list[dict[str, Any]]:
-    """Return just the topic-list portion of the legacy row.
+def session_topics(session_id: str) -> list[dict[str, Any]]:
+    """Return just the topic-list portion of the row.
 
-    Same shape as the `topics` entry in `legacy_row_from_session_id`'s
-    return. Provided as a convenience for callers that only want the
-    topic list (matches the pre-Phase-3 `query_topic_summaries` shape).
+    Same shape as the `topics` entry in `session_summary_row`'s return.
+    Provided as a convenience for callers that only want the topic list.
     """
     from work_buddy.conversation_observability.summarizer_binding import (
         get_session_summarizer,
@@ -128,7 +127,7 @@ def legacy_topics_from_session_id(session_id: str) -> list[dict[str, Any]]:
     node = summarizer.store.load(session_id)
     if node is None:
         return []
-    return _legacy_topics_from_node(session_id, node)
+    return _topics_from_node(session_id, node)
 
 
 # ---------------------------------------------------------------------------
@@ -136,7 +135,7 @@ def legacy_topics_from_session_id(session_id: str) -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-def _legacy_topics_from_node(
+def _topics_from_node(
     session_id: str,
     node: Any,
 ) -> list[dict[str, Any]]:

--- a/work_buddy/conversation_observability/summaries.py
+++ b/work_buddy/conversation_observability/summaries.py
@@ -125,21 +125,21 @@ def summarize_session(
 
 
 def query_session_summary(session_id: str) -> dict[str, Any] | None:
-    """Return the legacy `session_summaries` row dict (with `topics`).
+    """Return the `session_summaries` row dict (with `topics`).
 
-    NEW CODE: prefer
-    :func:`work_buddy.conversation_observability.legacy_row_adapter.legacy_row_from_session_id` —
-    it lives in a separate, narrowly-scoped module dedicated to the legacy
-    row shape. This function remains as a back-compat shim for the sidecar
-    job and any out-of-tree caller that imports it directly; both paths
-    are byte-equivalent.
+    Prefer
+    :func:`work_buddy.conversation_observability.session_summary_row.session_summary_row`
+    in new code — it owns the canonical implementation. This function
+    remains as a back-compat shim for the sidecar job and any out-of-tree
+    caller that imports it directly; both paths return the same dict.
 
-    Consumed (historically) by:
-    - the dashboard `/api/chats/<id>/topics` endpoint (migrated to the
-      adapter in Phase 3b)
-    - the `claude_session_summary` context collector (migrated)
+    Consumed by:
+    - the dashboard `/api/chats/<id>/topics` endpoint (via the canonical
+      row helper)
+    - the `claude_session_summary` context collector (via the canonical
+      row helper)
     - the `session_summary_get` / `conversation_observability_summary_get`
-      MCP capabilities (now point at the adapter)
+      MCP capabilities (both bind to the canonical row helper)
     """
     summarizer = get_session_summarizer()
     store = summarizer.store
@@ -174,18 +174,17 @@ def query_session_summary(session_id: str) -> dict[str, Any] | None:
 
 
 def query_topic_summaries(session_id: str) -> list[dict[str, Any]]:
-    """Return the legacy `topic_summaries` row dicts (one per child node).
+    """Return the `topic_summaries` row dicts (one per child node).
 
-    NEW CODE: prefer
-    :func:`work_buddy.conversation_observability.legacy_row_adapter.legacy_topics_from_session_id` —
-    same return shape, lives in the dedicated adapter module.
+    Prefer
+    :func:`work_buddy.conversation_observability.session_summary_row.session_topics`
+    in new code — same return shape, owned by the canonical helper module.
 
     `turn_start` / `turn_end` are computed lazily from `span_start` /
-    `span_end` via `span_range_to_turn_range`. The previous implementation
-    pre-computed and persisted these at save time; the framework's
+    `span_end` via `span_range_to_turn_range`. The framework's
     `SummaryStrategy.parse` doesn't have session context, so computing at
-    read time is cleaner. Cost: one `ConversationSession` load per
-    dashboard topics-tab view.
+    read time is cleaner than persisting these fields. Cost: one
+    `ConversationSession` load per dashboard topics-tab view.
     """
     summarizer = get_session_summarizer()
     node = summarizer.store.load(session_id)

--- a/work_buddy/dashboard/service.py
+++ b/work_buddy/dashboard/service.py
@@ -1147,14 +1147,14 @@ def api_chat_topics(session_id: str):
     topic-timeline rail entirely when topics is empty.
     """
     try:
-        from work_buddy.conversation_observability.legacy_row_adapter import (
-            legacy_row_from_session_id,
+        from work_buddy.conversation_observability.session_summary_row import (
+            session_summary_row,
         )
     except ImportError:
         return jsonify({"topics": [], "tldr": None})
 
     try:
-        row = legacy_row_from_session_id(session_id)
+        row = session_summary_row(session_id)
         if row is None:
             return jsonify({"topics": [], "tldr": None})
         tldr = None

--- a/work_buddy/mcp_server/ops/conversation_observability_ops.py
+++ b/work_buddy/mcp_server/ops/conversation_observability_ops.py
@@ -81,8 +81,8 @@ def conversation_observability_refresh(
 
 
 def _register() -> None:
-    from work_buddy.conversation_observability.legacy_row_adapter import (
-        legacy_row_from_session_id,
+    from work_buddy.conversation_observability.session_summary_row import (
+        session_summary_row,
     )
     from work_buddy.conversation_observability.sessions import (
         list_observed_sessions,
@@ -100,18 +100,17 @@ def _register() -> None:
     register_op("op.wb.conversation_observability_list", list_observed_sessions)
     register_op("op.wb.conversation_observability_summarize",
                 refresh_session_summaries)
-    # Canonical name for the legacy-row read. Both op IDs bind the same
-    # callable so existing `conversation_observability_summary_get` callers
-    # keep working; the capability declaration for the long-namespace name
-    # is marked as a deprecated alias. ``replace=True`` is set on the new
-    # ops so a registry reload (importlib.reload via load_builtin_ops)
-    # re-binds cleanly rather than crashing on the already-registered
-    # names — important under pytest collection when test ordering
-    # triggers the reload path.
+    # Both op IDs bind the same callable so existing
+    # `conversation_observability_summary_get` callers keep working;
+    # the capability declaration for the long-namespace name is marked
+    # as an alias. ``replace=True`` is set so a registry reload (the
+    # `importlib.reload` path in `load_builtin_ops`) re-binds cleanly
+    # rather than crashing on the already-registered names — important
+    # under pytest collection when test ordering triggers the reload path.
     register_op("op.wb.session_summary_get",
-                legacy_row_from_session_id, replace=True)
+                session_summary_row, replace=True)
     register_op("op.wb.conversation_observability_summary_get",
-                legacy_row_from_session_id, replace=True)
+                session_summary_row, replace=True)
 
 
 _register()


### PR DESCRIPTION
## Summary

Follow-up to PR #133 (and the rest of Phase 3) addressing `/wb-dev-pr`'s durable-surfaces audit findings. The audit fires programmatically in the `/wb-dev-pr` cleanup step — it should have caught these during the original work, but the AFK PRs skipped that step.

Two commits, each scoped to one rule violation:

### Commit 1 — `docs: remove stage labels from durable test docstrings`

The rule forbids stage-label transient narrative (\"Phase 3a\", \"Phase 3b\", etc.) in any durable surface. Four sentences crept into Phase 3:

- `tests/unit/test_dashboard_chat_topics_endpoint.py` — \"Phase 3b's consumer migration\" → describe the test's role (locks JSON shape)
- `tests/unit/test_find_op.py` — \"that's how Phase 3a keeps the back-compat alias honest\" → describe the parity assertion directly
- `tests/unit/test_ir_source_factory.py` — \"Phase 3d refactored the if/elif chain\" → describe what `_get_source` does today
- `work_buddy/conversation_observability/summaries.py` — \"NEW CODE\" labels + \"in Phase 3b\" → describe the canonical-helper recommendation without dating it

Docstrings only; no behavior change.

### Commit 2 — `refactor: rename legacy_row_* → session_summary_row`

The rule forbids archaeology naming (`legacy_*`, `_after_migration_shim`, `new_*`). A future agent reading the codebase would ask \"legacy from when?\" — exactly the trap the rule warns against. Rename to describe what the helper returns:

| Old | New |
|---|---|
| `legacy_row_adapter.py` | `session_summary_row.py` |
| `legacy_row_from_session_id()` | `session_summary_row()` |
| `legacy_topics_from_session_id()` | `session_topics()` |
| `_legacy_topics_from_node()` | `_topics_from_node()` |
| `test_legacy_row_adapter.py` | `test_session_summary_row.py` |
| `test_legacy_row_*` | `test_session_summary_row_*` |

Caller-site updates: dashboard endpoint, collector, MCP op bindings (both `session_summary_get` and `conversation_observability_summary_get` continue to bind to the same callable, just under its new name), summaries.py docstring refs, and one knowledge unit content edit.

Git detected both file moves as renames (62% and 73% similarity), so history is preserved.

## Test plan

- [x] `conda run -n work-buddy python -m pytest tests/unit/test_session_summary_row.py tests/unit/test_dashboard_chat_topics_endpoint.py tests/unit/test_find_op.py tests/unit/test_drill_registry.py tests/unit/test_walk_alias.py tests/unit/test_ir_source_factory.py tests/unit/test_disclosure.py tests/unit/test_summarization_funnel.py tests/unit/test_summarization_framework.py tests/unit/test_summarization_store.py tests/unit/test_ir_summary_source.py tests/unit/test_conversation_observability_summaries.py tests/unit/test_conversation_observability_capabilities.py -q` — 141 tests pass.
- [x] `capability_loader.load_declared_capabilities()` resolves both `session_summary_get` and `conversation_observability_summary_get` to the same callable (`session_summary_row`), zero issues.
- [ ] Restart MCP server. Verify `mcp__work-buddy__wb_run(\"session_summary_get\", {\"session_id\": \"<sid>\"})` and `mcp__work-buddy__wb_run(\"conversation_observability_summary_get\", {\"session_id\": \"<sid>\"})` return byte-identical dicts as before.
- [ ] Restart dashboard. Verify `GET /api/chats/<sid>/topics` returns the unchanged JSON shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)