### PR TITLE
feat(tasks): strengthen /wb-task-completeness with provenance + quality rubric

### DIFF
--- a/knowledge/store/tasks/task-completeness.md
+++ b/knowledge/store/tasks/task-completeness.md
@@ -27,10 +27,13 @@ steps:
     - evidence
     - completion_date
     - recommended_action
+    - confidence
     key_types:
       disposition: str
       evidence: list
       recommended_action: str
+      confidence: str
+      divergence: str
     min_items:
       evidence: 1
 - id: resolve
@@ -67,40 +70,59 @@ parents:
 
 Investigate whether a task the user is unsure about was ALREADY completed — fully, partially, or differently — and if so, mark it complete with the correct PRIOR date.
 
-Core principle — judge the SPIRIT, not the letter. Tasks are written before the work; designs change, get improved, or a sub-part is deliberately dropped. Something can look undone because it was done a better way, or not done on purpose. Your job is to decide whether what is PRESENT in the codebase/notes satisfies the task's INTENT.
+Core principle — judge the SPIRIT, not the letter. Tasks are written before the work; designs change, get improved, or a sub-part is deliberately dropped. Decide whether what is PRESENT in the codebase/notes satisfies the task's INTENT.
+
+**Provenance-first.** The gather-evidence bundle carries a `provenance` block (created_by / assigned / developed_by). `developed_by` is the structural answer to "who shipped this" — sessions whose commits reference the task id — each tagged with note-read `awareness` and an informed/convergent `classification`. Start there; it replaces hand git-archaeology. `session_search` into a developer's session recovers the design reasoning before you judge.
 
 Disposition rubric (pick one): done / done-differently / partial / consciously-descoped / not-done.
 
-Verification ladder — cheapest signal first, stop when confident: (1) the auto-gathered evidence bundle (task note + per-session commits/writes), (2) git log --grep/-S and gh PR/commit search, (3) reading the actual code and tests, (4) running the targeted test. Inactivity is NOT completion — a quiet task is not a done task.
+**done-differently is a QUALITY judgment, not just intent-coverage.** When the task prescribed a how-to (an approach/design in the note) and the implementation diverged, classify the divergence — better / lateral / worse — and justify it from the developer's rationale + the code. "Intent met by a different, better-reasoned design" and "intent met by a worse shortcut" are both done-differently but very different verdicts; say which.
 
-Dating: the completion date is the date the LANDING COMMIT merged, not today. Always cite the commit SHA as evidence.
+**Informed vs convergent.** Use `awareness`: informed development (read the note / assigned) that diverged is a deliberate design choice; convergent development (no signal) that hits the same intent is independent corroboration, not a footnote. `developed_by` empty + no structural link is the Rung-3 (intent-only) case — judge by reading the code/tests, never by absence of a link.
 
-Always confirm before mutating. The investigate step produces the judgment; the resolve step acts only on explicit user approval. Backdating uses task_toggle's done_date param (ISO YYYY-MM-DD).
+Verification ladder — cheapest first, stop when confident: (1) the provenance block + per-session commits/writes, (2) session_search into the developing session for rationale, plus `git log --grep`/`-S` and `gh` PR/commit search for anything provenance missed, (3) read the actual code and tests, (4) run the targeted test. Inactivity is NOT completion.
+
+Dating: completion date = the date the LANDING COMMIT merged, not today. Cite the SHA.
+
+**Confidence.** Every verdict states a `confidence` (high/medium/low) justified by signal strength — a structural `developed_by` plus read code is high; an intent-only Rung-3 inference is medium-at-best. Be authoritative where the evidence is, honest where it isn't.
+
+Always confirm before mutating. investigate produces the judgment; resolve acts only on explicit user approval. Backdating uses task_toggle's done_date (ISO YYYY-MM-DD).
 
 ## investigate
 
-You are judging whether this task was ALREADY completed — and if so, WHEN.
+You are judging whether this task was ALREADY completed — and if so, WHEN, BY WHOM, and HOW WELL.
 
-Read the evidence bundle in step_results['gather-evidence']: the task text + linked note (the original intent), its current state, and per assigned session the attributed commits/writes. Heed `cache_note` and any per-session `note` — when a session has no transcript (sidecar/pruned) there is no commit linkage, so you must attribute the work yourself.
+Start from `step_results['gather-evidence']`:
+- `task` — text + linked note = the original intent (and any prescribed how-to).
+- `provenance` — created_by / assigned / developed_by / intent_attribution. `developed_by` names the sessions that structurally shipped work (a commit referencing the task id), each with `rung`, note-read `awareness`, and informed/convergent `classification`. This is your starting point — no git archaeology from scratch.
+- `session_evidence` — per session (across created/assigned/developed roles): commits, writes, summary. Heed each `note` and the top-level `cache_note`.
 
-Then investigate ADAPTIVELY, cheapest signal first, stopping as soon as you are confident:
-1. The evidence bundle (commits/writes already attributed).
-2. `git log --grep`/`git log -S` for the task id, symptom, or key symbols; `gh pr list/view` and `gh search prs/commits` for related PRs.
-3. Read the ACTUAL code/tests in the repo to confirm the behavior exists now.
-4. Run the targeted test(s) only if code presence is still ambiguous.
+Investigate ADAPTIVELY, cheapest first, stopping when confident:
+1. The provenance block + session_evidence.
+2. `session_search` into a developer's session id to recover the design reasoning (WHY they built it that way). Plus `git log --grep`/`-S` and `gh` PR/commit search for anything provenance missed.
+3. Read the ACTUAL code/tests to confirm the behavior is present now.
+4. Run the targeted test(s) only if presence is still ambiguous.
 
-Judge the SPIRIT, not the letter — a design may have been improved, replaced, or a sub-part deliberately dropped. Decide whether what is PRESENT satisfies the task's INTENT. Pick exactly one disposition: done | done-differently | partial | consciously-descoped | not-done. Inactivity is NOT completion.
+Judge the SPIRIT, not the letter. Pick exactly one disposition: done | done-differently | partial | consciously-descoped | not-done.
 
-Return ONLY your new findings (a delta) with keys: disposition (one of the five); evidence (a non-empty list of concrete citations — commit SHAs, PR URLs, path:line, test names, note excerpts — each tied to what it proves); completion_date (ISO YYYY-MM-DD of the LANDING COMMIT that satisfied the intent, or null; cite its SHA in evidence); recommended_action (one sentence: mark done backdated / finish remainder / spin off residual / leave open).
+If done-differently AND the note prescribed a how-to: set `divergence` to better | lateral | worse and justify it — does the shipped design beat what was proposed, match it, or cut a corner? Use the developer's rationale (from session_search) + the code. Frame with `awareness`: informed divergence = deliberate; convergent match = independent corroboration. When `developed_by` is empty, that's the Rung-3 intent-only case — judge by reading code/tests, not by the missing link.
+
+Return ONLY your delta:
+- disposition (one of the five)
+- evidence (non-empty list of concrete citations: commit SHAs, PR URLs, path:line, test names, session-id+turn for rationale, note excerpts — each tied to what it proves)
+- completion_date (ISO YYYY-MM-DD of the LANDING COMMIT, or null; cite its SHA in evidence)
+- divergence (better | lateral | worse | na — `na` unless done-differently with a prescribed how-to)
+- confidence (high | medium | low, with a one-clause justification keyed to signal strength)
+- recommended_action (one sentence: mark done backdated / finish remainder / spin off residual / leave open)
 
 ## resolve
 
-Present the disposition from `investigate` with its evidence and completion date, then act ONLY on explicit user confirmation — never mutate first.
+Present the disposition + confidence + divergence + evidence + completion_date, and a one-line provenance summary (who created / developed it, informed vs convergent), then act ONLY on explicit user confirmation — never mutate first.
 
 Recommend by disposition:
-- done / done-differently: offer to mark complete BACKDATED via wb_run('task_toggle', {'task_id': '<id>', 'done': true, 'done_date': '<completion_date>'}). done_date is the landing-commit date from investigate.
-- consciously-descoped: same backdated toggle, and state plainly that the missing part was a deliberate descope.
-- partial: offer BOTH (a) finishing the remainder now and/or (b) spinning the remainder off as a handoff task via wb_run('task_create', {...}); optionally backdate-complete the shipped portion if separable.
+- done / done-differently: offer to mark complete BACKDATED via wb_run('task_toggle', {'task_id': '<id>', 'done': true, 'done_date': '<completion_date>'}). For done-differently, state the divergence verdict (better/lateral/worse) plainly so the user signs off on 'done a different way', not 'done as written'.
+- consciously-descoped: same backdated toggle; state plainly the dropped part was a deliberate descope.
+- partial: use `developed_by` to delineate what SHIPPED vs the remainder. Offer BOTH (a) finishing the remainder now and/or (b) spinning the remainder off as a handoff via wb_run('task_create', {...}); optionally backdate-complete the shipped portion if separable.
 - not-done: recommend leaving it open; optionally offer to narrow the task text to the true remainder.
 
-After the user picks, apply exactly what was approved and report what changed (the new ✅ date, any new task id). If they decline, leave the task untouched and say so.
+After the user picks, apply exactly what was approved and report what changed (the new ✅ date, any new task id). If they decline, leave it untouched and say so.

--- a/knowledge/store/tasks/task-completeness.md
+++ b/knowledge/store/tasks/task-completeness.md
@@ -72,6 +72,8 @@ Investigate whether a task the user is unsure about was ALREADY completed — fu
 
 Core principle — judge the SPIRIT, not the letter. Tasks are written before the work; designs change, get improved, or a sub-part is deliberately dropped. Decide whether what is PRESENT in the codebase/notes satisfies the task's INTENT.
 
+**Lead with intent.** Before you judge OR present, restate what the task actually asked for — read `task.note_content` for its INTENT and any prescribed how-to (a "Suggested Approach"/design in the note). Judge the implementation against THAT, never against the commit subject: a commit can bundle unrelated work, and its subject can under- or over-state the task's scope. Mistaking the commit subject for the intent is the classic shallow pass.
+
 **Provenance-first.** The gather-evidence bundle carries a `provenance` block (created_by / assigned / developed_by). `developed_by` is the structural answer to "who shipped this" — sessions whose commits reference the task id — each tagged with note-read `awareness` and an informed/convergent `classification`. Start there; it replaces hand git-archaeology. `session_search` into a developer's session recovers the design reasoning before you judge.
 
 Disposition rubric (pick one): done / done-differently / partial / consciously-descoped / not-done.
@@ -93,17 +95,19 @@ Always confirm before mutating. investigate produces the judgment; resolve acts 
 You are judging whether this task was ALREADY completed — and if so, WHEN, BY WHOM, and HOW WELL.
 
 Start from `step_results['gather-evidence']`:
-- `task` — text + linked note = the original intent (and any prescribed how-to).
+- `task` — text + linked `note_content` = the original intent (and any prescribed how-to).
 - `provenance` — created_by / assigned / developed_by / intent_attribution. `developed_by` names the sessions that structurally shipped work (a commit referencing the task id), each with `rung`, note-read `awareness`, and informed/convergent `classification`. This is your starting point — no git archaeology from scratch.
 - `session_evidence` — per session (across created/assigned/developed roles): commits, writes, summary. Heed each `note` and the top-level `cache_note`.
 
-Investigate ADAPTIVELY, cheapest first, stopping when confident:
+**Step 0 — restate the INTENT (do this FIRST).** From `task.note_content`, name (a) what the task actually asked for and (b) any prescribed how-to (a "Suggested Approach"/design in the note, possibly with a v1-vs-follow-up split). Judge the implementation against THIS intent — NOT the commit subject, which may bundle unrelated work or mis-state scope. The prescribed how-to is what makes the divergence judgment possible: did the impl follow it, improve on it, or cut a corner? Skipping Step 0 is how a shallow "looks done" pass slips through.
+
+Then investigate ADAPTIVELY, cheapest first, stopping when confident:
 1. The provenance block + session_evidence.
 2. `session_search` into a developer's session id to recover the design reasoning (WHY they built it that way). Plus `git log --grep`/`-S` and `gh` PR/commit search for anything provenance missed.
-3. Read the ACTUAL code/tests to confirm the behavior is present now.
+3. Read the ACTUAL code/tests to confirm the behavior is present now and matches (or diverges from) the prescribed how-to.
 4. Run the targeted test(s) only if presence is still ambiguous.
 
-Judge the SPIRIT, not the letter. Pick exactly one disposition: done | done-differently | partial | consciously-descoped | not-done.
+Judge the SPIRIT, not the letter. Pick exactly one disposition: done | done-differently | partial | consciously-descoped | not-done. If the note scoped a v1 and blessed a follow-up, shipping the v1 is `done` — but surface the unbuilt follow-up explicitly (it is a scope boundary, not a gap).
 
 If done-differently AND the note prescribed a how-to: set `divergence` to better | lateral | worse and justify it — does the shipped design beat what was proposed, match it, or cut a corner? Use the developer's rationale (from session_search) + the code. Frame with `awareness`: informed divergence = deliberate; convergent match = independent corroboration. When `developed_by` is empty, that's the Rung-3 intent-only case — judge by reading code/tests, not by the missing link.
 
@@ -117,12 +121,16 @@ Return ONLY your delta:
 
 ## resolve
 
-Present the disposition + confidence + divergence + evidence + completion_date, and a one-line provenance summary (who created / developed it, informed vs convergent), then act ONLY on explicit user confirmation — never mutate first.
+**Open with a plain-language recap BEFORE any verdict fields** — enough that the user can judge without reading the evidence list:
+1. **What the task asked for** — its intent + any prescribed how-to (from the note), including any v1-vs-follow-up scoping.
+2. **The situation found** — who developed it (informed vs convergent), when, and how the implementation compares to what was prescribed (followed it / improved on it / diverged / partial), plus any deliberately-deferred follow-up.
+
+THEN give the verdict fields: disposition + confidence + divergence + completion_date + a one-line provenance summary. Act ONLY on explicit user confirmation — never mutate first.
 
 Recommend by disposition:
-- done / done-differently: offer to mark complete BACKDATED via wb_run('task_toggle', {'task_id': '<id>', 'done': true, 'done_date': '<completion_date>'}). For done-differently, state the divergence verdict (better/lateral/worse) plainly so the user signs off on 'done a different way', not 'done as written'.
+- done / done-differently: offer to mark complete BACKDATED via wb_run('task_toggle', {'task_id': '<id>', 'done': true, 'done_date': '<completion_date>'}). For done-differently, state the divergence verdict (better/lateral/worse) plainly so the user signs off on 'done a different way', not 'done as written'. If a follow-up was deferred, offer to spin it off via task_create.
 - consciously-descoped: same backdated toggle; state plainly the dropped part was a deliberate descope.
 - partial: use `developed_by` to delineate what SHIPPED vs the remainder. Offer BOTH (a) finishing the remainder now and/or (b) spinning the remainder off as a handoff via wb_run('task_create', {...}); optionally backdate-complete the shipped portion if separable.
 - not-done: recommend leaving it open; optionally offer to narrow the task text to the true remainder.
 
-After the user picks, apply exactly what was approved and report what changed (the new ✅ date, any new task id). If they decline, leave it untouched and say so.
+If the task is ALREADY `state=done`, say so up front — no toggle needed; the value of the run is the contextualized confirmation (and surfacing any deferred follow-up), not a mutation.

--- a/tests/unit/test_task_completeness.py
+++ b/tests/unit/test_task_completeness.py
@@ -1,15 +1,20 @@
 """Unit tests for the ``/wb-task-completeness`` evidence gatherer.
 
 Verifies :func:`work_buddy.task_completeness.gather_completeness_evidence`:
+- folds the ``build_task_provenance`` block (created_by / assigned /
+  developed_by) into the bundle and gathers per-session evidence over the
+  UNION of all provenance roles — not just assigned sessions
 - composes read_task + per-session commits/writes/summary into one bundle
 - degrades gracefully (status flips, errors recorded) when a sub-call raises
 - treats a missing transcript (sidecar/pruned session) as a *note*, not a
   degradation — commit refresh is a freshening optimization, not required
-- short-circuits cleanly when the task can't be read or has no sessions
+- short-circuits cleanly when the task can't be read; flags the Rung-3
+  (no structural link) case when nothing relates to the task
 """
 
 from __future__ import annotations
 
+import contextlib
 from unittest.mock import patch
 
 from work_buddy import task_completeness as tc
@@ -20,35 +25,139 @@ def _ok_payload(sessions):
             "assigned_sessions": sessions}
 
 
+def _prov(created_by=None, assigned=None, developed_by=None):
+    """A build_task_provenance-shaped dict."""
+    return {
+        "task_id": "t-abc123",
+        "created_by": created_by,
+        "assigned": assigned or [],
+        "developed_by": developed_by or [],
+        "intent_attribution": {
+            "computed": False, "hook": "wb-task-completeness", "reason": "r",
+        },
+    }
+
+
+@contextlib.contextmanager
+def _patched(payload, *, prov=None, commits=None, writes=None, summary=None,
+             refresh_exc=None, commits_exc=None, writes_exc=None, prov_exc=None):
+    """Patch every dependency the gatherer touches once a task reads OK."""
+    def _rv(value, exc):
+        return {"side_effect": exc} if exc else {"return_value": value}
+
+    stack = contextlib.ExitStack()
+    stack.enter_context(patch(
+        "work_buddy.obsidian.tasks.mutations.read_task", return_value=payload))
+    stack.enter_context(patch(
+        "work_buddy.obsidian.tasks.provenance.build_task_provenance",
+        **_rv(prov, prov_exc)))
+    stack.enter_context(patch(
+        "work_buddy.conversation_observability.commits.refresh_session_commits",
+        **_rv(None, refresh_exc)))
+    stack.enter_context(patch(
+        "work_buddy.conversation_observability.commits.query_session_commits",
+        **_rv(commits or [], commits_exc)))
+    stack.enter_context(patch(
+        "work_buddy.conversation_observability.writes.query_session_writes",
+        **_rv(writes or [], writes_exc)))
+    stack.enter_context(patch(
+        "work_buddy.conversation_observability.session_summary_row"
+        ".session_summary_row", return_value=summary))
+    with stack:
+        yield
+
+
 class TestGatherEvidenceHappyPath:
     """A fully-populated task yields an ``ok`` bundle with per-session rows."""
 
     def test_bundle_shape(self):
         sessions = [{"session_id": "s-1", "assigned_at": "2026-05-01"}]
-        with patch("work_buddy.obsidian.tasks.mutations.read_task",
-                   return_value=_ok_payload(sessions)), \
-             patch("work_buddy.conversation_observability.commits"
-                   ".refresh_session_commits", return_value=None), \
-             patch("work_buddy.conversation_observability.commits"
-                   ".query_session_commits", return_value=[{"sha": "abc"}]), \
-             patch("work_buddy.conversation_observability.writes"
-                   ".query_session_writes", return_value=[{"path": "f.py"}]), \
-             patch("work_buddy.conversation_observability.session_summary_row"
-                   ".session_summary_row", return_value={"topic": "t"}):
+        prov = _prov(assigned=sessions)
+        with _patched(_ok_payload(sessions), prov=prov,
+                      commits=[{"sha": "abc"}], writes=[{"path": "f.py"}],
+                      summary={"topic": "t"}):
             out = tc.gather_completeness_evidence("t-abc123")
 
         assert out["status"] == "ok"
         assert out["task_id"] == "t-abc123"
         assert out["assigned_sessions"] == sessions
+        assert out["provenance"] == prov
         assert len(out["session_evidence"]) == 1
         entry = out["session_evidence"][0]
         assert entry["session_id"] == "s-1"
+        assert entry["roles"] == ["assigned"]
         assert entry["commits"] == [{"sha": "abc"}]
         assert entry["writes"] == [{"path": "f.py"}]
         assert entry["summary"] == {"topic": "t"}
         assert entry["note"] is None
         assert out["errors"] == []
         assert "now_iso" in out
+
+
+class TestGatherEvidenceProvenance:
+    """The provenance block drives a union-of-roles evidence sweep."""
+
+    def test_developed_but_unassigned_session_is_gathered(self):
+        """A developed-by session with no assignment still gets an evidence
+        row (roles=['developed']) — the archaeology we used to do by hand."""
+        assigned = [{"session_id": "s-assigned", "assigned_at": "2026-05-01"}]
+        prov = _prov(
+            assigned=assigned,
+            developed_by=[{"session_id": "s-dev", "rung": 2,
+                           "awareness": "read_note", "classification": "informed"}],
+        )
+        with _patched(_ok_payload(assigned), prov=prov, commits=[{"sha": "x"}]):
+            out = tc.gather_completeness_evidence("t-abc123")
+
+        by_sid = {e["session_id"]: e for e in out["session_evidence"]}
+        assert set(by_sid) == {"s-assigned", "s-dev"}
+        assert by_sid["s-assigned"]["roles"] == ["assigned"]
+        assert by_sid["s-dev"]["roles"] == ["developed"]
+
+    def test_created_by_role_surfaced(self):
+        prov = _prov(created_by="s-creator")
+        with _patched(_ok_payload([]), prov=prov):
+            out = tc.gather_completeness_evidence("t-abc123")
+
+        by_sid = {e["session_id"]: e for e in out["session_evidence"]}
+        assert by_sid["s-creator"]["roles"] == ["created"]
+
+    def test_same_session_multiple_roles(self):
+        sessions = [{"session_id": "s-1", "assigned_at": "2026-05-01"}]
+        prov = _prov(
+            created_by="s-1", assigned=sessions,
+            developed_by=[{"session_id": "s-1", "rung": 1,
+                           "awareness": "assigned", "classification": "informed"}],
+        )
+        with _patched(_ok_payload(sessions), prov=prov):
+            out = tc.gather_completeness_evidence("t-abc123")
+
+        assert len(out["session_evidence"]) == 1
+        roles = out["session_evidence"][0]["roles"]
+        assert set(roles) == {"created", "assigned", "developed"}
+
+    def test_no_structural_link_flags_rung3(self):
+        """No assignment, no developer, no creator → Rung-3 cache note."""
+        with _patched(_ok_payload([]), prov=_prov()):
+            out = tc.gather_completeness_evidence("t-abc123")
+
+        assert out["status"] == "ok"
+        assert out["session_evidence"] == []
+        assert "rung-3" in out["cache_note"].lower()
+
+    def test_provenance_build_failure_degrades_but_continues(self):
+        """If build_task_provenance raises, degrade + provenance None, but
+        assigned-session evidence is still gathered."""
+        sessions = [{"session_id": "s-1", "assigned_at": "2026-05-01"}]
+        with _patched(_ok_payload(sessions), prov_exc=RuntimeError("boom"),
+                      commits=[{"sha": "abc"}]):
+            out = tc.gather_completeness_evidence("t-abc123")
+
+        assert out["status"] == "degraded"
+        assert out["provenance"] is None
+        assert any(e["step"] == "provenance" for e in out["errors"])
+        # assigned session still produced an evidence row
+        assert [e["session_id"] for e in out["session_evidence"]] == ["s-1"]
 
 
 class TestGatherEvidenceShortCircuits:
@@ -72,15 +181,6 @@ class TestGatherEvidenceShortCircuits:
         assert out["status"] == "error"
         assert out["cache_note"] == "Task not found."
 
-    def test_no_sessions_assigned(self):
-        with patch("work_buddy.obsidian.tasks.mutations.read_task",
-                   return_value=_ok_payload([])):
-            out = tc.gather_completeness_evidence("t-abc123")
-
-        assert out["status"] == "ok"
-        assert out["session_evidence"] == []
-        assert "no session" in out["cache_note"].lower()
-
 
 class TestGatherEvidenceDegradation:
     """Sub-call failures degrade gracefully instead of aborting."""
@@ -88,17 +188,8 @@ class TestGatherEvidenceDegradation:
     def test_missing_transcript_is_a_note_not_degradation(self):
         """refresh raising 'no session found' → note, status stays ok."""
         sessions = [{"session_id": "sidecar-x", "assigned_at": "2026-05-01"}]
-        with patch("work_buddy.obsidian.tasks.mutations.read_task",
-                   return_value=_ok_payload(sessions)), \
-             patch("work_buddy.conversation_observability.commits"
-                   ".refresh_session_commits",
-                   side_effect=RuntimeError("No session found")), \
-             patch("work_buddy.conversation_observability.commits"
-                   ".query_session_commits", return_value=[]), \
-             patch("work_buddy.conversation_observability.writes"
-                   ".query_session_writes", return_value=[]), \
-             patch("work_buddy.conversation_observability.session_summary_row"
-                   ".session_summary_row", return_value=None):
+        with _patched(_ok_payload(sessions), prov=_prov(assigned=sessions),
+                      refresh_exc=RuntimeError("No session found")):
             out = tc.gather_completeness_evidence("t-abc123")
 
         assert out["status"] == "ok"
@@ -109,17 +200,8 @@ class TestGatherEvidenceDegradation:
 
     def test_query_commits_failure_degrades(self):
         sessions = [{"session_id": "s-1", "assigned_at": "2026-05-01"}]
-        with patch("work_buddy.obsidian.tasks.mutations.read_task",
-                   return_value=_ok_payload(sessions)), \
-             patch("work_buddy.conversation_observability.commits"
-                   ".refresh_session_commits", return_value=None), \
-             patch("work_buddy.conversation_observability.commits"
-                   ".query_session_commits",
-                   side_effect=RuntimeError("db locked")), \
-             patch("work_buddy.conversation_observability.writes"
-                   ".query_session_writes", return_value=[]), \
-             patch("work_buddy.conversation_observability.session_summary_row"
-                   ".session_summary_row", return_value=None):
+        with _patched(_ok_payload(sessions), prov=_prov(assigned=sessions),
+                      commits_exc=RuntimeError("db locked")):
             out = tc.gather_completeness_evidence("t-abc123")
 
         assert out["status"] == "degraded"
@@ -127,17 +209,8 @@ class TestGatherEvidenceDegradation:
 
     def test_query_writes_failure_degrades(self):
         sessions = [{"session_id": "s-1", "assigned_at": "2026-05-01"}]
-        with patch("work_buddy.obsidian.tasks.mutations.read_task",
-                   return_value=_ok_payload(sessions)), \
-             patch("work_buddy.conversation_observability.commits"
-                   ".refresh_session_commits", return_value=None), \
-             patch("work_buddy.conversation_observability.commits"
-                   ".query_session_commits", return_value=[]), \
-             patch("work_buddy.conversation_observability.writes"
-                   ".query_session_writes",
-                   side_effect=RuntimeError("db locked")), \
-             patch("work_buddy.conversation_observability.session_summary_row"
-                   ".session_summary_row", return_value=None):
+        with _patched(_ok_payload(sessions), prov=_prov(assigned=sessions),
+                      writes_exc=RuntimeError("db locked")):
             out = tc.gather_completeness_evidence("t-abc123")
 
         assert out["status"] == "degraded"

--- a/work_buddy/task_completeness.py
+++ b/work_buddy/task_completeness.py
@@ -53,10 +53,16 @@ def gather_completeness_evidence(task_id: str) -> dict[str, Any]:
           contract, note_content, …) — empty dict on read failure
         - ``assigned_sessions``: list of ``{task_id, session_id,
           assigned_at}`` rows (the sessions that ever claimed this task)
-        - ``session_evidence``: per-session
-          ``{session_id, assigned_at, commits, writes, summary}``
-        - ``cache_note``: human-readable note on data freshness +
-          guidance (e.g. "no sessions assigned — rely on git/PR search")
+        - ``provenance``: ``build_task_provenance`` output —
+          ``{created_by, assigned, developed_by, intent_attribution}``;
+          ``developed_by`` entries carry rung + note-read ``awareness`` +
+          informed/convergent ``classification``. None on a build failure.
+        - ``session_evidence``: one entry per session in the UNION of all
+          provenance roles —
+          ``{session_id, roles, assigned_at, commits, writes, summary, note}``
+          where ``roles`` ⊆ {created, assigned, developed}
+        - ``cache_note``: human-readable note on provenance + data
+          freshness + guidance (e.g. the Rung-3 intent-only case)
         - ``now_iso``: assembly timestamp
         - ``errors``: list of ``{step, error}`` for any degraded sub-call
     """
@@ -95,31 +101,74 @@ def gather_completeness_evidence(task_id: str) -> dict[str, Any]:
     sessions = payload.get("assigned_sessions") or []
     out["assigned_sessions"] = sessions
 
-    if not sessions:
+    # --- Provenance roles (created-by / assigned / developed-by) --------
+    # The structured "who related to this task, and how" — the investigate
+    # step's starting point. ``developed_by`` gives structural authorship
+    # (a commit referencing the task id) WITH note-read awareness +
+    # informed/convergent classification, so the agent no longer has to
+    # reconstruct "who shipped this" from raw git archaeology. The
+    # ``intent_attribution`` signpost names the Rung-3 (intent-only) case.
+    prov: dict[str, Any] | None = None
+    try:
+        from work_buddy.obsidian.tasks import provenance as _prov
+        prov = _prov.build_task_provenance(task_id, include_awareness=True)
+    except Exception as exc:  # pragma: no cover — best-effort
+        logger.warning("task_completeness: provenance build failed: %s", exc)
+        out["status"] = "degraded"
+        out["errors"].append({"step": "provenance", "error": str(exc)})
+    out["provenance"] = prov
+
+    # Gather evidence for the UNION of every provenance role, not just
+    # assigned. A developed-but-unassigned session — the common case for
+    # work done without /wb-task-assign, or older tasks whose assignment
+    # row was a bootstrap id — is exactly the session whose commits/writes
+    # we most want in front of the investigate step.
+    roles_by_session: dict[str, list[str]] = {}
+
+    def _add_role(sid: str | None, role: str) -> None:
+        if not sid:
+            return
+        roles = roles_by_session.setdefault(sid, [])
+        if role not in roles:
+            roles.append(role)
+
+    for sess in sessions:
+        _add_role(sess.get("session_id"), "assigned")
+    if prov:
+        _add_role(prov.get("created_by"), "created")
+        for dev in prov.get("developed_by") or []:
+            _add_role(dev.get("session_id"), "developed")
+
+    if not roles_by_session:
         out["cache_note"] = (
-            "No sessions are assigned to this task. There is no "
-            "session->commit linkage to lean on — the investigate step "
-            "should rely on native `git log --grep`, `gh` PR/commit "
-            "search, and reading the code/tests directly."
+            "No session is structurally linked to this task — none assigned, "
+            "no commit references the task id, and no recorded creator. There "
+            "is no session->commit linkage to lean on: the investigate step "
+            "must rely on native `git log --grep`/`-S`, `gh` PR/commit search, "
+            "and reading the code/tests. This is the Rung-3 (intent-only) case "
+            "the provenance signpost flags — absence of a structural link is "
+            "NOT evidence the task is undone."
         )
         return out
 
-    # --- Per-session evidence ------------------------------------------
-    # Refresh each assigned session's commits individually: passing an
-    # explicit session_id forces a single-session rescan (bounded work,
-    # so we stay within the auto_run timeout even on a cold cache), and
-    # guarantees a fix that landed today is attributed before we query.
+    # --- Per-session evidence over the role union ----------------------
+    # Refresh each session's commits individually: passing an explicit
+    # session_id forces a single-session rescan (bounded work, so we stay
+    # within the auto_run timeout even on a cold cache), and guarantees a
+    # fix that landed today is attributed before we query.
     from work_buddy.conversation_observability import commits as commits_mod
     from work_buddy.conversation_observability import writes as writes_mod
 
+    assigned_at = {
+        s.get("session_id"): s.get("assigned_at") for s in sessions
+    }
+
     writes_stale = False
-    for sess in sessions:
-        sid = sess.get("session_id")
-        if not sid:
-            continue
+    for sid in roles_by_session:
         entry: dict[str, Any] = {
             "session_id": sid,
-            "assigned_at": sess.get("assigned_at"),
+            "roles": roles_by_session[sid],
+            "assigned_at": assigned_at.get(sid),
             "commits": [],
             "writes": [],
             "summary": None,
@@ -186,9 +235,24 @@ def gather_completeness_evidence(task_id: str) -> dict[str, Any]:
 
         out["session_evidence"].append(entry)
 
-    notes = [
-        "Commit attribution was refreshed per-session before querying.",
-    ]
+    notes: list[str] = []
+    if prov is not None:
+        dev_n = len(prov.get("developed_by") or [])
+        notes.append(
+            "Provenance: created_by=" + (prov.get("created_by") or "unrecorded")
+            + f"; assigned={len(sessions)}; developed_by={dev_n} "
+            "(structural — sessions whose commits reference the task id, each "
+            "carrying note-read awareness + informed/convergent classification)."
+        )
+        if dev_n == 0:
+            notes.append(
+                "developed_by is empty — no commit references the task id; "
+                "treat as the Rung-3 (intent-only) case: judge by reading the "
+                "code/tests, not by absence of a structural link."
+            )
+    notes.append(
+        "Commit attribution was refreshed per-session before querying."
+    )
     if writes_stale:
         notes.append(
             "File-write rows come from the existing cache and may be stale; "


### PR DESCRIPTION
## Summary
Rebuilds the `/wb-task-completeness` workflow on the now-merged task↔session provenance machinery, so it no longer reconstructs "who shipped this" from raw git archaeology — and adds the quality judgment it was missing.

**Gatherer (`task_completeness.py`):**
- Folds `build_task_provenance(include_awareness=True)` into the evidence bundle as a `provenance` block: created_by / assigned / developed_by (each with rung + note-read awareness + informed/convergent classification) + the Rung-3 `intent_attribution` signpost.
- Gathers per-session evidence over the **union of all provenance roles**, not just assigned — a developed-but-unassigned session's commits/writes/summary now land in front of the investigate step. Each `session_evidence` entry carries `roles` ⊆ {created, assigned, developed}.
- `cache_note` summarizes provenance and frames the Rung-3 (no structural link) case as "not evidence the task is undone."

**Workflow rubric (`tasks/task-completeness`):**
- `investigate` starts from the provenance block; pulls a developer's session via `session_search` for design rationale before judging.
- **`done-differently` is now a QUALITY judgment**: when the note prescribed a how-to and the impl diverged, classify the divergence **better / lateral / worse** and justify it — not just "intent met." (Closes the original critique that the workflow rewarded *detecting* divergence but never *evaluating* it.)
- Informed-vs-convergent framing via `awareness`; Rung-3 = judge by reading the code, never by absence of a link.
- `result_schema` gains `confidence` (required) + `divergence`.
- `resolve` surfaces the provenance one-liner; `partial` uses `developed_by` to delineate shipped vs remainder.

## Test plan
- [x] 11 gatherer tests (incl. union-of-roles, created/developed roles, provenance-failure degradation, Rung-3 flag) + 30 provenance tests — **41 passing**
- [ ] Reviewer: `mcp_registry_reload` so the updated workflow definition goes live, then dogfood `/wb-task-completeness` on a task with a structural developer (verify it leads with the provenance block + a confidence/divergence verdict)
- [ ] Reviewer: run it on a known *partial* task to exercise the never-live-walked partial branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)