### PR TITLE
feat: /wb-task-completeness + Windows Job Object hard-kill reaping

### DIFF
--- a/.claude/commands/wb-task-completeness.md
+++ b/.claude/commands/wb-task-completeness.md
@@ -1,0 +1,5 @@
+---
+short: Investigate whether a task is already done
+workflow: task-completeness
+---
+Load directions via `mcp__work-buddy__wb_run("agent_docs", {"path": "tasks/task-completeness", "depth": "full"})`, then run the workflow with `$ARGUMENTS` as `task_id`.

--- a/knowledge/store/services/sidecar.md
+++ b/knowledge/store/services/sidecar.md
@@ -50,6 +50,18 @@ dev_notes: |-
 
   `compat.find_child_pids`: Windows uses WMIC (~100ms, deprecated but ships) with `Get-CimInstance -NoProfile` fallback (~6-15s cold). Unix uses `pgrep -P`. Best-effort — returns `set()` on enumeration failure; the supervisor's per-port clean-up in `_start_child` (`_kill_process_on_port`) is the secondary backstop.
 
+  ### Defense 1b — OS-enforced kill-time reaping (Windows Job Object)
+
+  Defense 1 only runs on the *next* startup, and every signal-handler / watchdog / `_shutdown` layer only runs if the dying daemon's own code runs. A **hard kill** (`taskkill /F`, `kill -9`, crash, power loss) vaporizes the daemon mid-instruction — no code runs, and on Windows children do **not** die with their parent. That leaves a window (hard-kill → next boot) where an orphan keeps holding its port and serving stale bytecode.
+
+  `compat.create_kill_on_close_job()` creates a Windows Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`; `daemon.py:run()` creates it once (module global `_kill_job`, kept alive for the daemon's whole life) before spawning children, and `_start_child` assigns each child via `compat.assign_process_to_job(_kill_job, pid)` right after `Popen`. When the daemon's process object is destroyed by any means, the **OS** — not our code — kills everything in the job. This is the only mechanism that closes the hard-kill case.
+
+  **Handle lifetime is the rule**: the kill fires when the job's *last* handle closes, so `_kill_job` must be a module global, never a local that can be GC'd. After assigning, the per-child *process* handle is closed (`win32api.CloseHandle`); only the *job* handle stays open.
+
+  **Best-effort assignment**: `AssignProcessToJobObject` can fail when the daemon is itself nested inside another restrictive job (some VS Code terminals / scheduled-task wrappers). A failed assign is logged and non-fatal — Defense 1's startup sweep is the fallback.
+
+  **Windows-only by design, not bias**: there is no cross-platform OS guarantee for kill-time reaping. Linux's `prctl(PR_SET_PDEATHSIG)` needs an unsafe `preexec_fn` in a threaded process and fires on *thread* death; macOS has only a cooperative child-side kqueue self-watch. Both are deliberately not implemented (commented as such next to the Windows code). The cross-platform baseline stays Defense 1. Windows is also the only OS the sidecar actually runs on.
+
   ### Defense 2 — children spawn under a pinned interpreter
 
   `work_buddy/sidecar/daemon.py:_resolve_child_python(cfg)` is the single chokepoint for which Python children get spawned with: `cfg['sidecar']['python_executable']` if set and existing, else `sys.executable`.

--- a/knowledge/store/tasks/task-completeness.md
+++ b/knowledge/store/tasks/task-completeness.md
@@ -1,0 +1,106 @@
+---
+name: Task Completeness
+kind: workflow
+description: Investigate whether a task was already completed (fully/partially/differently), judge the spirit not the letter, then optionally mark it complete with the correct prior date.
+summary: 'Investigate-and-retro-complete a task: auto-gather task + session commit/write evidence, judge completeness against a spirit-over-letter rubric (done/done-differently/partial/consciously-descoped/not-done), then on confirmation mark it done with the landing-commit date via task_toggle''s done_date.'
+workflow_name: task-completeness
+execution: main
+allow_override: false
+steps:
+- id: gather-evidence
+  name: Gather completion evidence
+  step_type: code
+  depends_on: []
+  auto_run:
+    callable: work_buddy.task_completeness.gather_completeness_evidence
+    input_map:
+      task_id: __params__.task_id
+    timeout: 90
+- id: investigate
+  name: Investigate completeness
+  step_type: reasoning
+  depends_on:
+  - gather-evidence
+  result_schema:
+    required_keys:
+    - disposition
+    - evidence
+    - completion_date
+    - recommended_action
+    key_types:
+      disposition: str
+      evidence: list
+      recommended_action: str
+    min_items:
+      evidence: 1
+- id: resolve
+  name: Confirm and apply
+  step_type: reasoning
+  depends_on:
+  - investigate
+  invokes:
+  - task_toggle
+  - task_create
+params_schema:
+  task_id:
+    type: str
+    description: Task ID to investigate (e.g. t-99b8a4ff)
+    required: true
+command: wb-task-completeness
+tags:
+- tasks
+- task
+- completeness
+- stale
+- retroactive
+- investigate
+- done-date
+aliases:
+- was this done
+- already completed
+- retroactive complete
+- check task completeness
+- did we already fix this
+parents:
+- tasks
+---
+
+Investigate whether a task the user is unsure about was ALREADY completed — fully, partially, or differently — and if so, mark it complete with the correct PRIOR date.
+
+Core principle — judge the SPIRIT, not the letter. Tasks are written before the work; designs change, get improved, or a sub-part is deliberately dropped. Something can look undone because it was done a better way, or not done on purpose. Your job is to decide whether what is PRESENT in the codebase/notes satisfies the task's INTENT.
+
+Disposition rubric (pick one): done / done-differently / partial / consciously-descoped / not-done.
+
+Verification ladder — cheapest signal first, stop when confident: (1) the auto-gathered evidence bundle (task note + per-session commits/writes), (2) git log --grep/-S and gh PR/commit search, (3) reading the actual code and tests, (4) running the targeted test. Inactivity is NOT completion — a quiet task is not a done task.
+
+Dating: the completion date is the date the LANDING COMMIT merged, not today. Always cite the commit SHA as evidence.
+
+Always confirm before mutating. The investigate step produces the judgment; the resolve step acts only on explicit user approval. Backdating uses task_toggle's done_date param (ISO YYYY-MM-DD).
+
+## investigate
+
+You are judging whether this task was ALREADY completed — and if so, WHEN.
+
+Read the evidence bundle in step_results['gather-evidence']: the task text + linked note (the original intent), its current state, and per assigned session the attributed commits/writes. Heed `cache_note` and any per-session `note` — when a session has no transcript (sidecar/pruned) there is no commit linkage, so you must attribute the work yourself.
+
+Then investigate ADAPTIVELY, cheapest signal first, stopping as soon as you are confident:
+1. The evidence bundle (commits/writes already attributed).
+2. `git log --grep`/`git log -S` for the task id, symptom, or key symbols; `gh pr list/view` and `gh search prs/commits` for related PRs.
+3. Read the ACTUAL code/tests in the repo to confirm the behavior exists now.
+4. Run the targeted test(s) only if code presence is still ambiguous.
+
+Judge the SPIRIT, not the letter — a design may have been improved, replaced, or a sub-part deliberately dropped. Decide whether what is PRESENT satisfies the task's INTENT. Pick exactly one disposition: done | done-differently | partial | consciously-descoped | not-done. Inactivity is NOT completion.
+
+Return ONLY your new findings (a delta) with keys: disposition (one of the five); evidence (a non-empty list of concrete citations — commit SHAs, PR URLs, path:line, test names, note excerpts — each tied to what it proves); completion_date (ISO YYYY-MM-DD of the LANDING COMMIT that satisfied the intent, or null; cite its SHA in evidence); recommended_action (one sentence: mark done backdated / finish remainder / spin off residual / leave open).
+
+## resolve
+
+Present the disposition from `investigate` with its evidence and completion date, then act ONLY on explicit user confirmation — never mutate first.
+
+Recommend by disposition:
+- done / done-differently: offer to mark complete BACKDATED via wb_run('task_toggle', {'task_id': '<id>', 'done': true, 'done_date': '<completion_date>'}). done_date is the landing-commit date from investigate.
+- consciously-descoped: same backdated toggle, and state plainly that the missing part was a deliberate descope.
+- partial: offer BOTH (a) finishing the remainder now and/or (b) spinning the remainder off as a handoff task via wb_run('task_create', {...}); optionally backdate-complete the shipped portion if separable.
+- not-done: recommend leaving it open; optionally offer to narrow the task text to the true remainder.
+
+After the user picks, apply exactly what was approved and report what changed (the new ✅ date, any new task id). If they decline, leave the task untouched and say so.

--- a/knowledge/store/tasks/task_toggle.md
+++ b/knowledge/store/tasks/task_toggle.md
@@ -15,6 +15,10 @@ parameters:
     type: bool
     description: True=complete, False=incomplete, omit=toggle
     required: false
+  done_date:
+    type: str
+    description: ISO YYYY-MM-DD to stamp as the completion date when marking done. Defaults to today. Use for retroactive completion (e.g. the landing-commit date a completeness check uncovered). Ignored when reopening.
+    required: false
 mutates_state: true
 retry_policy: verify_first
 consent_operations:

--- a/tests/unit/test_sidecar_orphan_reaping.py
+++ b/tests/unit/test_sidecar_orphan_reaping.py
@@ -202,3 +202,142 @@ def test_takeover_with_no_children_still_kills_daemon(monkeypatch):
     assert sidecar_pid.takeover_existing_daemon(7260, wait_seconds=0.3) is True
     # No children → no force-kill calls during the children-reap step.
     assert fk_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Job Object — OS-enforced kill-time reaping (Windows hard-kill window)
+# ---------------------------------------------------------------------------
+#
+# The takeover sweep above closes the cross-restart orphan window, but only
+# on the *next* startup. The Job Object closes the gap in between: when the
+# daemon is hard-killed (taskkill /F, crash) no signal handler runs, so on
+# Windows children orphan until the next boot. KILL_ON_JOB_CLOSE makes the
+# OS reap them the instant the daemon's process object is destroyed.
+
+
+class _FakeWin32Job:
+    """Minimal stand-in for the ``win32job`` module."""
+
+    JobObjectExtendedLimitInformation = 9
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+
+    def __init__(self):
+        self.created = False
+        self.set_flags = None
+
+    def CreateJobObject(self, sa, name):
+        self.created = True
+        return "JOB_HANDLE"
+
+    def QueryInformationJobObject(self, job, kind):
+        return {"BasicLimitInformation": {"LimitFlags": 0}}
+
+    def SetInformationJobObject(self, job, kind, info):
+        self.set_flags = info["BasicLimitInformation"]["LimitFlags"]
+
+    def AssignProcessToJobObject(self, job, handle):
+        pass
+
+
+def test_create_job_returns_none_on_non_windows(monkeypatch):
+    """Windows-only: on Unix the helper no-ops to None (the cross-platform
+    baseline is the startup orphan sweep, not a Job Object)."""
+    monkeypatch.setattr(compat, "IS_WINDOWS", False)
+    assert compat.create_kill_on_close_job() is None
+
+
+def test_assign_returns_false_on_non_windows(monkeypatch):
+    monkeypatch.setattr(compat, "IS_WINDOWS", False)
+    assert compat.assign_process_to_job("JOB", 1234) is False
+
+
+def test_assign_returns_false_when_job_is_none(monkeypatch):
+    """A None job (creation failed) must make assignment a safe no-op."""
+    monkeypatch.setattr(compat, "IS_WINDOWS", True)
+    assert compat.assign_process_to_job(None, 1234) is False
+
+
+def test_create_job_sets_kill_on_close_flag(monkeypatch):
+    """The job must carry KILL_ON_JOB_CLOSE — that flag is the whole point."""
+    monkeypatch.setattr(compat, "IS_WINDOWS", True)
+    fake = _FakeWin32Job()
+    monkeypatch.setitem(__import__("sys").modules, "win32job", fake)
+
+    job = compat.create_kill_on_close_job()
+    assert job == "JOB_HANDLE"
+    assert fake.created
+    assert fake.set_flags & fake.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+
+
+def test_create_job_swallows_errors_returns_none(monkeypatch):
+    """Job creation must never raise — a failure degrades to None and the
+    startup sweep remains the fallback."""
+    monkeypatch.setattr(compat, "IS_WINDOWS", True)
+
+    class _Boom:
+        JobObjectExtendedLimitInformation = 9
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+
+        def CreateJobObject(self, *a):
+            raise OSError("access denied")
+
+    monkeypatch.setitem(__import__("sys").modules, "win32job", _Boom())
+    assert compat.create_kill_on_close_job() is None
+
+
+def test_assign_is_best_effort_on_failure(monkeypatch):
+    """Assignment can fail under nested-job restrictions — must return False,
+    never raise, so a child still starts and the sweep covers it."""
+    monkeypatch.setattr(compat, "IS_WINDOWS", True)
+
+    class _BoomJob:
+        def AssignProcessToJobObject(self, job, h):
+            raise OSError("nested job limits")
+
+    class _Api:
+        def OpenProcess(self, *a):
+            return "PROC_HANDLE"
+
+        def CloseHandle(self, h):
+            pass
+
+    class _Con:
+        PROCESS_SET_QUOTA = 0x0100
+        PROCESS_TERMINATE = 0x0001
+
+    import sys as _sys
+    monkeypatch.setitem(_sys.modules, "win32job", _BoomJob())
+    monkeypatch.setitem(_sys.modules, "win32api", _Api())
+    monkeypatch.setitem(_sys.modules, "win32con", _Con())
+
+    assert compat.assign_process_to_job("JOB_HANDLE", 4321) is False
+
+
+def test_assign_closes_process_handle_on_success(monkeypatch):
+    """The *process* handle must be closed after assigning; only the *job*
+    handle stays open (closing the job handle early would kill children)."""
+    monkeypatch.setattr(compat, "IS_WINDOWS", True)
+    closed: list[str] = []
+
+    class _Job:
+        def AssignProcessToJobObject(self, job, h):
+            pass
+
+    class _Api:
+        def OpenProcess(self, *a):
+            return "PROC_HANDLE"
+
+        def CloseHandle(self, h):
+            closed.append(h)
+
+    class _Con:
+        PROCESS_SET_QUOTA = 0x0100
+        PROCESS_TERMINATE = 0x0001
+
+    import sys as _sys
+    monkeypatch.setitem(_sys.modules, "win32job", _Job())
+    monkeypatch.setitem(_sys.modules, "win32api", _Api())
+    monkeypatch.setitem(_sys.modules, "win32con", _Con())
+
+    assert compat.assign_process_to_job("JOB_HANDLE", 4321) is True
+    assert closed == ["PROC_HANDLE"]

--- a/tests/unit/test_task_completeness.py
+++ b/tests/unit/test_task_completeness.py
@@ -1,0 +1,144 @@
+"""Unit tests for the ``/wb-task-completeness`` evidence gatherer.
+
+Verifies :func:`work_buddy.task_completeness.gather_completeness_evidence`:
+- composes read_task + per-session commits/writes/summary into one bundle
+- degrades gracefully (status flips, errors recorded) when a sub-call raises
+- treats a missing transcript (sidecar/pruned session) as a *note*, not a
+  degradation — commit refresh is a freshening optimization, not required
+- short-circuits cleanly when the task can't be read or has no sessions
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from work_buddy import task_completeness as tc
+
+
+def _ok_payload(sessions):
+    return {"success": True, "text": "Fix the bug", "state": "inbox",
+            "assigned_sessions": sessions}
+
+
+class TestGatherEvidenceHappyPath:
+    """A fully-populated task yields an ``ok`` bundle with per-session rows."""
+
+    def test_bundle_shape(self):
+        sessions = [{"session_id": "s-1", "assigned_at": "2026-05-01"}]
+        with patch("work_buddy.obsidian.tasks.mutations.read_task",
+                   return_value=_ok_payload(sessions)), \
+             patch("work_buddy.conversation_observability.commits"
+                   ".refresh_session_commits", return_value=None), \
+             patch("work_buddy.conversation_observability.commits"
+                   ".query_session_commits", return_value=[{"sha": "abc"}]), \
+             patch("work_buddy.conversation_observability.writes"
+                   ".query_session_writes", return_value=[{"path": "f.py"}]), \
+             patch("work_buddy.conversation_observability.session_summary_row"
+                   ".session_summary_row", return_value={"topic": "t"}):
+            out = tc.gather_completeness_evidence("t-abc123")
+
+        assert out["status"] == "ok"
+        assert out["task_id"] == "t-abc123"
+        assert out["assigned_sessions"] == sessions
+        assert len(out["session_evidence"]) == 1
+        entry = out["session_evidence"][0]
+        assert entry["session_id"] == "s-1"
+        assert entry["commits"] == [{"sha": "abc"}]
+        assert entry["writes"] == [{"path": "f.py"}]
+        assert entry["summary"] == {"topic": "t"}
+        assert entry["note"] is None
+        assert out["errors"] == []
+        assert "now_iso" in out
+
+
+class TestGatherEvidenceShortCircuits:
+    """Task-level failures return early with status=error."""
+
+    def test_read_task_raises(self):
+        with patch("work_buddy.obsidian.tasks.mutations.read_task",
+                   side_effect=RuntimeError("boom")):
+            out = tc.gather_completeness_evidence("t-abc123")
+
+        assert out["status"] == "error"
+        assert out["task"] == {}
+        assert any(e["step"] == "read_task" for e in out["errors"])
+        assert "native" in out["cache_note"].lower()
+
+    def test_task_not_found(self):
+        with patch("work_buddy.obsidian.tasks.mutations.read_task",
+                   return_value={"success": False, "message": "Task not found."}):
+            out = tc.gather_completeness_evidence("t-missing")
+
+        assert out["status"] == "error"
+        assert out["cache_note"] == "Task not found."
+
+    def test_no_sessions_assigned(self):
+        with patch("work_buddy.obsidian.tasks.mutations.read_task",
+                   return_value=_ok_payload([])):
+            out = tc.gather_completeness_evidence("t-abc123")
+
+        assert out["status"] == "ok"
+        assert out["session_evidence"] == []
+        assert "no session" in out["cache_note"].lower()
+
+
+class TestGatherEvidenceDegradation:
+    """Sub-call failures degrade gracefully instead of aborting."""
+
+    def test_missing_transcript_is_a_note_not_degradation(self):
+        """refresh raising 'no session found' → note, status stays ok."""
+        sessions = [{"session_id": "sidecar-x", "assigned_at": "2026-05-01"}]
+        with patch("work_buddy.obsidian.tasks.mutations.read_task",
+                   return_value=_ok_payload(sessions)), \
+             patch("work_buddy.conversation_observability.commits"
+                   ".refresh_session_commits",
+                   side_effect=RuntimeError("No session found")), \
+             patch("work_buddy.conversation_observability.commits"
+                   ".query_session_commits", return_value=[]), \
+             patch("work_buddy.conversation_observability.writes"
+                   ".query_session_writes", return_value=[]), \
+             patch("work_buddy.conversation_observability.session_summary_row"
+                   ".session_summary_row", return_value=None):
+            out = tc.gather_completeness_evidence("t-abc123")
+
+        assert out["status"] == "ok"
+        entry = out["session_evidence"][0]
+        assert entry["note"] is not None
+        assert "transcript" in entry["note"].lower()
+        assert out["errors"] == []
+
+    def test_query_commits_failure_degrades(self):
+        sessions = [{"session_id": "s-1", "assigned_at": "2026-05-01"}]
+        with patch("work_buddy.obsidian.tasks.mutations.read_task",
+                   return_value=_ok_payload(sessions)), \
+             patch("work_buddy.conversation_observability.commits"
+                   ".refresh_session_commits", return_value=None), \
+             patch("work_buddy.conversation_observability.commits"
+                   ".query_session_commits",
+                   side_effect=RuntimeError("db locked")), \
+             patch("work_buddy.conversation_observability.writes"
+                   ".query_session_writes", return_value=[]), \
+             patch("work_buddy.conversation_observability.session_summary_row"
+                   ".session_summary_row", return_value=None):
+            out = tc.gather_completeness_evidence("t-abc123")
+
+        assert out["status"] == "degraded"
+        assert any(e["step"].startswith("query_commits:") for e in out["errors"])
+
+    def test_query_writes_failure_degrades(self):
+        sessions = [{"session_id": "s-1", "assigned_at": "2026-05-01"}]
+        with patch("work_buddy.obsidian.tasks.mutations.read_task",
+                   return_value=_ok_payload(sessions)), \
+             patch("work_buddy.conversation_observability.commits"
+                   ".refresh_session_commits", return_value=None), \
+             patch("work_buddy.conversation_observability.commits"
+                   ".query_session_commits", return_value=[]), \
+             patch("work_buddy.conversation_observability.writes"
+                   ".query_session_writes",
+                   side_effect=RuntimeError("db locked")), \
+             patch("work_buddy.conversation_observability.session_summary_row"
+                   ".session_summary_row", return_value=None):
+            out = tc.gather_completeness_evidence("t-abc123")
+
+        assert out["status"] == "degraded"
+        assert any(e["step"].startswith("query_writes:") for e in out["errors"])

--- a/tests/unit/test_task_mutations.py
+++ b/tests/unit/test_task_mutations.py
@@ -186,3 +186,98 @@ class TestToggleTaskDoneParam:
 
         assert result["success"] is False
         assert is_bridge_failure(result)
+
+
+# ── toggle_task: `done_date` backdating behavior ────────────────
+
+class TestToggleTaskDoneDate:
+    """toggle_task stamps a retroactive completion date when requested."""
+
+    def test_backdate_rewrites_stamp_on_unchecked(self, _patch_bridge_and_store):
+        """done_date on an unchecked->done transition stamps that date, not today."""
+        mock_bridge, _ = _patch_bridge_and_store
+        mock_bridge.read_file.return_value = UNCHECKED_LINE
+
+        with patch.object(mutations, "_run_js", return_value=None):
+            result = mutations.toggle_task(
+                task_id="t-abc123", done=True, done_date="2026-05-05"
+            )
+
+        assert result["success"] is True
+        assert result["new_state"] == "done"
+        assert "✅ 2026-05-05" in result["new_line"]
+        # No second (today's) date stamp leaked in.
+        assert result["new_line"].count("✅") == 1
+        written = mock_bridge.write_file.call_args.args[1]
+        assert "✅ 2026-05-05" in written
+
+    def test_backdate_overrides_plugin_today_stamp(self, _patch_bridge_and_store):
+        """Plugin API stamps today; done_date must override it to the backdate."""
+        mock_bridge, _ = _patch_bridge_and_store
+        mock_bridge.read_file.return_value = UNCHECKED_LINE
+        plugin_today = "- [x] #todo Fix the bug 🆔 t-abc123 ✅ 2026-05-28"
+
+        with patch.object(mutations, "_toggle_via_plugin_api",
+                          return_value=plugin_today):
+            result = mutations.toggle_task(
+                task_id="t-abc123", done=True, done_date="2026-05-05"
+            )
+
+        assert result["success"] is True
+        assert "✅ 2026-05-05" in result["new_line"]
+        assert "2026-05-28" not in result["new_line"]
+        assert result["new_line"].count("✅") == 1
+
+    def test_invalid_format_fails_without_write(self, _patch_bridge_and_store):
+        """A malformed done_date returns a clean failure and writes nothing."""
+        mock_bridge, mock_store = _patch_bridge_and_store
+        mock_bridge.read_file.return_value = UNCHECKED_LINE
+
+        result = mutations.toggle_task(
+            task_id="t-abc123", done=True, done_date="May 5 2026"
+        )
+
+        assert result["success"] is False
+        assert "done_date" in result["message"]
+        mock_bridge.write_file.assert_not_called()
+        mock_store.update.assert_not_called()
+
+    def test_impossible_calendar_date_fails(self, _patch_bridge_and_store):
+        """A well-formatted but impossible date (2026-13-40) is rejected."""
+        mock_bridge, _ = _patch_bridge_and_store
+        mock_bridge.read_file.return_value = UNCHECKED_LINE
+
+        result = mutations.toggle_task(
+            task_id="t-abc123", done=True, done_date="2026-13-40"
+        )
+
+        assert result["success"] is False
+        assert "done_date" in result["message"]
+        mock_bridge.write_file.assert_not_called()
+
+    def test_omitted_done_date_stamps_today(self, _patch_bridge_and_store):
+        """Omitting done_date keeps the default (today) stamp — regression."""
+        from datetime import date
+
+        mock_bridge, _ = _patch_bridge_and_store
+        mock_bridge.read_file.return_value = UNCHECKED_LINE
+
+        with patch.object(mutations, "_run_js", return_value=None):
+            result = mutations.toggle_task(task_id="t-abc123", done=True)
+
+        assert result["success"] is True
+        assert f"✅ {date.today().isoformat()}" in result["new_line"]
+
+    def test_backdate_ignored_when_reopening(self, _patch_bridge_and_store):
+        """done_date is ignored on a done->incomplete transition."""
+        mock_bridge, _ = _patch_bridge_and_store
+        mock_bridge.read_file.return_value = CHECKED_LINE
+
+        with patch.object(mutations, "_run_js", return_value=None):
+            result = mutations.toggle_task(
+                task_id="t-abc123", done=False, done_date="2026-05-05"
+            )
+
+        assert result["success"] is True
+        assert result["new_state"] == "inbox"
+        assert "✅" not in result["new_line"]

--- a/work_buddy/compat.py
+++ b/work_buddy/compat.py
@@ -380,6 +380,84 @@ def _find_child_pids_unix(pid: int) -> set[int]:
     return children
 
 
+def create_kill_on_close_job():
+    """Create a Windows Job Object that kills every assigned process when
+    its last handle closes — i.e. when this daemon dies by ANY means,
+    including a hard kill (``taskkill /F``, ``kill -9``, crash, power loss)
+    where the daemon's own signal handlers and atexit hooks never run.
+
+    Returns the job handle on Windows, or ``None`` on non-Windows / failure.
+
+    THE CALLER MUST KEEP THE RETURNED HANDLE ALIVE for the daemon's whole
+    life: the OS triggers the kill when the job's *last* handle closes, so
+    if the handle is garbage-collected early the children die immediately.
+    Store it in a module global, not a local.
+
+    Why Windows-only: there is no single cross-platform mechanism for
+    OS-automatic kill-time reaping. Linux's ``prctl(PR_SET_PDEATHSIG)``
+    needs an unsafe ``preexec_fn`` in a threaded process and fires on
+    *thread* (not process) death; macOS has no OS guarantee at all (only a
+    cooperative child-side kqueue self-watch). Both are deliberately not
+    implemented here — the cross-platform baseline is the next-startup
+    orphan sweep (``find_child_pids`` + ``kill_process_on_port``), which
+    already exists. Windows is also the only OS this sidecar actually runs
+    on, so this is the layer that executes in practice.
+    """
+    if not IS_WINDOWS:
+        return None
+    import logging
+    log = logging.getLogger(__name__)
+    try:
+        import win32job
+        job = win32job.CreateJobObject(None, "")  # unnamed, not inheritable
+        info = win32job.QueryInformationJobObject(
+            job, win32job.JobObjectExtendedLimitInformation
+        )
+        info["BasicLimitInformation"]["LimitFlags"] |= (
+            win32job.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        )
+        win32job.SetInformationJobObject(
+            job, win32job.JobObjectExtendedLimitInformation, info
+        )
+        return job
+    except Exception as exc:
+        log.warning("Could not create kill-on-close Job Object: %s", exc)
+        return None
+
+
+def assign_process_to_job(job, pid: int) -> bool:
+    """Best-effort: assign a child ``pid`` to ``job`` (from
+    :func:`create_kill_on_close_job`). Returns True on success.
+
+    Returns False (logged, never raises) on non-Windows, a ``None`` job,
+    or assignment failure. Assignment can legitimately fail when the
+    daemon itself is already inside another job with restrictive limits
+    (some VS Code terminals / scheduled-task wrappers nest jobs); that is
+    non-fatal because the next-startup orphan sweep remains the fallback.
+    """
+    if not IS_WINDOWS or job is None:
+        return False
+    import logging
+    log = logging.getLogger(__name__)
+    try:
+        import win32api
+        import win32con
+        import win32job
+        # Need SET_QUOTA | TERMINATE rights to assign. Close the *process*
+        # handle after assigning — only the *job* handle must stay open.
+        h = win32api.OpenProcess(
+            win32con.PROCESS_SET_QUOTA | win32con.PROCESS_TERMINATE, False, pid
+        )
+        try:
+            win32job.AssignProcessToJobObject(job, h)
+        finally:
+            win32api.CloseHandle(h)
+        return True
+    except Exception as exc:
+        log.warning("Could not assign pid %d to Job Object: %s", pid, exc)
+        return False
+
+
 def obsidian_log_path() -> Path:
     """Resolve the Obsidian main process log file path for the current OS."""
     if IS_WINDOWS:

--- a/work_buddy/obsidian/tasks/mutations.py
+++ b/work_buddy/obsidian/tasks/mutations.py
@@ -91,6 +91,16 @@ CHECKBOX_RE = re.compile(r"^(- \[)([ x])(\])")
 URGENCY_EMOJI_RE = re.compile(r"[🔽🔼⏫]")
 TASK_ID_RE = re.compile(r"🆔\s*(t-[0-9a-f]+)")
 
+
+def _is_valid_iso_date(value: str) -> bool:
+    """True iff ``value`` is a real calendar date (catches 2026-13-40)."""
+    try:
+        date.fromisoformat(value)
+        return True
+    except ValueError:
+        return False
+
+
 # User-supplied namespace tags must match this shape (no leading '#').
 # Mirrors sync.TAG_RE but as an anchored full-match pattern.
 NAMESPACE_TAG_RE = re.compile(r"^[a-z0-9][a-z0-9_/-]*$", re.IGNORECASE)
@@ -1876,6 +1886,7 @@ def toggle_task(
     task_id: str,
     done: bool | None = None,
     file_path: str | None = None,
+    done_date: str | None = None,
 ) -> dict[str, Any]:
     """Mark a task complete, incomplete, or toggle its current state.
 
@@ -1888,10 +1899,28 @@ def toggle_task(
         done: If True, mark complete. If False, mark incomplete.
               If None (default), toggle the current state.
         file_path: Vault-relative path. Default: tasks/master-task-list.md.
+        done_date: Optional ISO ``YYYY-MM-DD`` to stamp as the completion
+              date when transitioning to done. Defaults to today. Enables
+              *retroactive* completion — marking a task done with the date
+              it was actually finished (e.g. the landing-commit date a
+              completeness investigation uncovered). Ignored when the
+              transition is to incomplete.
 
     Uses the Tasks plugin API for the checkbox + done date,
     with regex fallback. Updates the store state accordingly.
     """
+    if done_date is not None and (
+        not re.fullmatch(r"\d{4}-\d{2}-\d{2}", done_date)
+        or not _is_valid_iso_date(done_date)
+    ):
+        return {
+            "success": False,
+            "task_id": task_id,
+            "message": (
+                f"Invalid done_date {done_date!r}: expected ISO YYYY-MM-DD"
+            ),
+        }
+
     fp = file_path or MASTER_TASK_FILE
     content = bridge.read_file(fp)
     if content is None:
@@ -1936,6 +1965,17 @@ def toggle_task(
             toggled = CHECKBOX_RE.sub(r"\g<1>x\3", old_line)
             if "✅" not in toggled:
                 toggled = toggled.rstrip() + f" ✅ {date.today().isoformat()}"
+
+    # Retroactive completion: when a done_date is supplied and we are
+    # transitioning *to* done (``not is_done``), rewrite the ✅ stamp to
+    # that date. Both the plugin-API path and the regex fallback stamp
+    # *today*, so we post-process the toggled line uniformly here rather
+    # than in each branch above.
+    if done_date and not is_done:
+        if DONE_DATE_RE.search(toggled):
+            toggled = DONE_DATE_RE.sub(f"✅ {done_date}", toggled)
+        else:
+            toggled = toggled.rstrip() + f" ✅ {done_date}"
 
     lines[idx] = toggled
     # Post-CP6: bridge.write_file raises typed exceptions on failure;

--- a/work_buddy/sidecar/daemon.py
+++ b/work_buddy/sidecar/daemon.py
@@ -24,6 +24,7 @@ from typing import Any
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
+from work_buddy.compat import assign_process_to_job, create_kill_on_close_job
 from work_buddy.config import load_config
 from work_buddy.logging_config import get_logger
 from work_buddy.sidecar.pid import (
@@ -500,6 +501,11 @@ def _start_child(svc: ChildService) -> None:
             "Started %s (pid=%d, port=%d, log=%s)",
             svc.name, svc.process.pid, svc.port, log_path.name,
         )
+        # Attach to the kill-on-close Job Object so the OS reaps this child
+        # if the daemon is hard-killed. Best-effort: a failed assignment is
+        # non-fatal (the next-startup orphan sweep is the fallback) and a
+        # no-op on non-Windows / when the job couldn't be created.
+        assign_process_to_job(_kill_job, svc.process.pid)
     except OSError as exc:
         logger.error("Failed to start %s: %s", svc.name, exc)
         if log_fh:
@@ -626,6 +632,12 @@ _shutdown_signal_count = 0
 _shutdown_requested_at: float = 0.0  # set when _shutdown_requested flips to True
 _force_kill_children: list[Any] = []  # populated in run() so the signal handler can reach them
 _SHUTDOWN_WATCHDOG_TIMEOUT = 15.0  # seconds: if graceful shutdown exceeds this, force-exit
+# Windows Job Object (KILL_ON_JOB_CLOSE) created in run(); every child is
+# assigned to it so the OS reaps them when this daemon dies by ANY means —
+# including a hard kill where no signal handler / atexit hook runs. Kept as
+# a module global so the handle outlives the daemon loop (the kill fires
+# when the job's last handle closes). None on non-Windows / creation failure.
+_kill_job: Any = None
 
 
 def _shutdown_watchdog() -> None:
@@ -810,6 +822,15 @@ def run(foreground: bool = True) -> None:
         "Children will spawn with: %s (daemon sys.executable=%s)",
         resolved_python, sys.executable,
     )
+
+    # --- OS-enforced hard-kill reaping (Windows) ---
+    # Create the kill-on-close Job Object before spawning any child so each
+    # child can be assigned to it the instant it starts. This is the only
+    # layer that survives a hard kill of the daemon (taskkill /F, crash):
+    # all the signal-handler / watchdog / takeover-sweep layers only run if
+    # the dying parent's own code runs. No-op on non-Windows.
+    global _kill_job
+    _kill_job = create_kill_on_close_job()
 
     # --- Start all children in parallel ---
     for child in children:

--- a/work_buddy/task_completeness.py
+++ b/work_buddy/task_completeness.py
@@ -1,0 +1,199 @@
+"""``/wb-task-completeness`` orchestration helper — gather completion evidence.
+
+A single pure-ish callable that the ``tasks/task-completeness`` workflow
+uses for its ``gather-evidence`` auto_run code step.
+
+:func:`gather_completeness_evidence` composes the work-buddy-native
+signals an agent needs to judge whether a task was *already* completed,
+so the agent doesn't have to issue a dozen tool calls by hand:
+
+* the task payload + linked note (``read_task`` — already includes
+  ``assigned_sessions``),
+* per assigned session: the commits attributed to it (with a targeted,
+  bounded refresh so freshly-landed fixes show up), its file writes, and
+  its cached topic summary.
+
+The agent then does the *adaptive* part in the reasoning step — grepping
+the actual code, ``git log --grep`` / ``gh`` keyword search, running
+tests — none of which is work-buddy-native and so can't be auto-run.
+
+Like the morning routine's collectors and ``task_me.load_context_for_task_me``,
+every sub-call degrades gracefully: a failure sets ``status="degraded"``
+and appends to ``errors`` rather than aborting the whole gather, so the
+investigate step always gets *something* to reason against.
+
+The workflow definition lives in the knowledge store under
+``tasks/task-completeness`` (authored via ``workflow_create``); the
+slash-command launcher in ``.claude/commands/wb-task-completeness.md``.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import Any
+
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def gather_completeness_evidence(task_id: str) -> dict[str, Any]:
+    """Collect work-buddy-native evidence about a task's completion state.
+
+    Args:
+        task_id: Task ID to investigate (e.g. ``"t-99b8a4ff"``).
+
+    Returns:
+        A dict the investigate step reasons against:
+
+        - ``status``: ``"ok"`` | ``"degraded"`` | ``"error"``
+          (``"error"`` only when the task itself can't be read)
+        - ``task_id``: echoed back
+        - ``task``: the read-only task payload (text, state, urgency,
+          contract, note_content, …) — empty dict on read failure
+        - ``assigned_sessions``: list of ``{task_id, session_id,
+          assigned_at}`` rows (the sessions that ever claimed this task)
+        - ``session_evidence``: per-session
+          ``{session_id, assigned_at, commits, writes, summary}``
+        - ``cache_note``: human-readable note on data freshness +
+          guidance (e.g. "no sessions assigned — rely on git/PR search")
+        - ``now_iso``: assembly timestamp
+        - ``errors``: list of ``{step, error}`` for any degraded sub-call
+    """
+    out: dict[str, Any] = {
+        "status": "ok",
+        "task_id": task_id,
+        "task": {},
+        "assigned_sessions": [],
+        "session_evidence": [],
+        "cache_note": "",
+        "now_iso": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "errors": [],
+    }
+
+    # --- Task payload (also carries assigned_sessions) ------------------
+    try:
+        from work_buddy.obsidian.tasks import mutations
+        payload = mutations.read_task(task_id)
+    except Exception as exc:  # pragma: no cover — best-effort
+        logger.warning("task_completeness: read_task failed: %s", exc)
+        out["status"] = "error"
+        out["errors"].append({"step": "read_task", "error": str(exc)})
+        out["cache_note"] = (
+            "Could not read the task. The investigate step must fall back "
+            "to native git/PR keyword search."
+        )
+        return out
+
+    if not payload.get("success"):
+        out["status"] = "error"
+        out["task"] = payload
+        out["cache_note"] = payload.get("message", "Task not found.")
+        return out
+
+    out["task"] = payload
+    sessions = payload.get("assigned_sessions") or []
+    out["assigned_sessions"] = sessions
+
+    if not sessions:
+        out["cache_note"] = (
+            "No sessions are assigned to this task. There is no "
+            "session->commit linkage to lean on — the investigate step "
+            "should rely on native `git log --grep`, `gh` PR/commit "
+            "search, and reading the code/tests directly."
+        )
+        return out
+
+    # --- Per-session evidence ------------------------------------------
+    # Refresh each assigned session's commits individually: passing an
+    # explicit session_id forces a single-session rescan (bounded work,
+    # so we stay within the auto_run timeout even on a cold cache), and
+    # guarantees a fix that landed today is attributed before we query.
+    from work_buddy.conversation_observability import commits as commits_mod
+    from work_buddy.conversation_observability import writes as writes_mod
+
+    writes_stale = False
+    for sess in sessions:
+        sid = sess.get("session_id")
+        if not sid:
+            continue
+        entry: dict[str, Any] = {
+            "session_id": sid,
+            "assigned_at": sess.get("assigned_at"),
+            "commits": [],
+            "writes": [],
+            "summary": None,
+            "note": None,
+        }
+
+        # Commits (targeted refresh, then read). The refresh is a
+        # freshening optimization — if the session has no Claude Code
+        # transcript to scan (sidecar-synthesized session id, or a
+        # pruned/older session), it raises "no session found". That is
+        # NOT a degradation: it just means there's no session->commit
+        # linkage for this assignment, so we note it (steering the agent
+        # to native git/PR search) and still query whatever is cached.
+        try:
+            commits_mod.refresh_session_commits(session_id=sid)
+        except Exception as exc:  # pragma: no cover — best-effort
+            logger.debug(
+                "task_completeness: commit refresh skipped for %s: %s", sid, exc
+            )
+            entry["note"] = (
+                "No conversation transcript for this session "
+                "(sidecar/pruned) — no session->commit linkage; use native "
+                "git/PR keyword search to attribute the work."
+            )
+        try:
+            entry["commits"] = commits_mod.query_session_commits(session_id=sid)
+        except Exception as exc:  # pragma: no cover — best-effort
+            logger.debug(
+                "task_completeness: commit query failed for %s: %s", sid, exc
+            )
+            out["status"] = "degraded"
+            out["errors"].append(
+                {"step": f"query_commits:{sid}", "error": str(exc)}
+            )
+
+        # File writes (read the existing cache; a broad refresh would
+        # scan every recent session's JSONL + run git, which risks the
+        # auto_run timeout — flag staleness instead and let the
+        # investigate step force a refresh via the
+        # conversation_observability_refresh capability if it matters).
+        try:
+            entry["writes"] = writes_mod.query_session_writes(session_id=sid)
+        except Exception as exc:  # pragma: no cover — best-effort
+            logger.debug(
+                "task_completeness: writes query failed for %s: %s", sid, exc
+            )
+            out["status"] = "degraded"
+            out["errors"].append(
+                {"step": f"query_writes:{sid}", "error": str(exc)}
+            )
+        else:
+            writes_stale = True
+
+        # Topic summary (best-effort; often absent).
+        try:
+            from work_buddy.conversation_observability.session_summary_row import (
+                session_summary_row,
+            )
+            entry["summary"] = session_summary_row(sid)
+        except Exception as exc:  # pragma: no cover — best-effort
+            logger.debug(
+                "task_completeness: summary lookup failed for %s: %s", sid, exc
+            )
+
+        out["session_evidence"].append(entry)
+
+    notes = [
+        "Commit attribution was refreshed per-session before querying.",
+    ]
+    if writes_stale:
+        notes.append(
+            "File-write rows come from the existing cache and may be stale; "
+            "call `conversation_observability_refresh` then re-query if the "
+            "dirty/committed state is decision-relevant."
+        )
+    out["cache_note"] = " ".join(notes)
+    return out


### PR DESCRIPTION
## Summary
- **`/wb-task-completeness`** — a workflow that investigates whether a task was *already* completed (fully / differently / partially / consciously-descoped / not-done), judging the **spirit** of the task rather than its literal wording, then optionally marks it complete with the correct **backdated** done-date. Auto-gathers task + assigned-session commit/write evidence up front (`gather-evidence`), reasons against a rubric (`investigate`), and acts on confirmation (`resolve`).
- **`task_toggle` gains a `done_date` param** — first-class retroactive completion. Stamps the supplied ISO date (rewriting the plugin's today-stamp); validates format and rejects impossible dates with no write; ignored on reopen.
- **Sidecar Windows Job Object hard-kill reaping** — every child is assigned to a Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, so the OS reaps orphans when the daemon dies by *any* means (`taskkill /F`, crash, power loss) where no signal handler / atexit hook runs. This closes the one gap left by the existing next-startup orphan sweep. Best-effort + no-op off-Windows.

## Test plan
- [x] 38/38 unit tests green: `test_task_mutations.py` (done_date backdating), `test_task_completeness.py` (evidence gatherer), `test_sidecar_orphan_reaping.py` (Job Object)
- [x] End-to-end dogfood of the workflow on a real task; backdated toggle verified
- [x] **Live hard-kill integration test**: `taskkill /F` the daemon (no `/T`) → all 5 children reaped by the OS in ~750ms, all ports freed; only mechanism that could have reaped them is the Job Object
- [ ] Reviewer: confirm Job Object behavior is acceptable as Windows-only (Linux/macOS have no equivalent OS guarantee; cross-platform baseline remains the startup sweep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)