### PR TITLE
feat(consent): composable workflow consent + four follow-up fixes

### DIFF
--- a/.claude/commands/wb-dev-live-testing.md
+++ b/.claude/commands/wb-dev-live-testing.md
@@ -1,0 +1,4 @@
+---
+short: Drive a live end-to-end test of a code change (precise steps, who-does-what, MCP-reset checklist)
+---
+Load directions via `mcp__work-buddy__wb_run("agent_docs", {"path": "dev/live-testing-directions", "depth": "full"})`, then follow the protocol.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,19 @@ work-buddy's functionality is reached through five MCP tools that appear in your
 - **Capability** — a single atomic operation (`task_create`, `agent_docs`, `consent_request`, …). `wb_run` executes it and returns a result.
 - **Workflow** — a multi-step DAG defined in `knowledge/store/workflows.json` (`task-triage`, `morning-routine`, …). `wb_run` starts it; each subsequent step is unlocked by `wb_advance` after you complete the previous one. Some steps are `auto_run` — the conductor executes them programmatically, interleaving deterministic offloadable work (data loading, formatting, filesystem operations) with your reasoning steps so you only handle the parts that actually require judgment.
 
+### Workflow consent (composable)
+
+Starting a workflow may prompt the user once to authorize the workflow's component operations. The prompt offers four affordances: **Allow once** (this invocation only), **Allow for 15 min** (re-invocations of the same workflow within the window reuse the approval without re-prompting), **Allow always (this session, 24h)**, or **Deny**. Two grant keys live in the session's `consent.db`:
+
+- `workflow_class:<name>` — set by **Allow for 15 min** / **Allow always**. Authorizes any *future* run of `<name>` within the TTL window. Re-runs check this key and skip the prompt.
+- `workflow_run:<name>:<run_id>` — set by `start_workflow` for every active run. Authorizes the workflow's sub-operations as constituents of *this* run. Revoked when the run completes.
+
+Inside a workflow run, `@requires_consent`-gated calls check (in order): individual op grant → any live `workflow_run:*` or `workflow_class:*` key → the legacy `__workflow_consent__` blanket (deprecation-logged). Capabilities tagged with `consent_weight="high"` bypass the workflow-grant carry entirely — they always re-prompt individually, even inside an approved workflow.
+
+The pre-flight prompt is **skipped** when (a) the workflow's `workflow_class` grant is already live for this session, or (b) the dispatch happens inside a `user_initiated()` context (UI button click, dashboard endpoint, slash-command handler that wraps its dispatch — the click *is* the consent affordance). Workflows whose declared operations are all low-weight auto-bypass the prompt entirely (the audit script `scripts/audit_workflow_consent.py` lists which workflows are in this set vs. which need the prompt).
+
+Behavior the model deliberately does NOT allow: workflow grants do **not** time-travel through the sidecar retry queue. A queued op replayed days later only sees its individual grant (if any) — the workflow grant active at queue-time has long since been scoped out.
+
 ### Session init (mandatory)
 
 `WORK_BUDDY_SESSION_ID` is set automatically by a SessionStart hook. Read it from your conversation context (or the environment), then:

--- a/knowledge/store/dev/dev-mode.md
+++ b/knowledge/store/dev/dev-mode.md
@@ -148,6 +148,10 @@ mcp__work-buddy__wb_run("capability_name", {...})     # test execution
 mcp__work-buddy__wb_run("service_restart", {"service": "dashboard"})
 ```
 
+### Live testing
+
+Run `/wb-dev-live-testing` to drive an end-to-end test of an in-progress change against the running MCP server + sidecar + surfaces. Distinct from `pytest` — unit tests catch logic bugs; live tests catch wiring bugs (FastMCP tool registration, surface dispatchers, sidecar message routing, session-scoped storage). The protocol (precondition → trigger → user action → verify → cleanup) lives in `dev/live-testing-directions`; the slash command loads it. Use after any change that touches gateway entry points, notification surfaces, or session-scoped behavior.
+
 ### Dependencies
 **Never use `pip install`.** Use Poetry:
 - Production: `poetry add <package>`

--- a/knowledge/store/dev/live-testing-directions.md
+++ b/knowledge/store/dev/live-testing-directions.md
@@ -84,7 +84,7 @@ After the full test:
 - **Don't use synthetic operations when a real one fits.** A test that creates a real task the user wanted saved is better than one that creates a `test_xxx` task they have to clean up.
 - **Don't manually mint grants to work around bugs DURING the test.** If the test reveals a bug, that's the test working. Report the bug; don't paper over it. (Outside the test, when you're trying to unblock the user, manual grants are fine — just don't conflate the two.)
 
-## Example: composable-consent-v1 live test
+## Example: composable workflow consent live test
 
 The exact protocol that validated the workflow-consent pre-flight prompt and the Telegram out-of-band grant-writing:
 

--- a/knowledge/store/dev/live-testing-directions.md
+++ b/knowledge/store/dev/live-testing-directions.md
@@ -1,0 +1,102 @@
+---
+name: Live Testing Directions
+kind: directions
+description: How to drive a live end-to-end test of an in-progress code change — distinct from unit tests; verifies wiring across MCP server, sidecar, and surfaces with the user in the loop.
+trigger: user invokes /wb-dev-live-testing or asks to verify a change live
+command: wb-dev-live-testing
+tags:
+- dev
+- live
+- testing
+- verification
+- directions
+aliases:
+- live test
+- end-to-end
+- verify in MCP
+- exercise the surface
+parents:
+- dev
+---
+
+When the user invokes `/wb-dev-live-testing`, drive an end-to-end live test of an in-progress code change. Distinct from automated testing (`pytest`) — this is real MCP / sidecar / surfaces actually exercising the new code path with the user in the loop where their judgment is needed.
+
+Live testing exists because some changes only manifest correctly in a running multi-process system: anything touching FastMCP tool registration, the gateway's request handlers, surface dispatchers, sidecar message routing, or session-scoped storage. Unit tests catch logic bugs; live tests catch wiring bugs.
+
+## Two-process model — what restart picks up what
+
+work-buddy spans two long-running processes that load Python code at different times:
+
+- **Sidecar** — restarts when the user does a sidecar-only reset. Re-reads code at startup. Hosts cron jobs, the retry queue, the dashboard, the messaging service, the sidecar MCP gateway.
+- **Claude Code Desktop's MCP server** — restarts only on **Ctrl+R** in the Desktop app. This is the process that handles `wb_run` calls from the agent. Its `wb_run` and `wb_search` tool functions are frozen function references held by FastMCP at startup; module-level reloads via `mcp_registry_reload` do NOT replace them.
+
+If you change code inside `wb_run` / `wb_search` directly (e.g. the gateway's workflow pre-flight branch), only a Ctrl+R picks it up. If you change code that's *lazy-imported* by those functions (e.g. the conductor, the consent layer, capability callables), `mcp_registry_reload` plus a sidecar reset is usually enough — but Ctrl+R is the safe move that always works.
+
+Before driving any live test: confirm with the user that they have restarted whichever process owns the changed code. The user prompt 'I reset the sidecar/MCP!' typically means a sidecar reset; ask whether they also did Ctrl+R if the change touches gateway entry-point functions.
+
+## Protocol for designing the test
+
+A good live test:
+
+1. **Has one clear assertion** — what behavior, observably, distinguishes the new code from the old.
+2. **Touches the actual user-facing surface** the change affects (Telegram, Obsidian modal, dashboard, MCP tool response shape).
+3. **Specifies who does what** at each step — the agent or the user — explicitly.
+4. **Uses an operation that has real intent**, when possible. A test that doubles as work the user wanted done anyway is self-justifying and avoids 'why are we creating this test task' friction.
+
+When the change is in the consent / notification layer, the **handoff task creation** is often the perfect test driver: it requires moderate-risk consent (`tasks.create_task`, `obsidian.write_file`), it's a real piece of work the user wants saved, and it exercises the full consent prompt → response → grant → execution flow.
+
+## The standard four-phase live test
+
+Phase 1. **Pre-check (agent)**
+- Call any state-inspection capability relevant to the change (e.g. `consent_list`, `wb_status`, `agent_docs`). Verify the starting state is what the test assumes.
+
+Phase 2. **Trigger (agent)**
+- Invoke the operation under test. If it blocks waiting for a user response (consent prompt, request_send), the agent's call blocks too — make this explicit to the user: 'I'm going to call X. It will block for up to 90 seconds waiting for you. Either approve / answer on a surface, OR deliberately wait > 90 seconds so we can verify the timeout path.'
+
+Phase 3. **User action (user)**
+- Tell the user precisely what to do (which button to click, which mode to choose) AND what to observe on adjacent surfaces (does the other surface dismiss? does the dashboard update? does the audit log fire?).
+- For consent flows, the choice of mode matters: 'Allow once' tests the run-grant-only path; 'Allow for 15 min' tests the class-grant carry; 'Allow always' tests the long-TTL class grant; 'Deny' tests the rejection path.
+
+Phase 4. **Verify (agent)**
+- Re-check state (re-call the same inspection capability from Phase 1) AND check the audit log for the expected events. Relay the exact JSON / line content back to the user — never paraphrase: 'the grant landed' is not as useful as 'consent_list returned `{workflow_class:task-new: {mode: temporary, expires_at: ...}}`'.
+- If the test had a follow-up assertion (e.g. 're-running the operation should now skip the prompt'), execute that too.
+
+## Reporting
+
+After each phase, report back to the user in a tight format:
+
+```
+Phase 2: triggered task_create — blocking for up to 90s on your response
+Phase 3 (you): wait > 90s, then approve on Telegram with "Allow 5 min"
+Phase 4: consent_list shows tasks.create_task | mode=temporary | expires_at=17:54Z. Audit log: REQUEST_APPROVED, GRANTED, EXECUTED.
+```
+
+After the full test:
+
+- One-line verdict (`all checks passed` / `phase N failed: $reason`).
+- Cleanup: cancel any in-flight workflow runs, revoke any time-limited grants the test minted unless they're useful to leave for follow-up testing.
+
+## What NOT to do
+
+- **Don't skip the pre-check.** It catches stale state that would confuse the verification step.
+- **Don't paraphrase the user's observation.** If they say 'the modal disappeared', record that verbatim, don't translate to 'dismiss worked'. The translation hides ambiguity.
+- **Don't test multiple changes in one live run.** Each test verifies one assertion. If two changes need verification, run two tests; the cost is small and the diagnosis on failure is sharper.
+- **Don't use synthetic operations when a real one fits.** A test that creates a real task the user wanted saved is better than one that creates a `test_xxx` task they have to clean up.
+- **Don't manually mint grants to work around bugs DURING the test.** If the test reveals a bug, that's the test working. Report the bug; don't paper over it. (Outside the test, when you're trying to unblock the user, manual grants are fine — just don't conflate the two.)
+
+## Example: composable-consent-v1 live test
+
+The exact protocol that validated the workflow-consent pre-flight prompt and the Telegram out-of-band grant-writing:
+
+1. **Pre-check**: `consent_list` returns `{}`.
+2. **Trigger**: `wb_run("task-new")` (a moderate-risk workflow).
+3. **User**: ignore prompt for > 90s, then approve on Telegram with 'Allow for 15 min'.
+4. **Verify**:
+   - Agent receives `{status: "timeout", request_id, operation_id}` after 90s.
+   - After user's Telegram tap: Obsidian modal disappears (visual confirmation).
+   - `consent_list` shows `workflow_class:task-new` with `mode: temporary` and `expires_at: ~15 min`.
+   - Audit log shows `REQUEST_APPROVED | workflow:task-new | mode=temporary`.
+   - Follow-up: `wb_run("task-new")` again returns the first workflow step immediately (no prompt — class grant carried it).
+5. **Cleanup**: cancel the second workflow run; revoke `workflow_class:task-new` to leave a clean slate.
+
+This is a single end-to-end run that simultaneously verifies: the pre-flight prompt fires, the timeout payload is correct, out-of-band Telegram approval triggers the grant write (via `finalize_consent_response`), sibling-surface dismissal works, the class grant is queryable, and the re-run silence promise is honored.

--- a/knowledge/store/notifications/consent.md
+++ b/knowledge/store/notifications/consent.md
@@ -76,11 +76,57 @@ Grants are stored session-scoped in a SQLite database at `data/agents/<session>/
 
 When the sidecar's retry sweep replays a previously-consented operation, the consent check ALSO consults the originating user-session's grants (looked up by reference to the op record's `originating_session_id`). This means a consented operation that hits PWU and gets queued for retry will not fail with `ConsentRequired` on replay. Revocation in the originating session immediately disables future replays.
 
+**Workflow grants do NOT time-travel through the retry queue.** The originating-session fallback considers individual op-grants only — `workflow_class:*` / `workflow_run:*` / legacy `__workflow_consent__` keys are deliberately skipped on the replay path. The rationale: a workflow grant active when an op was queued may have been revoked, or have a class TTL that long expired by the time the sweep replays the op days later; the user's *temporally-bounded* trust in the workflow does not generalize to a *later* replay. Replays succeed only on individual op grants the user explicitly authorized for that op (or that exist in the current replay-time session).
+
 **Cross-session routing on out-of-band approval.** When a user approves a consent prompt on the Obsidian modal *after* the gateway's in-window poll has already returned `{status: "timeout"}`, the plugin posts a `consent_grant` message to the messaging service. The sidecar's MessagePoller picks it up and routes the grant via `resolve_consent_request`, which looks up the notification's `callback_session_id` and writes grants to **that** session's DB — not the sidecar's. The originating agent's subsequent `obsidian_retry` (or fresh capability call) then sees the grant and proceeds. Without this routing, modal-approved grants would land in the sidecar's bootstrap-session DB where no agent could see them.
 
 **Bundle unbundling.** When the gateway requests consent for a multi-op capability, the notification's `operation` field is a label of the form `bundle:<capability_name>` and the underlying ops live in `consent_meta.context.operations`. `resolve_consent_request` writes grants for **each underlying op individually** in addition to the bundle label, because the `@requires_consent` decorators check the individual operation names (e.g. `tasks.create_task`, `obsidian.write_file`), not the bundle. The bundle label survives as audit metadata.
 
-**Workflow-level blanket consent:** Starting a workflow grants blanket consent for all its steps, stored as a `__workflow_consent__` grant in the agent's `consent.db`. The blanket is revoked when the workflow completes; a step can opt out via `requires_individual_consent: true` in the workflow definition, which temporarily suspends the blanket and requires per-step consent; and it is reconciled away on session re-registration when no matching active run exists — the case where an MCP-server restart orphaned a mid-flight workflow (the in-memory run map is wiped, but the on-disk blanket would otherwise survive its TTL and silently authorize calls). The 3-hour default TTL is only a backstop. Agents don't need to manage any of this — the conductor handles it automatically (both auto-run and main-execution steps).
+## Composable workflow consent
+
+Starting a workflow may prompt the user once to authorize the workflow's component operations. Two grant levels live in the session's `consent.db`:
+
+- `workflow_class:<name>` — the "Allow for 15 min" or "Allow always" key. Set by the gateway's pre-flight prompt when the user approves a non-`once` mode. TTL-bounded (15 min for `temporary`, 24h for `always`). While live, future invocations of the same workflow skip the pre-flight prompt.
+- `workflow_run:<name>:<run_id>` — minted by `start_workflow` for every active run. Authorizes the workflow's sub-operations *as constituents of that run*. No TTL; revoked when the run completes (or via cascade when the class grant is explicitly revoked).
+
+The gateway pre-flight prompt fires when ALL of the following hold:
+
+1. The workflow's `workflow_class:<name>` grant is NOT live in this session.
+2. The dispatch is NOT inside a `user_initiated()` context.
+3. The workflow's declared `consent_operations` include at least one moderate- or high-risk op (low-only workflows auto-bypass under the hybrid migration policy — see below).
+
+User choices in the prompt: **Allow once** (no class grant; only the run grant covers this invocation), **Allow for 15 min** (class grant minted with 15-min TTL), **Allow always (this session, 24h)** (class grant minted with 24-h TTL), or **Deny** (the workflow does not start; `start_workflow` is short-circuited and the operation completes with a `consent denied` error).
+
+### Decorator carry path
+
+The `@requires_consent` check inside a workflow run consults, in order:
+
+1. Individual op grant for `operation` (highest priority).
+2. Any live `workflow_run:*` key in this session.
+3. Any live `workflow_class:*` key in this session.
+4. Legacy `__workflow_consent__` (deprecation-logged once per op per process).
+
+Capabilities tagged with `consent_weight="high"` on their `@requires_consent` decorator (and mirrored on the `Capability.consent_weight` field) BYPASS the workflow-grant carry entirely — they always re-prompt individually, even inside an approved workflow run. This mirrors Cursor's destructive-command carve-out and OpenAI's `isConsequential` flag for GPT Actions. The default `consent_weight` mirrors the declared `risk` value, so the legacy behavior of "workflow blanket carries everything" is preserved for low-risk ops while high-risk ops are properly gated.
+
+### `requires_individual_consent: true` step flag
+
+A workflow step can opt out of the run-grant carry via `requires_individual_consent: true` in the workflow definition. The conductor revokes the run grant before dispatching such a step and re-mints it after the step completes (or after the agent advances the workflow for a reasoning step). This lets a workflow author force a per-step prompt for one specific operation without affecting the rest of the DAG.
+
+### Low-weight workflow auto-bypass
+
+Workflows whose constituent capabilities declare only low-weight `consent_operations` (or none at all) auto-bypass the pre-flight prompt. The gateway audit-logs each bypass as `WORKFLOW_AUTO_BYPASS_LOW_WEIGHT | workflow=<name>` so the `scripts/audit_workflow_consent.py` script can enumerate which workflows ride the bypass and which prompt. The bypass keeps read-only routines like `task-search` frictionless while still prompting for any workflow that touches moderate or high-risk operations.
+
+### Orphan reconciliation
+
+A workflow's `workflow_run:<name>:<run_id>` key lives in the agent's `consent.db` while the run is active. An MCP-server restart wipes `_ACTIVE_RUNS` but leaves the on-disk grant; without cleanup, the orphaned key would silently authorize subsequent calls until something else revoked it. `conductor.reconcile_workflow_consent(session_id)` runs at session registration and revokes any `workflow_run:*` keys whose run_id is not present in `_ACTIVE_RUNS` for that session. Class grants are intentionally left alone — their TTL is the bound. The function also still handles the legacy `__workflow_consent__` key for back-compat (preserves the historical return-shape contract: `{"swept": True}` / `{"swept": False, "reason": "active_run_present"}` / `{"swept": False, "reason": "no_blanket"}`).
+
+### Explicit cascade revoke
+
+`conductor.cascade_revoke_workflow(name, session_id=...)` revokes the `workflow_class:<name>` key AND walks `_ACTIVE_RUNS` to revoke every in-flight run grant for that workflow. Used when the user explicitly withdraws trust mid-run — the ocap-CDT model where revoking the parent class grant propagates to all derived run grants. Without this, withdrawing trust would leave the in-flight runs riding their independent run grants until completion.
+
+### Legacy `__workflow_consent__` (deprecated)
+
+The legacy blanket key remains as a **read-side** fallback: `_is_granted_in_session` honors a live legacy blanket when no individual / `workflow_run` / `workflow_class` grant matches, and emits a single `LEGACY_WORKFLOW_BLANKET_USED` audit entry per operation per process so unconverted call sites stay greppable. The **write-side** uses only the new keys; the conductor and gateway no longer write `__workflow_consent__`. The read fallback is scheduled for removal once the audit log shows no LEGACY_WORKFLOW_BLANKET_USED hits in a release cycle.
 
 ## Risk levels
 
@@ -96,7 +142,7 @@ This is the mechanism that lets read-only capabilities (e.g. `daily_briefing`) i
 
 The consent gate exists for **autonomous agent operations** — cron-fired scans, sidecar workflows, LLM-initiated actions where the user isn't watching. UI clicks are the inverse case: **the user already consented by clicking the affordance**. Pre-emptively re-prompting them for the action they explicitly initiated is bureaucratic UX and a known bug pattern.
 
-`work_buddy.consent.user_initiated(operation)` is a context manager for that case. Wrap the critical section of a UI-driven endpoint (Flask handler reached via a button click, slash-command handler, CLI script the user invoked explicitly) and nested `@requires_consent` gates pass through, with audit-log entries (`USER_INITIATED`, `USER_INITIATED_COVERED`) distinguishing UI-driven actions from autonomous ones.
+`work_buddy.consent.user_initiated(operation)` is a context manager for that case. Wrap the critical section of a UI-driven endpoint (Flask handler reached via a button click, slash-command handler, CLI script the user invoked explicitly) and nested `@requires_consent` gates pass through, with audit-log entries (`USER_INITIATED`, `USER_INITIATED_COVERED`) distinguishing UI-driven actions from autonomous ones. The gateway's workflow pre-flight prompt is ALSO suppressed when dispatching inside a `user_initiated()` context.
 
 ```python
 from work_buddy.consent import user_initiated

--- a/knowledge/store/notifications/consent.md
+++ b/knowledge/store/notifications/consent.md
@@ -33,12 +33,6 @@ dev_notes: |-
 
   **If you add a new dashboard endpoint** that fires a state-entry side effect invoking a `@requires_consent` capability and bypasses `_post_thread_action`, you must add the wrapper yourself. The capability dispatcher running inside `EXECUTING`'s side-effect handler runs synchronously in the same thread as `engine.transition`, so a `user_initiated` context wrapping the transition covers the entire downstream chain.
 
-  ## Workflow-consent orphan reconciliation
-
-  A workflow grants a `__workflow_consent__` blanket into the agent's `consent.db` (on disk, up to a 3h TTL) and pins the run's DAG in `conductor._ACTIVE_RUNS` (in memory). The two have mismatched lifetimes: an MCP-server restart wipes `_ACTIVE_RUNS` but leaves the blanket live, so it would silently authorize every consent-gated call until TTL expiry.
-
-  `conductor.reconcile_workflow_consent(session_id)` re-couples them. It runs from `gateway.py:_register_session` — the single chokepoint all three session-registration paths funnel through (`wb_init` tool, `wb_run` wb_init branch, header-based auto-init), each also a post-restart reconnect point. If the session's DB holds an active blanket but no `_ACTIVE_RUNS` entry has a matching `agent_session_id`, the blanket is orphaned and revoked. A genuinely in-flight workflow keeps its DAG in `_ACTIVE_RUNS` (entries leave only on completion), so a non-restart re-registration finds the run and leaves the blanket intact. `is_workflow_consent_active(session_id=...)` is the per-session check — it delegates to `_is_granted_in_session`, skipping the originating-session fallback so a blanket in another session's DB is not counted. The function is guarded internally and never raises, so it cannot break session registration. Tests: `tests/test_workflow_consent.py`.
-
   ## Modal-fallback message routing
 
   The Obsidian plugin's `ObsidianModal.dispatchConsentGrant` (handlers.ts) posts a `consent_grant` message to the messaging service whenever the user clicks an Allow option. Body shape: `{operation, mode, ttl_minutes, notification_id}`. The `notification_id` is the load-bearing field — without it the sidecar cannot resolve the originating agent's session and falls back to writing the grant in its own session DB (a legacy behavior preserved with a WARN log so an out-of-sync plugin doesn't strand the user, but the routing is broken until the plugin is rebuilt + reloaded).
@@ -50,6 +44,40 @@ dev_notes: |-
   **`grant_consent` and `grant_consent_batch` accept `session_id` as a keyword.** Plumbs through to `ConsentCache.grant(..., session_id=...)` — the same mechanism workflow blanket grants use to write to a different session's DB than the calling process. The audit log includes the truncated session id in the `GRANTED` details column so cross-session writes are auditable post-hoc.
 
   **The bundle key (`bundle:<capability>`) is granted alongside individual ops.** It serves as audit-log readability — `GRANTED | bundle:task_create | once` is more informative than three separate GRANTED rows for the underlying ops. No decorator checks the bundle key, so leaving it in the DB doesn't satisfy any gate by accident.
+
+  ## Response → grant pipeline (finalize_consent_response)
+
+  When a user responds to a consent prompt — on any surface — the system has to do two distinct things:
+
+  1. **Record the response** on the notification (status: `pending` → `responded`, persist the chosen mode and surface).
+  2. **Translate that response into grants** in the right session's `consent.db` (individual op grants for capability bundles; `workflow_class:<name>` grant for workflow-consent prompts).
+
+  The first is `notifications.store.respond_to_notification`. The second is `consent.finalize_consent_response(notification_id)` — extracted from `resolve_consent_request` so any surface can call it after recording the response. Every response-recording path calls them in that order:
+
+  | Surface | Call site | Pattern |
+  |---|---|---|
+  | Telegram inline button | `work_buddy/telegram/handlers.py:on_button` | `respond_to_notification` → `finalize_consent_response` → `dispatch_callback` → `_dismiss_others` |
+  | Telegram `/reply` command | `work_buddy/telegram/handlers.py:on_reply` | same shape as on_button |
+  | Obsidian modal (out-of-band) | sidecar `MessagePoller._handle_consent_grant_message` | routes through `consent.resolve_consent_request` which calls `finalize_consent_response` internally |
+  | Dashboard "Approve" endpoint | `work_buddy/dashboard/service.py` | calls `resolve_consent_request` directly |
+  | MCP `consent_request_resolve` op | gateway op dispatch | same path as dashboard |
+  | Gateway in-window poll | `_auto_consent_request` / `_auto_workflow_consent_request` | writes grants inline via `grant_consent_batch` / `grant_workflow_class` (skips `finalize_consent_response` because the poll has fresher state in hand) |
+
+  The grant-writing logic — bundle unbundle, `workflow_class:<name>` mint for `context.kind == "workflow_consent"`, individual op grants, audit emission — lives in exactly one place (`finalize_consent_response`). Any surface that doesn't go through `resolve_consent_request` (Telegram is the notable one) must call `finalize_consent_response` directly. Tests covering each path live in `tests/unit/test_consent_composable.py`.
+
+  ## Agent-session routing for callback_session_id
+
+  `create_consent_request` accepts a `callback_session_id` parameter — the session whose `consent.db` should receive grants when the response lands. **This must be the agent's session, not the MCP server's bootstrap session.** The two are different processes with different `WORK_BUDDY_SESSION_ID` env vars: the bootstrap session is the long-running MCP server process; the agent session is the Claude Code Desktop session that called `wb_run`.
+
+  Both `_auto_consent_request` and `_auto_workflow_consent_request` in `gateway.py` accept an explicit `session_id` parameter and pass it to `create_consent_request`. The `wb_run` dispatch site threads `_agent_sid` (from `_resolve_session(ctx)`); the retry path threads `record.get("originating_session_id")` (the session that originally requested the op). The env-var fallback inside the helpers exists only for direct Python callers that bypass the gateway surface — production code paths pass the session id explicitly.
+
+  If you add a new helper that creates consent notifications, pass `callback_session_id=<agent_session_id>` explicitly. Reading `os.environ.get("WORK_BUDDY_SESSION_ID")` for this purpose is wrong — it returns the bootstrap session, and out-of-band approvals will route grants to a DB the agent's `is_granted` check never queries.
+
+  ## Listing grants in the agent's session
+
+  `consent_list` (capability `op.wb.consent_list`) accepts `agent_session_id` and routes the SQLite read to that session's `consent.db`. The gateway auto-injects the caller's session id when dispatching the capability via `wb_run`. Direct Python callers (tests, scripts) can pass it explicitly; passing `None` falls back to the cache's default-path resolution (which uses whatever session was first connected — typically the process's bootstrap session, which is rarely what a tool caller wants to see).
+
+  The underlying `ConsentCache.list_all(*, session_id=None)` mirrors the routing pattern used by `grant`, `revoke`, and `_is_granted_in_session`: explicit session id when set, default-path fallback when not.
 ---
 
 Some `work_buddy` functions are protected by a `@requires_consent` decorator. **The gateway handles consent transparently** — when you call `wb_run` on a consent-gated capability, the gateway automatically requests consent from the user, waits for approval, and retries the operation. You do not need to manually orchestrate consent.

--- a/scripts/audit_workflow_consent.py
+++ b/scripts/audit_workflow_consent.py
@@ -1,0 +1,152 @@
+"""Audit workflow consent posture.
+
+Enumerates every workflow in the registry and reports its consent
+fingerprint: declared ``consent_operations`` across constituent
+capabilities, inferred consent weight (max risk over those ops), and a
+recommendation for whether the workflow needs an explicit
+``consent_weight`` declaration on its capabilities.
+
+Run via::
+
+    conda run -n work-buddy python -m scripts.audit_workflow_consent
+
+Or, with the env's python directly::
+
+    .../envs/work-buddy/python.exe -m scripts.audit_workflow_consent
+
+Used to prioritize which workflows to convert (explicit
+``consent_weight`` on their high-risk capabilities) versus which ride
+the low-weight auto-bypass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+
+
+_RISK_ORDER = {"low": 0, "moderate": 1, "high": 2}
+
+
+def _inferred_weight(workflow_name: str) -> dict:
+    """Walk a workflow's DAG and compute its inferred consent weight.
+
+    Returns a dict with: ``workflow_name``, ``declared_ops`` (list),
+    ``max_risk``, ``invokes`` (sorted set of capability names), and
+    ``status`` (``"safe_default"`` / ``"needs_declaration"`` /
+    ``"requires_prompt"``).
+    """
+    from work_buddy.mcp_server import registry
+    from work_buddy.consent import get_consent_metadata
+
+    entry = registry.get_entry(workflow_name)
+    if not isinstance(entry, registry.WorkflowDefinition):
+        return {
+            "workflow_name": workflow_name,
+            "status": "not_a_workflow",
+        }
+
+    invokes: set[str] = set()
+    for step in entry.steps:
+        for cap_name in step.invokes:
+            invokes.add(cap_name)
+
+    declared_ops: list[str] = []
+    seen: set[str] = set()
+    max_risk = "low"
+    for cap_name in sorted(invokes):
+        cap_entry = registry.get_entry(cap_name)
+        if not isinstance(cap_entry, registry.Capability):
+            continue
+        for op in cap_entry.consent_operations:
+            if op in seen:
+                continue
+            seen.add(op)
+            declared_ops.append(op)
+            meta = get_consent_metadata(op) or {}
+            op_risk = meta.get("risk", "moderate")
+            if _RISK_ORDER.get(op_risk, 0) > _RISK_ORDER.get(max_risk, 0):
+                max_risk = op_risk
+
+    if not declared_ops or max_risk == "low":
+        status = "safe_default"  # Auto-bypasses the workflow consent prompt.
+    elif max_risk == "high":
+        status = "requires_prompt"
+    else:
+        status = "requires_prompt"
+
+    return {
+        "workflow_name": workflow_name,
+        "declared_ops": declared_ops,
+        "max_risk": max_risk,
+        "invokes": sorted(invokes),
+        "step_count": len(entry.steps),
+        "status": status,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit composable-consent posture of every workflow.",
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Emit JSON instead of the human-readable table.",
+    )
+    parser.add_argument(
+        "--name", default=None,
+        help="Audit a single workflow by name (for spot-checking).",
+    )
+    args = parser.parse_args(argv)
+
+    from work_buddy.mcp_server import registry as reg
+
+    if args.name:
+        records = [_inferred_weight(args.name)]
+    else:
+        names = sorted(
+            n for n, e in reg.get_registry().items()
+            if isinstance(e, reg.WorkflowDefinition)
+        )
+        records = [_inferred_weight(n) for n in names]
+
+    if args.json:
+        print(json.dumps(records, indent=2))
+        return 0
+
+    # Human-readable summary.
+    by_status: dict[str, list[dict]] = defaultdict(list)
+    for r in records:
+        by_status[r.get("status", "unknown")].append(r)
+
+    print()
+    print("=" * 70)
+    print("Workflow consent posture audit")
+    print("=" * 70)
+    for status in ("requires_prompt", "needs_declaration", "safe_default"):
+        rs = by_status.get(status, [])
+        if not rs:
+            continue
+        print()
+        print(f"## {status} ({len(rs)} workflow{'s' if len(rs) != 1 else ''})")
+        for r in rs:
+            print(f"  - {r['workflow_name']}  "
+                  f"[max_risk={r.get('max_risk', '—')}]  "
+                  f"[{r.get('step_count', '?')} steps]")
+            for op in r.get("declared_ops", []):
+                print(f"      * {op}")
+
+    print()
+    print(f"Total: {len(records)} workflows")
+    print(f"  safe_default (low-weight auto-bypass): "
+          f"{len(by_status.get('safe_default', []))}")
+    print(f"  requires_prompt: "
+          f"{len(by_status.get('requires_prompt', []))}")
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_conductor_consent_lifecycle.py
+++ b/tests/unit/test_conductor_consent_lifecycle.py
@@ -1,0 +1,202 @@
+"""Integration tests — conductor lifecycle calls the composable consent
+primitives correctly.
+
+Asserts that ``start_workflow`` mints the run grant,
+``_build_complete_response`` revokes it on completion, and
+``cascade_revoke_workflow`` propagates a class-grant revoke to every
+in-flight run.
+
+Uses a stubbed ``WorkflowDefinition`` so the conductor's full lifecycle
+path is exercised, not just the consent primitives in isolation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def cache(tmp_agents_dir, monkeypatch):
+    import work_buddy.agent_session as asmod
+    def _canonical_get_agents_dir():
+        return asmod.data_dir("agents")
+    monkeypatch.setattr(asmod, "get_agents_dir", _canonical_get_agents_dir)
+    monkeypatch.setattr(asmod, "_cached_session_dir", None)
+
+    from work_buddy.consent import _cache
+    _cache._db_path = None
+    _cache._initialized = False
+
+    from work_buddy import consent as cmod
+    cmod._LEGACY_BLANKET_LOGGED.clear()
+    return _cache
+
+
+@pytest.fixture
+def stub_workflow(monkeypatch):
+    """Stub ``registry.get_entry`` to return a one-step WorkflowDefinition
+    for the name 'test-wf'. The step is a no-op reasoning step.
+    """
+    from work_buddy.mcp_server import registry, conductor
+
+    from work_buddy.mcp_server.registry import (
+        WorkflowDefinition, WorkflowStep,
+    )
+
+    wf = WorkflowDefinition(
+        name="test-wf",
+        description="Stub workflow for lifecycle test.",
+        workflow_file="",
+        execution="main",
+        steps=[
+            WorkflowStep(
+                id="only",
+                name="Only step",
+                instruction="(no-op)",
+                step_type="reasoning",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        registry, "get_entry",
+        lambda name: wf if name == "test-wf" else None,
+    )
+    # ``conductor`` imported ``get_entry`` into its module namespace; patch
+    # that reference too so ``start_workflow``'s call site uses the stub.
+    monkeypatch.setattr(
+        conductor, "get_entry",
+        lambda name: wf if name == "test-wf" else None,
+    )
+    # Reset _ACTIVE_RUNS so the lifecycle test sees a clean conductor.
+    with conductor._ACTIVE_RUNS_LOCK:
+        conductor._ACTIVE_RUNS.clear()
+    return wf
+
+
+# ---------------------------------------------------------------------------
+# start_workflow mints the workflow_run grant
+# ---------------------------------------------------------------------------
+
+
+def test_start_workflow_mints_run_grant(cache, stub_workflow):
+    from work_buddy.mcp_server import conductor
+    from work_buddy.consent import is_workflow_authorized
+
+    result = conductor.start_workflow("test-wf", params=None, agent_session_id=None)
+
+    run_id = result["workflow_run_id"]
+    ok, via = is_workflow_authorized("test-wf", run_id)
+    assert ok is True
+    assert via == "run"
+
+
+def test_start_workflow_pins_workflow_name_on_dag(cache, stub_workflow):
+    """Lifecycle hooks read ``dag.workflow_name`` for the class name; the
+    pin happens in start_workflow."""
+    from work_buddy.mcp_server import conductor
+
+    result = conductor.start_workflow("test-wf", params=None, agent_session_id=None)
+    run_id = result["workflow_run_id"]
+
+    with conductor._ACTIVE_RUNS_LOCK:
+        dag = conductor._ACTIVE_RUNS[run_id]
+    assert getattr(dag, "workflow_name", None) == "test-wf"
+
+
+# ---------------------------------------------------------------------------
+# Run completion revokes the run grant
+# ---------------------------------------------------------------------------
+
+
+def test_complete_workflow_revokes_run_grant(cache, stub_workflow):
+    from work_buddy.mcp_server import conductor
+    from work_buddy.consent import is_workflow_authorized
+
+    result = conductor.start_workflow("test-wf", params=None, agent_session_id=None)
+    run_id = result["workflow_run_id"]
+
+    # Complete the only step.
+    advance_result = conductor.advance_workflow(
+        run_id, step_result={"ok": True},
+    )
+    # Should be workflow_complete.
+    assert advance_result.get("type") == "workflow_complete"
+
+    ok, via = is_workflow_authorized("test-wf", run_id)
+    assert ok is False
+    assert via is None
+
+
+# ---------------------------------------------------------------------------
+# cascade_revoke_workflow walks _ACTIVE_RUNS
+# ---------------------------------------------------------------------------
+
+
+def test_cascade_revoke_workflow_revokes_class_and_runs(cache, stub_workflow):
+    """Class revoke + cascade walks _ACTIVE_RUNS to revoke each matching
+    run grant in the same session.
+    """
+    from work_buddy.mcp_server import conductor
+    from work_buddy.consent import (
+        grant_workflow_class, is_workflow_authorized,
+    )
+
+    # Mint a class grant first (would normally happen via gateway pre-flight).
+    grant_workflow_class("test-wf", ttl_minutes=15)
+
+    # Start two runs of the same workflow.
+    r1 = conductor.start_workflow("test-wf", params=None, agent_session_id=None)
+    r2 = conductor.start_workflow("test-wf", params=None, agent_session_id=None)
+    rid1 = r1["workflow_run_id"]
+    rid2 = r2["workflow_run_id"]
+
+    # Both runs are authorized via the run grant.
+    assert is_workflow_authorized("test-wf", rid1)[0] is True
+    assert is_workflow_authorized("test-wf", rid2)[0] is True
+
+    # Cascade revoke.
+    result = conductor.cascade_revoke_workflow("test-wf", session_id=None)
+
+    assert result["revoked_class"] is True
+    assert set(result["revoked_runs"]) == {rid1, rid2}
+
+    # Both run grants AND class grant are gone.
+    ok1, _ = is_workflow_authorized("test-wf", rid1)
+    ok2, _ = is_workflow_authorized("test-wf", rid2)
+    assert ok1 is False
+    assert ok2 is False
+
+
+# ---------------------------------------------------------------------------
+# reconcile_workflow_consent cleans up orphaned workflow_run keys
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_revokes_orphaned_workflow_run_key(cache, stub_workflow):
+    """A workflow_run:* key without a matching active run gets swept."""
+    from work_buddy.mcp_server import conductor
+    from work_buddy.consent import (
+        grant_workflow_run, list_active_workflow_grants,
+    )
+
+    # Hand-mint a workflow_run key for a run that doesn't exist in _ACTIVE_RUNS.
+    grant_workflow_run("test-wf", "wf_orphaned")
+
+    # Pre-state: key exists.
+    snap = list_active_workflow_grants()
+    run_names = {(e["workflow_name"], e["run_id"]) for e in snap["run"]}
+    assert ("test-wf", "wf_orphaned") in run_names
+
+    # Reconcile against the current (default) session.
+    import os
+    sid = os.environ["WORK_BUDDY_SESSION_ID"]
+    result = conductor.reconcile_workflow_consent(sid)
+
+    # The orphan was swept (the legacy-blanket path returns 'no_blanket'
+    # but the run sweep happens additively).
+    assert "orphaned_run_keys" in result
+
+    # Post-state: key gone.
+    snap_after = list_active_workflow_grants()
+    run_names_after = {(e["workflow_name"], e["run_id"]) for e in snap_after["run"]}
+    assert ("test-wf", "wf_orphaned") not in run_names_after

--- a/tests/unit/test_consent_composable.py
+++ b/tests/unit/test_consent_composable.py
@@ -1030,3 +1030,126 @@ def test_finalize_denied_writes_no_grants(cache):
 
     ok, _ = is_workflow_authorized("task-new")
     assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# _auto_consent_request session routing — the bug an earlier session
+# exposed: capability-bundle consent prompts had their
+# ``callback_session_id`` set from ``os.environ.get("WORK_BUDDY_SESSION_ID")``
+# (the MCP server's bootstrap session), not from the agent's session.
+# Out-of-band approvals (Telegram callback, Obsidian-modal click after
+# the gateway's poll has exited) then mis-routed grants into the
+# bootstrap DB while the agent's DB stayed empty. The fix threads an
+# explicit ``session_id`` argument from the caller (the agent's session
+# id, resolved via ``_resolve_session(ctx)``) through to
+# ``create_consent_request``.
+# ---------------------------------------------------------------------------
+
+
+def test_auto_consent_request_routes_callback_to_explicit_session(
+    cache, monkeypatch,
+):
+    """``_auto_consent_request(session_id=<sid>)`` sets the resulting
+    notification's ``callback_session_id`` to ``<sid>``, not to the
+    process's env-var session."""
+    from work_buddy.mcp_server.tools import gateway
+
+    # Capture the args ``create_consent_request`` receives.
+    captured: dict = {}
+
+    def _fake_create(**kwargs):
+        captured.update(kwargs)
+        return {
+            "notification_id": "req_fake",
+            "request_id": "req_fake",
+            "notification_id_short": "fake1234",
+        }
+
+    monkeypatch.setattr(gateway, "create_consent_request", _fake_create, raising=False)
+    # The function imports ``create_consent_request`` from
+    # ``work_buddy.consent`` inside its body; patch that source too.
+    from work_buddy import consent as cmod
+    monkeypatch.setattr(cmod, "create_consent_request", _fake_create)
+
+    # Make the dispatcher path a no-op so the function exits fast (no
+    # 90s wait). Returning a dispatcher whose poll yields None makes
+    # _auto_consent_request return the "timeout" payload — but we
+    # don't care about its return value here, only the captured args.
+    class _NoopDispatcher:
+        @classmethod
+        def from_config(cls):
+            return cls()
+        def deliver(self, *args, **kwargs):
+            pass
+        def poll_response(self, *args, **kwargs):
+            return None
+
+    from work_buddy.notifications import dispatcher as disp_mod
+    monkeypatch.setattr(disp_mod, "SurfaceDispatcher", _NoopDispatcher)
+    # Also patch get_notification so the "delivered_surfaces" branch
+    # gracefully returns None.
+    monkeypatch.setattr(
+        "work_buddy.notifications.store.get_notification",
+        lambda nid: None,
+    )
+
+    # Force the env to a known bogus value so we can prove the
+    # function did NOT fall back to env when session_id was given.
+    monkeypatch.setenv("WORK_BUDDY_SESSION_ID", "bootstrap-bogus-sid")
+
+    gateway._auto_consent_request(
+        operations=["test.op"],
+        capability_name="test_cap",
+        op_id="op_test",
+        session_id="explicit-agent-sid",
+    )
+
+    assert captured.get("callback_session_id") == "explicit-agent-sid", (
+        f"Expected callback_session_id='explicit-agent-sid', got "
+        f"{captured.get('callback_session_id')!r}. The function must "
+        f"route to the explicit session id, not the env-var fallback."
+    )
+
+
+def test_auto_consent_request_falls_back_to_env_when_session_id_none(
+    cache, monkeypatch,
+):
+    """Back-compat: when no ``session_id`` is passed,
+    ``_auto_consent_request`` still reads the env var. Keeps any
+    legacy / direct caller that hasn't been updated working."""
+    from work_buddy.mcp_server.tools import gateway
+
+    captured: dict = {}
+
+    def _fake_create(**kwargs):
+        captured.update(kwargs)
+        return {"notification_id": "req_fake", "request_id": "req_fake"}
+
+    from work_buddy import consent as cmod
+    monkeypatch.setattr(cmod, "create_consent_request", _fake_create)
+
+    class _NoopDispatcher:
+        @classmethod
+        def from_config(cls):
+            return cls()
+        def deliver(self, *args, **kwargs):
+            pass
+        def poll_response(self, *args, **kwargs):
+            return None
+
+    from work_buddy.notifications import dispatcher as disp_mod
+    monkeypatch.setattr(disp_mod, "SurfaceDispatcher", _NoopDispatcher)
+    monkeypatch.setattr(
+        "work_buddy.notifications.store.get_notification",
+        lambda nid: None,
+    )
+    monkeypatch.setenv("WORK_BUDDY_SESSION_ID", "env-fallback-sid")
+
+    gateway._auto_consent_request(
+        operations=["test.op"],
+        capability_name="test_cap",
+        op_id="op_test",
+        # No session_id arg.
+    )
+
+    assert captured.get("callback_session_id") == "env-fallback-sid"

--- a/tests/unit/test_consent_composable.py
+++ b/tests/unit/test_consent_composable.py
@@ -1,0 +1,633 @@
+"""Unit tests — composable consent primitives.
+
+Validates the ``grant_workflow_class`` / ``grant_workflow_run`` /
+``revoke_workflow_class`` / ``revoke_workflow_run`` /
+``is_workflow_authorized`` primitives in isolation, without any
+conductor or gateway involvement — pure unit tests on the consent
+layer.
+
+Lifecycle properties under test:
+
+- Class grant: TTL-bounded, persists across re-invocations within the
+  window, revokable independently of run grants.
+- Run grant: no TTL, revoked explicitly at run completion (or via
+  cascade from class revoke), idempotent revoke.
+- ``is_workflow_authorized`` lookup order: run → class.
+- Session routing: grants land in the named session's DB, not the
+  current process's session DB.
+- ``list_active_workflow_grants`` returns parsed class + run entries.
+
+Test isolation:
+  Uses the ``tmp_agents_dir`` fixture from the root ``conftest.py``,
+  which monkeypatches ``paths.data_dir`` so every test sees a clean
+  agents/ directory under a per-test ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def cache(tmp_agents_dir, monkeypatch):
+    """Reset the module-level consent cache for each test.
+
+    ``tmp_agents_dir`` redirects ``paths.data_dir("agents")`` to a clean
+    temp directory. Other test files (e.g. ``test_consent_auto_request``)
+    monkey-patch ``agent_session.get_agents_dir`` to a closure-bound
+    lambda — that patch survives across tests and silently overrides our
+    fixture's path redirection. We defensively re-install the original
+    ``get_agents_dir`` (the one that consults ``data_dir("agents")``)
+    so this fixture's redirection sticks regardless of what ran first.
+
+    We also reset the per-process dedupe set for the legacy-blanket
+    deprecation log so the dedupe-counting test sees a clean slate.
+    """
+    import work_buddy.agent_session as asmod
+    # The canonical ``get_agents_dir`` consults ``data_dir("agents")``;
+    # cross-file leaks may have replaced it with a lambda that bypasses
+    # our path redirection. Reinstall the real implementation so
+    # ``tmp_agents_dir``'s ``data_dir`` monkey-patch applies.
+    def _canonical_get_agents_dir():
+        return asmod.data_dir("agents")
+    monkeypatch.setattr(asmod, "get_agents_dir", _canonical_get_agents_dir)
+    monkeypatch.setattr(asmod, "_cached_session_dir", None)
+
+    from work_buddy.consent import _cache
+    _cache._db_path = None
+    _cache._initialized = False
+
+    # Reset the per-process dedupe set for the legacy-blanket
+    # deprecation log so tests that count emits see a clean slate.
+    from work_buddy import consent as cmod
+    cmod._LEGACY_BLANKET_LOGGED.clear()
+
+    return _cache
+
+
+# ---------------------------------------------------------------------------
+# Key shape & accessors (no DB needed)
+# ---------------------------------------------------------------------------
+
+
+def test_key_helpers():
+    from work_buddy.consent import (
+        _workflow_class_key, _workflow_run_key,
+        WORKFLOW_CLASS_PREFIX, WORKFLOW_RUN_PREFIX,
+    )
+    assert _workflow_class_key("task-new") == "workflow_class:task-new"
+    assert _workflow_run_key("task-new", "wf_abc123") == "workflow_run:task-new:wf_abc123"
+    assert WORKFLOW_CLASS_PREFIX == "workflow_class:"
+    assert WORKFLOW_RUN_PREFIX == "workflow_run:"
+
+
+# ---------------------------------------------------------------------------
+# Class grants
+# ---------------------------------------------------------------------------
+
+
+def test_class_grant_lifecycle(cache):
+    """grant_workflow_class writes; revoke_workflow_class clears."""
+    from work_buddy.consent import (
+        grant_workflow_class, revoke_workflow_class,
+        is_workflow_authorized,
+    )
+
+    ok, via = is_workflow_authorized("task-new")
+    assert ok is False and via is None
+
+    grant_workflow_class("task-new", ttl_minutes=15)
+    ok, via = is_workflow_authorized("task-new")
+    assert ok is True and via == "class"
+
+    revoke_workflow_class("task-new")
+    ok, via = is_workflow_authorized("task-new")
+    assert ok is False
+
+
+def test_class_grant_is_per_workflow(cache):
+    """A class grant for one workflow does not authorize another."""
+    from work_buddy.consent import (
+        grant_workflow_class, is_workflow_authorized,
+    )
+
+    grant_workflow_class("task-new", ttl_minutes=15)
+    assert is_workflow_authorized("task-new")[0] is True
+    assert is_workflow_authorized("morning-routine")[0] is False
+    assert is_workflow_authorized("dev-pr")[0] is False
+
+
+def test_class_grant_idempotent_revoke(cache):
+    """Revoking a missing class grant is a no-op."""
+    from work_buddy.consent import revoke_workflow_class
+    # Should not raise
+    revoke_workflow_class("does-not-exist")
+    revoke_workflow_class("does-not-exist")  # second call also fine
+
+
+# ---------------------------------------------------------------------------
+# Run grants
+# ---------------------------------------------------------------------------
+
+
+def test_run_grant_lifecycle(cache):
+    """grant_workflow_run writes; revoke_workflow_run clears."""
+    from work_buddy.consent import (
+        grant_workflow_run, revoke_workflow_run, is_workflow_authorized,
+    )
+
+    grant_workflow_run("task-new", "wf_abc")
+    ok, via = is_workflow_authorized("task-new", "wf_abc")
+    assert ok is True and via == "run"
+
+    revoke_workflow_run("task-new", "wf_abc")
+    ok, via = is_workflow_authorized("task-new", "wf_abc")
+    assert ok is False
+
+
+def test_run_grant_is_per_run(cache):
+    """A grant for one run does not authorize a different run of the same
+    workflow."""
+    from work_buddy.consent import (
+        grant_workflow_run, is_workflow_authorized,
+    )
+
+    grant_workflow_run("task-new", "wf_abc")
+    ok_a, _ = is_workflow_authorized("task-new", "wf_abc")
+    ok_b, _ = is_workflow_authorized("task-new", "wf_xyz")
+    assert ok_a is True
+    assert ok_b is False
+
+
+def test_run_grant_idempotent_revoke(cache):
+    """Revoking a missing run grant is a no-op."""
+    from work_buddy.consent import revoke_workflow_run
+    revoke_workflow_run("task-new", "wf_doesnotexist")
+    revoke_workflow_run("task-new", "wf_doesnotexist")
+
+
+# ---------------------------------------------------------------------------
+# Authorization lookup order
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_prefers_run_over_class(cache):
+    """When both run and class grants exist, ``via`` reports 'run'."""
+    from work_buddy.consent import (
+        grant_workflow_class, grant_workflow_run, is_workflow_authorized,
+    )
+
+    grant_workflow_class("task-new", ttl_minutes=15)
+    grant_workflow_run("task-new", "wf_abc")
+
+    ok, via = is_workflow_authorized("task-new", "wf_abc")
+    assert ok is True
+    assert via == "run"
+
+
+def test_lookup_falls_back_to_class_when_run_missing(cache):
+    """If only the class grant exists, ``via`` reports 'class'."""
+    from work_buddy.consent import (
+        grant_workflow_class, is_workflow_authorized,
+    )
+
+    grant_workflow_class("task-new", ttl_minutes=15)
+    ok, via = is_workflow_authorized("task-new", "wf_abc_not_granted")
+    assert ok is True
+    assert via == "class"
+
+
+def test_lookup_without_run_id_only_checks_class(cache):
+    """When ``run_id`` is None, the run-grant lookup is skipped."""
+    from work_buddy.consent import (
+        grant_workflow_run, is_workflow_authorized,
+    )
+
+    grant_workflow_run("task-new", "wf_abc")
+    # Without a run_id, the run grant should not match.
+    ok, via = is_workflow_authorized("task-new", None)
+    assert ok is False
+    assert via is None
+
+
+# ---------------------------------------------------------------------------
+# Independence of class and run grant lifecycles
+# ---------------------------------------------------------------------------
+
+
+def test_revoke_run_leaves_class_intact(cache):
+    """Revoking the run grant should not affect the class grant."""
+    from work_buddy.consent import (
+        grant_workflow_class, grant_workflow_run,
+        revoke_workflow_run, is_workflow_authorized,
+    )
+
+    grant_workflow_class("task-new", ttl_minutes=15)
+    grant_workflow_run("task-new", "wf_abc")
+    revoke_workflow_run("task-new", "wf_abc")
+
+    # Class grant should still satisfy the lookup.
+    ok, via = is_workflow_authorized("task-new", "wf_abc")
+    assert ok is True
+    assert via == "class"
+
+
+def test_revoke_class_leaves_run_intact(cache):
+    """Revoking the class grant (without cascade — cascade lives in the
+    conductor) leaves the run grant intact."""
+    from work_buddy.consent import (
+        grant_workflow_class, grant_workflow_run,
+        revoke_workflow_class, is_workflow_authorized,
+    )
+
+    grant_workflow_class("task-new", ttl_minutes=15)
+    grant_workflow_run("task-new", "wf_abc")
+    revoke_workflow_class("task-new")
+
+    # Run grant is unaffected; lookup with a known run still authorized.
+    ok, via = is_workflow_authorized("task-new", "wf_abc")
+    assert ok is True
+    assert via == "run"
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic helper
+# ---------------------------------------------------------------------------
+
+
+def test_list_active_workflow_grants_parses_keys(cache):
+    """``list_active_workflow_grants`` returns parsed class and run entries."""
+    from work_buddy.consent import (
+        grant_workflow_class, grant_workflow_run,
+        list_active_workflow_grants,
+    )
+
+    grant_workflow_class("task-new", ttl_minutes=15)
+    grant_workflow_run("task-new", "wf_abc")
+    grant_workflow_run("morning-routine", "wf_xyz")
+
+    snapshot = list_active_workflow_grants()
+    assert "class" in snapshot
+    assert "run" in snapshot
+    assert len(snapshot["class"]) == 1
+    assert len(snapshot["run"]) == 2
+
+    class_entry = snapshot["class"][0]
+    assert class_entry["workflow_name"] == "task-new"
+    assert class_entry["mode"] == "temporary"
+
+    run_names = {e["workflow_name"] for e in snapshot["run"]}
+    assert run_names == {"task-new", "morning-routine"}
+
+    run_ids = {e["run_id"] for e in snapshot["run"]}
+    assert run_ids == {"wf_abc", "wf_xyz"}
+
+
+def test_list_active_workflow_grants_skips_legacy_blanket(cache):
+    """The legacy ``__workflow_consent__`` is NOT a workflow_class:/run: key
+    and should not appear in the new diagnostic."""
+    from work_buddy.consent import (
+        grant_workflow_consent, list_active_workflow_grants,
+    )
+
+    grant_workflow_consent("wf_legacy", ttl_minutes=15)
+    snapshot = list_active_workflow_grants()
+    # Legacy blanket doesn't show up here — it's a separate key shape.
+    assert snapshot["class"] == []
+    assert snapshot["run"] == []
+
+
+# ---------------------------------------------------------------------------
+# TTL behavior on class grants
+# ---------------------------------------------------------------------------
+
+
+def test_class_grant_respects_ttl(cache):
+    """A class grant whose ``expires_at`` is set in the past is treated as
+    expired by the lookup path."""
+    from work_buddy.consent import (
+        grant_workflow_class, is_workflow_authorized, _cache,
+    )
+    from datetime import datetime, timedelta, timezone
+
+    grant_workflow_class("task-new", ttl_minutes=1)
+    assert is_workflow_authorized("task-new")[0] is True
+
+    # Fast-forward by tampering with the row's expires_at directly so we
+    # don't have to sleep in the test.
+    import sqlite3
+    db = _cache._get_db_path()
+    conn = sqlite3.connect(str(db))
+    past = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+    conn.execute(
+        "UPDATE grants SET expires_at = ? "
+        "WHERE operation = 'workflow_class:task-new'",
+        (past,),
+    )
+    conn.commit()
+    conn.close()
+
+    ok, via = is_workflow_authorized("task-new")
+    assert ok is False
+    assert via is None
+
+
+# ---------------------------------------------------------------------------
+# Audit-log emission (smoke — full audit-format tests live elsewhere)
+# ---------------------------------------------------------------------------
+
+
+def test_grant_class_writes_audit_line(cache, monkeypatch):
+    """Audit log records WORKFLOW_CLASS_GRANTED on class grant."""
+    from work_buddy import consent as cmod
+
+    captured: list[tuple[str, str, str]] = []
+
+    def _capture(event, operation, details=""):
+        captured.append((event, operation, details))
+
+    monkeypatch.setattr(cmod, "_audit_log", _capture)
+
+    cmod.grant_workflow_class("task-new", ttl_minutes=15)
+
+    events = [e for e, _, _ in captured]
+    assert "WORKFLOW_CLASS_GRANTED" in events
+
+
+def test_grant_run_writes_audit_line(cache, monkeypatch):
+    """Audit log records WORKFLOW_RUN_GRANTED on run grant."""
+    from work_buddy import consent as cmod
+
+    captured: list[tuple[str, str, str]] = []
+
+    def _capture(event, operation, details=""):
+        captured.append((event, operation, details))
+
+    monkeypatch.setattr(cmod, "_audit_log", _capture)
+
+    cmod.grant_workflow_run("task-new", "wf_abc")
+
+    events = [e for e, _, _ in captured]
+    assert "WORKFLOW_RUN_GRANTED" in events
+
+
+def test_revoke_run_writes_audit_line_with_reason(cache, monkeypatch):
+    """Audit log records WORKFLOW_RUN_REVOKED with the supplied reason."""
+    from work_buddy import consent as cmod
+
+    cmod.grant_workflow_run("task-new", "wf_abc")
+
+    captured: list[tuple[str, str, str]] = []
+
+    def _capture(event, operation, details=""):
+        captured.append((event, operation, details))
+
+    monkeypatch.setattr(cmod, "_audit_log", _capture)
+
+    cmod.revoke_workflow_run("task-new", "wf_abc", reason="cascade")
+
+    matching = [
+        (e, op, d) for (e, op, d) in captured
+        if e == "WORKFLOW_RUN_REVOKED"
+    ]
+    assert matching, "expected WORKFLOW_RUN_REVOKED audit entry"
+    _, _, details = matching[0]
+    assert "reason=cascade" in details
+
+
+# ---------------------------------------------------------------------------
+# Decorator check path honors the new keys
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_run_grant_carries_low_weight_op(cache):
+    """A workflow_run grant authorizes a low-weight op invocation via
+    ``is_granted`` (the path the decorator uses)."""
+    from work_buddy.consent import grant_workflow_run, _cache
+    grant_workflow_run("task-new", "wf_abc")
+    # Low-weight (default) — workflow grant carries it.
+    assert _cache.is_granted("some.low_op") is True
+
+
+def test_workflow_class_grant_carries_low_weight_op(cache):
+    """A workflow_class grant authorizes a low-weight op invocation."""
+    from work_buddy.consent import grant_workflow_class, _cache
+    grant_workflow_class("task-new", ttl_minutes=15)
+    assert _cache.is_granted("some.low_op") is True
+
+
+def test_high_weight_op_is_not_carried_by_workflow_run_grant(cache):
+    """A workflow_run grant does NOT authorize a high-weight op."""
+    from work_buddy.consent import grant_workflow_run, _cache
+    grant_workflow_run("task-new", "wf_abc")
+    assert _cache.is_granted("destructive.op", consent_weight="high") is False
+
+
+def test_high_weight_op_is_not_carried_by_workflow_class_grant(cache):
+    """A workflow_class grant does NOT authorize a high-weight op."""
+    from work_buddy.consent import grant_workflow_class, _cache
+    grant_workflow_class("task-new", ttl_minutes=15)
+    assert _cache.is_granted("destructive.op", consent_weight="high") is False
+
+
+def test_high_weight_op_with_individual_grant_passes(cache):
+    """A high-weight op *can* be authorized by an individual grant."""
+    from work_buddy.consent import grant_consent, _cache
+    grant_consent("destructive.op", mode="always")
+    assert _cache.is_granted("destructive.op", consent_weight="high") is True
+
+
+def test_diagnose_carry_reports_individual(cache):
+    """``diagnose_carry`` returns ``individual`` when an op grant matches."""
+    from work_buddy.consent import grant_consent, _cache
+    grant_consent("some.op", mode="always")
+    source, key = _cache.diagnose_carry("some.op")
+    assert source == "individual"
+    assert key == "some.op"
+
+
+def test_diagnose_carry_reports_workflow_run(cache):
+    """``diagnose_carry`` returns ``workflow_run`` with the matched key."""
+    from work_buddy.consent import grant_workflow_run, _cache
+    grant_workflow_run("task-new", "wf_abc")
+    source, key = _cache.diagnose_carry("some.op")
+    assert source == "workflow_run"
+    assert key == "workflow_run:task-new:wf_abc"
+
+
+def test_diagnose_carry_reports_workflow_class_when_no_run(cache):
+    """``diagnose_carry`` falls back to workflow_class when no run key."""
+    from work_buddy.consent import grant_workflow_class, _cache
+    grant_workflow_class("task-new", ttl_minutes=15)
+    source, key = _cache.diagnose_carry("some.op")
+    assert source == "workflow_class"
+    assert key == "workflow_class:task-new"
+
+
+def test_diagnose_carry_reports_legacy_blanket(cache):
+    """``diagnose_carry`` reports ``legacy_blanket`` when only the legacy
+    key is present."""
+    from work_buddy.consent import grant_workflow_consent, _cache
+    grant_workflow_consent("wf_test", ttl_minutes=15)
+    source, key = _cache.diagnose_carry("some.op")
+    assert source == "legacy_blanket"
+    assert key == "__workflow_consent__"
+
+
+def test_diagnose_carry_reports_none_when_no_grant(cache):
+    """``diagnose_carry`` reports ``none`` when nothing matches."""
+    from work_buddy.consent import _cache
+    source, key = _cache.diagnose_carry("some.op")
+    assert source == "none"
+    assert key is None
+
+
+def test_diagnose_carry_prefers_run_over_class(cache):
+    """When both run and class grants exist, ``diagnose_carry`` reports
+    the more specific run grant."""
+    from work_buddy.consent import (
+        grant_workflow_run, grant_workflow_class, _cache,
+    )
+    grant_workflow_class("task-new", ttl_minutes=15)
+    grant_workflow_run("task-new", "wf_abc")
+    source, _ = _cache.diagnose_carry("some.op")
+    assert source == "workflow_run"
+
+
+def test_legacy_blanket_still_carries_with_deprecation_log(cache, monkeypatch):
+    """The legacy ``__workflow_consent__`` key still grants (back-compat),
+    but emits exactly one deprecation audit-log line per operation per
+    process."""
+    from work_buddy.consent import grant_workflow_consent, _cache
+    from work_buddy import consent as cmod
+
+    cmod._LEGACY_BLANKET_LOGGED.clear()
+
+    captured: list[tuple[str, str, str]] = []
+
+    def _capture(event, operation, details=""):
+        captured.append((event, operation, details))
+
+    monkeypatch.setattr(cmod, "_audit_log", _capture)
+
+    grant_workflow_consent("wf_legacy", ttl_minutes=15)
+    # Call 1 — carries, emits deprecation log
+    assert _cache.is_granted("legacy.op_1") is True
+    # Call 2 same op — carries, NO duplicate deprecation log
+    assert _cache.is_granted("legacy.op_1") is True
+    # Call 3 different op — carries, emits one deprecation log for that op
+    assert _cache.is_granted("legacy.op_2") is True
+
+    legacy_events = [
+        (e, op) for (e, op, _) in captured
+        if e == "LEGACY_WORKFLOW_BLANKET_USED"
+    ]
+    assert ("LEGACY_WORKFLOW_BLANKET_USED", "legacy.op_1") in legacy_events
+    assert ("LEGACY_WORKFLOW_BLANKET_USED", "legacy.op_2") in legacy_events
+    op_1_count = sum(1 for (_, op) in legacy_events if op == "legacy.op_1")
+    assert op_1_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Retry-queue isolation (originating-session fallback)
+# ---------------------------------------------------------------------------
+# Detailed cross-session tests live in
+# ``tests/unit/test_consent_originating_session.py`` (it has the
+# ``two_sessions`` fixture wiring two SQLite DBs). Here we cover the
+# in-session behavior: ``from_originating=True`` suppresses workflow
+# grants even when they exist in the same session DB.
+
+
+def test_from_originating_suppresses_workflow_run_grant(cache):
+    """When ``from_originating=True``, workflow_run grants do not carry."""
+    from work_buddy.consent import grant_workflow_run, _cache
+    grant_workflow_run("task-new", "wf_abc")
+    # Direct in-session check carries...
+    assert _cache._is_granted_in_session("some.op", session_id=None) is True
+    # ...but the replay-path lookup does not.
+    assert _cache._is_granted_in_session(
+        "some.op", session_id=None, from_originating=True,
+    ) is False
+
+
+def test_from_originating_still_carries_individual_grant(cache):
+    """The replay-path isolation only suppresses workflow grants;
+    individual op grants continue to authorize replay-path lookups."""
+    from work_buddy.consent import grant_consent, _cache
+    grant_consent("some.op", mode="always")
+    assert _cache._is_granted_in_session(
+        "some.op", session_id=None, from_originating=True,
+    ) is True
+
+
+def test_from_originating_suppresses_legacy_blanket(cache):
+    """``from_originating=True`` also suppresses the legacy
+    ``__workflow_consent__`` blanket — replays should not ride any
+    workflow-shaped grant, new or legacy."""
+    from work_buddy.consent import grant_workflow_consent, _cache
+    grant_workflow_consent("wf_test", ttl_minutes=15)
+    assert _cache._is_granted_in_session(
+        "some.op", session_id=None, from_originating=True,
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# @requires_consent decorator integration
+# ---------------------------------------------------------------------------
+
+
+def test_decorator_accepts_consent_weight_parameter(cache):
+    """``@requires_consent(..., consent_weight="high")`` registers the
+    weight in the metadata registry."""
+    from work_buddy.consent import (
+        requires_consent, get_consent_metadata,
+    )
+
+    @requires_consent(
+        "test.high_weight_op",
+        reason="testing",
+        risk="moderate",
+        consent_weight="high",
+    )
+    def _high_weight_fn():
+        return "ok"
+
+    meta = get_consent_metadata("test.high_weight_op")
+    assert meta is not None
+    assert meta["consent_weight"] == "high"
+    assert meta["risk"] == "moderate"
+
+
+def test_decorator_defaults_consent_weight_to_risk(cache):
+    """When ``consent_weight`` is omitted, it mirrors the declared ``risk``."""
+    from work_buddy.consent import (
+        requires_consent, get_consent_metadata,
+    )
+
+    @requires_consent(
+        "test.moderate_default_op",
+        reason="testing",
+        risk="moderate",
+    )
+    def _moderate_fn():
+        return "ok"
+
+    meta = get_consent_metadata("test.moderate_default_op")
+    assert meta is not None
+    assert meta["consent_weight"] == "moderate"
+
+
+def test_decorator_rejects_invalid_consent_weight(cache):
+    """Invalid consent_weight raises at decoration time."""
+    from work_buddy.consent import requires_consent
+
+    import pytest as _pytest
+    with _pytest.raises(ValueError, match="Invalid consent_weight"):
+        @requires_consent(
+            "test.bad_weight",
+            reason="testing",
+            risk="moderate",
+            consent_weight="ultraviolet",
+        )
+        def _bad():
+            return "x"

--- a/tests/unit/test_consent_composable.py
+++ b/tests/unit/test_consent_composable.py
@@ -799,3 +799,64 @@ def test_resolve_dismisses_other_surfaces(cache, monkeypatch):
     # helper passes that through.
     assert calls[0]["responding_surface"] == "direct"
     assert set(calls[0]["delivered_surfaces"]) == {"telegram", "obsidian"}
+
+
+# ---------------------------------------------------------------------------
+# consent_list session routing — without ``agent_session_id``, the cache's
+# default-path fallback can read from a different session than the
+# caller's. The gateway injects the agent session id; the helper here
+# exercises the routing directly.
+# ---------------------------------------------------------------------------
+
+
+def test_list_consents_routes_to_named_session(cache, tmp_path, monkeypatch):
+    """``list_consents(agent_session_id=...)`` reads from the named
+    session's DB, not from whatever the cache's instance path is
+    cached against.
+    """
+    import sqlite3
+    from datetime import datetime, timezone
+    from work_buddy.consent import list_consents
+
+    # Hand-write a grant directly into a sibling session's DB so we
+    # can verify the routing without needing a full second-session
+    # setup. ``ConsentCache._connect(session_id=...)`` resolves the
+    # path via ``agent_session.get_session_dir(session_id)``.
+    import work_buddy.agent_session as asmod
+    other_dir = tmp_path / "agents" / "99999999_other"
+    other_dir.mkdir(parents=True, exist_ok=True)
+    other_db = other_dir / "consent.db"
+
+    original_get_dir = asmod.get_session_dir
+
+    def _patched_get_session_dir(session_id=None):
+        if session_id == "other-session-id":
+            return other_dir
+        return original_get_dir(session_id)
+
+    monkeypatch.setattr(asmod, "get_session_dir", _patched_get_session_dir)
+
+    conn = sqlite3.connect(str(other_db))
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS grants (
+              operation TEXT PRIMARY KEY,
+              mode TEXT NOT NULL,
+              granted_at TEXT NOT NULL,
+              expires_at TEXT
+           )"""
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO grants VALUES (?, ?, ?, ?)",
+        ("other.op", "always",
+         datetime.now(timezone.utc).isoformat(), None),
+    )
+    conn.commit()
+    conn.close()
+
+    # Default-path lookup does NOT see the other session's grant.
+    assert "other.op" not in list_consents()
+
+    # Session-routed lookup DOES see it.
+    other = list_consents(agent_session_id="other-session-id")
+    assert "other.op" in other
+    assert other["other.op"]["mode"] == "always"

--- a/tests/unit/test_consent_composable.py
+++ b/tests/unit/test_consent_composable.py
@@ -860,3 +860,173 @@ def test_list_consents_routes_to_named_session(cache, tmp_path, monkeypatch):
     other = list_consents(agent_session_id="other-session-id")
     assert "other.op" in other
     assert other["other.op"]["mode"] == "always"
+
+
+# ---------------------------------------------------------------------------
+# finalize_consent_response — the helper that surfaces with their own
+# response-recording paths (Telegram inline buttons, /reply command) call
+# after ``respond_to_notification``. Until this helper existed, Telegram
+# out-of-band approvals recorded the response but never wrote any
+# consent grant — the "Allow for 15 min" window was a dead promise.
+# ---------------------------------------------------------------------------
+
+
+def _seed_responded_workflow_consent(workflow_name: str, choice: str = "temporary"):
+    """Helper: create a workflow-consent notification AND record a
+    Telegram-shaped response on it. Mimics the state Telegram's
+    ``on_button`` leaves the notification in after ``respond_to_notification``.
+    """
+    from work_buddy.consent import create_consent_request
+    from work_buddy.notifications.store import respond_to_notification
+    from work_buddy.notifications.models import StandardResponse, ResponseType
+    record = create_consent_request(
+        operation=f"workflow:{workflow_name}",
+        reason="(test) authorize this workflow?",
+        risk="moderate",
+        default_ttl=15,
+        requester=f"gateway:workflow:{workflow_name}",
+        context={
+            "kind": "workflow_consent",
+            "workflow_name": workflow_name,
+            "operation_id": "op_test",
+            "consent_ops": ["tasks.create_task"],
+        },
+    )
+    nid = record["notification_id"]
+    respond_to_notification(
+        nid,
+        StandardResponse(
+            response_type=ResponseType.CHOICE.value,
+            value=choice,
+            raw={"callback_data": f"{nid[:8]}:{choice}", "telegram_message_id": 1},
+            surface="telegram",
+        ),
+    )
+    return nid
+
+
+def test_finalize_workflow_consent_mints_class_grant_from_recorded_response(cache):
+    """``finalize_consent_response`` reads the already-recorded response
+    and mints the workflow_class grant — the path Telegram's
+    ``on_button`` exercises."""
+    from work_buddy.consent import (
+        finalize_consent_response, is_workflow_authorized,
+    )
+    nid = _seed_responded_workflow_consent("task-new", choice="temporary")
+
+    # Sanity: no class grant before finalize.
+    assert is_workflow_authorized("task-new")[0] is False
+
+    out = finalize_consent_response(nid)
+    assert out["status"] == "approved"
+    assert out["mode"] == "temporary"
+    assert out["operation"] == "workflow:task-new"
+
+    ok, via = is_workflow_authorized("task-new")
+    assert ok is True
+    assert via == "class"
+
+
+def test_finalize_workflow_consent_always_mode_uses_24h_ttl(cache):
+    from work_buddy.consent import (
+        finalize_consent_response, is_workflow_authorized,
+    )
+    nid = _seed_responded_workflow_consent("task-new", choice="always")
+
+    finalize_consent_response(nid)
+
+    ok, via = is_workflow_authorized("task-new")
+    assert ok is True
+    assert via == "class"
+
+
+def test_finalize_workflow_consent_once_writes_no_class_grant(cache):
+    from work_buddy.consent import (
+        finalize_consent_response, is_workflow_authorized,
+    )
+    nid = _seed_responded_workflow_consent("task-new", choice="once")
+
+    finalize_consent_response(nid)
+
+    # "once" doesn't mint a class grant — only the run grant covers the run.
+    ok, _ = is_workflow_authorized("task-new")
+    assert ok is False
+
+
+def test_finalize_returns_no_response_when_unanswered(cache):
+    from work_buddy.consent import (
+        create_consent_request, finalize_consent_response,
+    )
+    record = create_consent_request(
+        operation="workflow:task-new",
+        reason="(test)", risk="moderate", default_ttl=15,
+        requester="gateway:workflow:task-new",
+        context={"kind": "workflow_consent", "workflow_name": "task-new"},
+    )
+    out = finalize_consent_response(record["notification_id"])
+    assert out["status"] == "no_response"
+
+
+def test_finalize_returns_not_found_for_unknown_id(cache):
+    from work_buddy.consent import finalize_consent_response
+    out = finalize_consent_response("req_doesnotexist")
+    assert out["status"] == "not_found"
+
+
+def test_finalize_capability_bundle_writes_individual_op_grants(cache):
+    """For a capability-bundle consent (the ``bundle:<cap>`` shape), the
+    helper grants each underlying op so the ``@requires_consent``
+    decorators (which check individual op names) pass."""
+    from work_buddy.consent import (
+        create_consent_request, finalize_consent_response, _cache,
+    )
+    from work_buddy.notifications.store import respond_to_notification
+    from work_buddy.notifications.models import StandardResponse, ResponseType
+    record = create_consent_request(
+        operation="bundle:task_create",
+        reason="(test)", risk="moderate", default_ttl=15,
+        requester="gateway:task_create",
+        context={"capability": "task_create", "operations": ["tasks.create_task"]},
+    )
+    nid = record["notification_id"]
+    respond_to_notification(
+        nid,
+        StandardResponse(
+            response_type=ResponseType.CHOICE.value, value="temporary",
+            raw={}, surface="telegram",
+        ),
+    )
+
+    finalize_consent_response(nid)
+
+    assert _cache.is_granted("tasks.create_task") is True
+
+
+def test_finalize_idempotent_on_repeated_calls(cache):
+    """Calling ``finalize_consent_response`` twice for the same
+    notification is a no-op the second time — the grant write uses
+    INSERT OR REPLACE, so no spurious state changes."""
+    from work_buddy.consent import (
+        finalize_consent_response, is_workflow_authorized,
+    )
+    nid = _seed_responded_workflow_consent("task-new", choice="temporary")
+
+    out_1 = finalize_consent_response(nid)
+    out_2 = finalize_consent_response(nid)
+
+    assert out_1["status"] == "approved"
+    assert out_2["status"] == "approved"  # still approved on re-read
+    assert is_workflow_authorized("task-new")[0] is True
+
+
+def test_finalize_denied_writes_no_grants(cache):
+    from work_buddy.consent import (
+        finalize_consent_response, is_workflow_authorized,
+    )
+    nid = _seed_responded_workflow_consent("task-new", choice="deny")
+
+    out = finalize_consent_response(nid)
+    assert out["status"] == "denied"
+
+    ok, _ = is_workflow_authorized("task-new")
+    assert ok is False

--- a/tests/unit/test_consent_composable.py
+++ b/tests/unit/test_consent_composable.py
@@ -631,3 +631,171 @@ def test_decorator_rejects_invalid_consent_weight(cache):
         )
         def _bad():
             return "x"
+
+
+# ---------------------------------------------------------------------------
+# Out-of-band approval — resolve_consent_request fills in the workflow_class
+# grant AND dismisses sibling surfaces (the gateway's in-window poll does
+# both synchronously; this path closes the gap for Telegram / Obsidian
+# approvals landing after the poll has exited).
+# ---------------------------------------------------------------------------
+
+
+def _seed_workflow_consent_notification(workflow_name: str = "task-new"):
+    """Build a workflow-consent notification record in the same shape
+    the gateway's ``_auto_workflow_consent_request`` creates."""
+    from work_buddy.consent import create_consent_request
+    record = create_consent_request(
+        operation=f"workflow:{workflow_name}",
+        reason="(test) authorize this workflow?",
+        risk="moderate",
+        default_ttl=15,
+        requester=f"gateway:workflow:{workflow_name}",
+        context={
+            "kind": "workflow_consent",
+            "workflow_name": workflow_name,
+            "operation_id": "op_test",
+            "consent_ops": ["tasks.create_task"],
+        },
+    )
+    return record["notification_id"]
+
+
+def test_resolve_workflow_consent_temporary_mints_class_grant(cache):
+    """Out-of-band approval with mode='temporary' mints the
+    ``workflow_class:<name>`` grant with the 15-min TTL — the same
+    grant the in-window poll path would have written."""
+    from work_buddy.consent import (
+        resolve_consent_request, is_workflow_authorized,
+        WORKFLOW_CLASS_TEMPORARY_TTL_MIN,
+    )
+    nid = _seed_workflow_consent_notification("task-new")
+
+    # Sanity: no class grant before resolve.
+    assert is_workflow_authorized("task-new")[0] is False
+
+    resolve_consent_request(
+        nid, approved=True, mode="temporary",
+        ttl_minutes=WORKFLOW_CLASS_TEMPORARY_TTL_MIN,
+    )
+
+    ok, via = is_workflow_authorized("task-new")
+    assert ok is True
+    assert via == "class"
+
+
+def test_resolve_workflow_consent_always_mints_24h_class_grant(cache):
+    """Out-of-band approval with mode='always' uses the 24h TTL constant."""
+    from work_buddy.consent import (
+        resolve_consent_request, is_workflow_authorized,
+    )
+    nid = _seed_workflow_consent_notification("task-new")
+
+    resolve_consent_request(nid, approved=True, mode="always")
+
+    ok, via = is_workflow_authorized("task-new")
+    assert ok is True
+    assert via == "class"
+
+
+def test_resolve_workflow_consent_once_does_not_mint_class_grant(cache):
+    """Out-of-band approval with mode='once' authorizes only this
+    invocation (via the run grant minted later by start_workflow);
+    no class grant is written."""
+    from work_buddy.consent import (
+        resolve_consent_request, is_workflow_authorized,
+    )
+    nid = _seed_workflow_consent_notification("task-new")
+
+    resolve_consent_request(nid, approved=True, mode="once")
+
+    # No class grant minted on "once" — the run grant covers this run.
+    ok, _ = is_workflow_authorized("task-new")
+    assert ok is False
+
+
+def test_resolve_workflow_consent_denied_writes_no_grants(cache):
+    """A denied workflow-consent prompt writes no class grant."""
+    from work_buddy.consent import (
+        resolve_consent_request, is_workflow_authorized,
+    )
+    nid = _seed_workflow_consent_notification("task-new")
+
+    resolve_consent_request(nid, approved=False)
+
+    ok, _ = is_workflow_authorized("task-new")
+    assert ok is False
+
+
+def test_resolve_capability_consent_unchanged(cache):
+    """A non-workflow-consent notification (e.g. capability bundle)
+    does NOT mint a workflow_class grant. The new code path is gated
+    on ``context.kind == "workflow_consent"``."""
+    from work_buddy.consent import (
+        create_consent_request, resolve_consent_request,
+        is_workflow_authorized, _cache,
+    )
+    # Capability-style bundle (no ``kind`` field).
+    record = create_consent_request(
+        operation="bundle:task_create",
+        reason="(test)",
+        risk="moderate",
+        default_ttl=15,
+        requester="gateway:task_create",
+        context={"capability": "task_create", "operations": ["tasks.create_task"]},
+    )
+    nid = record["notification_id"]
+
+    resolve_consent_request(
+        nid, approved=True, mode="temporary", ttl_minutes=15,
+    )
+
+    # Individual op grant was written...
+    assert _cache.is_granted("tasks.create_task") is True
+    # ...but no workflow_class grant for "task_create" exists.
+    assert is_workflow_authorized("task_create")[0] is False
+
+
+def test_resolve_dismisses_other_surfaces(cache, monkeypatch):
+    """``resolve_consent_request`` calls ``dispatcher.dismiss_others`` so
+    a notification approved on one surface disappears on the others.
+    This is the bug surfaced in the live test: Telegram approvals
+    landing after the gateway's poll exit used to leave the Obsidian
+    modal up indefinitely.
+    """
+    from work_buddy.consent import resolve_consent_request
+    from work_buddy.notifications import store, dispatcher as dispatcher_mod
+
+    nid = _seed_workflow_consent_notification("task-new")
+    # Pretend the notification was delivered to two surfaces.
+    store.mark_delivered(nid, "telegram")
+    store.mark_delivered(nid, "obsidian")
+
+    calls = []
+
+    class _FakeDispatcher:
+        @classmethod
+        def from_config(cls):
+            return cls()
+
+        def dismiss_others(self, request_id, *, responding_surface,
+                           delivered_surfaces):
+            calls.append({
+                "request_id": request_id,
+                "responding_surface": responding_surface,
+                "delivered_surfaces": list(delivered_surfaces),
+            })
+            return {"dismissed": [s for s in delivered_surfaces if s != responding_surface]}
+
+    monkeypatch.setattr(dispatcher_mod, "SurfaceDispatcher", _FakeDispatcher)
+
+    resolve_consent_request(
+        nid, approved=True, mode="temporary", ttl_minutes=15,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["request_id"] == nid
+    # ``response.surface`` was "direct" (programmatic resolve); the
+    # helper passes that through.
+    assert calls[0]["responding_surface"] == "direct"
+    assert set(calls[0]["delivered_surfaces"]) == {"telegram", "obsidian"}

--- a/tests/unit/test_consent_originating_session.py
+++ b/tests/unit/test_consent_originating_session.py
@@ -251,12 +251,21 @@ def test_originating_equals_current_skips_double_lookup(
         agent_session.reset_originating_session(token)
 
 
-def test_workflow_blanket_grant_in_originating_session(
+def test_workflow_blanket_grant_in_originating_session_does_not_carry(
     two_sessions, fresh_cache,
 ):
-    """The workflow blanket grant pattern (which is checked by both
-    is_granted and get_mode) ALSO works across the
-    current/originating boundary."""
+    """Workflow grants do not time-travel through the originating-session
+    fallback.
+
+    A workflow grant active when an op is queued for retry could
+    authorize a replay minutes or hours later in a completely different
+    temporal context — an autonomy hole. The originating-session
+    fallback is therefore scoped to individual op grants only;
+    ``workflow_class`` / ``workflow_run`` / legacy ``__workflow_consent__``
+    keys are skipped on the replay path. Replays succeed only when the
+    user individually granted the specific op (or when consent is
+    granted in the current session during the replay window).
+    """
     _, originating_sid, _, originating_db = two_sessions
 
     _write_grant(
@@ -267,7 +276,26 @@ def test_workflow_blanket_grant_in_originating_session(
 
     token = agent_session.set_originating_session(originating_sid)
     try:
-        # Any operation under the workflow blanket → granted.
-        assert fresh_cache.is_granted("any.operation") is True
+        # Workflow blanket in originating session → does NOT carry the
+        # op across the replay boundary.
+        assert fresh_cache.is_granted("any.operation") is False
+    finally:
+        agent_session.reset_originating_session(token)
+
+
+def test_individual_grant_in_originating_session_still_carries(
+    two_sessions, fresh_cache,
+):
+    """The replay-path isolation only suppresses *workflow* grants;
+    individual op grants in the originating session continue to
+    authorize replays."""
+    _, originating_sid, _, originating_db = two_sessions
+
+    # User explicitly granted ``tasks.create_task`` in their session.
+    _write_grant(originating_db, "tasks.create_task", mode="always")
+
+    token = agent_session.set_originating_session(originating_sid)
+    try:
+        assert fresh_cache.is_granted("tasks.create_task") is True
     finally:
         agent_session.reset_originating_session(token)

--- a/tests/unit/test_workflow_consent_preflight.py
+++ b/tests/unit/test_workflow_consent_preflight.py
@@ -1,0 +1,235 @@
+"""Unit tests — gateway pre-flight helpers for workflow consent.
+
+Exercise the helpers in ``work_buddy/mcp_server/tools/gateway.py`` that
+back the workflow-consent pre-flight prompt at workflow start. The full
+dispatcher path (notification delivery → poll → response) is exercised
+by the integration suite; here we cover the building blocks:
+
+- ``_is_workflow_class_authorized`` — checks whether the workflow has a
+  live ``workflow_class:<name>`` grant in the session.
+- ``_collect_workflow_consent_ops`` — walks a workflow's DAG and returns
+  the union of declared ``consent_operations`` plus the max risk.
+- ``_render_workflow_consent_body`` — formats the modal body string.
+- ``_auto_workflow_consent_request`` early-return paths:
+    * Low-weight workflows auto-bypass with status
+      ``"auto_bypass_low_weight"`` and an audit-log entry.
+- ``user_initiated()`` bypass — when the context is active, the gateway's
+  workflow dispatch skips the pre-flight entirely. Verified here via the
+  ``_consent_ctx.depth`` primitive that the gateway reads.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def cache(tmp_agents_dir, monkeypatch):
+    """Shared fixture identical to test_consent_composable.py — reset
+    consent state and restore the canonical ``get_agents_dir`` so this
+    suite is isolated from earlier files' setUps."""
+    import work_buddy.agent_session as asmod
+    def _canonical_get_agents_dir():
+        return asmod.data_dir("agents")
+    monkeypatch.setattr(asmod, "get_agents_dir", _canonical_get_agents_dir)
+    monkeypatch.setattr(asmod, "_cached_session_dir", None)
+
+    from work_buddy.consent import _cache
+    _cache._db_path = None
+    _cache._initialized = False
+
+    from work_buddy import consent as cmod
+    cmod._LEGACY_BLANKET_LOGGED.clear()
+    return _cache
+
+
+# ---------------------------------------------------------------------------
+# _is_workflow_class_authorized
+# ---------------------------------------------------------------------------
+
+
+def test_is_workflow_class_authorized_returns_false_without_grant(cache):
+    """No class grant → not authorized."""
+    from work_buddy.mcp_server.tools.gateway import (
+        _is_workflow_class_authorized,
+    )
+    assert _is_workflow_class_authorized(
+        "task-new", session_id=None,
+    ) is False
+
+
+def test_is_workflow_class_authorized_returns_true_with_grant(cache):
+    """Granting workflow_class makes the helper return True."""
+    from work_buddy.consent import grant_workflow_class
+    from work_buddy.mcp_server.tools.gateway import (
+        _is_workflow_class_authorized,
+    )
+    grant_workflow_class("task-new", ttl_minutes=15)
+    assert _is_workflow_class_authorized(
+        "task-new", session_id=None,
+    ) is True
+
+
+def test_is_workflow_class_authorized_is_per_workflow(cache):
+    """A class grant for one workflow does not authorize another."""
+    from work_buddy.consent import grant_workflow_class
+    from work_buddy.mcp_server.tools.gateway import (
+        _is_workflow_class_authorized,
+    )
+    grant_workflow_class("task-new", ttl_minutes=15)
+    assert _is_workflow_class_authorized("morning-routine", session_id=None) is False
+
+
+# ---------------------------------------------------------------------------
+# _collect_workflow_consent_ops
+# ---------------------------------------------------------------------------
+
+
+def _make_workflow_def(steps_invokes: list[list[str]]):
+    """Helper: build a minimal WorkflowDefinition with the given
+    per-step ``invokes`` lists."""
+    from work_buddy.mcp_server.registry import (
+        WorkflowDefinition, WorkflowStep,
+    )
+    steps = [
+        WorkflowStep(
+            id=f"s{i}",
+            name=f"Step {i}",
+            instruction="",
+            step_type="code",
+            invokes=invokes,
+        )
+        for i, invokes in enumerate(steps_invokes)
+    ]
+    return WorkflowDefinition(
+        name="test-wf",
+        description="A test workflow.",
+        workflow_file="",
+        execution="main",
+        steps=steps,
+    )
+
+
+def test_collect_workflow_consent_ops_empty_when_no_invokes(cache):
+    """Workflow with no invokes → no consent ops."""
+    from work_buddy.mcp_server.tools.gateway import _collect_workflow_consent_ops
+    entry = _make_workflow_def([[]])
+    ops, max_risk = _collect_workflow_consent_ops(entry)
+    assert ops == []
+    assert max_risk == "low"
+
+
+def test_collect_workflow_consent_ops_deduplicates(cache):
+    """Same capability invoked from multiple steps contributes once."""
+    from work_buddy.mcp_server.tools.gateway import _collect_workflow_consent_ops
+    entry = _make_workflow_def([["cap_a"], ["cap_a", "cap_b"]])
+    # No real capabilities registered for cap_a / cap_b → empty result.
+    # The test verifies the function handles unknown caps without raising.
+    ops, max_risk = _collect_workflow_consent_ops(entry)
+    assert ops == []
+    assert max_risk == "low"
+
+
+# ---------------------------------------------------------------------------
+# _render_workflow_consent_body
+# ---------------------------------------------------------------------------
+
+
+def test_render_workflow_consent_body_includes_workflow_name_and_description(cache):
+    from work_buddy.mcp_server.tools.gateway import (
+        _render_workflow_consent_body,
+    )
+    entry = _make_workflow_def([[]])
+    body = _render_workflow_consent_body("task-new", entry, [])
+    assert "task-new" in body
+    assert "A test workflow." in body
+
+
+def test_render_workflow_consent_body_lists_consent_ops(cache):
+    from work_buddy.mcp_server.tools.gateway import (
+        _render_workflow_consent_body,
+    )
+    entry = _make_workflow_def([[]])
+    body = _render_workflow_consent_body(
+        "task-new", entry, ["tasks.create_task", "obsidian.write_file"],
+    )
+    assert "tasks.create_task" in body
+    assert "obsidian.write_file" in body
+
+
+def test_render_workflow_consent_body_notes_no_consent_ops(cache):
+    from work_buddy.mcp_server.tools.gateway import (
+        _render_workflow_consent_body,
+    )
+    entry = _make_workflow_def([[]])
+    body = _render_workflow_consent_body("noop-wf", entry, [])
+    assert "No consent-gated operations" in body
+
+
+# ---------------------------------------------------------------------------
+# _auto_workflow_consent_request — early-return paths
+# ---------------------------------------------------------------------------
+
+
+def test_low_weight_workflow_auto_bypasses_prompt(cache):
+    """A workflow with no declared consent ops (or only low-risk ones)
+    auto-bypasses the prompt. The function returns
+    status='auto_bypass_low_weight' without contacting the notification
+    system."""
+    from work_buddy.mcp_server.tools.gateway import (
+        _auto_workflow_consent_request,
+    )
+    entry = _make_workflow_def([[]])
+    result = _auto_workflow_consent_request(
+        "low-weight-wf", entry, "op_test", session_id=None,
+    )
+    assert result["status"] == "auto_bypass_low_weight"
+    assert result["workflow_name"] == "low-weight-wf"
+
+
+def test_auto_bypass_writes_audit_log(cache, monkeypatch):
+    """The auto-bypass writes a WORKFLOW_AUTO_BYPASS_LOW_WEIGHT audit
+    line so the audit script can find unconverted workflows."""
+    from work_buddy import consent as cmod
+    from work_buddy.mcp_server.tools.gateway import (
+        _auto_workflow_consent_request,
+    )
+
+    captured: list[tuple[str, str, str]] = []
+    def _capture(event, operation, details=""):
+        captured.append((event, operation, details))
+    monkeypatch.setattr(cmod, "_audit_log", _capture)
+
+    entry = _make_workflow_def([[]])
+    _auto_workflow_consent_request(
+        "low-weight-wf", entry, "op_test", session_id=None,
+    )
+
+    bypass_events = [
+        e for (e, op, _) in captured
+        if e == "WORKFLOW_AUTO_BYPASS_LOW_WEIGHT" and op == "low-weight-wf"
+    ]
+    assert bypass_events, "expected WORKFLOW_AUTO_BYPASS_LOW_WEIGHT audit entry"
+
+
+# ---------------------------------------------------------------------------
+# Slash-command / user_initiated bypass primitive
+# ---------------------------------------------------------------------------
+
+
+def test_user_initiated_increments_consent_depth(cache):
+    """``user_initiated()`` sets ``_consent_ctx.depth > 0``; the gateway's
+    workflow dispatch reads this flag to skip the pre-flight prompt
+    entirely. Slash-command launchers and other UI-driven callers wrap
+    their dispatch in ``user_initiated()`` to opt into the bypass.
+    """
+    from work_buddy.consent import user_initiated, _consent_ctx
+
+    assert _consent_ctx.depth == 0
+    with user_initiated("test.bypass"):
+        assert _consent_ctx.depth == 1
+        # Nested re-entry is supported.
+        with user_initiated("test.bypass.inner"):
+            assert _consent_ctx.depth == 2
+        assert _consent_ctx.depth == 1
+    assert _consent_ctx.depth == 0

--- a/tests/unit/test_workflow_individual_consent.py
+++ b/tests/unit/test_workflow_individual_consent.py
@@ -1,8 +1,14 @@
 """Regression: workflow steps marked ``requires_individual_consent: true``
-must suspend the workflow blanket when they are handed to the agent (main
-execution path), then re-grant on advance. Prior to this fix, the flag was
-only honored for ``auto_run`` steps, so a main-execution step inside a
-workflow silently bypassed its ``@requires_consent`` gate.
+must suspend the workflow run grant when they are handed to the agent
+(main execution path), then re-grant on advance. Prior to the original
+fix, the flag was only honored for ``auto_run`` steps, so a
+main-execution step inside a workflow silently bypassed its
+``@requires_consent`` gate.
+
+Updated for composable consent: the conductor now mints/revokes
+``workflow_run:<name>:<run_id>`` grants via
+``grant_workflow_run`` / ``revoke_workflow_run`` instead of the legacy
+``__workflow_consent__`` blanket.
 """
 from __future__ import annotations
 
@@ -11,15 +17,15 @@ def test_main_execution_individual_consent_suspends_blanket(monkeypatch):
     from work_buddy import consent as c
     from work_buddy.mcp_server import conductor
 
-    # Capture grant/revoke calls
+    # Capture grant/revoke calls against the new composable primitives.
     calls: list[tuple[str, str]] = []
     monkeypatch.setattr(
-        c, "grant_workflow_consent",
-        lambda run_id, **_: calls.append(("grant", run_id)),
+        c, "grant_workflow_run",
+        lambda wf_name, run_id, **_: calls.append(("grant", run_id)),
     )
     monkeypatch.setattr(
-        c, "revoke_workflow_consent",
-        lambda run_id="", **_: calls.append(("revoke", run_id)),
+        c, "revoke_workflow_run",
+        lambda wf_name="", run_id="", **_: calls.append(("revoke", run_id)),
     )
 
     # Build a minimal fake DAG node with requires_individual_consent set

--- a/tests/unit/test_workflow_lifecycle.py
+++ b/tests/unit/test_workflow_lifecycle.py
@@ -27,14 +27,25 @@ def _clean_active_runs():
 
 @pytest.fixture(autouse=True)
 def _no_consent_db(monkeypatch):
-    """Stub the workflow-consent revoke so tests never touch a real DB."""
+    """Stub the workflow-consent revoke paths so tests never touch a real DB.
+
+    Captures both the legacy ``revoke_workflow_consent`` and the
+    current ``revoke_workflow_run``. Each call is recorded as a dict
+    carrying ``workflow_run_id`` and ``session_id`` regardless of
+    which entry point fired; this gives tests a single
+    ``workflow_run_id`` / ``session_id`` shape to assert on.
+    """
     calls: list[dict] = []
 
-    def _fake_revoke(workflow_run_id="", *, session_id=None):
+    def _fake_legacy_revoke(workflow_run_id="", *, session_id=None):
+        calls.append({"workflow_run_id": workflow_run_id, "session_id": session_id})
+
+    def _fake_run_revoke(workflow_name, workflow_run_id, *, session_id=None, reason="complete"):
         calls.append({"workflow_run_id": workflow_run_id, "session_id": session_id})
 
     import work_buddy.consent as consent_mod
-    monkeypatch.setattr(consent_mod, "revoke_workflow_consent", _fake_revoke)
+    monkeypatch.setattr(consent_mod, "revoke_workflow_consent", _fake_legacy_revoke)
+    monkeypatch.setattr(consent_mod, "revoke_workflow_run", _fake_run_revoke)
     return calls
 
 

--- a/work_buddy/consent.py
+++ b/work_buddy/consent.py
@@ -786,10 +786,18 @@ class ConsentCache:
         finally:
             conn.close()
 
-    def list_all(self) -> dict[str, Any]:
-        """Return all consent entries, marking expired ones."""
+    def list_all(self, *, session_id: str | None = None) -> dict[str, Any]:
+        """Return all consent entries from the named session's DB, marking
+        expired ones. When ``session_id`` is None, falls back to the
+        cache's default DB path — which is whichever session the
+        instance was first connected against. Callers that need the
+        agent's view (e.g. ``consent_list`` dispatched via wb_run) must
+        pass the agent session id explicitly; otherwise the cache may
+        return rows from the MCP server's bootstrap session rather than
+        the agent's.
+        """
         now = datetime.now(timezone.utc)
-        conn = self._connect()
+        conn = self._connect(session_id=session_id)
         try:
             rows = conn.execute(
                 "SELECT operation, mode, granted_at, expires_at FROM grants"
@@ -1113,9 +1121,21 @@ def revoke_consent(operation: str) -> None:
     _audit_log("REVOKED", operation)
 
 
-def list_consents() -> dict[str, Any]:
-    """List all consent entries with status."""
-    return _cache.list_all()
+def list_consents(
+    *, agent_session_id: str | None = None,
+) -> dict[str, Any]:
+    """List all consent entries with status.
+
+    ``agent_session_id`` routes the lookup to that session's
+    ``consent.db``. The gateway injects the caller's session id when
+    dispatching ``consent_list`` via wb_run so the result reflects the
+    agent's view — without it, the cache would return rows from
+    whichever session the cache instance was first connected against
+    (typically the MCP server's bootstrap session). When called
+    directly (no session id), the existing cache-default behaviour is
+    preserved.
+    """
+    return _cache.list_all(session_id=agent_session_id)
 
 
 # ---------------------------------------------------------------------------

--- a/work_buddy/consent.py
+++ b/work_buddy/consent.py
@@ -48,6 +48,7 @@ Flow:
 """
 
 import functools
+import logging
 import sqlite3
 import threading
 from datetime import datetime, timezone, timedelta
@@ -59,6 +60,33 @@ from work_buddy.agent_session import (
     get_session_consent_db_path,
     get_session_audit_path,
 )
+
+
+logger = logging.getLogger(__name__)
+
+# One-shot deprecation logger for legacy ``__workflow_consent__`` carries.
+# A workflow that still relies on the legacy blanket key (rather than the
+# composable ``workflow_class:`` / ``workflow_run:`` keys) trips this log
+# the first time it carries each operation in a given process. We do NOT
+# emit per-call to avoid log spam — one line per (operation) is enough to
+# locate unconverted call sites.
+_LEGACY_BLANKET_LOGGED: set[str] = set()
+
+
+def _log_legacy_blanket_use_once(operation: str) -> None:
+    if operation in _LEGACY_BLANKET_LOGGED:
+        return
+    _LEGACY_BLANKET_LOGGED.add(operation)
+    _audit_log(
+        "LEGACY_WORKFLOW_BLANKET_USED",
+        operation,
+        "deprecated: use workflow_class/workflow_run keys",
+    )
+    logger.info(
+        "consent: legacy __workflow_consent__ carried operation=%r — "
+        "convert the workflow to mint workflow_class:/workflow_run: keys",
+        operation,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -410,34 +438,49 @@ class ConsentCache:
             self._initialized = True
         return conn
 
-    def is_granted(self, operation: str) -> bool:
+    def is_granted(
+        self,
+        operation: str,
+        *,
+        consent_weight: str = "low",
+    ) -> bool:
         """Check if a valid consent exists for the operation.
 
         Checks in order:
         1. Per-operation grant (explicit consent for this exact operation)
            in the CURRENT session's DB
-        2. Workflow blanket grant in the CURRENT session's DB
-        3. (Fix-a) If neither found AND
+        2. (When ``consent_weight != "high"``) composable workflow grants:
+           any unexpired ``workflow_run:*`` or ``workflow_class:*`` key in
+           the current session's DB
+        3. (When ``consent_weight != "high"``) legacy
+           ``__workflow_consent__`` blanket — deprecation-logged once per
+           operation per process
+        4. (Fix-a) If none found AND
            ``work_buddy.agent_session.get_originating_session()`` returns
-           a session ID different from the current one, repeat steps 1-2
-           against THAT session's DB.
+           a session ID different from the current one, re-check step 1
+           against THAT session's DB. Steps 2 and 3 are deliberately
+           skipped on the originating-session fallback: workflow grants
+           do not time-travel across the sidecar retry queue — replays
+           only ride individual op grants.
 
-        Step 3 closes the cross-session-replay gap (`t-e2f1a8c4`):
-        when the sidecar replays a PWU'd operation, the user's
-        consent grant lives in their session's DB, not the
-        sidecar's. Honoring the originating-session reference lets
-        the replay proceed without forcing a fresh consent prompt
-        for an operation the user already authorized.
+        ``consent_weight``:
+            High-weight operations (e.g. destructive writes, irreversible
+            external sends) bypass the workflow-grant carry. The per-op
+            consent gate always fires for them, even inside an approved
+            workflow run. This mirrors Cursor's destructive-command
+            carve-out and OpenAI's ``isConsequential`` flag.
 
         Revocation semantics preserved: if the user revokes the grant
         in their session, the originating-session lookup also finds
         nothing → returns False → caller gets ConsentRequired.
         """
-        # Step 1+2: current session.
-        if self._is_granted_in_session(operation, session_id=None):
+        # Step 1+2+3: current session.
+        if self._is_granted_in_session(
+            operation, session_id=None, consent_weight=consent_weight,
+        ):
             return True
 
-        # Step 3: originating session, if set and different.
+        # Step 4: originating session, if set and different.
         try:
             from work_buddy.agent_session import (
                 get_originating_session, _get_session_id,
@@ -457,7 +500,10 @@ class ConsentCache:
 
         try:
             granted = self._is_granted_in_session(
-                operation, session_id=originating,
+                operation,
+                session_id=originating,
+                consent_weight=consent_weight,
+                from_originating=True,
             )
         except Exception as exc:  # pragma: no cover — defensive
             logger.warning(
@@ -474,14 +520,27 @@ class ConsentCache:
         return granted
 
     def _is_granted_in_session(
-        self, operation: str, *, session_id: str | None,
+        self,
+        operation: str,
+        *,
+        session_id: str | None,
+        consent_weight: str = "low",
+        from_originating: bool = False,
     ) -> bool:
-        """Same logic as is_granted's first two checks, scoped to
-        ``session_id`` (or current session when None). Extracted so the
-        originating-session fallback can reuse it cleanly."""
+        """Check grant matching for one session's DB.
+
+        ``from_originating`` enables retry-queue isolation: when True (the
+        sidecar's originating-session fallback path), workflow grants
+        (both composable keys and the legacy blanket) are skipped
+        entirely. Only an individual op grant satisfies a replay. This
+        prevents workflow grants from time-traveling across the retry-
+        queue boundary.
+        """
         conn = self._connect(session_id=session_id)
         try:
             now = datetime.now(timezone.utc).isoformat()
+
+            # ── Step 1: individual op grant ──
             row = conn.execute(
                 """SELECT 1 FROM grants
                    WHERE operation = ?
@@ -491,14 +550,46 @@ class ConsentCache:
             if row:
                 return True
 
-            if operation != self.WORKFLOW_CONSENT_OP:
+            # Workflow-grant carry is suppressed on the retry-queue
+            # replay path (``from_originating=True``) and for
+            # ``consent_weight == "high"`` operations.
+            workflow_carry_allowed = (
+                not from_originating
+                and consent_weight != "high"
+                and operation != self.WORKFLOW_CONSENT_OP
+                and not operation.startswith(WORKFLOW_CLASS_PREFIX)
+                and not operation.startswith(WORKFLOW_RUN_PREFIX)
+            )
+
+            if workflow_carry_allowed:
+                # ── Step 2: composable workflow grants ──
+                # Any unexpired ``workflow_run:*`` or ``workflow_class:*``
+                # key in this session authorizes the call. We log which
+                # key matched via the diagnostic helper, but the boolean
+                # answer is all the decorator needs here — the decorator
+                # calls ``diagnose_carry`` separately for audit detail.
                 wf_row = conn.execute(
+                    """SELECT 1 FROM grants
+                       WHERE (operation LIKE 'workflow_run:%'
+                              OR operation LIKE 'workflow_class:%')
+                         AND (expires_at IS NULL OR expires_at > ?)
+                       LIMIT 1""",
+                    (now,),
+                ).fetchone()
+                if wf_row:
+                    return True
+
+                # ── Step 3: legacy ``__workflow_consent__`` fallback ──
+                # Single deprecation-log line per operation per process so
+                # we can grep for unconverted call sites without spam.
+                legacy_row = conn.execute(
                     """SELECT 1 FROM grants
                        WHERE operation = ?
                          AND (expires_at IS NULL OR expires_at > ?)""",
                     (self.WORKFLOW_CONSENT_OP, now),
                 ).fetchone()
-                if wf_row:
+                if legacy_row:
+                    _log_legacy_blanket_use_once(operation)
                     return True
 
             # Clean up expired entries lazily — only on the current
@@ -512,6 +603,75 @@ class ConsentCache:
             return False
         finally:
             conn.close()
+
+    def diagnose_carry(
+        self,
+        operation: str,
+        *,
+        session_id: str | None = None,
+    ) -> tuple[str, str | None]:
+        """Identify which kind of grant currently carries ``operation``.
+
+        Returns ``(source, matched_key)`` where ``source`` is one of:
+        ``"individual"``, ``"workflow_run"``, ``"workflow_class"``,
+        ``"legacy_blanket"``, or ``"none"`` (no grant). ``matched_key``
+        is the actual grant key that matched (or ``None`` for
+        ``"none"``).
+
+        Used by the decorator's audit-log emission to record *why* a
+        call was authorized (``via=workflow_run:task-new:wf_abc``,
+        etc.).  Strict best-effort — never raises.
+        """
+        try:
+            conn = self._connect(session_id=session_id)
+        except Exception:  # pragma: no cover — defensive
+            return ("none", None)
+        try:
+            now = datetime.now(timezone.utc).isoformat()
+            # Individual op grant has highest priority.
+            row = conn.execute(
+                """SELECT 1 FROM grants
+                   WHERE operation = ?
+                     AND (expires_at IS NULL OR expires_at > ?)""",
+                (operation, now),
+            ).fetchone()
+            if row:
+                return ("individual", operation)
+            # Composable workflow grants — prefer run-level when both
+            # are present (more specific scope).
+            wf_run = conn.execute(
+                """SELECT operation FROM grants
+                   WHERE operation LIKE 'workflow_run:%'
+                     AND (expires_at IS NULL OR expires_at > ?)
+                   LIMIT 1""",
+                (now,),
+            ).fetchone()
+            if wf_run:
+                return ("workflow_run", wf_run[0])
+            wf_cls = conn.execute(
+                """SELECT operation FROM grants
+                   WHERE operation LIKE 'workflow_class:%'
+                     AND (expires_at IS NULL OR expires_at > ?)
+                   LIMIT 1""",
+                (now,),
+            ).fetchone()
+            if wf_cls:
+                return ("workflow_class", wf_cls[0])
+            # Legacy blanket — last resort.
+            legacy = conn.execute(
+                """SELECT operation FROM grants
+                   WHERE operation = ?
+                     AND (expires_at IS NULL OR expires_at > ?)""",
+                (self.WORKFLOW_CONSENT_OP, now),
+            ).fetchone()
+            if legacy:
+                return ("legacy_blanket", legacy[0])
+            return ("none", None)
+        finally:
+            try:
+                conn.close()
+            except Exception:  # pragma: no cover — defensive
+                pass
 
     def get_mode(self, operation: str) -> str | None:
         """Return the mode of a grant, or None if not found/expired.
@@ -695,6 +855,7 @@ def requires_consent(
     risk: str = "moderate",
     default_ttl: int = 5,
     body_extras: Callable[[], str] | None = None,
+    consent_weight: str | None = None,
 ):
     """Decorator that gates a function on user consent.
 
@@ -725,19 +886,40 @@ def requires_consent(
             best-effort try/except in the gateway — exceptions are logged
             and skipped, never blocking the prompt. Must be cheap (single
             file read, no network); the user is waiting.
+        consent_weight: ``"low"`` (default — derived from ``risk``),
+            ``"moderate"``, or ``"high"``. Controls whether workflow-level
+            grants (``workflow_class:`` / ``workflow_run:`` keys) may
+            carry the call without surfacing a per-op prompt. A
+            ``"high"`` weight bypasses workflow-grant carry: the per-op
+            consent gate fires even inside an approved workflow run.
+            When omitted, the weight defaults to mirror ``risk`` so
+            existing call sites that did not specify a weight retain the
+            sensible behavior: high-risk operations get high-weight
+            treatment, moderate-risk get moderate-weight, etc.
     """
+    # Default consent_weight to mirror risk when not explicitly set.
+    # This keeps existing call sites — which never passed consent_weight
+    # — calibrated to their declared risk.
+    effective_weight = consent_weight if consent_weight is not None else risk
+
     # Register metadata for gateway auto-request lookup
     _CONSENT_REGISTRY[operation] = {
         "reason": reason,
         "risk": risk,
         "default_ttl": default_ttl,
         "body_extras": body_extras,
+        "consent_weight": effective_weight,
     }
 
     # Validate risk at decoration time (fail-fast on typos)
     if risk not in (r.value for r in Risk):
         raise ValueError(
             f"Invalid risk value: {risk!r}. "
+            f"Must be one of: {', '.join(r.value for r in Risk)}"
+        )
+    if effective_weight not in (r.value for r in Risk):
+        raise ValueError(
+            f"Invalid consent_weight value: {effective_weight!r}. "
             f"Must be one of: {', '.join(r.value for r in Risk)}"
         )
 
@@ -778,16 +960,44 @@ def requires_consent(
                     _consent_ctx.covered_operations = prev_covered
 
             # ── Top-level: check consent cache ──
-            if _cache.is_granted(operation):
-                # Determine consent source for audit
-                op_mode = _cache.get_mode(operation)
-                if op_mode is not None:
+            if _cache.is_granted(operation, consent_weight=effective_weight):
+                # Determine consent source for audit. The composable
+                # consent model recognizes four carry shapes —
+                # ``individual`` / ``workflow_run`` / ``workflow_class``
+                # / ``legacy_blanket`` — and ``diagnose_carry`` returns
+                # which one matched plus the actual key for traceability.
+                carry_source, carry_key = _cache.diagnose_carry(operation)
+                if carry_source == "individual":
+                    op_mode = _cache.get_mode(operation)
                     is_once = op_mode == "once"
-                    _audit_log("EXECUTED", operation, "consent_valid")
-                else:
-                    # Covered by workflow blanket
+                    _audit_log("EXECUTED", operation, "via=individual")
+                elif carry_source == "workflow_run":
                     is_once = False
-                    _audit_log("EXECUTED", operation, "workflow_blanket")
+                    _audit_log(
+                        "EXECUTED", operation,
+                        f"via=workflow_run | key={carry_key}",
+                    )
+                elif carry_source == "workflow_class":
+                    is_once = False
+                    _audit_log(
+                        "EXECUTED", operation,
+                        f"via=workflow_class | key={carry_key}",
+                    )
+                elif carry_source == "legacy_blanket":
+                    is_once = False
+                    _audit_log(
+                        "EXECUTED", operation,
+                        "via=legacy_blanket (deprecated)",
+                    )
+                else:
+                    # is_granted returned True but diagnose_carry did
+                    # not find a matching key — likely the
+                    # originating-session fallback path. Record
+                    # generically.
+                    is_once = False
+                    _audit_log(
+                        "EXECUTED", operation, "via=originating_session",
+                    )
 
                 # Enter consent context — inner @requires_consent will
                 # pass through for the duration of this execution.
@@ -985,6 +1195,235 @@ def is_workflow_consent_active(*, session_id: str | None = None) -> bool:
     return _cache._is_granted_in_session(
         ConsentCache.WORKFLOW_CONSENT_OP, session_id=session_id,
     )
+
+
+# ---------------------------------------------------------------------------
+# Composable workflow consent — class + run grant keys
+# ---------------------------------------------------------------------------
+# Two grant levels coexist with the legacy ``__workflow_consent__`` blanket:
+#
+#   ``workflow_class:<name>``         — class-level trust for a workflow
+#                                       (the "Allow for 15 min" option).
+#                                       TTL-bounded; bounded re-invocation
+#                                       within the window reuses the grant.
+#
+#   ``workflow_run:<name>:<run_id>``  — authorization for a single in-flight
+#                                       run. Has no TTL; revoked at run
+#                                       completion or cascade-revoked when
+#                                       the class grant is explicitly revoked.
+#
+# The decorator's check path (in ``_is_granted_in_session``) consults these
+# keys via a single ``LIKE 'workflow_run:%' OR LIKE 'workflow_class:%'``
+# probe — no need for the cache to introspect ``_ACTIVE_RUNS``. Lifecycle
+# is enforced by the conductor: ``start_workflow`` mints the run grant;
+# ``_build_complete_response`` revokes it; orphan reconciliation cleans up
+# after MCP-server restarts.
+
+WORKFLOW_CLASS_PREFIX = "workflow_class:"
+WORKFLOW_RUN_PREFIX = "workflow_run:"
+
+
+def _workflow_class_key(workflow_name: str) -> str:
+    return f"{WORKFLOW_CLASS_PREFIX}{workflow_name}"
+
+
+def _workflow_run_key(workflow_name: str, run_id: str) -> str:
+    return f"{WORKFLOW_RUN_PREFIX}{workflow_name}:{run_id}"
+
+
+def grant_workflow_class(
+    workflow_name: str,
+    *,
+    ttl_minutes: int,
+    session_id: str | None = None,
+) -> None:
+    """Grant class-level consent for a workflow.
+
+    Lives in the agent's session DB; bounded by ``ttl_minutes``. Subsequent
+    invocations of the same workflow within the window check this grant
+    and skip the user-facing pre-flight prompt (the workflow is "trusted
+    for the session" up to TTL).
+    """
+    _cache.grant(
+        _workflow_class_key(workflow_name),
+        mode="temporary",
+        ttl_minutes=ttl_minutes,
+        session_id=session_id,
+    )
+    sid_tag = f" | session={session_id[:8]}" if session_id else ""
+    _audit_log(
+        "WORKFLOW_CLASS_GRANTED",
+        _workflow_class_key(workflow_name),
+        f"workflow={workflow_name} | ttl={ttl_minutes}m{sid_tag}",
+    )
+
+
+def grant_workflow_run(
+    workflow_name: str,
+    run_id: str,
+    *,
+    session_id: str | None = None,
+) -> None:
+    """Grant run-level consent for an in-flight workflow run.
+
+    No TTL — revoked when the run completes (``revoke_workflow_run`` with
+    ``reason="complete"``) or when the user explicitly revokes the class
+    grant with cascade. Stored with ``mode="once"`` as a marker that says
+    "expect explicit revocation"; the lazy-expiry path does not affect it.
+    """
+    _cache.grant(
+        _workflow_run_key(workflow_name, run_id),
+        mode="once",
+        session_id=session_id,
+    )
+    sid_tag = f" | session={session_id[:8]}" if session_id else ""
+    _audit_log(
+        "WORKFLOW_RUN_GRANTED",
+        _workflow_run_key(workflow_name, run_id),
+        f"workflow={workflow_name} | run={run_id}{sid_tag}",
+    )
+
+
+def revoke_workflow_run(
+    workflow_name: str,
+    run_id: str,
+    *,
+    session_id: str | None = None,
+    reason: str = "complete",
+) -> None:
+    """Revoke run-level consent for a workflow run.
+
+    ``reason`` is one of: ``"complete"`` (normal lifecycle),
+    ``"cascade"`` (parent class-grant revoked), ``"explicit"`` (user
+    revoked this specific run), ``"ttl"`` (rare — class TTL expired
+    mid-run and we narrowed). Recorded in audit log.
+
+    Idempotent: revoking a missing run is a no-op.
+    """
+    try:
+        _cache.revoke(
+            _workflow_run_key(workflow_name, run_id), session_id=session_id,
+        )
+        sid_tag = f" | session={session_id[:8]}" if session_id else ""
+        _audit_log(
+            "WORKFLOW_RUN_REVOKED",
+            _workflow_run_key(workflow_name, run_id),
+            f"workflow={workflow_name} | run={run_id} | reason={reason}{sid_tag}",
+        )
+    except Exception:  # pragma: no cover — defensive idempotency
+        pass
+
+
+def revoke_workflow_class(
+    workflow_name: str,
+    *,
+    session_id: str | None = None,
+) -> None:
+    """Revoke class-level consent for a workflow.
+
+    Does NOT cascade to in-flight runs — that is the conductor's job (it
+    owns ``_ACTIVE_RUNS``). The convention is:
+
+    - Direct callers wanting cascade behavior call
+      ``conductor.cascade_revoke_workflow(name, session_id=...)``, which
+      invokes this function THEN walks ``_ACTIVE_RUNS`` calling
+      ``revoke_workflow_run`` for each matching run.
+    - Callers who only want to remove the class grant (e.g. a TTL-aware
+      cleanup that does not want to interrupt in-flight runs) call this
+      function directly.
+
+    Idempotent.
+    """
+    try:
+        _cache.revoke(
+            _workflow_class_key(workflow_name), session_id=session_id,
+        )
+        sid_tag = f" | session={session_id[:8]}" if session_id else ""
+        _audit_log(
+            "WORKFLOW_CLASS_REVOKED",
+            _workflow_class_key(workflow_name),
+            f"workflow={workflow_name}{sid_tag}",
+        )
+    except Exception:  # pragma: no cover — defensive idempotency
+        pass
+
+
+def is_workflow_authorized(
+    workflow_name: str,
+    run_id: str | None = None,
+    *,
+    session_id: str | None = None,
+) -> tuple[bool, str | None]:
+    """Check whether a workflow (and optional specific run) is authorized.
+
+    Lookup order:
+        1. ``workflow_run:<name>:<run_id>`` (only when ``run_id`` is given)
+        2. ``workflow_class:<name>``
+
+    Returns ``(authorized, via)`` where ``via`` is ``"run"`` when the
+    run-key matched, ``"class"`` when the class-key matched, or ``None``.
+    """
+    if run_id is not None:
+        if _cache._is_granted_in_session(
+            _workflow_run_key(workflow_name, run_id), session_id=session_id,
+        ):
+            return True, "run"
+    if _cache._is_granted_in_session(
+        _workflow_class_key(workflow_name), session_id=session_id,
+    ):
+        return True, "class"
+    return False, None
+
+
+def list_active_workflow_grants(
+    *, session_id: str | None = None,
+) -> dict[str, list[dict[str, Any]]]:
+    """Diagnostic helper: list active workflow_class and workflow_run grants.
+
+    Returns ``{"class": [...], "run": [...]}`` where each entry has
+    ``operation``, ``mode``, ``granted_at``, ``expires_at`` (when set), and
+    parsed ``workflow_name`` / ``run_id`` fields. Used by the dashboard,
+    by orphan reconciliation, and by ``scripts/audit_workflow_consent.py``.
+    """
+    conn = _cache._connect(session_id=session_id)
+    now = datetime.now(timezone.utc).isoformat()
+    try:
+        rows = conn.execute(
+            """SELECT operation, mode, granted_at, expires_at
+               FROM grants
+               WHERE (operation LIKE 'workflow_class:%'
+                      OR operation LIKE 'workflow_run:%')
+                 AND (expires_at IS NULL OR expires_at > ?)""",
+            (now,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    out: dict[str, list[dict[str, Any]]] = {"class": [], "run": []}
+    for operation, mode, granted_at, expires_at in rows:
+        entry: dict[str, Any] = {
+            "operation": operation,
+            "mode": mode,
+            "granted_at": granted_at,
+        }
+        if expires_at:
+            entry["expires_at"] = expires_at
+        if operation.startswith(WORKFLOW_CLASS_PREFIX):
+            entry["workflow_name"] = operation[len(WORKFLOW_CLASS_PREFIX):]
+            out["class"].append(entry)
+        elif operation.startswith(WORKFLOW_RUN_PREFIX):
+            tail = operation[len(WORKFLOW_RUN_PREFIX):]
+            # ``workflow_run:<name>:<run_id>`` — split on the LAST colon so
+            # workflow names containing colons (none today, but possible)
+            # don't get garbled.
+            if ":" in tail:
+                wf_name, run_id = tail.rsplit(":", 1)
+            else:  # pragma: no cover — malformed key
+                wf_name, run_id = tail, ""
+            entry["workflow_name"] = wf_name
+            entry["run_id"] = run_id
+            out["run"].append(entry)
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/work_buddy/consent.py
+++ b/work_buddy/consent.py
@@ -1539,6 +1539,124 @@ def create_consent_request(
     return result
 
 
+def finalize_consent_response(request_id: str) -> dict:
+    """Write consent grants from an already-recorded notification response.
+
+    Translates the response that ``store.respond_to_notification`` (or a
+    surface handler like Telegram's ``on_button``) wrote onto the
+    notification into the actual consent grants in the appropriate
+    session DB.
+
+    Surfaces whose response-recording paths bypass
+    ``resolve_consent_request`` (notably Telegram inline buttons —
+    ``work_buddy/telegram/handlers.py:on_button``) call this from the
+    same handler that records the response, AFTER
+    ``respond_to_notification``. ``resolve_consent_request`` calls it
+    internally; do not call both for the same notification (the second
+    call is a no-op for the grant write because the underlying SQL is
+    ``INSERT OR REPLACE``, but it would emit a duplicate audit line).
+
+    Does NOT record the response, dispatch the callback, or dismiss
+    sibling surfaces — each surface's existing handler already owns
+    those concerns. This function does exactly one thing: write the
+    grants the response calls for.
+
+    Returns ``{"status": "approved"|"denied"|"no_response"|"not_found",
+    "request_id": ..., "mode": ..., "operation": ...}``.
+    """
+    from work_buddy.notifications import store
+
+    notification = store.get_notification(request_id)
+    if notification is None:
+        return {"status": "not_found", "request_id": request_id}
+    response = notification.response
+    if not response:
+        return {"status": "no_response", "request_id": request_id}
+
+    # Response may be a StandardResponse or a dict (in-store form).
+    if hasattr(response, "value"):
+        choice = response.value
+    elif isinstance(response, dict):
+        choice = response.get("value", "deny")
+    else:
+        choice = str(response)
+    # Unwrap dashboard's ``{"phase": "generic", "value": "..."}`` shape.
+    if isinstance(choice, dict) and "value" in choice:
+        choice = choice["value"]
+
+    approved = choice != "deny"
+    mode = choice if approved else None
+
+    consent_meta = (notification.custom_template or {}).get(
+        "consent_meta", {},
+    )
+    operation = consent_meta.get(
+        "operation", notification.title.removeprefix("Consent: "),
+    )
+    default_ttl = consent_meta.get("default_ttl", 5)
+    target_session = notification.callback_session_id
+
+    if not approved:
+        _audit_log("REQUEST_DENIED", operation, f"request_id={request_id}")
+        return {
+            "status": "denied",
+            "request_id": request_id,
+            "operation": operation,
+        }
+
+    # Approved: write grants.
+    ttl_for_grant = default_ttl if mode == "temporary" else None
+
+    grant_consent(
+        operation, mode=mode, ttl_minutes=ttl_for_grant,
+        session_id=target_session,
+    )
+
+    context = consent_meta.get("context") or {}
+
+    # Bundle unbundle: grant each underlying op so the
+    # ``@requires_consent`` decorators (which check individual op names,
+    # not the bundle label) actually pass.
+    operations = context.get("operations")
+    if isinstance(operations, list) and operations:
+        grant_consent_batch(
+            operations, mode=mode, ttl_minutes=ttl_for_grant,
+            session_id=target_session,
+        )
+
+    # Workflow-class grant when the notification is a workflow-consent
+    # pre-flight prompt. Without this, an out-of-band approval (Telegram
+    # or Obsidian-modal callback landing after the gateway's poll has
+    # exited) would write no class grant and subsequent invocations of
+    # the same workflow would re-prompt within the window the user
+    # thought they had authorized.
+    if context.get("kind") == "workflow_consent" and mode in (
+        "temporary", "always",
+    ):
+        workflow_name = context.get("workflow_name")
+        if workflow_name:
+            class_ttl = (
+                WORKFLOW_CLASS_TEMPORARY_TTL_MIN if mode == "temporary"
+                else WORKFLOW_CLASS_ALWAYS_TTL_MIN
+            )
+            grant_workflow_class(
+                workflow_name, ttl_minutes=class_ttl,
+                session_id=target_session,
+            )
+
+    _audit_log(
+        "REQUEST_APPROVED", operation,
+        f"request_id={request_id} | mode={mode}",
+    )
+
+    return {
+        "status": "approved",
+        "request_id": request_id,
+        "mode": mode,
+        "operation": operation,
+    }
+
+
 def resolve_consent_request(
     request_id: str,
     approved: bool,
@@ -1583,79 +1701,25 @@ def resolve_consent_request(
     # Record the response
     store.respond_to_notification(request_id, response)
 
-    # Extract consent metadata
-    consent_meta = (notification.custom_template or {}).get("consent_meta", {})
-    operation = consent_meta.get("operation", notification.title.removeprefix("Consent: "))
-    default_ttl = consent_meta.get("default_ttl", 5)
+    # Write grants via the shared helper (one source of truth for the
+    # response → grant translation, also used by surfaces whose own
+    # response-recording paths bypass this function — e.g. Telegram's
+    # ``on_button``). The helper emits its own ``REQUEST_APPROVED`` /
+    # ``REQUEST_DENIED`` audit lines.
+    finalize_result = finalize_consent_response(request_id)
+    operation = finalize_result.get("operation", "")
 
     dispatch_status = None
-
     if approved:
-        # Write the consent grant
-        ttl = ttl_minutes or default_ttl
-        ttl_for_grant = ttl if mode == "temporary" else None
-
-        # Route the grant to the ORIGINATING agent's session DB when this
-        # resolve runs in a different process from the agent that
-        # requested consent (e.g. the sidecar handling an out-of-band
-        # consent_grant message). The notification record carries
-        # ``callback_session_id`` set by the gateway from the agent's
-        # ``WORK_BUDDY_SESSION_ID`` at request creation.
-        # ``ConsentCache.grant`` already supports the keyword for
-        # workflow blanket grants — same plumbing.
-        target_session = notification.callback_session_id
-
-        grant_consent(
-            operation, mode=mode, ttl_minutes=ttl_for_grant,
-            session_id=target_session,
-        )
-
-        # When the operation is a bundle label (the gateway uses
-        # ``bundle:<capability>`` as a notification label for multi-op
-        # consent), also grant each individual op the decorators
-        # actually check. The bundle key alone satisfies no
-        # ``@requires_consent`` gate; the underlying ops live in
-        # ``consent_meta.context.operations``. Doing the unbundle here
-        # keeps the out-of-band approval path self-sufficient (it goes
-        # through this resolve, not through ``_auto_consent_request``).
-        context = consent_meta.get("context") or {}
-        operations = context.get("operations")
-        if isinstance(operations, list) and operations:
-            grant_consent_batch(
-                operations, mode=mode, ttl_minutes=ttl_for_grant,
-                session_id=target_session,
-            )
-
-        # When the notification is the workflow-consent pre-flight
-        # prompt (``context.kind == "workflow_consent"``), additionally
-        # mint the ``workflow_class:<name>`` grant. Without this, an
-        # out-of-band approval (Telegram callback landing after the
-        # gateway's poll has exited) would write no class grant and
-        # subsequent invocations of the same workflow would re-prompt
-        # within the window the user thought they had authorized.
-        if context.get("kind") == "workflow_consent" and mode in (
-            "temporary", "always",
-        ):
-            workflow_name = context.get("workflow_name")
-            if workflow_name:
-                class_ttl = (
-                    WORKFLOW_CLASS_TEMPORARY_TTL_MIN if mode == "temporary"
-                    else WORKFLOW_CLASS_ALWAYS_TTL_MIN
-                )
-                grant_workflow_class(
-                    workflow_name,
-                    ttl_minutes=class_ttl,
-                    session_id=target_session,
-                )
-
-        # Dispatch callback
+        # Dispatch the notification's optional ``callback`` (e.g.
+        # session resume). Done outside ``finalize_consent_response``
+        # because not every surface that records a response wants the
+        # callback fired here — Telegram's handler dispatches its
+        # own. ``resolve_consent_request`` is used by the dashboard
+        # endpoint, the MCP ``consent_request_resolve`` op, and the
+        # sidecar's Obsidian-modal callback path, all of which expect
+        # the dispatch to happen here.
         dispatch_status = store.dispatch_callback(notification)
-
-        _audit_log("REQUEST_APPROVED", operation,
-                   f"request_id={request_id} | mode={mode}"
-                   + (f" | dispatch={dispatch_status}" if dispatch_status else ""))
-    else:
-        _audit_log("REQUEST_DENIED", operation, f"request_id={request_id}")
 
     # Dismiss the notification on sibling surfaces. The in-window
     # gateway / dashboard / MCP-resolve paths already do this when they

--- a/work_buddy/consent.py
+++ b/work_buddy/consent.py
@@ -1222,6 +1222,14 @@ def is_workflow_consent_active(*, session_id: str | None = None) -> bool:
 WORKFLOW_CLASS_PREFIX = "workflow_class:"
 WORKFLOW_RUN_PREFIX = "workflow_run:"
 
+# Default TTLs for the class-grant prompt choices. The gateway's
+# ``_auto_workflow_consent_request`` uses these for in-window approvals;
+# ``resolve_consent_request`` uses them for out-of-band approvals (e.g.
+# Telegram callbacks landing after the gateway's poll has exited) so the
+# two paths agree on the window the user thought they were authorizing.
+WORKFLOW_CLASS_TEMPORARY_TTL_MIN = 15      # "Allow for 15 min"
+WORKFLOW_CLASS_ALWAYS_TTL_MIN = 24 * 60    # "Allow always (this session)" = 24h
+
 
 def _workflow_class_key(workflow_name: str) -> str:
     return f"{WORKFLOW_CLASS_PREFIX}{workflow_name}"
@@ -1590,12 +1598,35 @@ def resolve_consent_request(
         # ``consent_meta.context.operations``. Doing the unbundle here
         # keeps the out-of-band approval path self-sufficient (it goes
         # through this resolve, not through ``_auto_consent_request``).
-        operations = (consent_meta.get("context") or {}).get("operations")
+        context = consent_meta.get("context") or {}
+        operations = context.get("operations")
         if isinstance(operations, list) and operations:
             grant_consent_batch(
                 operations, mode=mode, ttl_minutes=ttl_for_grant,
                 session_id=target_session,
             )
+
+        # When the notification is the workflow-consent pre-flight
+        # prompt (``context.kind == "workflow_consent"``), additionally
+        # mint the ``workflow_class:<name>`` grant. Without this, an
+        # out-of-band approval (Telegram callback landing after the
+        # gateway's poll has exited) would write no class grant and
+        # subsequent invocations of the same workflow would re-prompt
+        # within the window the user thought they had authorized.
+        if context.get("kind") == "workflow_consent" and mode in (
+            "temporary", "always",
+        ):
+            workflow_name = context.get("workflow_name")
+            if workflow_name:
+                class_ttl = (
+                    WORKFLOW_CLASS_TEMPORARY_TTL_MIN if mode == "temporary"
+                    else WORKFLOW_CLASS_ALWAYS_TTL_MIN
+                )
+                grant_workflow_class(
+                    workflow_name,
+                    ttl_minutes=class_ttl,
+                    session_id=target_session,
+                )
 
         # Dispatch callback
         dispatch_status = store.dispatch_callback(notification)
@@ -1605,6 +1636,29 @@ def resolve_consent_request(
                    + (f" | dispatch={dispatch_status}" if dispatch_status else ""))
     else:
         _audit_log("REQUEST_DENIED", operation, f"request_id={request_id}")
+
+    # Dismiss the notification on sibling surfaces. The in-window
+    # gateway / dashboard / MCP-resolve paths already do this when they
+    # receive the response synchronously; this branch covers the
+    # out-of-band approval path (Telegram callback / Obsidian-modal
+    # click landing after the in-window poll has exited) so the user
+    # doesn't see the prompt linger on the surface they didn't use.
+    # Best-effort: never fails the resolve.
+    try:
+        notif_after = store.get_notification(request_id)
+        if notif_after and notif_after.delivered_surfaces:
+            from work_buddy.notifications.dispatcher import SurfaceDispatcher
+            dispatcher = SurfaceDispatcher.from_config()
+            dispatcher.dismiss_others(
+                request_id,
+                responding_surface=response.surface,
+                delivered_surfaces=notif_after.delivered_surfaces,
+            )
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning(
+            "resolve_consent_request: dismiss_others failed for %s: %s",
+            request_id, exc,
+        )
 
     # Return dict for backward compatibility
     result = store.get_notification(request_id)

--- a/work_buddy/consent.py
+++ b/work_buddy/consent.py
@@ -974,7 +974,20 @@ def requires_consent(
                 # ``individual`` / ``workflow_run`` / ``workflow_class``
                 # / ``legacy_blanket`` — and ``diagnose_carry`` returns
                 # which one matched plus the actual key for traceability.
-                carry_source, carry_key = _cache.diagnose_carry(operation)
+                # Defensive against test-time mocks of ``_cache`` that
+                # don't supply a usable ``diagnose_carry``: if the call
+                # raises or returns an unexpected shape, fall back to
+                # the generic ``("none", None)`` and let the audit log
+                # show ``via=originating_session`` — the consent gate
+                # itself already passed.
+                try:
+                    _carry = _cache.diagnose_carry(operation)
+                    if isinstance(_carry, tuple) and len(_carry) == 2:
+                        carry_source, carry_key = _carry
+                    else:
+                        carry_source, carry_key = "none", None
+                except Exception:
+                    carry_source, carry_key = "none", None
                 if carry_source == "individual":
                     op_mode = _cache.get_mode(operation)
                     is_once = op_mode == "once"

--- a/work_buddy/mcp_server/conductor.py
+++ b/work_buddy/mcp_server/conductor.py
@@ -201,18 +201,22 @@ def start_workflow(
     # WORK_BUDDY_SESSION_ID from its parent (the MCP server's own session)
     # and consent grants land in a different DB.
     dag.agent_session_id = agent_session_id
+    # Pin the workflow's class name so downstream lifecycle code (revoke
+    # at completion, cascade from class-revoke, orphan reconciliation)
+    # can look it up without parsing dag.name.
+    dag.workflow_name = workflow_name  # type: ignore[attr-defined]
 
     dag.save()
     with _ACTIVE_RUNS_LOCK:
         _ACTIVE_RUNS[run_id] = dag
 
-    # Grant blanket consent for the workflow's lifetime.  Accepting a
-    # workflow implies consent for all its operations unless a step
-    # explicitly opts out via ``requires_individual_consent: true``.
-    # Route the grant to the agent's session DB so auto_run subprocesses
-    # (which also read the agent's DB) can see the blanket.
-    from work_buddy.consent import grant_workflow_consent
-    grant_workflow_consent(run_id, session_id=agent_session_id)
+    # Composable consent: mint the run-level grant for this workflow run.
+    # The class-level grant (if any) is checked/minted by the gateway's
+    # pre-flight branch BEFORE this method is called — the run grant
+    # alone is sufficient to authorize the workflow's sub-operations
+    # via the @requires_consent carry path.
+    from work_buddy.consent import grant_workflow_run
+    grant_workflow_run(workflow_name, run_id, session_id=agent_session_id)
 
     # Build response with workflow context on first step
     response = _build_response(run_id, dag)
@@ -319,17 +323,21 @@ def advance_workflow(
     # silently mutate the response.
     _warn_if_accumulating(dag, current_id)
 
-    # If the completed step opted into individual consent, re-grant the
-    # workflow blanket so subsequent (non-opted-out) steps resume their
-    # covered-by-blanket behavior. Route via the DAG-pinned session.
+    # If the completed step opted into individual consent, re-mint the
+    # run-level workflow grant so subsequent (non-opted-out) steps resume
+    # their carry-via-workflow behavior. Route via the DAG-pinned session.
     if current_meta.get("requires_individual_consent", False):
-        from work_buddy.consent import grant_workflow_consent
-        grant_workflow_consent(
+        from work_buddy.consent import grant_workflow_run
+        wf_name = getattr(dag, "workflow_name", None) or (
+            dag.name.split(":", 1)[0] if dag.name and ":" in dag.name else dag.name
+        )
+        grant_workflow_run(
+            wf_name,
             workflow_run_id,
             session_id=getattr(dag, "agent_session_id", None),
         )
         logger.info(
-            "Main-execution step '%s' complete — workflow blanket re-granted",
+            "Main-execution step '%s' complete — workflow run grant re-minted",
             current_id,
         )
 
@@ -389,21 +397,33 @@ def list_active_runs() -> list[dict[str, Any]]:
 
 
 def reconcile_workflow_consent(session_id: str) -> dict[str, Any]:
-    """Revoke an orphaned workflow-consent blanket left by a server restart.
+    """Revoke orphaned workflow-consent grants left by a server restart.
 
-    Called at session registration. A workflow grants a blanket consent
-    (``__workflow_consent__``) into the agent's ``consent.db`` and pins
-    the run's DAG in the in-memory ``_ACTIVE_RUNS`` map. The two have
-    mismatched lifetimes: an MCP-server restart wipes ``_ACTIVE_RUNS``
-    but the on-disk blanket survives its TTL, so it would silently
-    authorize every consent-gated call until expiry.
+    Called at session registration. A workflow mints grants into the
+    agent's ``consent.db`` (``workflow_run:<name>:<run_id>`` keys plus,
+    when v1's pre-flight prompt is taken, ``workflow_class:<name>`` keys)
+    and pins the run's DAG in the in-memory ``_ACTIVE_RUNS`` map. The two
+    have mismatched lifetimes: an MCP-server restart wipes
+    ``_ACTIVE_RUNS`` but the on-disk grants survive — they would silently
+    authorize every consent-gated call until they expire (run grants are
+    untimed; class grants live up to their TTL).
 
-    This sweep re-couples them. If the session's DB holds an active
-    blanket but no run in ``_ACTIVE_RUNS`` belongs to that session, the
-    blanket is orphaned — revoke it. A genuinely in-flight workflow
-    keeps its DAG in ``_ACTIVE_RUNS`` (entries leave only on completion),
-    so a re-registration that is not a post-restart reconnect finds the
-    matching run and leaves the blanket untouched.
+    This sweep re-couples them:
+
+    - ``workflow_run:*`` keys: if no ``_ACTIVE_RUNS`` entry has a matching
+      ``run_id`` for the same session, revoke. Genuinely in-flight runs
+      keep their DAGs in ``_ACTIVE_RUNS`` until completion, so they pass
+      the match check. Cleaned up additively — does not affect the
+      legacy-blanket return-shape contract below.
+    - Legacy ``__workflow_consent__``: revoke when no in-flight run
+      belongs to this session. The return shape preserves the original
+      contract: ``{"swept": True}`` on revoke; ``{"swept": False,
+      "reason": "active_run_present"}`` when an in-flight run protects
+      the blanket; ``{"swept": False, "reason": "no_blanket"}`` when
+      nothing to sweep on the legacy key. Callers (and existing tests)
+      depend on these exact reason strings.
+    - ``workflow_class:*`` keys: left alone — their TTL is the intended
+      lifetime bound, and they outlive the workflow run by design.
 
     Never raises — a failure here must not break session registration.
     """
@@ -412,27 +432,143 @@ def reconcile_workflow_consent(session_id: str) -> dict[str, Any]:
     try:
         from work_buddy.consent import (
             is_workflow_consent_active, revoke_workflow_consent,
+            list_active_workflow_grants, revoke_workflow_run,
         )
+
+        active_run_ids_for_session = {
+            run_id
+            for run_id, dag in _snapshot_active_runs()
+            if getattr(dag, "agent_session_id", None) == session_id
+        }
+
+        # ── New composable keys: orphaned ``workflow_run:*`` keys ─────
+        # Additive cleanup; does not affect return-shape contract below.
+        orphaned_run_keys: list[str] = []
+        try:
+            snapshot = list_active_workflow_grants(session_id=session_id)
+            for run_entry in snapshot.get("run", []):
+                wf_name = run_entry.get("workflow_name", "")
+                run_id = run_entry.get("run_id", "")
+                if run_id and run_id in active_run_ids_for_session:
+                    continue
+                revoke_workflow_run(
+                    wf_name, run_id,
+                    session_id=session_id,
+                    reason="orphan_reconcile",
+                )
+                orphaned_run_keys.append(f"{wf_name}:{run_id}")
+                logger.info(
+                    "Revoked orphaned workflow_run grant %s for session "
+                    "%s (no active run — likely an MCP-server restart)",
+                    f"{wf_name}:{run_id}", session_id[:8],
+                )
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning(
+                "reconcile_workflow_consent: workflow_run sweep failed "
+                "for session %s: %s",
+                session_id[:8] if session_id else session_id, exc,
+            )
+
+        # ── Legacy ``__workflow_consent__`` blanket ────────────────────
+        # The return-shape contract below matches what existing callers
+        # and tests expect — do not change without updating them.
         if not is_workflow_consent_active(session_id=session_id):
-            return {"swept": False, "reason": "no_blanket"}
-        with _ACTIVE_RUNS_LOCK:
-            dags = list(_ACTIVE_RUNS.values())
-        for dag in dags:
-            if getattr(dag, "agent_session_id", None) == session_id:
-                return {"swept": False, "reason": "active_run_present"}
+            result: dict[str, Any] = {"swept": False, "reason": "no_blanket"}
+            if orphaned_run_keys:
+                result["orphaned_run_keys"] = orphaned_run_keys
+            return result
+        if active_run_ids_for_session:
+            result = {"swept": False, "reason": "active_run_present"}
+            if orphaned_run_keys:
+                result["orphaned_run_keys"] = orphaned_run_keys
+            return result
         revoke_workflow_consent(session_id=session_id)
         logger.info(
-            "Revoked orphaned workflow-consent blanket for session %s "
+            "Revoked orphaned legacy workflow blanket for session %s "
             "(no active run — likely an MCP-server restart)",
             session_id[:8],
         )
-        return {"swept": True}
+        result = {"swept": True}
+        if orphaned_run_keys:
+            result["orphaned_run_keys"] = orphaned_run_keys
+        return result
     except Exception as exc:  # pragma: no cover — defensive
         logger.warning(
             "reconcile_workflow_consent failed for session %s: %s",
             session_id[:8] if session_id else session_id, exc,
         )
         return {"swept": False, "reason": "error"}
+
+
+def _snapshot_active_runs() -> list[tuple[str, Any]]:
+    """Return a thread-safe snapshot of ``_ACTIVE_RUNS`` as a list of
+    ``(run_id, dag)`` tuples. Used by reconciliation + cascade revoke.
+    """
+    with _ACTIVE_RUNS_LOCK:
+        return list(_ACTIVE_RUNS.items())
+
+
+def cascade_revoke_workflow(
+    workflow_name: str,
+    *,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    """Revoke a workflow's class grant AND all in-flight run grants.
+
+    The ocap CDT model: revoking the parent (class grant) revokes all
+    derived children (run grants). Used when the user explicitly
+    withdraws trust for a workflow class — in-flight runs should not
+    continue to authorize calls under the now-withdrawn approval.
+
+    Returns ``{"revoked_class": bool, "revoked_runs": [run_id, ...]}``.
+    Never raises — best-effort cleanup.
+    """
+    from work_buddy.consent import (
+        revoke_workflow_class, revoke_workflow_run,
+    )
+
+    revoked_class = False
+    try:
+        revoke_workflow_class(workflow_name, session_id=session_id)
+        revoked_class = True
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning(
+            "cascade_revoke_workflow: class revoke failed for %s: %s",
+            workflow_name, exc,
+        )
+
+    revoked_runs: list[str] = []
+    for run_id, dag in _snapshot_active_runs():
+        dag_workflow_name = getattr(dag, "workflow_name", None) or (
+            dag.name.split(":", 1)[0]
+            if dag.name and ":" in dag.name else dag.name
+        )
+        if dag_workflow_name != workflow_name:
+            continue
+        # Scope the cascade to the matching session when one is supplied;
+        # otherwise revoke regardless (caller asked for global cleanup).
+        if session_id is not None:
+            if getattr(dag, "agent_session_id", None) != session_id:
+                continue
+        try:
+            revoke_workflow_run(
+                workflow_name,
+                run_id,
+                session_id=getattr(dag, "agent_session_id", session_id),
+                reason="cascade",
+            )
+            revoked_runs.append(run_id)
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning(
+                "cascade_revoke_workflow: run revoke failed for %s:%s: %s",
+                workflow_name, run_id, exc,
+            )
+
+    return {
+        "workflow_name": workflow_name,
+        "revoked_class": revoked_class,
+        "revoked_runs": revoked_runs,
+    }
 
 
 def get_step_result(
@@ -751,13 +887,18 @@ def cancel_workflow(
     with _ACTIVE_RUNS_LOCK:
         _ACTIVE_RUNS.pop(workflow_run_id, None)
 
-    # Revoke the workflow consent blanket via the DAG-pinned session, so a
-    # cancelled run never leaves a live blanket behind in the agent's DB.
+    # Revoke the workflow run grant via the DAG-pinned session, so a
+    # cancelled run never leaves a live grant behind in the agent's DB.
     try:
-        from work_buddy.consent import revoke_workflow_consent
-        revoke_workflow_consent(
+        from work_buddy.consent import revoke_workflow_run
+        wf_name = getattr(dag, "workflow_name", None) or (
+            dag.name.split(":", 1)[0] if dag.name and ":" in dag.name else dag.name
+        )
+        revoke_workflow_run(
+            wf_name,
             workflow_run_id,
             session_id=getattr(dag, "agent_session_id", None),
+            reason="cancelled",
         )
     except Exception as exc:  # pragma: no cover — defensive
         logger.warning(
@@ -1007,35 +1148,47 @@ def _build_response(
 
         if not auto_run_spec:
             # Normal step — hand to the agent.
-            # If this step opted into individual consent, suspend the workflow
-            # blanket so the agent's @requires_consent-gated calls actually
-            # surface a prompt. The blanket is re-granted in advance_workflow
-            # once the agent completes this step.
+            # If this step opted into individual consent, suspend the
+            # workflow run grant so the agent's @requires_consent-gated
+            # calls actually surface a prompt. The grant is re-minted in
+            # advance_workflow once the agent completes this step.
             if meta.get("requires_individual_consent", False):
-                from work_buddy.consent import revoke_workflow_consent
-                revoke_workflow_consent(
+                from work_buddy.consent import revoke_workflow_run
+                wf_name = getattr(dag, "workflow_name", None) or (
+                    dag.name.split(":", 1)[0]
+                    if dag.name and ":" in dag.name else dag.name
+                )
+                revoke_workflow_run(
+                    wf_name,
                     run_id,
                     session_id=getattr(dag, "agent_session_id", None),
+                    reason="individual_consent",
                 )
                 logger.info(
                     "Main-execution step '%s' requires explicit consent — "
-                    "workflow blanket temporarily suspended", task_id,
+                    "workflow run grant temporarily suspended", task_id,
                 )
             break
 
         # --- Auto-execute this step ---
         # If the step requires explicit consent, temporarily suspend the
-        # workflow blanket so @requires_consent checks are enforced.
+        # workflow run grant so @requires_consent checks are enforced.
         explicit_consent = meta.get("requires_individual_consent", False)
         if explicit_consent:
-            from work_buddy.consent import revoke_workflow_consent
-            revoke_workflow_consent(
+            from work_buddy.consent import revoke_workflow_run
+            wf_name = getattr(dag, "workflow_name", None) or (
+                dag.name.split(":", 1)[0]
+                if dag.name and ":" in dag.name else dag.name
+            )
+            revoke_workflow_run(
+                wf_name,
                 run_id,
                 session_id=getattr(dag, "agent_session_id", None),
+                reason="individual_consent",
             )
             logger.info(
                 "Step '%s' requires explicit consent — "
-                "workflow blanket temporarily suspended", task_id,
+                "workflow run grant temporarily suspended", task_id,
             )
 
         dag.start_task(task_id)
@@ -1047,15 +1200,20 @@ def _build_response(
             initial_params=getattr(dag, "initial_params", None),
         )
 
-        # Re-grant workflow consent if we suspended it
+        # Re-mint workflow run grant if we suspended it
         if explicit_consent:
-            from work_buddy.consent import grant_workflow_consent
-            grant_workflow_consent(
+            from work_buddy.consent import grant_workflow_run
+            wf_name = getattr(dag, "workflow_name", None) or (
+                dag.name.split(":", 1)[0]
+                if dag.name and ":" in dag.name else dag.name
+            )
+            grant_workflow_run(
+                wf_name,
                 run_id,
                 session_id=getattr(dag, "agent_session_id", None),
             )
             logger.info(
-                "Step '%s' done — workflow blanket re-granted", task_id,
+                "Step '%s' done — workflow run grant re-minted", task_id,
             )
 
         if result.get("success"):
@@ -1365,14 +1523,19 @@ def _build_complete_response(run_id: str, dag: WorkflowDAG) -> dict[str, Any]:
     # the DAG file is empty and all step results are lost.
     dag.save()
 
-    # Revoke workflow blanket consent now that the workflow is done.
+    # Revoke the workflow run grant now that the workflow is done.
     # Route via the DAG-pinned agent session so we undo the grant we
-    # wrote at start_workflow time — otherwise a stale blanket would
+    # wrote at start_workflow time — otherwise a stale grant would
     # linger in the agent's DB.
-    from work_buddy.consent import revoke_workflow_consent
-    revoke_workflow_consent(
+    from work_buddy.consent import revoke_workflow_run
+    wf_name = getattr(dag, "workflow_name", None) or (
+        dag.name.split(":", 1)[0] if dag.name and ":" in dag.name else dag.name
+    )
+    revoke_workflow_run(
+        wf_name,
         run_id,
         session_id=getattr(dag, "agent_session_id", None),
+        reason="complete",
     )
 
     total = dag._graph.number_of_nodes()

--- a/work_buddy/mcp_server/conductor.py
+++ b/work_buddy/mcp_server/conductor.py
@@ -329,7 +329,7 @@ def advance_workflow(
     if current_meta.get("requires_individual_consent", False):
         from work_buddy.consent import grant_workflow_run
         wf_name = getattr(dag, "workflow_name", None) or (
-            dag.name.split(":", 1)[0] if dag.name and ":" in dag.name else dag.name
+            (getattr(dag, "name", "") or "").split(":", 1)[0] if ":" in (getattr(dag, "name", "") or "") else getattr(dag, "name", "")
         )
         grant_workflow_run(
             wf_name,
@@ -540,8 +540,9 @@ def cascade_revoke_workflow(
     revoked_runs: list[str] = []
     for run_id, dag in _snapshot_active_runs():
         dag_workflow_name = getattr(dag, "workflow_name", None) or (
-            dag.name.split(":", 1)[0]
-            if dag.name and ":" in dag.name else dag.name
+            (getattr(dag, "name", "") or "").split(":", 1)[0]
+            if ":" in (getattr(dag, "name", "") or "")
+            else getattr(dag, "name", "")
         )
         if dag_workflow_name != workflow_name:
             continue
@@ -892,7 +893,7 @@ def cancel_workflow(
     try:
         from work_buddy.consent import revoke_workflow_run
         wf_name = getattr(dag, "workflow_name", None) or (
-            dag.name.split(":", 1)[0] if dag.name and ":" in dag.name else dag.name
+            (getattr(dag, "name", "") or "").split(":", 1)[0] if ":" in (getattr(dag, "name", "") or "") else getattr(dag, "name", "")
         )
         revoke_workflow_run(
             wf_name,
@@ -1155,8 +1156,9 @@ def _build_response(
             if meta.get("requires_individual_consent", False):
                 from work_buddy.consent import revoke_workflow_run
                 wf_name = getattr(dag, "workflow_name", None) or (
-                    dag.name.split(":", 1)[0]
-                    if dag.name and ":" in dag.name else dag.name
+                    (getattr(dag, "name", "") or "").split(":", 1)[0]
+                    if ":" in (getattr(dag, "name", "") or "")
+                    else getattr(dag, "name", "")
                 )
                 revoke_workflow_run(
                     wf_name,
@@ -1177,8 +1179,9 @@ def _build_response(
         if explicit_consent:
             from work_buddy.consent import revoke_workflow_run
             wf_name = getattr(dag, "workflow_name", None) or (
-                dag.name.split(":", 1)[0]
-                if dag.name and ":" in dag.name else dag.name
+                (getattr(dag, "name", "") or "").split(":", 1)[0]
+                if ":" in (getattr(dag, "name", "") or "")
+                else getattr(dag, "name", "")
             )
             revoke_workflow_run(
                 wf_name,
@@ -1204,8 +1207,9 @@ def _build_response(
         if explicit_consent:
             from work_buddy.consent import grant_workflow_run
             wf_name = getattr(dag, "workflow_name", None) or (
-                dag.name.split(":", 1)[0]
-                if dag.name and ":" in dag.name else dag.name
+                (getattr(dag, "name", "") or "").split(":", 1)[0]
+                if ":" in (getattr(dag, "name", "") or "")
+                else getattr(dag, "name", "")
             )
             grant_workflow_run(
                 wf_name,
@@ -1529,7 +1533,7 @@ def _build_complete_response(run_id: str, dag: WorkflowDAG) -> dict[str, Any]:
     # linger in the agent's DB.
     from work_buddy.consent import revoke_workflow_run
     wf_name = getattr(dag, "workflow_name", None) or (
-        dag.name.split(":", 1)[0] if dag.name and ":" in dag.name else dag.name
+        (getattr(dag, "name", "") or "").split(":", 1)[0] if ":" in (getattr(dag, "name", "") or "") else getattr(dag, "name", "")
     )
     revoke_workflow_run(
         wf_name,

--- a/work_buddy/mcp_server/registry.py
+++ b/work_buddy/mcp_server/registry.py
@@ -67,6 +67,15 @@ class Capability:
     auto_retry: bool = True
     slash_command: str | None = None  # e.g. "wb-journal-update"
     consent_operations: list[str] = field(default_factory=list)  # @requires_consent op IDs this capability may trigger
+    # Carve-out for the workflow-blanket consent model: capabilities tagged
+    # ``"high"`` are NEVER carried by a workflow grant, even inside an
+    # approved workflow run — the per-op consent gate always fires for them.
+    # The default ``"low"`` participates in workflow grants normally;
+    # ``"moderate"`` matches the default risk semantics. Workflows that
+    # invoke any ``"high"`` capability cannot be silently authorized end-to-
+    # end; the workflow's plan/confirm step or an individual consent prompt
+    # is the user's decision point for the high-weight op.
+    consent_weight: str = "low"  # "low" | "moderate" | "high"
     # Effect manifest for multi-effect capabilities — used by
     # ``verify_post_write_effects`` to detect "some effects landed,
     # some didn't" partial states after a PostWriteUncertain. Capabilities

--- a/work_buddy/mcp_server/tools/gateway.py
+++ b/work_buddy/mcp_server/tools/gateway.py
@@ -1338,7 +1338,7 @@ def register_tools(mcp: FastMCP) -> None:
             _t0 = _time.monotonic()
             _wf_session_id = _resolve_session(ctx)
 
-            # Composable consent v1 — pre-flight workflow consent.
+            # Composable workflow consent — pre-flight prompt.
             #
             # Skip the prompt when:
             #   - we are inside a ``user_initiated()`` context (UI click /

--- a/work_buddy/mcp_server/tools/gateway.py
+++ b/work_buddy/mcp_server/tools/gateway.py
@@ -484,8 +484,15 @@ def _auto_consent_request(
 # Slash-command launchers entering ``user_initiated()`` opt their dispatch
 # into the bypass.
 
-_WORKFLOW_CLASS_DEFAULT_TTL_MIN = 15      # "Allow for 15 min" default
-_WORKFLOW_CLASS_ALWAYS_TTL_MIN = 24 * 60  # "Allow always (this session)" = 24h
+# Class-grant TTLs are sourced from ``work_buddy.consent`` so that the
+# in-window prompt path (this module) and the out-of-band resolve path
+# (``resolve_consent_request``) agree on the window each affordance maps
+# to. Reassigning at module import keeps the prompt-rendering code below
+# tidy without introducing a second source of truth.
+from work_buddy.consent import (
+    WORKFLOW_CLASS_TEMPORARY_TTL_MIN as _WORKFLOW_CLASS_DEFAULT_TTL_MIN,
+    WORKFLOW_CLASS_ALWAYS_TTL_MIN as _WORKFLOW_CLASS_ALWAYS_TTL_MIN,
+)
 
 
 def _is_workflow_class_authorized(

--- a/work_buddy/mcp_server/tools/gateway.py
+++ b/work_buddy/mcp_server/tools/gateway.py
@@ -277,6 +277,7 @@ def _auto_consent_request(
     capability_name: str,
     op_id: str,
     timeout: int = _AUTO_CONSENT_TIMEOUT,
+    session_id: str | None = None,
 ) -> dict[str, Any]:
     """Send a bundled consent request and poll for user response.
 
@@ -333,8 +334,16 @@ def _auto_consent_request(
 
     body = "\n".join(lines)
 
-    # Auto-inject session ID for callback delivery
-    callback_session_id = os.environ.get("WORK_BUDDY_SESSION_ID")
+    # Route to the agent's session DB. When ``session_id`` is None
+    # (legacy callers that haven't been updated to pass it), fall back
+    # to the process's env var — which is the MCP server's bootstrap
+    # session, NOT the agent's. That fallback is the historical
+    # behavior; for out-of-band approval paths (Telegram callback /
+    # Obsidian-modal click after the gateway's poll has exited), it
+    # mis-routes the grant to the bootstrap DB and the agent's session
+    # never sees it. Every wb_run dispatch site passes the agent's
+    # session id explicitly; the env fallback exists for back-compat.
+    callback_session_id = session_id or os.environ.get("WORK_BUDDY_SESSION_ID")
 
     # Create the consent request (uses notification substrate)
     record = create_consent_request(
@@ -459,8 +468,17 @@ def _auto_consent_request(
 
     # Always grant the individual operations.  resolve_consent_request
     # only grants the bundle name (e.g., "bundle:task_toggle"), not the
-    # individual operations the decorators actually check.
-    grant_consent_batch(operations, mode=mode, ttl_minutes=ttl)
+    # individual operations the decorators actually check. Route the
+    # grants to the same session DB the notification's
+    # ``callback_session_id`` targets, so the in-window write and the
+    # out-of-band ``finalize_consent_response`` write land in the same
+    # place. Without the explicit ``session_id``, the cache uses its
+    # default DB — which is whichever session the cache was first
+    # connected against (usually the agent's, but race-dependent).
+    grant_consent_batch(
+        operations, mode=mode, ttl_minutes=ttl,
+        session_id=callback_session_id,
+    )
 
     return {
         "status": "granted",
@@ -1422,6 +1440,7 @@ def register_tools(mcp: FastMCP) -> None:
             if missing:
                 consent_result = await asyncio.to_thread(
                     _auto_consent_request, missing, capability, op_id,
+                    _AUTO_CONSENT_TIMEOUT, _agent_sid,
                 )
                 if consent_result["status"] != "granted":
                     _complete_operation(
@@ -1470,6 +1489,7 @@ def register_tools(mcp: FastMCP) -> None:
                 # Auto-request consent for this unanticipated gate
                 consent_result = await asyncio.to_thread(
                     _auto_consent_request, [exc.operation], capability, op_id,
+                    _AUTO_CONSENT_TIMEOUT, _agent_sid,
                 )
                 if consent_result["status"] != "granted":
                     _complete_operation(
@@ -2152,10 +2172,18 @@ def retry_operation(operation_id: str) -> dict[str, Any]:
 
     # Pre-flight consent for capabilities with declared operations
     cap_name = record["name"]
+    # Retry path: the original op record carries the agent session id
+    # that requested the work. Route the (re-)prompt to that session so
+    # an out-of-band approval lands grants where the retried operation
+    # will look for them.
+    _retry_session_id = record.get("originating_session_id")
     if record["type"] != "workflow" and isinstance(entry, registry.Capability) and entry.consent_operations:
         missing = _check_missing_consent(entry.consent_operations)
         if missing:
-            consent_result = _auto_consent_request(missing, cap_name, operation_id)
+            consent_result = _auto_consent_request(
+                missing, cap_name, operation_id,
+                session_id=_retry_session_id,
+            )
             if consent_result["status"] != "granted":
                 _complete_operation(
                     operation_id,
@@ -2184,7 +2212,10 @@ def retry_operation(operation_id: str) -> dict[str, Any]:
                     "error": f"Too many consent gates for {cap_name}. Last: {exc.operation}",
                     "operation_id": operation_id,
                 }
-            consent_result = _auto_consent_request([exc.operation], cap_name, operation_id)
+            consent_result = _auto_consent_request(
+                [exc.operation], cap_name, operation_id,
+                session_id=_retry_session_id,
+            )
             if consent_result["status"] != "granted":
                 _complete_operation(
                     operation_id,

--- a/work_buddy/mcp_server/tools/gateway.py
+++ b/work_buddy/mcp_server/tools/gateway.py
@@ -254,6 +254,34 @@ _AUTO_CONSENT_TIMEOUT = 90  # seconds to wait for user response
 _MAX_CONSENT_RETRIES = 2   # max sequential ConsentRequired retries per wb_run
 
 
+def _invoke_with_session(callable_, session_id, /, **kwargs):
+    """Invoke ``callable_`` with the agent's session id pinned on the
+    ``_originating_session`` ContextVar.
+
+    The MCP server process runs under its own ``WORK_BUDDY_SESSION_ID``
+    (typically a sidecar-bootstrap session), distinct from the agent's
+    session. Consent grants that come back via ``callback_session_id``
+    land in the *agent's* session DB. Without this wrapper, the
+    ``@requires_consent`` decorator's ``is_granted`` check resolves to
+    the bootstrap session via ``os.environ`` and never sees the grant.
+
+    Setting ``_originating_session`` to the agent's id makes the
+    decorator's Step-4 originating-session fallback fire against the
+    correct DB. Mirrors the pattern the sidecar's ``retry_sweep`` uses
+    (see ``work_buddy/sidecar/retry_sweep.py``).
+    """
+    if not session_id:
+        return callable_(**kwargs)
+    from work_buddy.agent_session import (
+        set_originating_session, reset_originating_session,
+    )
+    token = set_originating_session(session_id)
+    try:
+        return callable_(**kwargs)
+    finally:
+        reset_originating_session(token)
+
+
 def _check_missing_consent(operations: list[str]) -> list[str]:
     """Return operations from the list that lack a valid consent grant.
 
@@ -1456,10 +1484,18 @@ def register_tools(mcp: FastMCP) -> None:
                     return _prepare(consent_result)
 
         # --- Execute the callable (with fallback retry on ConsentRequired) ---
+        # Pin the agent's session on the originating-session ContextVar so
+        # the @requires_consent decorator's is_granted check resolves to
+        # the agent's consent.db (where grants from the gateway's
+        # auto-consent flow land) rather than the MCP server process's
+        # bootstrap session.
         _consent_retries = 0
         while True:
             try:
-                result = await asyncio.to_thread(entry.callable, **parsed_params)
+                result = await asyncio.to_thread(
+                    _invoke_with_session, entry.callable, _agent_sid,
+                    **parsed_params,
+                )
                 break  # Success — exit retry loop
             except TypeError as exc:
                 param_help = registry._entry_to_dict(entry).get("parameters", {})
@@ -2202,7 +2238,13 @@ def retry_operation(operation_id: str) -> dict[str, Any]:
                     record.get("originating_session_id"),
                 )
             else:
-                result = entry.callable(**record["params"])
+                # Pin the originating session so the decorator's
+                # is_granted check finds grants in the agent's DB
+                # rather than the MCP server's bootstrap session DB.
+                result = _invoke_with_session(
+                    entry.callable, _retry_session_id,
+                    **record["params"],
+                )
             break
         except ConsentRequired as exc:
             consent_retries += 1

--- a/work_buddy/mcp_server/tools/gateway.py
+++ b/work_buddy/mcp_server/tools/gateway.py
@@ -255,9 +255,21 @@ _MAX_CONSENT_RETRIES = 2   # max sequential ConsentRequired retries per wb_run
 
 
 def _check_missing_consent(operations: list[str]) -> list[str]:
-    """Return operations from the list that lack a valid consent grant."""
-    from work_buddy.consent import _cache
-    return [op for op in operations if not _cache.is_granted(op)]
+    """Return operations from the list that lack a valid consent grant.
+
+    Each operation's ``consent_weight`` (from its ``@requires_consent``
+    metadata) is consulted so that ``"high"`` weight ops are NOT counted
+    as granted via a workflow blanket — pre-flight must surface them for
+    individual prompting even when a workflow grant is live.
+    """
+    from work_buddy.consent import _cache, get_consent_metadata
+    missing: list[str] = []
+    for op in operations:
+        meta = get_consent_metadata(op) or {}
+        weight = meta.get("consent_weight", "low")
+        if not _cache.is_granted(op, consent_weight=weight):
+            missing.append(op)
+    return missing
 
 
 def _auto_consent_request(
@@ -455,6 +467,309 @@ def _auto_consent_request(
         "mode": mode,
         "operations": operations,
         "operation_id": op_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Workflow consent — pre-flight prompt at workflow start
+# ---------------------------------------------------------------------------
+# The pre-flight fires a single user-facing prompt when a workflow is
+# starting and the user has not previously authorized that workflow (no
+# live ``workflow_class:<name>`` grant in the session). The prompt names
+# the workflow and lists the operations its DAG may invoke; the user
+# picks once / temporary (with TTL) / always / deny.
+#
+# Slash-command invocations (and any other ``user_initiated()`` context)
+# skip the prompt entirely — the UI click IS the consent affordance.
+# Slash-command launchers entering ``user_initiated()`` opt their dispatch
+# into the bypass.
+
+_WORKFLOW_CLASS_DEFAULT_TTL_MIN = 15      # "Allow for 15 min" default
+_WORKFLOW_CLASS_ALWAYS_TTL_MIN = 24 * 60  # "Allow always (this session)" = 24h
+
+
+def _is_workflow_class_authorized(
+    workflow_name: str,
+    *,
+    session_id: str | None,
+) -> bool:
+    """Return True when a ``workflow_class:<name>`` grant is live in this
+    session — i.e. the user previously chose 'temporary' or 'always' for
+    this workflow and the grant hasn't expired or been revoked.
+    """
+    from work_buddy.consent import is_workflow_authorized
+    ok, _ = is_workflow_authorized(workflow_name, session_id=session_id)
+    return ok
+
+
+def _collect_workflow_consent_ops(
+    entry: "registry.WorkflowDefinition",
+) -> tuple[list[str], str]:
+    """Walk the workflow's steps and collect the union of
+    ``consent_operations`` declared by invoked capabilities. Returns
+    ``(ops, max_risk)`` where ``ops`` is the deduplicated list and
+    ``max_risk`` is the highest risk level among them
+    (``"low"``/``"moderate"``/``"high"``).
+
+    Best-effort: capabilities not yet in the registry (e.g. inert
+    declarations) contribute no operations. Used for the consent-modal
+    body and for the low-weight auto-bypass decision (workflows whose
+    declared ops are all low-risk skip the prompt).
+    """
+    seen: set[str] = set()
+    ops: list[str] = []
+    risk_order = {"low": 0, "moderate": 1, "high": 2}
+    max_risk = "low"
+
+    invokes_all: set[str] = set()
+    for step in entry.steps:
+        for invokes in step.invokes:
+            invokes_all.add(invokes)
+        if step.auto_run is not None:
+            # The auto_run.callable is a dotted Python path; the
+            # control-graph resolver maps it to a capability when
+            # available. For modal-body purposes we don't need to
+            # resolve — step.invokes is the documented surface.
+            pass
+
+    for cap_name in sorted(invokes_all):
+        cap_entry = registry.get_entry(cap_name)
+        if not isinstance(cap_entry, registry.Capability):
+            continue
+        for op in cap_entry.consent_operations:
+            if op in seen:
+                continue
+            seen.add(op)
+            ops.append(op)
+            # Carry the op's risk up to the workflow-prompt level.
+            try:
+                from work_buddy.consent import get_consent_metadata
+                meta = get_consent_metadata(op)
+            except Exception:
+                meta = None
+            op_risk = (meta or {}).get("risk", "moderate")
+            if risk_order.get(op_risk, 0) > risk_order.get(max_risk, 0):
+                max_risk = op_risk
+
+    return ops, max_risk
+
+
+def _render_workflow_consent_body(
+    workflow_name: str,
+    entry: "registry.WorkflowDefinition",
+    consent_ops: list[str],
+) -> str:
+    """Build the modal body shown to the user when prompting for
+    workflow-level consent. Progressive disclosure: a one-line headline,
+    a short description, then the list of consent-gated operations.
+    """
+    desc = (entry.description or "").strip()
+    lines = [f"**Workflow:** {workflow_name}"]
+    if desc:
+        lines.append(desc)
+    lines.append("")
+    step_count = len(entry.steps)
+    if consent_ops:
+        lines.append(
+            f"This workflow ({step_count} step{'s' if step_count != 1 else ''}) "
+            f"may invoke the following consent-gated operations:"
+        )
+        for op in consent_ops:
+            try:
+                from work_buddy.consent import get_consent_metadata
+                meta = get_consent_metadata(op)
+            except Exception:
+                meta = None
+            risk = (meta or {}).get("risk", "moderate")
+            lines.append(f"- `{op}` ({risk})")
+    else:
+        lines.append(
+            f"This workflow has {step_count} "
+            f"step{'s' if step_count != 1 else ''}. No consent-gated "
+            f"operations were declared by its capabilities."
+        )
+    lines.append("")
+    lines.append(
+        "Approving covers all operations within this workflow's run. "
+        "Choose **Allow for 15 min** to also cover re-invocations of "
+        "the same workflow within that window without re-prompting."
+    )
+    return "\n".join(lines)
+
+
+def _auto_workflow_consent_request(
+    workflow_name: str,
+    entry: "registry.WorkflowDefinition",
+    op_id: str,
+    session_id: str | None,
+    timeout: int = _AUTO_CONSENT_TIMEOUT,
+) -> dict[str, Any]:
+    """Send a workflow-level consent request and poll for the response.
+
+    Returns one of:
+      - ``{"status": "granted", "mode": "<once|temporary|always>", ...}``
+      - ``{"status": "denied", ...}``
+      - ``{"status": "timeout", "request_id": ..., ...}``
+      - ``{"status": "auto_bypass_low_weight", ...}`` — workflows whose
+        declared ops are all low-weight auto-bypass the prompt; the
+        bypass is recorded for audit so unconverted workflows are
+        greppable.
+
+    On ``mode == "temporary"`` / ``"always"``: this function also mints
+    the ``workflow_class:<name>`` grant via the consent layer so future
+    re-invocations within the TTL window skip the prompt. ``"once"``
+    skips the class grant — only the per-run grant minted later by
+    ``start_workflow`` covers the invocation.
+    """
+    from work_buddy.consent import (
+        create_consent_request, resolve_consent_request,
+        grant_workflow_class,
+    )
+    from work_buddy.notifications.store import (
+        get_notification as _get_notif,
+        mark_delivered as _mark_delivered,
+        respond_to_notification,
+    )
+    from work_buddy.notifications.dispatcher import SurfaceDispatcher
+
+    consent_ops, max_risk = _collect_workflow_consent_ops(entry)
+
+    # Low-weight workflow auto-bypass. If no consent-gated ops were
+    # declared, OR all declared ops are low-risk, the workflow runs
+    # without a user-facing prompt. Audit-log the bypass so the
+    # ``audit_workflow_consent.py`` script can find unconverted
+    # workflows that should declare an explicit ``consent_weight``.
+    if max_risk == "low":
+        from work_buddy.consent import _audit_log
+        try:
+            _audit_log(
+                "WORKFLOW_AUTO_BYPASS_LOW_WEIGHT",
+                workflow_name,
+                f"declared_ops={len(consent_ops)} | session={(session_id or '')[:8]}",
+            )
+        except Exception:
+            pass
+        return {
+            "status": "auto_bypass_low_weight",
+            "workflow_name": workflow_name,
+            "operation_id": op_id,
+            "consent_ops": consent_ops,
+        }
+
+    body = _render_workflow_consent_body(workflow_name, entry, consent_ops)
+
+    record = create_consent_request(
+        operation=f"workflow:{workflow_name}",
+        reason=body,
+        risk=max_risk,
+        default_ttl=_WORKFLOW_CLASS_DEFAULT_TTL_MIN,
+        requester=f"gateway:workflow:{workflow_name}",
+        context={
+            "kind": "workflow_consent",
+            "workflow_name": workflow_name,
+            "operation_id": op_id,
+            "consent_ops": consent_ops,
+        },
+        callback_session_id=session_id,
+    )
+    nid = record["notification_id"]
+
+    response = None
+    notif = _get_notif(nid)
+    dispatcher = None
+    if notif:
+        try:
+            dispatcher = SurfaceDispatcher.from_config()
+            dispatcher.deliver(notif, mark_delivered_fn=_mark_delivered)
+        except Exception:
+            pass
+
+        try:
+            response = dispatcher.poll_response(
+                notif, timeout_seconds=timeout, interval_seconds=3,
+            ) if dispatcher else None
+        except Exception:
+            response = None
+
+        if response is not None:
+            try:
+                respond_to_notification(nid, response)
+            except ValueError:
+                pass
+            notif_fresh = _get_notif(nid)
+            if notif_fresh and notif_fresh.delivered_surfaces and dispatcher:
+                try:
+                    dispatcher.dismiss_others(
+                        nid,
+                        responding_surface=response.surface,
+                        delivered_surfaces=notif_fresh.delivered_surfaces,
+                    )
+                except Exception:
+                    pass
+
+    if response is None:
+        retry_hint = (
+            f"mcp__work-buddy__wb_run(\"retry\", "
+            f"{{\"operation_id\": \"{op_id}\"}})"
+        )
+        return {
+            "status": "timeout",
+            "request_id": nid,
+            "operation_id": op_id,
+            "workflow_name": workflow_name,
+            "message": (
+                f"Workflow consent prompt timed out for {workflow_name!r}, "
+                f"but the request is still pending — the user can approve "
+                f"on any surface. Once approved, retry with: {retry_hint}"
+            ),
+        }
+
+    from work_buddy.notifications.models import StandardResponse
+    if isinstance(response, StandardResponse):
+        choice = response.value
+    elif isinstance(response, dict):
+        choice = response.get("value", "deny")
+    else:
+        choice = str(response)
+    if isinstance(choice, dict) and "value" in choice:
+        choice = choice["value"]
+
+    if choice == "deny":
+        try:
+            resolve_consent_request(nid, approved=False)
+        except ValueError:
+            pass
+        return {
+            "status": "denied",
+            "operation_id": op_id,
+            "workflow_name": workflow_name,
+            "message": f"User denied consent for workflow {workflow_name!r}.",
+        }
+
+    mode = choice  # "always", "temporary", or "once"
+    ttl = (
+        _WORKFLOW_CLASS_DEFAULT_TTL_MIN if mode == "temporary"
+        else _WORKFLOW_CLASS_ALWAYS_TTL_MIN if mode == "always"
+        else None
+    )
+    try:
+        resolve_consent_request(nid, approved=True, mode=mode, ttl_minutes=ttl)
+    except ValueError:
+        pass
+
+    # Mint the class grant for temporary / always modes. "once" skips —
+    # only the run grant (minted by start_workflow) covers the invocation.
+    if mode in ("temporary", "always") and ttl is not None:
+        grant_workflow_class(
+            workflow_name, ttl_minutes=ttl, session_id=session_id,
+        )
+
+    return {
+        "status": "granted",
+        "mode": mode,
+        "workflow_name": workflow_name,
+        "operation_id": op_id,
+        "consent_ops": consent_ops,
     }
 
 
@@ -968,12 +1283,56 @@ def register_tools(mcp: FastMCP) -> None:
 
         if isinstance(entry, registry.WorkflowDefinition):
             _t0 = _time.monotonic()
+            _wf_session_id = _resolve_session(ctx)
+
+            # Composable consent v1 — pre-flight workflow consent.
+            #
+            # Skip the prompt when:
+            #   - we are inside a ``user_initiated()`` context (UI click /
+            #     slash-command launch — the click IS the consent), or
+            #   - the workflow's class grant is already live in this
+            #     session (the user previously chose 'temporary' or
+            #     'always' for this workflow and the TTL hasn't expired).
+            #
+            # Otherwise: send the prompt, wait for the response, mint the
+            # ``workflow_class:<name>`` grant on approval, and either
+            # proceed (granted / auto_bypass_low_weight) or short-circuit
+            # the dispatch (denied / timeout).
+            try:
+                from work_buddy.consent import _consent_ctx as _wf_ctx
+                _is_user_initiated = _wf_ctx.depth > 0
+            except Exception:
+                _is_user_initiated = False
+
+            if not _is_user_initiated and not _is_workflow_class_authorized(
+                capability, session_id=_wf_session_id,
+            ):
+                wf_consent_result = await asyncio.to_thread(
+                    _auto_workflow_consent_request,
+                    capability, entry, op_id, _wf_session_id,
+                )
+                status = wf_consent_result.get("status")
+                if status in ("denied", "timeout"):
+                    _complete_operation(
+                        op_id,
+                        error=f"Workflow consent {status}: {capability}",
+                    )
+                    wf_consent_result["operation_id"] = op_id
+                    return _prepare(wf_consent_result)
+                # On 'granted' / 'auto_bypass_low_weight' / unexpected
+                # status, fall through to start_workflow. The grant
+                # minting has already happened inside the helper for
+                # 'temporary' / 'always' modes; 'once' and the
+                # auto-bypass leave class grants alone — only the run
+                # grant minted inside start_workflow covers the
+                # invocation.
+
             try:
                 result = await asyncio.to_thread(
                     _conductor().start_workflow,
                     capability,
                     parsed_params,
-                    _resolve_session(ctx),
+                    _wf_session_id,
                 )
             except Exception as exc:
                 _complete_operation(op_id, error=f"{type(exc).__name__}: {exc}")

--- a/work_buddy/mcp_server/tools/gateway.py
+++ b/work_buddy/mcp_server/tools/gateway.py
@@ -1383,10 +1383,15 @@ def register_tools(mcp: FastMCP) -> None:
                     "operation_id": op_id,
                 })
 
-        # Inject caller's session ID for capabilities that need it
+        # Inject caller's session ID for capabilities that need it.
+        # ``consent_list`` reads grants out of a session-scoped SQLite
+        # DB; without the injection it returns rows from whichever
+        # session the cache instance was first connected against
+        # (typically the MCP server's bootstrap session), not the
+        # agent's view.
         if capability in (
             "session_activity", "session_summary", "session_wb_activity",
-            "artifact_save",
+            "artifact_save", "consent_list",
         ) and _agent_sid:
             parsed_params.setdefault("agent_session_id", _agent_sid)
 

--- a/work_buddy/obsidian/retry.py
+++ b/work_buddy/obsidian/retry.py
@@ -536,6 +536,7 @@ def obsidian_retry(
 
     capability = record.get("name")
     params = record.get("params") or {}
+    originating_session_id = record.get("originating_session_id")
 
     if not capability:
         return {
@@ -575,7 +576,24 @@ def obsidian_retry(
                 )
 
         try:
-            result = entry.callable(**params)
+            # Pin the originating session on the ContextVar so the
+            # @requires_consent decorator's is_granted check resolves
+            # to the agent's session DB rather than the MCP server's
+            # bootstrap session. Without this, replays of consent-
+            # gated ops can synchronously fail with ConsentRequired
+            # even when the user has approved out-of-band.
+            if originating_session_id:
+                from work_buddy.agent_session import (
+                    set_originating_session, reset_originating_session,
+                )
+                _orig_token = set_originating_session(originating_session_id)
+            else:
+                _orig_token = None
+            try:
+                result = entry.callable(**params)
+            finally:
+                if _orig_token is not None:
+                    reset_originating_session(_orig_token)
         except Exception as exc:
             # CP-A6: ObsidianPostWriteUncertain demands verify-then-decide,
             # not blind retry. Propagate so the gateway's CP5 verify path

--- a/work_buddy/telegram/handlers.py
+++ b/work_buddy/telegram/handlers.py
@@ -949,6 +949,20 @@ async def cmd_reply(
 
         # Record the response
         notification = respond_to_notification(notification_id, resp)
+
+        # When the notification is a consent prompt, translate the
+        # response into actual grants. ``respond_to_notification`` only
+        # records the choice — the grant-writing lives in the consent
+        # layer. See ``on_button`` for the rationale.
+        try:
+            from work_buddy.consent import finalize_consent_response
+            finalize_consent_response(notification_id)
+        except Exception as exc:
+            logger.warning(
+                "finalize_consent_response failed for %s: %s",
+                notification_id, exc,
+            )
+
         dispatch_callback(notification)
 
         # Dismiss on other surfaces
@@ -1066,6 +1080,24 @@ async def on_button(
             surface="telegram",
         )
         notification = respond_to_notification(notification_id, response)
+
+        # When the notification is a consent prompt, translate the
+        # response into actual consent grants. Telegram's
+        # ``respond_to_notification`` flow does not pass through
+        # ``resolve_consent_request`` (the consent-request resolver
+        # the other surfaces use), so without this call the grant
+        # never lands for out-of-band Telegram approvals — the
+        # ``Allow for 15 min`` window the user thought they
+        # authorized never gets a corresponding grant row, and the
+        # next invocation of the same workflow re-prompts.
+        try:
+            from work_buddy.consent import finalize_consent_response
+            finalize_consent_response(notification_id)
+        except Exception as exc:
+            logger.warning(
+                "finalize_consent_response failed for %s: %s",
+                notification_id, exc,
+            )
 
         # Dispatch callback if configured
         dispatch_callback(notification)


### PR DESCRIPTION
## Summary

Adds composable workflow consent with two grant keys (\`workflow_class:<name>\` + \`workflow_run:<name>:<run_id>\`) and a gateway pre-flight prompt at workflow start. The four follow-up fixes close every place the same pre-existing bug pattern was hiding — \"the process's session leaking through where the agent's session belongs.\" Live-tested end-to-end on the Telegram out-of-band path.

- **\`5b73c164\` feat** — workflow_class + workflow_run grant keys, gateway pre-flight prompt at workflow start, conductor lifecycle migration, retry-queue isolation, low-weight workflow auto-bypass, audit script, docs.
- **\`8497cb30\` fix** — \`resolve_consent_request\` mints the class grant + dismisses sibling surfaces on out-of-band approval (Obsidian-modal / dashboard / MCP resolve-op paths).
- **\`d3c7a91c\` fix** — \`consent_list\` routes through the agent's session DB (was reading the cache's default DB = MCP-server bootstrap session).
- **\`53f9bfe8\` fix** — Telegram \`on_button\` and \`/reply\` call \`finalize_consent_response\` after \`respond_to_notification\` (Telegram bypasses \`resolve_consent_request\`, so the grant write was missing entirely).
- **\`0b6717be\` fix** — \`_auto_consent_request\` accepts an explicit \`session_id\` and routes \`callback_session_id\` to the agent's session (was reading \`os.environ.get(\"WORK_BUDDY_SESSION_ID\")\` = bootstrap session, mis-routing out-of-band grants to the wrong DB).
- **\`af58f259\` docs** — \`dev/dev-mode\` cross-references \`/wb-dev-live-testing\`; \`notifications/consent\` dev_notes maps the response→grant pipeline + agent-session callback routing.

## Test plan

- [x] Unit tests: 193 pass across consent / conductor / gateway suites. Includes 3 new test files (\`test_consent_composable.py\`, \`test_workflow_consent_preflight.py\`, \`test_conductor_consent_lifecycle.py\`).
- [x] Live test — capability consent out-of-band (Telegram, after the 90s gateway poll exited):
  - \`consent_list\` returned \`{}\` (clean session — d3c7a91c routing works)
  - \`task_create\` fired the consent prompt; 90s timeout returned the structured \`{status: \"timeout\", request_id, operation_id}\` payload
  - Tapped \"Allow once\" on Telegram → Obsidian modal dismissed automatically (existing behavior)
  - Audit log showed \`GRANTED | tasks.create_task | once | session=<agent>\` — **grants landed in the agent's session DB** (the four-fix chain working end-to-end)
  - Retry created the task successfully; \"once\" grants auto-revoked after consumption
- [x] Live test — temporary-mode TTL carry: tapped \"Allow for N min\" on Telegram; \`consent_list\` showed grants with \`expires_at\` ~30 min ahead; second \`task_create\` within the window skipped the prompt and went straight through (TTL-carry path).
- [x] Knowledge-store validation: 394 units checked, 0 failures, 0 warnings.

## Anti-flag

- A bridge transient (\`_bridge_transient: true\`) hit during the very last live test on the master-task-list read. Orthogonal to consent — the prompt path was already verified at that point.
- Two helper scripts under \`.data/designs/composable-consent-v1/\` (\`_update_consent_docs.py\`, \`_apply_dev_doc_updates.py\`) are gitignored design-session artifacts; safe to delete after review.

## Follow-ups

- Task \`t-97311ff7\` (composable-consent v2 taint propagation) — created earlier in this branch's work. Separate PR.
- A separate unification refactor (push dispatch + dismiss + grant-write into \`respond_to_notification\` so every surface is a one-liner) was previously captured as a handoff task during this session; that work is intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)