### PR TITLE
fix(dashboard): eliminate hot-path latency across all views

### DIFF
--- a/knowledge/store/architecture/hot-path-discipline.md
+++ b/knowledge/store/architecture/hot-path-discipline.md
@@ -1,0 +1,87 @@
+---
+name: Hot-Path Discipline
+kind: concept
+description: 'Why store reads and request-serving surfaces must stay cheap: the two root causes of multi-second dashboard stalls (once-only work repeated on the hot path; unbounded external/blocking calls) and the fix shapes (memoize-on-change-signal, per-process schema gate, connection-share/batch, stale-while-revalidate + prewarm, deadline-bound external calls).'
+tags:
+- performance
+- hot-path
+- caching
+- memoization
+- stale-while-revalidate
+- prewarm
+- n-plus-one
+- sqlite
+- dashboard
+- store
+aliases:
+- hot path discipline
+- store read performance
+- dashboard latency
+- memoize on mtime
+- stale while revalidate
+- prewarm cache
+- n+1 store opens
+- once-only work
+parents:
+- architecture
+dev_notes: |-
+  ## Diagnosis discipline
+
+  - Profile to find the *dominant* cost; don't optimize by hypothesis. Decompose aggregates -- a store-open's wall time is dominated by the config parse, not the migration step, so attributing it to the migration runner sends the fix to the wrong place.
+  - When a fix underperforms its predicted gain, re-profile rather than rationalize.
+  - A per-surface sweep (one profiling pass per dashboard view) catches under-fixes that a spot-fix leaves behind -- several views shared one un-memoized config reader.
+
+  ## Caching hazards
+
+  - **Process-lifetime gates** assume the resource isn't deleted out-of-band -- safe for live DBs; a hazard only if a test deletes and recreates a file at the same path (tests use fresh tmp paths, so each migrates once).
+  - **Test isolation:** module-level caches persist across tests; key on a per-test-distinct identity (path, repo_root) or weak-ref throwaways. In-memory / empty-path resources must not collide in a path-keyed cache.
+  - **load->mutate->save:** `chat_collector._load_cache` returns a dict the caller mutates then saves; the memo returns a shallow copy so added keys don't poison it, and the save bumps the file mtime to invalidate the next read.
+  - **Concurrency:** single-flight the background refresh (a `_refreshing` flag) so a stale key doesn't spawn many refreshers; last-writer-wins on a deterministic global is harmless.
+---
+Work that lands on a hot path -- every store connection open, or every request to a serving surface (dashboard handler, MCP capability, sidecar job) -- must be cheap. Two root causes account for the multi-second stalls this discipline prevents.
+
+## The two root patterns
+
+**1. Once-only work repeated on the hot path** -- work whose result can't change between calls, redone every time:
+- Parsing config files on every DB open (`config.load_config` and `paths` data-root resolution; both are reached from a store's `_db_path` on every `get_connection`).
+- Running schema-ensure / migrations on every `get_connection`.
+- Re-aggregating a large dataset in Python on every request.
+- Re-reading + parsing a whole cache file on every request.
+
+Fix shape: **do it once, remember the result** -- memoize, gate, or cache, with a correct invalidation signal.
+
+**2. Unbounded external/blocking calls on the hot path** -- calls into something slow and outside the process:
+- Subprocess spawns (scheduled-task / `gh` / `tailscale` checks).
+- Obsidian-bridge / network calls, which carry intermittent multi-second latency spikes.
+
+Caching does not help the first (uncached) call, and an unbounded external dependency can stall a handler arbitrarily. Fix shape: **bound it with a deadline AND move it off the request path** (background refresh + serve last-known). See `architecture/resilience` for the deadline machinery.
+
+## Fix shapes
+
+- **Memoize on a change-signal.** Key an expensive pure result on the source's identity (file mtime, schema version). A hit then means *provably unchanged* -- no staleness window. Prefer this over a TTL whenever the source exposes a cheap change-signal.
+- **Per-process "already did it" gate.** For idempotent-but-not-free setup (schema-ensure, migrations), run it once per resource per process via a module-level `set` keyed on the resource path.
+- **Share one connection, or batch the query.** For an N+1 over a store, thread one connection through the loop (heterogeneous reads) or collapse it to a single `WHERE id IN (...)` (homogeneous reads).
+- **Stale-while-revalidate + prewarm.** For expensive builds with no cheap change-signal (health/requirement sweeps, git-activity scans, system-state): serve the last snapshot immediately, refresh on a single-flight background thread, and pre-warm at startup. A plain TTL cache that *rebuilds synchronously on expiry* still stalls one request per cycle -- stale-while-revalidate does not.
+- **Deadline-bound external calls** so a slow dependency can't stall the handler.
+
+## Current applications
+
+- Config-parse memo (mtime-keyed): `config.load_config`, `paths._load_data_root_from_config`.
+- Schema-ensure gates (per-path `_schema_ready` set): `get_connection` in `threads/store`, `conversation_observability/db`, `summarization/db`.
+- Connection-share / batch: `threads/render`, `projects/activity`, `obsidian/tasks/store.get_many`.
+- Stale-while-revalidate + prewarm: `dashboard/api.get_system_state`, `control/graph.build_graph`, the `dashboard/service` requirements snapshot and its startup pre-warm thread; `projects/activity` git cache.
+- Source-mtime cache: `llm/claude_code_usage/aggregator` (DB mtime), `collectors/chat_collector._load_cache` ((mtime, size)).
+
+## Guardrails
+
+- Don't reintroduce per-call config parsing or per-open schema work; don't revert `conn=` threading to per-row opens; don't put a synchronous bridge/subprocess/embedding call on a request path without a deadline and an off-path refresh.
+- A point-fix is not a pattern-fix: when you fix one instance, grep for sibling call sites of the same shape.
+- Memoize only pure values; if callers mutate the returned value, return a copy.
+- Respect the dashboard smart-refresh contract (`architecture/event-bus`): faster endpoints and SSE push compound. The regression test `test_no_wholesale_loader_calls_in_event_handlers` enforces part of it.
+- Add a regression test that proves the cache short-circuits -- a latency regression is invisible to ordinary correctness tests.
+
+## See also
+
+- `architecture/migrations` -- the migration runner; its audit hash is memoized because `run()` is on the store hot path.
+- `architecture/event-bus` -- SSE push and the smart-refresh contract; the natural cache-invalidation channel.
+- `architecture/resilience` -- deadlines/timeouts for bounding external calls.

--- a/knowledge/store/architecture/migrations.md
+++ b/knowledge/store/architecture/migrations.md
@@ -42,6 +42,10 @@ dev_notes: |-
   ## Test helper requirement
 
   `inspect.getsource` is the source-extraction mechanism, so migrations defined inside `exec`-d strings are invisible to it. Tests that need to compile functions dynamically must register source in `linecache` under a unique synthetic filename before `exec` -- see `tests/unit/test_storage_migrations.py::_compile_fn` for the pattern.
+
+  ## Audit-hash memoization
+
+  `_hash_callable` memoizes its result, weak-keyed on the migration callable. `MigrationRunner.run()` runs on the hot path of every projects / entities / tasks store `get_connection`, and a callable's source-AST hash is invariant across a process lifetime, so re-deriving it (`inspect.getsource` + `ast.parse` + `ast.unparse` + SHA-256) on every open was wasted work. The weak key lets test-compiled throwaway callables be garbage-collected. See `architecture/hot-path-discipline`.
 ---
 
 Per-DB versioned migration framework built on `PRAGMA user_version` plus a `_migration_history` audit table. Lives in `work_buddy/storage/migrations.py`. Used by every vital DB store module and by the `data_restore` pipeline to forward-roll a staged snapshot to current schema.

--- a/knowledge/store/services/dashboard.md
+++ b/knowledge/store/services/dashboard.md
@@ -121,3 +121,4 @@ Triage runs through the unified source pipeline (``run_source_pipeline`` capabil
 * **Same-origin only** for any fetch from the frontend.
 * **Silent conversation create for sidebar-bound chats** — call ``conversations.store.create_conversation`` directly, NOT the ``conversation_create`` capability, so ``_notify_conversation_created`` does not double-mount the conversation as both a CHAT toast/workflow-view tab and a sidebar.
 * **Do not subscribe to ``dashboard.form.*`` events directly** from per-tab JS. The ``wbFormBridge`` (``core/form_bridge.py``) owns that event family; tab modules register handlers via ``window.wbFormBridge.register(form_id, ...)``.
+* **Keep request handlers off the hot-path anti-patterns** — no per-request config parse, per-open schema work, N+1 store opens, or unbounded synchronous bridge/subprocess calls. Serve expensive reads from a background-refreshed cache and pre-warm at startup. See ``architecture/hot-path-discipline``.

--- a/tests/unit/test_paths_local_overlay.py
+++ b/tests/unit/test_paths_local_overlay.py
@@ -91,3 +91,51 @@ def test_data_dir_picks_up_overlay(fake_repo, monkeypatch):
     result = pmod.data_dir()
     assert result == fake_repo / ".data"
     assert result.exists() and result.is_dir()
+
+
+def test_result_is_memoized_on_unchanged_mtime(fake_repo, monkeypatch):
+    """Regression guard: a second call with unchanged config files must
+    NOT re-parse YAML.
+
+    ``_load_data_root_from_config`` runs on every DB connection open
+    app-wide; an uncached parse put ~60ms of YAML on every query. The
+    cache (keyed on config-file mtimes) is what keeps that off the hot
+    path — assert it actually short-circuits.
+    """
+    import yaml
+
+    _write(fake_repo / "config.yaml", "paths:\n  data_root: '.data'\n")
+    monkeypatch.setattr(pmod, "_data_root_cache", None)
+
+    calls = {"n": 0}
+    real_safe_load = yaml.safe_load
+
+    def counting_safe_load(*a, **k):
+        calls["n"] += 1
+        return real_safe_load(*a, **k)
+
+    monkeypatch.setattr(yaml, "safe_load", counting_safe_load)
+
+    assert pmod._load_data_root_from_config() == ".data"
+    after_first = calls["n"]
+    assert after_first >= 1  # first call parses
+
+    assert pmod._load_data_root_from_config() == ".data"
+    assert calls["n"] == after_first  # second call: cache hit, no re-parse
+
+
+def test_mtime_change_invalidates_cache(fake_repo, monkeypatch):
+    """A config edit (new mtime) must invalidate the cache and re-read."""
+    import os
+
+    cfg = fake_repo / "config.yaml"
+    _write(cfg, "paths:\n  data_root: '.data'\n")
+    monkeypatch.setattr(pmod, "_data_root_cache", None)
+    assert pmod._load_data_root_from_config() == ".data"
+
+    # Rewrite with a different value and force a distinct mtime so the
+    # cache key changes deterministically (avoids same-tick coalescing).
+    _write(cfg, "paths:\n  data_root: 'other'\n")
+    st = cfg.stat()
+    os.utime(cfg, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+    assert pmod._load_data_root_from_config() == "other"

--- a/work_buddy/collectors/chat_collector.py
+++ b/work_buddy/collectors/chat_collector.py
@@ -12,11 +12,35 @@ from typing import Any
 _CACHE_PATH = Path.home() / ".claude" / "projects" / "work_buddy_chat_cache.json"
 _CACHE_VERSION = 2  # v2: added user_messages, all_assistant_text
 
+# In-process memo of the parsed cache file, keyed on its (mtime, size). The
+# file holds hundreds of parsed-session summaries and json.load of it cost
+# ~400ms on every Chats-tab load; this keeps the parse off warm requests.
+# _save_cache rewrites the file (changing mtime/size), so a save naturally
+# invalidates this memo on the next read.
+_parsed_cache: dict[str, Any] | None = None
+_parsed_cache_state: tuple[float, int] | None = None
+
 
 def _load_cache() -> dict[str, Any]:
-    """Load the conversation summary cache, discarding if version mismatches."""
+    """Load the conversation summary cache, discarding if version mismatches.
+
+    Memoized on the cache file's (mtime, size); returns a shallow copy so a
+    caller adding newly-parsed entries (then saving) doesn't mutate the memo.
+    """
+    global _parsed_cache, _parsed_cache_state
     if not _CACHE_PATH.exists():
         return {}
+    try:
+        st = _CACHE_PATH.stat()
+        state: tuple[float, int] | None = (st.st_mtime, st.st_size)
+    except OSError:
+        state = None
+    if (
+        state is not None
+        and state == _parsed_cache_state
+        and _parsed_cache is not None
+    ):
+        return dict(_parsed_cache)
     try:
         with open(_CACHE_PATH, encoding="utf-8") as f:
             data = json.load(f)
@@ -24,7 +48,9 @@ def _load_cache() -> dict[str, Any]:
         return {}
     if data.get("_version") != _CACHE_VERSION:
         return {}
-    return data
+    _parsed_cache = data
+    _parsed_cache_state = state
+    return dict(data)
 
 
 def _save_cache(cache: dict[str, Any]) -> None:

--- a/work_buddy/config.py
+++ b/work_buddy/config.py
@@ -1,5 +1,6 @@
 """Configuration loading for work-buddy context bundle collector."""
 
+import copy
 import logging
 from pathlib import Path
 from typing import Any
@@ -8,6 +9,40 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import yaml
 
 logger = logging.getLogger(__name__)
+
+# Memoized parsed YAML, keyed on file path → (mtime_ns, parsed dict). The
+# config files don't change for the life of a process (except via
+# ``write_config_local``, which bumps the mtime and so invalidates the
+# entry). ``load_config`` runs on the hot path of every store's
+# ``get_connection`` via ``_db_path``; an unmemoized parse put ~45ms of
+# PyYAML on every DB open across the app. A runtime edit is picked up
+# because the cache key is the file mtime.
+_PARSED_YAML_CACHE: dict[str, tuple[int, dict[str, Any]]] = {}
+
+
+def _read_yaml_memoized(path: Path) -> dict[str, Any]:
+    """Parse ``path`` as YAML, memoized on its mtime.
+
+    Returns a deep copy so neither callers nor ``_deep_merge`` (which
+    shares override leaves by reference) can mutate the cached parse.
+    Missing or unreadable files yield ``{}``.
+    """
+    try:
+        mtime = path.stat().st_mtime_ns
+    except OSError:
+        return {}
+    cached = _PARSED_YAML_CACHE.get(str(path))
+    if cached is None or cached[0] != mtime:
+        try:
+            with open(path) as f:
+                parsed = yaml.safe_load(f) or {}
+        except Exception:
+            parsed = {}
+        if not isinstance(parsed, dict):
+            parsed = {}
+        cached = (mtime, parsed)
+        _PARSED_YAML_CACHE[str(path)] = cached
+    return copy.deepcopy(cached[1])
 
 
 DEFAULTS = {
@@ -165,16 +200,15 @@ def load_config(config_path: Path | None = None) -> dict[str, Any]:
         # Look relative to the repo root (parent of work_buddy/)
         config_path = Path(__file__).parent.parent / "config.yaml"
 
-    if config_path.exists():
-        with open(config_path) as f:
-            user_cfg = yaml.safe_load(f) or {}
+    # Parses are memoized on file mtime (see ``_read_yaml_memoized``);
+    # the merge itself is cheap and still produces a fresh dict per call.
+    user_cfg = _read_yaml_memoized(config_path)
+    if user_cfg:
         cfg = _deep_merge(cfg, user_cfg)
 
     # Local overrides (gitignored, machine-specific)
-    local_path = config_path.with_name("config.local.yaml")
-    if local_path.exists():
-        with open(local_path) as f:
-            local_cfg = yaml.safe_load(f) or {}
+    local_cfg = _read_yaml_memoized(config_path.with_name("config.local.yaml"))
+    if local_cfg:
         cfg = _deep_merge(cfg, local_cfg)
 
     return cfg

--- a/work_buddy/control/graph.py
+++ b/work_buddy/control/graph.py
@@ -37,6 +37,7 @@ log = logging.getLogger(__name__)
 _GRAPH_TTL_SECONDS = 45.0
 _cache: NodeCache | None = None
 _cache_lock = threading.Lock()
+_refreshing = False
 
 
 # ---------------------------------------------------------------------------
@@ -46,20 +47,58 @@ _cache_lock = threading.Lock()
 def build_graph(force: bool = False) -> dict[str, ControlNode]:
     """Return the current control graph.
 
-    ``force=True`` bypasses the TTL cache and rebuilds from scratch.
+    Served from a background-refreshed cache. ``_assemble`` runs a full
+    health + requirement sweep (subprocess-heavy: scheduled-task, gh,
+    tailscale checks) that can take 10s+, so a stale snapshot is served
+    immediately while a background thread refreshes it — the cost never
+    lands on a request after the first build. ``force=True`` (the Reprobe
+    button) rebuilds synchronously and replaces the cache.
     """
     global _cache
+    if force:
+        nodes = _assemble()
+        with _cache_lock:
+            _cache = NodeCache(nodes=nodes, built_at=time.time())
+        return nodes
+
+    cache = _cache
+    if cache is not None:
+        if (time.time() - cache.built_at) >= _GRAPH_TTL_SECONDS:
+            _kick_graph_refresh()  # stale — refresh for next time
+        return cache.nodes
+
+    # Cold start: build once synchronously. The lock makes concurrent
+    # first-callers wait for the single build rather than each starting
+    # their own. The dashboard pre-warms this at startup.
     with _cache_lock:
-        now = time.time()
-        if (
-            not force
-            and _cache is not None
-            and (now - _cache.built_at) < _GRAPH_TTL_SECONDS
-        ):
+        if _cache is not None:
             return _cache.nodes
         nodes = _assemble()
-        _cache = NodeCache(nodes=nodes, built_at=now)
-        return nodes
+        _cache = NodeCache(nodes=nodes, built_at=time.time())
+        return _cache.nodes
+
+
+def _kick_graph_refresh() -> None:
+    """Rebuild the control-graph snapshot on a background thread (single-flight)."""
+    global _refreshing
+    with _cache_lock:
+        if _refreshing:
+            return
+        _refreshing = True
+
+    def _refresh() -> None:
+        global _cache, _refreshing
+        try:
+            nodes = _assemble()
+            _cache = NodeCache(nodes=nodes, built_at=time.time())
+        except Exception:
+            log.warning("Background control-graph refresh failed", exc_info=True)
+        finally:
+            _refreshing = False
+
+    threading.Thread(
+        target=_refresh, name="control-graph-refresh", daemon=True,
+    ).start()
 
 
 def invalidate_graph() -> None:

--- a/work_buddy/conversation_observability/db.py
+++ b/work_buddy/conversation_observability/db.py
@@ -34,14 +34,25 @@ def db_path(cfg: dict | None = None) -> Path:
     return _default_db_path()
 
 
+# DB paths whose schema has already been ensured this process. The
+# schema + ALTER migration pass is idempotent but not free (a full
+# executescript + a PRAGMA table_info per connect); the sidecar refresh
+# cron and inline collector open this DB frequently, so running it on
+# every connect put that cost on every open. Keyed on the resolved path
+# (which varies with ``cfg``) so a test pointing at a fresh DB still
+# migrates it exactly once. Process-lifetime; assumes the DB file is not
+# externally deleted out from under a live process.
+_schema_ready: set[str] = set()
+
+
 def get_connection(cfg: dict | None = None) -> sqlite3.Connection:
     """Open (or create) the conversation-observability DB.
 
-    Idempotent: schema is re-run on every connect via
-    ``CREATE TABLE IF NOT EXISTS`` so a missing file becomes a populated
-    one transparently. ``Row`` factory is set so callers can use column
-    access by name. Forward-only ALTER migrations run on every connect
-    so existing DBs pick up new columns without intervention.
+    Idempotent: the schema + forward-only ALTER migrations are ensured
+    once per DB path per process (see ``_schema_ready``), so a missing
+    file becomes a populated one transparently on first open. ``Row``
+    factory is set so callers can use column access by name; the
+    per-connection WAL pragma always runs.
     """
     path = db_path(cfg)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -56,8 +67,11 @@ def get_connection(cfg: dict | None = None) -> sqlite3.Connection:
     conn = sqlite3.connect(str(path), timeout=30)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")
-    conn.executescript(SCHEMA)
-    _migrate_schema(conn)
+    key = str(path)
+    if key not in _schema_ready:
+        conn.executescript(SCHEMA)
+        _migrate_schema(conn)
+        _schema_ready.add(key)
     return conn
 
 

--- a/work_buddy/dashboard/costs.py
+++ b/work_buddy/dashboard/costs.py
@@ -19,6 +19,7 @@ spend" separately from "model usage."
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 from collections import defaultdict
@@ -177,8 +178,13 @@ def _round_cost(bucket: dict[str, Any]) -> dict[str, Any]:
     return bucket
 
 
+@functools.lru_cache(maxsize=8192)
 def _resolve_project_name(path_or_slug: str) -> str:
     """Canonical project name for a cwd / project path.
+
+    Memoized: pure mapping from a cwd/slug to a canonical name, called
+    once per usage turn during cost aggregation (the same handful of
+    project paths recur across hundreds of thousands of rows).
 
     Reuses :func:`work_buddy.collectors.chat_collector.project_name_from_slug`
     so the Costs tab matches the Chats tab — worktrees and nested

--- a/work_buddy/dashboard/service.py
+++ b/work_buddy/dashboard/service.py
@@ -4604,6 +4604,15 @@ def _prewarm_projects_activity() -> None:
     sort_active_by_activity(list_projects())
 
 
+def _prewarm_costs() -> None:
+    """Warm the default Claude-Code-usage summary so the first Costs-tab
+    load doesn't eat the multi-second aggregation over all usage turns."""
+    from work_buddy.dashboard.costs_claude_code_usage import (
+        get_claude_code_usage_summary,
+    )
+    get_claude_code_usage_summary()
+
+
 def main():
     import sys
 
@@ -4675,6 +4684,7 @@ def main():
                 ("requirements", get_requirements_snapshot),
                 ("control-graph", _prewarm_control_graph),
                 ("projects-activity", _prewarm_projects_activity),
+                ("costs", _prewarm_costs),
             ):
                 try:
                     fn()

--- a/work_buddy/dashboard/service.py
+++ b/work_buddy/dashboard/service.py
@@ -2819,17 +2819,26 @@ def api_threads_list():
         )
         total = count_threads(q, **filter_kwargs)
         threads = []
-        for t in threads_models:
-            data = build_render_data(t.thread_id)
-            if data is None:
-                continue
-            # Post-query filters — neither has a SQL index, but the
-            # cardinality at this point (post search) is small.
-            if urgency and data.get("urgency") != urgency:
-                continue
-            if has_cleanup_only and not data.get("can_clean_up"):
-                continue
-            threads.append(data)
+        # Share one DB connection across the whole render batch — each
+        # build_render_data otherwise opens + closes its own (×3 reads),
+        # and that connection churn was the dominant cost after the
+        # config-parse fix.
+        from work_buddy.threads import store as _threads_store
+        _conn = _threads_store.get_connection()
+        try:
+            for t in threads_models:
+                data = build_render_data(t.thread_id, conn=_conn)
+                if data is None:
+                    continue
+                # Post-query filters — neither has a SQL index, but the
+                # cardinality at this point (post search) is small.
+                if urgency and data.get("urgency") != urgency:
+                    continue
+                if has_cleanup_only and not data.get("can_clean_up"):
+                    continue
+                threads.append(data)
+        finally:
+            _conn.close()
         return jsonify({
             "threads": threads,
             "total": total,
@@ -4569,6 +4578,43 @@ def main():
 
     from work_buddy.web.access_log_filter import install_probe_log_filter
     install_probe_log_filter(["/health"])
+
+    # Pre-warm the /api/state cache on a background thread. The first
+    # build runs a requirement sweep + probe reads and takes 10s+; doing
+    # it at startup (rather than lazily on the first Jobs-tab load) means
+    # the user never eats that cold-build stall. get_system_state's build
+    # lock makes this single-flight — a request that races the warm-up
+    # blocks on the lock, then gets the cached result.
+    #
+    # Skip in the dev reloader's watcher process: with debug=True Werkzeug
+    # runs main() in both the watcher and the reloaded child, and the
+    # watcher's cache is discarded on every reload — warming it there is a
+    # wasted 10s+ build. WERKZEUG_RUN_MAIN is set only in the child; in
+    # prod (debug=False) it's unset but there's no watcher, so `not dev`
+    # lets the single process warm normally.
+    import os as _os
+    import threading as _threading
+
+    if not dev or _os.environ.get("WERKZEUG_RUN_MAIN") == "true":
+        def _prewarm() -> None:
+            try:
+                get_system_state()
+            except Exception as exc:  # pragma: no cover - best-effort warm-up
+                logger.warning("System-state pre-warm failed: %s", exc)
+            # Warm the per-folder git-activity cache so the first
+            # Projects-tab load doesn't eat the cold git walk. Scores are
+            # discarded; the side effect (populated _GIT_CACHE) is the point.
+            try:
+                from work_buddy.projects.activity import sort_active_by_activity
+                from work_buddy.projects.store import list_projects
+                sort_active_by_activity(list_projects())
+            except Exception as exc:  # pragma: no cover - best-effort warm-up
+                logger.warning("Projects activity pre-warm failed: %s", exc)
+
+        _threading.Thread(
+            target=_prewarm, name="dashboard-prewarm", daemon=True,
+        ).start()
+
     logger.info("Dashboard starting on http://%s:%d%s", host, port, " (dev mode)" if dev else "")
     app.run(host=host, port=port, debug=dev)
 

--- a/work_buddy/dashboard/service.py
+++ b/work_buddy/dashboard/service.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 import time
 from pathlib import Path
 
@@ -783,24 +784,79 @@ def api_dashboard_cards(mount_point: str):
         return jsonify({"error": str(exc)}), 500
 
 
+# Background-refreshed cache for the full requirements snapshot. The
+# requirement sweep spawns subprocesses (scheduled-task / gh / tailscale
+# checks) that take 10s+, so — like /api/state — we serve a possibly-stale
+# snapshot and refresh on a background thread, keeping the cost off every
+# request after the first.
+_REQ_CACHE_TTL = 30.0
+_req_cache: dict[str, Any] | None = None
+_req_cache_ts: float = 0.0
+_req_cache_lock = threading.Lock()
+_req_refreshing = False
+
+
+def _build_requirements_snapshot() -> dict[str, Any]:
+    from work_buddy.health.requirements import RequirementChecker
+    checker = RequirementChecker()
+    bootstrap = checker.check_bootstrap()
+    all_reqs = checker.check_all(include_unwanted=False)
+    return {
+        "bootstrap": {
+            "summary": checker.summarize(bootstrap),
+            "results": [r.to_dict() for r in bootstrap],
+        },
+        "all": {
+            "summary": checker.summarize(all_reqs),
+            "results": [r.to_dict() for r in all_reqs],
+        },
+    }
+
+
+def _kick_requirements_refresh() -> None:
+    global _req_refreshing
+    with _req_cache_lock:
+        if _req_refreshing:
+            return
+        _req_refreshing = True
+
+    def _refresh() -> None:
+        global _req_cache, _req_cache_ts, _req_refreshing
+        try:
+            fresh = _build_requirements_snapshot()
+            _req_cache = fresh
+            _req_cache_ts = time.time()
+        except Exception as exc:
+            logger.warning("Background requirements refresh failed: %s", exc)
+        finally:
+            _req_refreshing = False
+
+    threading.Thread(
+        target=_refresh, name="requirements-refresh", daemon=True,
+    ).start()
+
+
+def get_requirements_snapshot() -> dict[str, Any]:
+    """Requirements snapshot, served from a background-refreshed cache."""
+    global _req_cache, _req_cache_ts
+    cache = _req_cache
+    if cache is not None:
+        if time.time() - _req_cache_ts >= _REQ_CACHE_TTL:
+            _kick_requirements_refresh()
+        return cache
+    with _req_cache_lock:
+        if _req_cache is not None:
+            return _req_cache
+        _req_cache = _build_requirements_snapshot()
+        _req_cache_ts = time.time()
+        return _req_cache
+
+
 @app.get("/api/requirements")
 def api_requirements():
-    """Full requirements validation results."""
+    """Full requirements validation results (background-cached)."""
     try:
-        from work_buddy.health.requirements import RequirementChecker
-        checker = RequirementChecker()
-        bootstrap = checker.check_bootstrap()
-        all_reqs = checker.check_all(include_unwanted=False)
-        return jsonify({
-            "bootstrap": {
-                "summary": checker.summarize(bootstrap),
-                "results": [r.to_dict() for r in bootstrap],
-            },
-            "all": {
-                "summary": checker.summarize(all_reqs),
-                "results": [r.to_dict() for r in all_reqs],
-            },
-        })
+        return jsonify(get_requirements_snapshot())
     except Exception as exc:
         return jsonify({"error": str(exc)}), 500
 
@@ -4532,6 +4588,22 @@ def _start_acknowledge_poller():
     logger.info("Acknowledge poller started")
 
 
+def _prewarm_control_graph() -> None:
+    """Build the control-graph snapshot once so the first Settings load
+    doesn't block on the cold health + requirement sweep."""
+    from work_buddy.control.graph import build_graph
+    build_graph()
+
+
+def _prewarm_projects_activity() -> None:
+    """Warm the per-folder git-activity cache so the first Projects-tab
+    load doesn't eat the cold git walk. Scores are discarded; the
+    populated ``_GIT_CACHE`` side effect is the point."""
+    from work_buddy.projects.activity import sort_active_by_activity
+    from work_buddy.projects.store import list_projects
+    sort_active_by_activity(list_projects())
+
+
 def main():
     import sys
 
@@ -4593,25 +4665,23 @@ def main():
     # prod (debug=False) it's unset but there's no watcher, so `not dev`
     # lets the single process warm normally.
     import os as _os
-    import threading as _threading
 
     if not dev or _os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         def _prewarm() -> None:
-            try:
-                get_system_state()
-            except Exception as exc:  # pragma: no cover - best-effort warm-up
-                logger.warning("System-state pre-warm failed: %s", exc)
-            # Warm the per-folder git-activity cache so the first
-            # Projects-tab load doesn't eat the cold git walk. Scores are
-            # discarded; the side effect (populated _GIT_CACHE) is the point.
-            try:
-                from work_buddy.projects.activity import sort_active_by_activity
-                from work_buddy.projects.store import list_projects
-                sort_active_by_activity(list_projects())
-            except Exception as exc:  # pragma: no cover - best-effort warm-up
-                logger.warning("Projects activity pre-warm failed: %s", exc)
+            # Each warm-up is independent and best-effort: a failure in one
+            # must not skip the others, and none should crash startup.
+            for label, fn in (
+                ("system-state", get_system_state),
+                ("requirements", get_requirements_snapshot),
+                ("control-graph", _prewarm_control_graph),
+                ("projects-activity", _prewarm_projects_activity),
+            ):
+                try:
+                    fn()
+                except Exception as exc:  # pragma: no cover - best-effort
+                    logger.warning("%s pre-warm failed: %s", label, exc)
 
-        _threading.Thread(
+        threading.Thread(
             target=_prewarm, name="dashboard-prewarm", daemon=True,
         ).start()
 

--- a/work_buddy/llm/claude_code_usage/aggregator.py
+++ b/work_buddy/llm/claude_code_usage/aggregator.py
@@ -75,7 +75,59 @@ def _project_matches(cwd: str, project_filter: str | None) -> bool:
     return pf in canonical or pf in sp or pf in last
 
 
+# Memoized summary read models, keyed on (db path, db mtime, filters).
+# The aggregation scans every usage turn (100k+ rows) in Python and is a
+# pure function of the cache DB's contents — which change only when the
+# scanner rescans. So a rescan bumps the file mtime and drops every stale
+# entry; until then the multi-second aggregation is computed once per
+# filter combination instead of on every /api/costs load.
+_summary_cache: dict[tuple[Any, ...], dict[str, Any]] = {}
+_summary_cache_mtime: int | None = None
+
+
 def get_claude_code_usage_summary(
+    *,
+    db_path: Path | None = None,
+    project: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    models: list[str] | set[str] | tuple[str, ...] | None = None,
+) -> dict[str, Any]:
+    """Cached entry point for the Claude-Code-usage read model.
+
+    Memoizes :func:`_compute_claude_code_usage_summary` on the cache DB's
+    mtime + filter params (see ``_summary_cache``). Falls through to a
+    fresh compute when the DB is missing/unreadable (that "unavailable"
+    shape is not cached).
+    """
+    global _summary_cache, _summary_cache_mtime
+    p = db_path or _scanner.get_db_path()
+    try:
+        mtime = p.stat().st_mtime_ns
+    except OSError:
+        mtime = None
+    if mtime is None:
+        return _compute_claude_code_usage_summary(
+            db_path=db_path, project=project, start_date=start_date,
+            end_date=end_date, models=models,
+        )
+    if mtime != _summary_cache_mtime:
+        _summary_cache = {}  # rescan changed the DB — stale entries are useless
+        _summary_cache_mtime = mtime
+    model_key = tuple(sorted(set(models))) if models is not None else None
+    key = (str(p), project, start_date, end_date, model_key)
+    cached = _summary_cache.get(key)
+    if cached is not None:
+        return cached
+    result = _compute_claude_code_usage_summary(
+        db_path=db_path, project=project, start_date=start_date,
+        end_date=end_date, models=models,
+    )
+    _summary_cache[key] = result
+    return result
+
+
+def _compute_claude_code_usage_summary(
     *,
     db_path: Path | None = None,
     project: str | None = None,

--- a/work_buddy/llm/claude_code_usage/pricing.py
+++ b/work_buddy/llm/claude_code_usage/pricing.py
@@ -25,6 +25,7 @@ data needed to apply cache rates retroactively.
 
 from __future__ import annotations
 
+import functools
 
 PRICING: dict[str, dict[str, float]] = {
     "claude-opus-4-7":   {"input": 5.00,  "output": 25.00, "cache_write": 6.25, "cache_read": 0.50},
@@ -39,8 +40,13 @@ PRICING: dict[str, dict[str, float]] = {
 }
 
 
+@functools.lru_cache(maxsize=None)
 def get_pricing(model: str | None) -> dict[str, float] | None:
     """Resolve a pricing dict for ``model`` using the upstream strategy.
+
+    Memoized: pure function of ``model``, called once per usage turn
+    (hundreds of thousands of times) when aggregating the cost read model.
+    The model vocabulary is tiny, so an unbounded cache is safe.
 
     1. Exact match.
     2. Prefix match (e.g. ``claude-sonnet-4-6-extended-context`` falls
@@ -66,8 +72,12 @@ def get_pricing(model: str | None) -> dict[str, float] | None:
     return None
 
 
+@functools.lru_cache(maxsize=None)
 def is_billable(model: str | None) -> bool:
-    """A model is billable if its name suggests an Anthropic frontier family."""
+    """A model is billable if its name suggests an Anthropic frontier family.
+
+    Memoized (pure, called once per usage turn during cost aggregation).
+    """
     if not model:
         return False
     m = model.lower()

--- a/work_buddy/obsidian/tasks/manager.py
+++ b/work_buddy/obsidian/tasks/manager.py
@@ -226,8 +226,9 @@ def stale_check() -> dict[str, Any]:
     focused_no_date: list[dict] = []
     focused_overdue: list[dict] = []
 
+    store_meta = _store_meta_for_tasks(tasks)
     for t in tasks:
-        meta = _get_task_meta(t)
+        meta = _get_task_meta(t, store_meta)
         state = meta["state"]
         due = t.get("due_date")
         due_dt = _parse_date(due) if due else None
@@ -315,8 +316,9 @@ def suggest_focus(max_suggestions: int = 3) -> list[dict[str, Any]]:
 
     scored: list[tuple[int, dict]] = []
 
+    store_meta = _store_meta_for_tasks(tasks)
     for t in tasks:
-        meta = _get_task_meta(t)
+        meta = _get_task_meta(t, store_meta)
         state = meta["state"]
         urgency = meta["urgency"]
         contract = meta.get("contract")
@@ -435,8 +437,9 @@ def get_tasks_by_state(target_state: str) -> list[dict[str, Any]]:
     tasks = result.get("tasks", [])
 
     matched = []
+    store_meta = _store_meta_for_tasks(tasks)
     for t in tasks:
-        meta = _get_task_meta(t)
+        meta = _get_task_meta(t, store_meta)
         if meta["state"] == target_state:
             matched.append({
                 **t,
@@ -529,10 +532,35 @@ def _extract_tag_value(tags: list[str], prefix: str) -> str | None:
     return None
 
 
-def _get_task_meta(task: dict[str, Any]) -> dict[str, str | None]:
+def _store_meta_for_tasks(
+    tasks: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Batch-resolve store metadata for a list of markdown tasks.
+
+    Extracts each task's ID from its description and fetches all rows in a
+    single store query, so the per-task enrichment loops below don't open
+    one DB connection per task (the N+1 that dominated the daily briefing).
+    Pass the result as ``store_meta`` to :func:`_get_task_meta`.
+    """
+    ids: list[str] = []
+    for t in tasks:
+        m = TASK_ID_RE.search(t.get("description", ""))
+        if m:
+            ids.append(m.group(1))
+    return store.get_many(ids) if ids else {}
+
+
+def _get_task_meta(
+    task: dict[str, Any],
+    store_meta: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, str | None]:
     """Get state and urgency for a task, checking store first then inline tags.
 
     Returns dict with 'state', 'urgency', 'task_id', 'contract'.
+
+    ``store_meta`` is an optional pre-fetched ``{task_id: row}`` map (see
+    :func:`_store_meta_for_tasks`); when supplied, the store lookup is a
+    dict hit instead of a per-task DB connection.
     """
     tags = task.get("tags", [])
     desc = task.get("description", "")
@@ -545,7 +573,10 @@ def _get_task_meta(task: dict[str, Any]) -> dict[str, str | None]:
 
     # Check store first (if task has an ID)
     if task_id:
-        meta = store.get(task_id)
+        meta = (
+            store_meta.get(task_id) if store_meta is not None
+            else store.get(task_id)
+        )
         if meta:
             return {
                 "state": meta["state"],

--- a/work_buddy/obsidian/tasks/store.py
+++ b/work_buddy/obsidian/tasks/store.py
@@ -507,6 +507,42 @@ def get(task_id: str, *, include_deleted: bool = False) -> dict[str, Any] | None
         conn.close()
 
 
+def get_many(
+    task_ids: list[str], *, include_deleted: bool = False,
+    conn: "sqlite3.Connection | None" = None,
+) -> dict[str, dict[str, Any]]:
+    """Batch form of :func:`get` — resolve many task IDs in one query.
+
+    Returns ``{task_id: row_dict}`` for the IDs that exist (missing IDs are
+    simply absent). Lets a per-task enrichment loop fetch all store rows in
+    a single connection + query instead of opening one connection per task
+    (the N+1 that dominated the daily briefing). Soft-deleted rows are
+    excluded unless ``include_deleted=True``.
+    """
+    ids = [t for t in dict.fromkeys(task_ids) if t]  # dedupe, drop falsy
+    if not ids:
+        return {}
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        out: dict[str, dict[str, Any]] = {}
+        # Chunk under SQLite's parameter limit (999).
+        for start in range(0, len(ids), 900):
+            chunk = ids[start:start + 900]
+            placeholders = ",".join("?" * len(chunk))
+            sql = f"SELECT * FROM task_metadata WHERE task_id IN ({placeholders})"
+            if not include_deleted:
+                sql += " AND deleted_at IS NULL"
+            for row in conn.execute(sql, chunk):
+                d = dict(row)
+                out[d["task_id"]] = d
+        return out
+    finally:
+        if own_conn:
+            conn.close()
+
+
 def get_created_by(task_id: str) -> str | None:
     """Return the session id that created ``task_id``, or None.
 

--- a/work_buddy/paths.py
+++ b/work_buddy/paths.py
@@ -119,6 +119,16 @@ def repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
+# Memoized (cache_key, value) for the resolved data root. The parse is
+# keyed on the config files' (repo_root, mtime) identity so a runtime edit
+# — or a test that rewrites config under a monkeypatched ``repo_root`` —
+# still invalidates, while the common case skips the YAML parse entirely.
+# This matters because ``resolve()`` / ``data_dir()`` run on every DB
+# connection open across the app; an uncached parse put ~60ms of YAML on
+# every query (≈10s across a single dashboard list endpoint).
+_data_root_cache: tuple[tuple[str, ...], str] | None = None
+
+
 def _load_data_root_from_config() -> str:
     """Read ``paths.data_root`` from config without importing config.py eagerly.
 
@@ -128,17 +138,37 @@ def _load_data_root_from_config() -> str:
     ``paths``, so a future change there could otherwise create a cycle).
 
     Falls back to ``"data"`` when nothing is set or PyYAML is missing.
+
+    The result is memoized on the config files' mtimes (see
+    ``_data_root_cache``) — repeated calls in a hot path stat two files
+    instead of re-parsing YAML.
     """
+    global _data_root_cache
     try:
         import yaml
     except ImportError:
         return "data"
 
     root = repo_root()
-    paths_section: dict[str, Any] = {}
+    files: list[tuple[Path, int | None]] = []
+    key_parts: list[str] = [str(root)]
     for name in ("config.yaml", "config.local.yaml"):
         path = root / name
-        if not path.exists():
+        try:
+            mtime: int | None = path.stat().st_mtime_ns
+        except OSError:
+            mtime = None
+        files.append((path, mtime))
+        key_parts.append(f"{name}:{mtime}")
+    cache_key = tuple(key_parts)
+
+    cached = _data_root_cache
+    if cached is not None and cached[0] == cache_key:
+        return cached[1]
+
+    paths_section: dict[str, Any] = {}
+    for path, mtime in files:
+        if mtime is None:
             continue
         try:
             with open(path) as f:
@@ -148,7 +178,9 @@ def _load_data_root_from_config() -> str:
         local_paths = cfg.get("paths") or {}
         if isinstance(local_paths, dict):
             paths_section.update(local_paths)
-    return paths_section.get("data_root", "data")
+    value = paths_section.get("data_root", "data")
+    _data_root_cache = (cache_key, value)
+    return value
 
 
 def data_dir(category: str = "") -> Path:

--- a/work_buddy/projects/activity.py
+++ b/work_buddy/projects/activity.py
@@ -27,6 +27,8 @@ a single dashboard auto-refresh cycle don't pay the cost twice.
 from __future__ import annotations
 
 import math
+import sqlite3
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -58,6 +60,12 @@ _DEFAULT_HALF_LIFE_DAYS = 14.0
 _GIT_CACHE: dict[str, tuple[float, dict[str, Any] | None]] = {}
 _GIT_CACHE_TTL_SECONDS = 300.0
 
+# Single-flight guard for background git-activity refreshes. Keyed on the
+# same resolved-path key as ``_GIT_CACHE`` so a stale entry kicks at most
+# one refresh thread at a time.
+_GIT_REFRESHING: set[str] = set()
+_GIT_REFRESH_LOCK = threading.Lock()
+
 
 def _parse_iso_utc(s: str) -> datetime | None:
     """Parse an ISO 8601 timestamp into a UTC-aware datetime, or None."""
@@ -79,6 +87,37 @@ def _age_days(event_time: datetime, now: datetime) -> float:
     return (now - event_time).total_seconds() / 86400.0
 
 
+def _read_git_activity(repo_path: Path, window_days: int) -> dict[str, Any] | None:
+    """Read git activity for one folder (the ~300ms-per-repo call)."""
+    # Import lazily to avoid pulling sync's module-level dependencies
+    # into every caller of activity scoring.
+    from work_buddy.projects.sync import _read_git_repo_activity
+    try:
+        return _read_git_repo_activity(repo_path, score_window_days=window_days)
+    except Exception:
+        logger.debug("Git activity read failed for %s", repo_path, exc_info=True)
+        return None
+
+
+def _kick_git_refresh(repo_path: Path, key: str, window_days: int) -> None:
+    """Refresh one folder's git activity on a background thread (single-flight)."""
+    with _GIT_REFRESH_LOCK:
+        if key in _GIT_REFRESHING:
+            return
+        _GIT_REFRESHING.add(key)
+
+    def _refresh() -> None:
+        try:
+            _GIT_CACHE[key] = (time.time(), _read_git_activity(repo_path, window_days))
+        finally:
+            with _GIT_REFRESH_LOCK:
+                _GIT_REFRESHING.discard(key)
+
+    threading.Thread(
+        target=_refresh, name="git-activity-refresh", daemon=True,
+    ).start()
+
+
 def _get_git_activity_cached(
     repo_path: Path,
     *,
@@ -87,9 +126,15 @@ def _get_git_activity_cached(
 ) -> dict[str, Any] | None:
     """Read git activity for a folder with a short-lived in-process cache.
 
-    Wraps :func:`work_buddy.projects.sync._read_git_repo_activity`. The
-    cache key is the resolved absolute path so symlink and case-normal
-    paths share entries.
+    Wraps :func:`work_buddy.projects.sync._read_git_repo_activity` (~300ms
+    per repo). The cache key is the resolved absolute path so symlink and
+    case-normal paths share entries.
+
+    Stale-while-revalidate: a present-but-expired entry is returned
+    immediately while a single background thread refreshes it, so the
+    ~300ms/repo git walk never lands on the request path once the cache is
+    warm (the dashboard pre-warms it at startup). Only a genuinely cold
+    entry (never read this process) is fetched synchronously.
     """
     try:
         key = str(repo_path.resolve())
@@ -98,19 +143,16 @@ def _get_git_activity_cached(
 
     now = time.time()
     cached = _GIT_CACHE.get(key)
-    if cached and (now - cached[0]) < ttl_seconds:
+    if cached is not None:
+        if (now - cached[0]) < ttl_seconds:
+            return cached[1]  # fresh
+        # Stale: serve the old value now, refresh for next time.
+        _kick_git_refresh(repo_path, key, window_days)
         return cached[1]
 
-    # Import lazily to avoid pulling sync's module-level dependencies
-    # into every caller of activity scoring.
-    from work_buddy.projects.sync import _read_git_repo_activity
-    try:
-        activity = _read_git_repo_activity(
-            repo_path, score_window_days=window_days,
-        )
-    except Exception:
-        logger.debug("Git activity read failed for %s", repo_path, exc_info=True)
-        activity = None
+    # Cold: no entry yet. Read synchronously so the first-ever score is
+    # correct; the startup pre-warm makes this rare during a real request.
+    activity = _read_git_activity(repo_path, window_days)
     _GIT_CACHE[key] = (now, activity)
     return activity
 
@@ -121,6 +163,7 @@ def compute_activity_score(
     half_life_days: float = _DEFAULT_HALF_LIFE_DAYS,
     window_days: int = _DEFAULT_WINDOW_DAYS,
     now: datetime | None = None,
+    conn: "sqlite3.Connection | None" = None,
 ) -> float:
     """Return a non-negative activity score for ``project``.
 
@@ -136,12 +179,15 @@ def compute_activity_score(
     now = now or datetime.now(timezone.utc)
     score = 0.0
 
-    # 1. Project revisions — cheap SQL query.
+    # 1. Project revisions — only the timestamps matter here, so use the
+    # lightweight query that skips list_revisions' per-row folders/aliases
+    # enrichment (an N+1 that dominated this endpoint's warm-cache cost).
     try:
         from work_buddy.projects import store
-        revs = store.list_revisions(project["id"], limit=200)
-        for r in revs:
-            rev_time = _parse_iso_utc(r.get("created_at", ""))
+        for created in store.list_revision_times(
+            project["id"], limit=200, conn=conn,
+        ):
+            rev_time = _parse_iso_utc(created)
             if rev_time is None:
                 continue
             age = _age_days(rev_time, now)
@@ -205,11 +251,19 @@ def sort_active_by_activity(
     other = [p for p in projects if p.get("status") != "active"]
 
     now = datetime.now(timezone.utc)
-    for p in active:
-        p["activity_score"] = compute_activity_score(
-            p, half_life_days=half_life_days,
-            window_days=window_days, now=now,
-        )
+    # Share one DB connection across the batch — each list_revision_times
+    # open otherwise runs MigrationRunner's write-locked hash audit
+    # (~80ms), which dominated the warm-cache cost at N active projects.
+    from work_buddy.projects import store
+    conn = store.get_connection()
+    try:
+        for p in active:
+            p["activity_score"] = compute_activity_score(
+                p, half_life_days=half_life_days,
+                window_days=window_days, now=now, conn=conn,
+            )
+    finally:
+        conn.close()
     active.sort(
         key=lambda p: (-p.get("activity_score", 0.0), p.get("slug", "")),
     )

--- a/work_buddy/projects/store.py
+++ b/work_buddy/projects/store.py
@@ -953,6 +953,48 @@ def list_revisions(
         conn.close()
 
 
+def list_revision_times(
+    project_id: int, *, limit: int | None = None,
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Return just the ``created_at`` timestamps for a project's
+    revisions, newest first.
+
+    Lightweight counterpart to :func:`list_revisions` for callers that
+    only need recency (e.g. activity scoring). ``list_revisions`` joins
+    ``project_folders_history`` + ``project_aliases_history`` per row —
+    an N+1 that's pure waste when the caller never reads ``folders`` /
+    ``aliases``. This is a single indexed query
+    (``idx_pr_project_id_created``) returning only the timestamp column.
+
+    ``conn`` lets a caller scoring many projects share one connection
+    across the batch — opening one runs ``MigrationRunner.run`` (a
+    write-locked hash-audit pass, ~80ms), so per-project opens dominated
+    the activity-sort cost. When omitted, a private connection is opened
+    and closed here.
+    """
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        sql = (
+            "SELECT created_at FROM project_revisions WHERE project_id = ? "
+            "ORDER BY created_at DESC"
+        )
+        params: tuple[Any, ...] = (project_id,)
+        if limit is not None:
+            sql += " LIMIT ?"
+            params = (project_id, limit)
+        return [
+            r["created_at"]
+            for r in conn.execute(sql, params).fetchall()
+            if r["created_at"]
+        ]
+    finally:
+        if own_conn:
+            conn.close()
+
+
 def get_state_at(
     project_id: int, timestamp: str,
 ) -> dict[str, Any] | None:

--- a/work_buddy/storage/migrations.py
+++ b/work_buddy/storage/migrations.py
@@ -73,12 +73,20 @@ import hashlib
 import inspect
 import sqlite3
 import textwrap
+import weakref
 from dataclasses import dataclass
 from typing import Callable
 
 from work_buddy.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+# Memoized per-callable audit hashes — see ``MigrationRunner._hash_callable``.
+# A migration callable's source is immutable for the process lifetime, so its
+# AST hash never changes; the audit otherwise re-derived it on every
+# connection open. Weak-keyed so test-compiled / throwaway callables are
+# garbage-collected normally instead of leaking.
+_HASH_CACHE: "weakref.WeakKeyDictionary[Callable, str]" = weakref.WeakKeyDictionary()
 
 
 # Identifier baked into every newly-stamped hash. Bumping this string
@@ -331,6 +339,32 @@ class MigrationRunner:
 
     @staticmethod
     def _hash_callable(fn: Callable) -> str:
+        """Audit hash for a migration callable (memoized wrapper).
+
+        The hash is a pure function of the callable's source, which is
+        immutable for the process lifetime — yet ``_verify_history_hashes``
+        re-derives it for every migration on every connection open
+        (projects/entities/tasks stores). Memoizing on the callable object
+        removes that repeated AST parse/unparse. Weak-keyed so throwaway
+        callables (e.g. test-compiled functions) don't leak. The
+        computation is unchanged — see ``_compute_callable_hash``.
+        """
+        try:
+            cached = _HASH_CACHE.get(fn)
+        except TypeError:
+            # Unhashable / non-weakreffable callable — compute uncached.
+            return MigrationRunner._compute_callable_hash(fn)
+        if cached is not None:
+            return cached
+        result = MigrationRunner._compute_callable_hash(fn)
+        try:
+            _HASH_CACHE[fn] = result
+        except TypeError:
+            pass
+        return result
+
+    @staticmethod
+    def _compute_callable_hash(fn: Callable) -> str:
         """Hash a migration callable from its source AST.
 
         ``inspect.getsource`` returns the function text; ``ast.parse``

--- a/work_buddy/summarization/db.py
+++ b/work_buddy/summarization/db.py
@@ -31,22 +31,33 @@ def db_path(cfg: dict | None = None) -> Path:
     return _default_db_path()
 
 
+# DB paths whose schema has already been ensured this process. The schema
+# + ALTER migration pass is idempotent but not free (executescript + a
+# PRAGMA table_info per connect); running it on every open put that cost on
+# every summarization read (e.g. the Chats-tab tldr batch). Keyed on the
+# resolved path so a test pointing at a fresh DB still migrates it once.
+# Process-lifetime; assumes the DB file is not externally deleted.
+_schema_ready: set[str] = set()
+
+
 def get_connection(cfg: dict | None = None) -> sqlite3.Connection:
     """Open (or create) the summarization DB.
 
-    Idempotent: `CREATE TABLE IF NOT EXISTS` re-runs on every connect, so a
-    missing file becomes a populated one transparently. WAL mode allows
-    concurrent readers + a single writer. Forward-only `ALTER TABLE` columns
-    are added in `_migrate_schema` for existing DBs that pre-date the
-    column.
+    The schema + forward-only ALTER migrations are ensured once per DB path
+    per process (see ``_schema_ready``); a missing file becomes a populated
+    one on first open. WAL mode allows concurrent readers + a single writer;
+    the per-connection WAL pragma always runs.
     """
     path = db_path(cfg)
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(path), timeout=30)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")
-    conn.executescript(SCHEMA)
-    _migrate_schema(conn)
+    key = str(path)
+    if key not in _schema_ready:
+        conn.executescript(SCHEMA)
+        _migrate_schema(conn)
+        _schema_ready.add(key)
     return conn
 
 

--- a/work_buddy/threads/render.py
+++ b/work_buddy/threads/render.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sqlite3
 from typing import Any, Optional
 
 from work_buddy.threads import cleanup, store
@@ -26,16 +27,40 @@ from work_buddy.threads.models import Thread
 logger = logging.getLogger(__name__)
 
 
-def build_render_data(thread_id: str) -> Optional[dict[str, Any]]:
+def build_render_data(
+    thread_id: str, *, conn: Optional["sqlite3.Connection"] = None,
+) -> Optional[dict[str, Any]]:
     """Return the JSON shape consumed by ``renderConfirmationCard``.
 
     Returns None if the Thread doesn't exist.
+
+    ``conn`` lets a caller rendering many threads (e.g. the Threads-list
+    endpoint) share one DB connection across the whole batch instead of
+    each ``build_render_data`` opening + closing its own — opening a
+    connection runs WAL/FK pragmas and a path resolve, so per-thread
+    churn dominated the list endpoint's latency. When omitted, a private
+    connection is opened and closed here, preserving the old behaviour
+    for single-thread callers.
     """
-    thread = store.get_thread(thread_id)
+    own_conn = conn is None
+    if own_conn:
+        conn = store.get_connection()
+    try:
+        return _render_thread(thread_id, conn)
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def _render_thread(
+    thread_id: str, conn: "sqlite3.Connection",
+) -> Optional[dict[str, Any]]:
+    """Build one thread's render data using the supplied connection."""
+    thread = store.get_thread(thread_id, conn=conn)
     if thread is None:
         return None
 
-    events = store.list_events(thread_id)
+    events = store.list_events(thread_id, conn=conn)
 
     # Inciting summary → for title fallback
     inciting = thread.inciting_event_summary or {}
@@ -151,7 +176,7 @@ def build_render_data(thread_id: str) -> Optional[dict[str, Any]]:
     # hoist (below) and for sub_thread_count / state-aggregation badges
     # (further below). `list_threads(parent_id=...)` orders by
     # `order_index ASC`, so iteration here is in spawn order.
-    sub_threads = store.list_threads(parent_id=thread_id)
+    sub_threads = store.list_threads(parent_id=thread_id, conn=conn)
 
     # Singular-pattern hoist: when this thread is a `parent_relationship='singular'`
     # umbrella (created by `pipelines/inline.py:_spawn_inline_umbrella` for inline
@@ -167,7 +192,7 @@ def build_render_data(thread_id: str) -> Optional[dict[str, Any]]:
         and not actions  # Umbrella shouldn't have its own action; defensive.
     ):
         for _child in sub_threads:
-            _child_render = build_render_data(_child.thread_id)
+            _child_render = _render_thread(_child.thread_id, conn)
             if _child_render is None:
                 continue
             _child_state = _per_action_state_from_fsm(_child.fsm_state.value)
@@ -441,26 +466,30 @@ def list_render_data(
     For top-level (parent_id=None), filters out future-resurface
     Threads unless ``include_resurface_future=True``.
     """
-    threads = store.list_threads(parent_id=parent_id)
-    # store.list_threads with parent_id=None returns ALL threads;
-    # for "top-level only" we filter post-query.
-    if parent_id is None:
-        threads = [t for t in threads if t.parent_id is None]
-    out: list[dict[str, Any]] = []
-    from datetime import datetime, timezone
-    now = datetime.now(timezone.utc).isoformat()
-    for t in threads:
-        if (parent_id is None
-                and not include_resurface_future
-                and getattr(t, "resurface_at", None)
-                and t.resurface_at > now):
-            continue
-        rd = build_render_data(t.thread_id)
-        if rd is not None:
-            out.append(rd)
-        if len(out) >= limit:
-            break
-    return out
+    conn = store.get_connection()
+    try:
+        threads = store.list_threads(parent_id=parent_id, conn=conn)
+        # store.list_threads with parent_id=None returns ALL threads;
+        # for "top-level only" we filter post-query.
+        if parent_id is None:
+            threads = [t for t in threads if t.parent_id is None]
+        out: list[dict[str, Any]] = []
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).isoformat()
+        for t in threads:
+            if (parent_id is None
+                    and not include_resurface_future
+                    and getattr(t, "resurface_at", None)
+                    and t.resurface_at > now):
+                continue
+            rd = _render_thread(t.thread_id, conn)
+            if rd is not None:
+                out.append(rd)
+            if len(out) >= limit:
+                break
+        return out
+    finally:
+        conn.close()
 
 
 # ---------------------------------------------------------------------------

--- a/work_buddy/threads/store.py
+++ b/work_buddy/threads/store.py
@@ -262,12 +262,26 @@ def _migrate_stage_5(conn: sqlite3.Connection) -> None:
     )
 
 
+# DB paths whose schema has already been ensured this process. The
+# migration + ``executescript(_SCHEMA)`` pass is idempotent but not free
+# (DDL + PRAGMA table_info per column); running it on every connection
+# open put the schema-ensure cost on every query. Keyed on the DB path so
+# tests (which monkeypatch ``_db_path`` to a fresh tmp file each) still
+# migrate every distinct DB exactly once. Process-lifetime; assumes the
+# DB file is not externally deleted out from under a live process (no
+# runtime code does this — only test teardown, which uses fresh paths).
+_schema_ready: set[str] = set()
+
+
 def get_connection() -> sqlite3.Connection:
     """Open the threads DB with WAL + FK enforcement; ensure schema.
 
     Order matters: pre-existing tables get Stage-4 / Stage-5 columns
     added before the index-creation pass, so the index DDL doesn't
     fail on missing columns.
+
+    The schema-ensure pass runs once per DB path per process (see
+    ``_schema_ready``); the per-connection WAL/FK pragmas always run.
     """
     path = _db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -275,10 +289,13 @@ def get_connection() -> sqlite3.Connection:
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA foreign_keys=ON")
-    _migrate_stage_4(conn)
-    _migrate_stage_5(conn)
-    conn.executescript(_SCHEMA)
-    conn.commit()
+    key = str(path)
+    if key not in _schema_ready:
+        _migrate_stage_4(conn)
+        _migrate_stage_5(conn)
+        conn.executescript(_SCHEMA)
+        conn.commit()
+        _schema_ready.add(key)
     return conn
 
 


### PR DESCRIPTION
## Summary

Profiled every dashboard view. The dominant cost was never slow SQL — it was **once-only work repeated on the hot path** (and, in one case, an unbounded external call):

- **Config parsing on every DB open.** `config.load_config` + `paths` data-root resolution re-parsed YAML on every `get_connection`. Memoized both on file mtime (store opens ~58ms → ~13ms; this was the single biggest, app-wide win).
- **Schema-ensure / migrations per connection open.** Gated behind a per-DB-path `_schema_ready` set (threads, conversation-observability, summarization stores); memoized the migration runner's AST audit hash.
- **N+1 store opens.** Shared one connection through the threads render loop and projects activity loop; added `tasks.store.get_many` and batched the daily-briefing's per-task lookups.
- **Expensive work synchronously in the request.** Stale-while-revalidate + startup pre-warm for `/api/state`, `/api/control/graph`, `/api/requirements`, projects git-activity; mtime-keyed result caches for the Costs aggregation (108K-row Python re-aggregation) and the Chats cache file.

Documented the discipline as a durable knowledge unit (`architecture/hot-path-discipline`).

### Before → after (live, steady-state)

| View | Before | After |
|---|---|---|
| Jobs `/api/state` | 13s cold | 0.005s |
| Threads | ~10s | 0.07s |
| Projects | ~4s | 0.05s |
| Tasks | 0.6–1.3s | 0.08s |
| Today | ~13s | 0.37s |
| Settings (control-graph) | ~12s cold | 0.01s |
| Settings (requirements) | 10–15s | 0.005s |
| Costs | 5–18s | 0.23s |
| Chats | ~8s | ~1s (warm) |
| Memory (entities) | ~0.6s | 0.02s |

## Test plan

- [x] Restart the dashboard; curl-time every `/api/*` endpoint — confirm sub-second steady-state.
- [x] Click through each tab in a fresh browser session; content renders fast.
- [x] Touched test suites pass (config, paths, migrations, threads, conv-obs, projects/activity, entities, tasks, costs/pricing, chats, summarization, control-graph, requirements).
- [x] Smart-refresh regression guard `test_no_wholesale_loader_calls_in_event_handlers` passes.

## Verification (live, on a freshly-reset sidecar)

**Endpoint sweep — steady-state, all HTTP 200:** state 0.005s · threads 0.07s · projects 0.05s · tasks 0.08s · today 0.37s · control/graph 0.01s · requirements 0.005s · costs 0.23s · entities 0.02s · contracts 0.004s · conversations 0.01s · chats ~1s (the one residual, see follow-ups). Pass-1 transients (threads ~1.2s, today ~20s) are the startup pre-warm window colliding with the single-threaded Flask server; they settle on the next request.

**Tests:** the touched-module suites pass (config, paths, storage-migrations, threads, conv-obs, dashboard-event-bus in batch one; costs/claude-code-usage, control-graph, summarization, entities, tasks, projects in batch two — 331 passed); the named smart-refresh guard passes (1 passed). The only failures in a broad mixed `-k` run are pre-existing capability-registry test-ordering pollution (pass in isolation), unrelated to this change.

**Browser:** drove the real dashboard UI (preview on :5127) through Today → Jobs → Costs → Chats → Settings — every tab rendered fast with correct content and **zero console errors**. Settings shows the control-graph served from its background-refreshed snapshot (the SWR path working).

## Known follow-ups (not in this PR)

- **Chats** residual ~1–2.5s from the `~/.claude/projects` directory scan (needs a higher-level cache).
- **Today** has an intermittent multi-second Obsidian-bridge spike in `build_now_plan` (steady-state 0.37s) — wants a deadline/timeout, see `architecture/resilience`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)