### PR TITLE
docs(session-identify): fix summary_search example to use scope, not namespace

### DIFF
--- a/knowledge/store/context/session-identify.md
+++ b/knowledge/store/context/session-identify.md
@@ -64,7 +64,7 @@ Run `summary_search` with the user's strongest topic phrase. This is the **load-
 ```
 mcp__work-buddy__wb_run("summary_search", {
   "query": "<topic phrase>",
-  "namespace": "conversation_session",
+  "scope": "conversation_session",
   "top_k": 12,
   "drill": true,
   "drill_top_k": 4,


### PR DESCRIPTION
## Summary

- The `summary_search` capability accepts `scope` (named to match `context_search` / `agent_docs`), but the session-identify directions' first example invoked it with `namespace`.
- An agent following the directions literally got a parameter error and fell back to the raw-span `context_search` sweep — which doesn't index summary titles, so queries whose answer lived in a topic title (e.g. "Gate AST & card registry infrastructure") could not surface the right session at all.
- One-line fix: `"namespace"` → `"scope"` in the first fenced code block. The second example (the universal `find` form) already used `scope` correctly.

## Why this matters

This was found via a `/wb-dev-retro` on a session-identify run that took ~30 tool calls to find a session that `summary_search` returns at rank 1 with `score=0.0328` once the example is called correctly. The directions told the agent to call the tool in a way the tool refuses.

## Test plan

- [x] `agent_docs(path="context/session-identify", depth="full")` after `agent_docs_rebuild(force=true)` shows the corrected `"scope": "conversation_session"` line.
- [x] End-to-end smoke: `summary_search({query: "boolean expression gate AST", scope: "conversation_session", top_k: 5, drill: false})` returns the gate-AST session (`d77fb692-…`) at rank 1.
- [x] Negative test: passing the old `namespace=` form produces the clean `Parameter error: Unknown parameter(s): namespace. Accepted: drill, drill_per_item_top_k, drill_top_k, method, query, scope, top_k.` surface — not the AttributeError observed earlier this session, which traced to in-flight edits on the consent branch and not to a defect in `main`.

## Notes

- Pure docs change; no Python or test code touched. The `document` step of `/wb-dev-pr` was skipped — the only changed file IS the knowledge unit, so dev-document's "propagate code changes into docs" pass has nothing to propose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)