### PR TITLE
feat(threads): WorkItem foundation — invert Thread/Task onto a shared base

### DIFF
--- a/knowledge/store/threads.md
+++ b/knowledge/store/threads.md
@@ -1,7 +1,7 @@
 ---
 name: Threads — universal-entity primitive
 kind: system
-description: The Thread is the FSM-resolution subtype of the WorkItem base (2026-05-31 inversion). Replaces the older split between PoolEntry (now folded into states) and ActionItem (now folded into sub-Threads). Task is a sibling subtype on the shared WorkItem base — Task(WorkItem), NOT a Thread subclass.
+description: The Thread is the FSM-resolution subtype of the WorkItem base. Replaces the older split between PoolEntry (now folded into states) and ActionItem (now folded into sub-Threads). Task is a sibling subtype on the shared WorkItem base — Task(WorkItem), NOT a Thread subclass.
 summary: 'v5 collapses v4''s overlapping entities into one primitive: Thread. A Thread has FSM state, an event log, an autonomy policy, optional parent_id (for sub-threads), optional subtype (''task'' for the master-list contract). Stage 1: types frozen, schemas migrated, scaffolding in place. Stage 2 wires the engine. Stage 3 migrates v4 data. Stage 4 redesigns surfaces.'
 tags:
 - threads
@@ -10,7 +10,7 @@ tags:
 - core
 ---
 
-## WorkItem inversion (2026-05-31) — read this first
+## WorkItem inversion — read this first
 
 The original framing below ("Thread is THE universal entity; Task is a Thread
 subclass") is **superseded**. A thin **`WorkItem`** base
@@ -24,8 +24,8 @@ and **`Task`** are its two *sibling* subtypes (neither subclasses the other):
   the ``threads`` table. It is a real type (a facade reading the live task store),
   **not** the old ``NotImplementedError`` stub and **not** a Thread subclass.
 
-Rationale + plan: ``.data/designs/workflow-induction/design/07-roadmap.md`` §2 (the
-locked inversion) and ``08``/``09`` (implementation + Phase-5 design). The sections
+Rationale + plan live in the workflow-induction design dossier (the roadmap's
+locked-inversion decision, plus the implementation + cutover design). The sections
 below predate the inversion — read "Thread = universal entity" as "Thread = the
 FSM-resolution subtype of WorkItem."
 

--- a/knowledge/store/threads.md
+++ b/knowledge/store/threads.md
@@ -1,7 +1,7 @@
 ---
 name: Threads — universal-entity primitive
 kind: system
-description: The Thread is the universal entity for 'context that may need an action'. Replaces the older split between PoolEntry (now folded into states) and ActionItem (now folded into sub-Threads). Task survives as a subclass.
+description: The Thread is the FSM-resolution subtype of the WorkItem base (2026-05-31 inversion). Replaces the older split between PoolEntry (now folded into states) and ActionItem (now folded into sub-Threads). Task is a sibling subtype on the shared WorkItem base — Task(WorkItem), NOT a Thread subclass.
 summary: 'v5 collapses v4''s overlapping entities into one primitive: Thread. A Thread has FSM state, an event log, an autonomy policy, optional parent_id (for sub-threads), optional subtype (''task'' for the master-list contract). Stage 1: types frozen, schemas migrated, scaffolding in place. Stage 2 wires the engine. Stage 3 migrates v4 data. Stage 4 redesigns surfaces.'
 tags:
 - threads
@@ -10,10 +10,31 @@ tags:
 - core
 ---
 
+## WorkItem inversion (2026-05-31) — read this first
+
+The original framing below ("Thread is THE universal entity; Task is a Thread
+subclass") is **superseded**. A thin **`WorkItem`** base
+(``work_buddy/threads/workitem.py``) is now the universal primitive; **`Thread`**
+and **`Task`** are its two *sibling* subtypes (neither subclasses the other):
+
+- **`Thread(WorkItem)`** — the FSM-resolution subtype (the 14-state engine,
+  inference, autonomy). Everything below about "the Thread" describes *this* subtype.
+- **`Task(WorkItem)`** — the master-list-contract subtype. **No FSM.** Persists in
+  the ``obsidian/tasks`` ``task_metadata`` store + the markdown master list, **not**
+  the ``threads`` table. It is a real type (a facade reading the live task store),
+  **not** the old ``NotImplementedError`` stub and **not** a Thread subclass.
+
+Rationale + plan: ``.data/designs/workflow-induction/design/07-roadmap.md`` §2 (the
+locked inversion) and ``08``/``09`` (implementation + Phase-5 design). The sections
+below predate the inversion — read "Thread = universal entity" as "Thread = the
+FSM-resolution subtype of WorkItem."
+
 ## Where this lives in the code
 
 - ``work_buddy/threads/enums.py`` — FSMState, InferenceTarget, ReasoningTier, InvocationContext, ActionKind, Authorship, SurfaceUrgency.
-- ``work_buddy/threads/models.py`` — Thread, Task(Thread), ContextItem, AutonomyPolicy, ResolutionRequest, Proposal.
+- ``work_buddy/threads/workitem.py`` — the thin **WorkItem** base (id, lineage, attached context, risk profile, lifecycle timestamps; **NO FSM**) that both subtypes share.
+- ``work_buddy/threads/models.py`` — Thread(WorkItem), Task(WorkItem), ContextItem, AutonomyPolicy, ResolutionRequest, Proposal.
+- ``work_buddy/threads/work_item_events.py`` — the WorkItem base provenance log (durable audit of lifecycle events across subtypes).
 - ``work_buddy/threads/events.py`` — ThreadEvent, ALL_KINDS catalog, OptimisticLockConflict.
 - ``work_buddy/threads/fsm.py`` — TRANSITION_TABLE (DESIGN.md §7.6), lookup helpers, state-entry side-effect catalog.
 - ``work_buddy/threads/store.py`` — SQLite schema for ``threads`` + ``thread_events``; minimum CRUD; optimistic-lock event submission.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,25 @@ def _set_session_env(monkeypatch):
     monkeypatch.setenv("WORK_BUDDY_SESSION_ID", "test-session-00000000")
 
 
+@pytest.fixture(autouse=True)
+def _isolate_work_item_events(tmp_path, monkeypatch):
+    """Redirect the WorkItem base event log to a per-test temp DB.
+
+    Task mutations fire ``_publish_task_event`` which best-effort emits into
+    ``work_buddy.threads.work_item_events``. Without this, any test that
+    creates/toggles a task would write rows into the real
+    ``.data/db/work_item_events.db``. Autouse keeps every test's emission
+    isolated. Best-effort import so this never breaks collection.
+    """
+    try:
+        import work_buddy.threads.work_item_events as wie
+    except Exception:  # pragma: no cover - defensive
+        return
+    monkeypatch.setattr(
+        wie, "_db_path", lambda: tmp_path / "work_item_events.db",
+    )
+
+
 @pytest.fixture
 def tmp_agents_dir(tmp_path, monkeypatch):
     """Redirect agent_session to write into a temp directory.

--- a/tests/unit/test_task_ingest_events.py
+++ b/tests/unit/test_task_ingest_events.py
@@ -1,0 +1,88 @@
+"""External-markdown-edit ingest: the task reconciler records hand-edits
+(made directly in Obsidian) into the WorkItem audit log.
+
+Agent/code mutations go through mutations.py (which emits its own
+origin='task_mutation' events and leaves no drift). A *drift* the
+reconciler resolves in markdown's favour is therefore an external edit —
+it must surface as a WorkItem event with actor='user',
+origin='external_markdown'. Store-wins drift is NOT an external edit and
+must emit nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from work_buddy.markdown_db.types import ReconcileReport
+from work_buddy.obsidian.tasks import store as task_store
+from work_buddy.obsidian.tasks.markdown_db import TaskMarkdownDB
+from work_buddy.threads import work_item_events as wie
+
+
+@pytest.fixture
+def fresh_events_db(tmp_path: Path, monkeypatch):
+    # Explicit isolation (belt-and-suspenders over the autouse conftest one).
+    monkeypatch.setattr(wie, "_db_path", lambda: tmp_path / "wie.db")
+    return tmp_path
+
+
+def _report(*, created=(), deleted=(), drift=None) -> ReconcileReport:
+    r = ReconcileReport()
+    r.created = list(created)
+    r.deleted = list(deleted)
+    r.drift = drift or {}
+    return r
+
+
+def test_markdown_wins_drift_emits_user_ingest_event(fresh_events_db):
+    report = _report(drift={
+        "checkbox": [{"pk": "t-chg01", "old": "inbox", "new": "done", "winner": "markdown"}],
+    })
+    TaskMarkdownDB(task_store)._emit_ingest_events(report)
+
+    events = wie.list_events("t-chg01")
+    assert len(events) == 1
+    e = events[0]
+    assert e["kind"] == "task.ingested_changed"
+    assert e["actor"] == "user"
+    assert e["origin"] == "external_markdown"
+    assert e["subtype"] == "task"
+    assert e["data"]["field"] == "checkbox"
+    assert e["data"]["old"] == "inbox"
+    assert e["data"]["new"] == "done"
+
+
+def test_store_wins_drift_emits_nothing(fresh_events_db):
+    # The store won the conflict — that's not an external markdown edit, so
+    # no ingest event (the agent-side change already logged its own event).
+    report = _report(drift={
+        "urgency": [{"pk": "t-chg02", "old": "high", "new": "low", "winner": "store"}],
+    })
+    TaskMarkdownDB(task_store)._emit_ingest_events(report)
+    assert wie.list_events("t-chg02") == []
+
+
+def test_created_and_deleted_orphans_emit_ingest_events(fresh_events_db):
+    report = _report(created=["t-new01"], deleted=["t-del01"])
+    TaskMarkdownDB(task_store)._emit_ingest_events(report)
+
+    created = wie.list_events("t-new01")
+    deleted = wie.list_events("t-del01")
+    assert [e["kind"] for e in created] == ["task.ingested_created"]
+    assert [e["kind"] for e in deleted] == ["task.ingested_deleted"]
+    assert created[0]["origin"] == "external_markdown"
+    assert deleted[0]["actor"] == "user"
+
+
+def test_emission_is_best_effort(fresh_events_db, monkeypatch):
+    # If the event layer raises, the reconcile post-pass must not blow up.
+    monkeypatch.setattr(
+        wie, "emit",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    # Should not raise.
+    TaskMarkdownDB(task_store)._emit_ingest_events(
+        _report(created=["t-x"]),
+    )

--- a/tests/unit/threads/test_fsm_golden_master.py
+++ b/tests/unit/threads/test_fsm_golden_master.py
@@ -1,0 +1,179 @@
+"""Golden-master snapshot of the Thread resolution FSM.
+
+This is a *parity oracle* for the WorkItem-base extraction
+(`.data/designs/workflow-induction/design/08-...`). The extraction moves
+universal fields off `Thread` onto a new `WorkItem` base but must NOT
+touch the FSM. This test freezes the entire transition table, the
+state-entry side-effect catalog, and the reachability map as literals so
+any accidental change to `fsm.py` / the engine's branch reachability is
+caught immediately.
+
+If this test fails after a change you believe is intentional, regenerate
+the literals deliberately — do not loosen the assertions.
+"""
+
+from __future__ import annotations
+
+from work_buddy.threads import engine, fsm
+from work_buddy.threads.enums import FSMState
+
+
+def _serialize_table() -> dict[str, str]:
+    out: dict[str, str] = {}
+    for (state, trig), outcome in fsm.TRANSITION_TABLE.items():
+        key = f"{state.value}|{trig}"
+        if outcome.next_state is not None:
+            out[key] = f"->{outcome.next_state.value}"
+        elif outcome.next_state_via_branch is not None:
+            out[key] = f"branch:{outcome.next_state_via_branch}"
+        else:
+            out[key] = "unspecified"
+    return out
+
+
+EXPECTED_TABLE: dict[str, str] = {
+    "awaiting_action_clarification|cleanup_requested": "->cleaning_up",
+    "awaiting_action_clarification|dismissed_by_user": "->dismissed",
+    "awaiting_action_clarification|parent_force_close": "->dismissed",
+    "awaiting_action_clarification|provided": "->awaiting_confirmation",
+    "awaiting_confirmation|cleanup_requested": "->cleaning_up",
+    "awaiting_confirmation|dismissed_by_user": "->dismissed",
+    "awaiting_confirmation|edited": "->awaiting_confirmation",
+    "awaiting_confirmation|execute": "->executing",
+    "awaiting_confirmation|parent_force_close": "->dismissed",
+    "awaiting_confirmation|redirected": "->awaiting_inference",
+    "awaiting_confirmation|rejected": "->dismissed",
+    "awaiting_context_clarification|cleanup_requested": "->cleaning_up",
+    "awaiting_context_clarification|dismissed_by_user": "->dismissed",
+    "awaiting_context_clarification|parent_force_close": "->dismissed",
+    "awaiting_context_clarification|provided": "->awaiting_inference",
+    "awaiting_context_confirmation|cleanup_requested": "->cleaning_up",
+    "awaiting_context_confirmation|confirmed": "->awaiting_inference",
+    "awaiting_context_confirmation|dismissed_by_user": "->dismissed",
+    "awaiting_context_confirmation|edited": "->awaiting_inference",
+    "awaiting_context_confirmation|parent_force_close": "->dismissed",
+    "awaiting_context_confirmation|redirected": "->awaiting_inference",
+    "awaiting_inference|dismissed_by_user": "->dismissed",
+    "awaiting_inference|parent_force_close": "->dismissed",
+    "awaiting_intent_clarification|cleanup_requested": "->cleaning_up",
+    "awaiting_intent_clarification|dismissed_by_user": "->dismissed",
+    "awaiting_intent_clarification|parent_force_close": "->dismissed",
+    "awaiting_intent_clarification|provided": "->awaiting_inference",
+    "awaiting_intent_confirmation|cleanup_requested": "->cleaning_up",
+    "awaiting_intent_confirmation|confirmed": "->awaiting_inference",
+    "awaiting_intent_confirmation|dismissed_by_user": "->dismissed",
+    "awaiting_intent_confirmation|edited": "->awaiting_inference",
+    "awaiting_intent_confirmation|parent_force_close": "->dismissed",
+    "awaiting_intent_confirmation|redirected": "->awaiting_inference",
+    "awaiting_redirect|cleanup_requested": "->cleaning_up",
+    "awaiting_redirect|dismissed_by_user": "->dismissed",
+    "awaiting_redirect|parent_force_close": "->dismissed",
+    "awaiting_redirect|provided": "->awaiting_inference",
+    "awaiting_redirect|redirected": "->awaiting_inference",
+    "awaiting_review|cleanup_requested": "->cleaning_up",
+    "awaiting_review|dismissed_by_user": "->dismissed",
+    "awaiting_review|parent_force_close": "->dismissed",
+    "awaiting_review|redirected": "->awaiting_inference",
+    "awaiting_review|review_accepted": "->done",
+    "awaiting_review|timeout": "->done",
+    "cleaning_up|cleanup_failed": "->done_cleanup_unsuccessful",
+    "cleaning_up|cleanup_succeeded": "->done_cleanup_successful",
+    "cleaning_up|dismissed_by_user": "->dismissed",
+    "cleaning_up|parent_force_close": "->dismissed",
+    "done_cleanup_unsuccessful|accept_cleanup_failure": "->done",
+    "done_cleanup_unsuccessful|dismissed_by_user": "->dismissed",
+    "done_cleanup_unsuccessful|parent_force_close": "->dismissed",
+    "done_cleanup_unsuccessful|retry_cleanup": "->cleaning_up",
+    "executing|execution_done": "branch:done_or_review",
+    "executing|execution_failed": "->awaiting_redirect",
+    "executing|parent_force_close": "->dismissed",
+    "inferring_action|dismissed_by_user": "->dismissed",
+    "inferring_action|inference_done": "branch:action_review_or_execute",
+    "inferring_action|inference_failed": "->awaiting_action_clarification",
+    "inferring_action|parent_force_close": "->dismissed",
+    "inferring_context|dismissed_by_user": "->dismissed",
+    "inferring_context|inference_done": "branch:context_review_or_advance",
+    "inferring_context|inference_failed": "->awaiting_context_clarification",
+    "inferring_context|parent_force_close": "->dismissed",
+    "inferring_intent|dismissed_by_user": "->dismissed",
+    "inferring_intent|inference_done": "branch:intent_review_or_advance",
+    "inferring_intent|inference_failed": "->awaiting_intent_clarification",
+    "inferring_intent|parent_force_close": "->dismissed",
+    "monitoring|dismissed_by_user": "->dismissed",
+    "monitoring|execution_done": "branch:done_when_all_subthreads_terminal",
+    "monitoring|parent_force_close": "->dismissed",
+    "proposed|begin_inference": "->awaiting_inference",
+    "proposed|dismissed_by_user": "->dismissed",
+    "proposed|parent_force_close": "->dismissed",
+    "proposed|timeout": "->dismissed",
+}
+
+EXPECTED_SIDE_EFFECT_STATES: set[str] = {
+    "awaiting_action_clarification",
+    "awaiting_confirmation",
+    "awaiting_context_clarification",
+    "awaiting_context_confirmation",
+    "awaiting_inference",
+    "awaiting_intent_clarification",
+    "awaiting_intent_confirmation",
+    "awaiting_redirect",
+    "awaiting_review",
+    "cleaning_up",
+    "dismissed",
+    "done",
+    "done_cleanup_successful",
+    "done_cleanup_unsuccessful",
+    "executing",
+    "handed_off",
+    "inferring_action",
+    "inferring_context",
+    "inferring_intent",
+    "monitoring",
+}
+
+EXPECTED_REACHABLE: dict[str, list[str]] = {
+    "awaiting_action_clarification": ["awaiting_confirmation", "cleaning_up", "dismissed"],
+    "awaiting_confirmation": ["awaiting_confirmation", "awaiting_inference", "cleaning_up", "dismissed", "executing"],
+    "awaiting_context_clarification": ["awaiting_inference", "cleaning_up", "dismissed"],
+    "awaiting_context_confirmation": ["awaiting_inference", "cleaning_up", "dismissed"],
+    "awaiting_inference": ["dismissed"],
+    "awaiting_intent_clarification": ["awaiting_inference", "cleaning_up", "dismissed"],
+    "awaiting_intent_confirmation": ["awaiting_inference", "cleaning_up", "dismissed"],
+    "awaiting_redirect": ["awaiting_inference", "cleaning_up", "dismissed"],
+    "awaiting_review": ["awaiting_inference", "cleaning_up", "dismissed", "done"],
+    "cleaning_up": ["dismissed", "done_cleanup_successful", "done_cleanup_unsuccessful"],
+    "dismissed": [],
+    "done": [],
+    "done_cleanup_successful": [],
+    "done_cleanup_unsuccessful": ["cleaning_up", "dismissed", "done"],
+    "executing": ["awaiting_redirect", "awaiting_review", "dismissed", "done"],
+    "handed_off": [],
+    "inferring_action": ["awaiting_action_clarification", "awaiting_confirmation", "dismissed", "executing"],
+    "inferring_context": ["awaiting_context_clarification", "awaiting_context_confirmation", "awaiting_inference", "dismissed"],
+    "inferring_intent": ["awaiting_inference", "awaiting_intent_clarification", "awaiting_intent_confirmation", "dismissed"],
+    "monitoring": ["dismissed", "done", "monitoring"],
+    "proposed": ["awaiting_inference", "dismissed"],
+}
+
+
+def test_transition_table_is_frozen():
+    """The full (state, trigger) -> outcome mapping is unchanged."""
+    assert _serialize_table() == EXPECTED_TABLE
+
+
+def test_transition_table_cell_count():
+    """Guards against silent additions/removals even if a swap nets zero."""
+    assert len(fsm.TRANSITION_TABLE) == 74
+
+
+def test_state_entry_side_effects_keys_frozen():
+    actual = {s.value for s in fsm.STATE_ENTRY_SIDE_EFFECTS}
+    assert actual == EXPECTED_SIDE_EFFECT_STATES
+
+
+def test_engine_reachability_frozen():
+    actual = {
+        s.value: sorted(x.value for x in engine.reachable_states_from(s))
+        for s in FSMState
+    }
+    assert actual == EXPECTED_REACHABLE

--- a/tests/unit/threads/test_null_risk_profile_char.py
+++ b/tests/unit/threads/test_null_risk_profile_char.py
@@ -1,0 +1,105 @@
+"""Characterization: NULL / empty ``risk_profile`` handling.
+
+`risk_profile` is one of the universal fields Phase 2 moves onto the
+`WorkItem` base. In production 0/79 open tasks carry a populated risk
+profile, so the NULL path is the *common* case and must be pinned before
+the field changes homes. The existing thread suite seeds populated
+profiles, so this path was previously unexercised (noted in
+`automation/risk.py`).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from work_buddy.threads import engine, store
+from work_buddy.threads.enums import FSMState
+from work_buddy.threads.models import Thread
+
+
+@pytest.fixture
+def fresh_db(tmp_path, monkeypatch):
+    db = tmp_path / "threads.db"
+    monkeypatch.setattr(store, "_db_path", lambda: db)
+    engine.clear_state_entry_handlers()
+    yield db
+    engine.clear_state_entry_handlers()
+
+
+def test_default_thread_has_empty_risk_profile(fresh_db):
+    t = Thread()
+    store.insert_thread(t)
+    fetched = store.get_thread(t.thread_id)
+    assert fetched.risk_profile == {}
+
+
+def test_from_row_none_risk_profile_json_becomes_empty_dict():
+    row = {
+        "thread_id": "th-legacy01",
+        "fsm_state": "proposed",
+        "autonomy_policy_json": None,
+        "context_items_json": None,
+        "risk_profile_json": None,
+        "inciting_event_summary_json": None,
+    }
+    t = Thread.from_row(row)
+    assert t.risk_profile == {}
+    assert t.inciting_event_summary == {}
+    assert t.context_items == ()
+
+
+def test_from_row_empty_json_string_becomes_empty_dict():
+    row = {
+        "thread_id": "th-legacy02",
+        "fsm_state": "proposed",
+        "risk_profile_json": "{}",
+    }
+    t = Thread.from_row(row)
+    assert t.risk_profile == {}
+
+
+def test_populated_risk_profile_round_trips(fresh_db):
+    profile = {"reversibility": "irreversible", "regret_potential": "high"}
+    t = Thread(risk_profile=profile)
+    store.insert_thread(t)
+    fetched = store.get_thread(t.thread_id)
+    assert fetched.risk_profile == profile
+    # to_dict surfaces it under the universal key (guards the Phase-2
+    # to_dict split — risk_profile must survive on the base side).
+    assert fetched.to_dict()["risk_profile"] == profile
+
+
+def test_to_dict_from_row_round_trip_preserves_all_keys(fresh_db):
+    """Full round-trip with a populated, non-default profile +
+    inciting summary — the 18-key to_dict contract the extraction's
+    _universal_dict() split must preserve."""
+    t = Thread(
+        fsm_state=FSMState.AWAITING_CONFIRMATION,
+        risk_profile={"accuracy": "critical"},
+        inciting_event_summary={"source": "journal", "key": "abc"},
+    )
+    store.insert_thread(t)
+    fetched = store.get_thread(t.thread_id)
+    d = fetched.to_dict()
+    # Re-hydrating the serialized form yields an equal dict.
+    again = Thread.from_row({
+        "thread_id": d["thread_id"],
+        "parent_id": d["parent_id"],
+        "subtype": d["subtype"],
+        "fsm_state": d["fsm_state"],
+        "parent_event_id": d["parent_event_id"],
+        "autonomy_policy_json": d["autonomy_policy"],
+        "context_items_json": d["context_items"],
+        "risk_profile_json": d["risk_profile"],
+        "inciting_event_summary_json": d["inciting_event_summary"],
+        "created_at": d["created_at"],
+        "updated_at": d["updated_at"],
+        "archived_at": d["archived_at"],
+        "current_focus_thread_id": d["current_focus_thread_id"],
+        "resurface_at": d["resurface_at"],
+        "order_index": d["order_index"],
+        "search_blob": d["search_blob"],
+        "parent_relationship": d["parent_relationship"],
+        "originating_scrape_id": d["originating_scrape_id"],
+    })
+    assert again.to_dict() == d

--- a/tests/unit/threads/test_store_schema.py
+++ b/tests/unit/threads/test_store_schema.py
@@ -169,11 +169,25 @@ class TestThreadCRUD:
         assert fetched.autonomy_policy.inference_confidence_floor == 0.7
 
     def test_subtype_column_persists(self, fresh_db):
+        # The threads.subtype column still round-trips (kept for future
+        # Thread subtypes). Post-WorkItem-inversion, Task no longer lives
+        # in the threads table — see test_task_not_threads_citizen.
+        t = Thread(subtype="probe")
+        store.insert_thread(t)
+        fetched = store.get_thread(t.thread_id)
+        assert fetched.subtype == "probe"
+
+    def test_task_not_threads_citizen(self):
+        # WorkItem inversion guard (plan Integration Risk #2): a Task is a
+        # WorkItem sibling of Thread — NOT a Thread — and is persisted in
+        # the obsidian/tasks task_metadata store, never the threads table.
+        # It has no fsm_state, so the threads-table loader path (which
+        # constructs Thread.from_row) does not apply to it.
+        from work_buddy.threads.workitem import WorkItem
         task = Task()
-        store.insert_thread(task)
-        fetched = store.get_thread(task.thread_id)
-        assert fetched.subtype == "task"
-        assert fetched.is_task
+        assert isinstance(task, WorkItem)
+        assert not isinstance(task, Thread)
+        assert not hasattr(task, "fsm_state")
 
     def test_parent_id_chain(self, fresh_db):
         parent = Thread()
@@ -194,13 +208,16 @@ class TestThreadCRUD:
         assert {r.thread_id for r in rows} == {b.thread_id, c.thread_id}
 
     def test_list_threads_filters_by_subtype(self, fresh_db):
+        # Subtype filtering on the threads table (exercised with a generic
+        # Thread subtype value; Task is no longer a threads citizen post
+        # WorkItem inversion).
         plain = Thread()
-        task = Task()
+        tagged = Thread(subtype="probe")
         store.insert_thread(plain)
-        store.insert_thread(task)
+        store.insert_thread(tagged)
 
-        rows = store.list_threads(subtype="task")
-        assert [r.thread_id for r in rows] == [task.thread_id]
+        rows = store.list_threads(subtype="probe")
+        assert [r.thread_id for r in rows] == [tagged.thread_id]
 
     def test_list_threads_filters_by_parent(self, fresh_db):
         parent = Thread()

--- a/tests/unit/threads/test_task_facade.py
+++ b/tests/unit/threads/test_task_facade.py
@@ -1,0 +1,70 @@
+"""Phase-3 facade: ``Task(WorkItem)`` wraps the live task store.
+
+Proves the transitional strangler facade reads through the real
+``obsidian/tasks`` task_metadata store (it does not duplicate task
+content), and that a Task is a WorkItem sibling of Thread — not a Thread,
+not a threads-table citizen.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from work_buddy.obsidian.tasks import store as task_store
+from work_buddy.threads.models import Task, Thread
+from work_buddy.threads.workitem import WorkItem
+
+
+@pytest.fixture
+def isolated_store(tmp_path: Path, monkeypatch) -> Path:
+    db_dir = tmp_path / "db"
+    db_dir.mkdir()
+    db_path = db_dir / "tasks.sqlite"
+    monkeypatch.setattr(task_store, "_db_path", lambda: db_path)
+    return db_path
+
+
+def test_task_is_workitem_not_thread():
+    task = Task()
+    assert isinstance(task, WorkItem)
+    assert not isinstance(task, Thread)
+    assert task.subtype == "task"
+    assert task.thread_id.startswith("t-")
+    assert not hasattr(task, "fsm_state")
+
+
+def test_live_row_returns_the_live_store_row(isolated_store):
+    task_store.create("t-facade01", state="focused", urgency="high")
+    task = Task(thread_id="t-facade01")
+    row = task.live_row()
+    assert row is not None
+    # The facade returns exactly what the store returns — no caching, no
+    # duplication of task content.
+    assert row == task_store.get("t-facade01")
+    assert row["state"] == "focused"
+    assert row["urgency"] == "high"
+
+
+def test_live_row_none_for_absent_task(isolated_store):
+    assert Task(thread_id="t-missing0").live_row() is None
+
+
+def test_from_store_row_maps_universal_slots(isolated_store):
+    task_store.create("t-facade02", state="inbox", urgency="medium")
+    row = task_store.get("t-facade02")
+    task = Task.from_store_row(row)
+    assert task.thread_id == "t-facade02"
+    assert task.subtype == "task"
+    # created_at carried across from the store row.
+    assert task.created_at == row["created_at"]
+
+
+def test_lineage_via_parent_id(isolated_store):
+    # A Task spawned from a Thread records provenance through the
+    # inherited WorkItem.parent_id slot (no separate spawned_from field
+    # is added in Phase 3).
+    parent = Thread()
+    task = Task(parent_id=parent.thread_id)
+    assert task.parent_id == parent.thread_id

--- a/tests/unit/threads/test_thread_walk_golden.py
+++ b/tests/unit/threads/test_thread_walk_golden.py
@@ -1,0 +1,99 @@
+"""Golden-master of a full Thread FSM walk's event log.
+
+The Phase-2 parity oracle for the WorkItem-base extraction: drive a
+Thread deterministically from inference through to DONE and freeze the
+exact emitted event sequence (state transitions + autonomy-audit
+records). The extraction moves universal fields onto a `WorkItem` base
+but must leave this byte-identical. A dismiss path and a
+parent_force_close cascade are pinned too.
+
+Event ids/timestamps are intentionally NOT snapshotted (DB-assigned,
+time-dependent); the stable projection — ordered (kind, actor, from/to,
+target/advance) — is the contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from work_buddy.threads import engine, fsm, store
+from work_buddy.threads.enums import FSMState
+from work_buddy.threads.models import Thread
+
+
+@pytest.fixture
+def fresh_db(tmp_path, monkeypatch):
+    db = tmp_path / "threads.db"
+    monkeypatch.setattr(store, "_db_path", lambda: db)
+    engine.clear_state_entry_handlers()
+    yield db
+    engine.clear_state_entry_handlers()
+
+
+def _project(thread_id: str) -> list[dict]:
+    proj: list[dict] = []
+    for e in store.list_events(thread_id):
+        row = {"kind": e.kind, "actor": e.actor}
+        if e.kind == "state_transition":
+            row["from"] = e.data.get("from")
+            row["to"] = e.data.get("to")
+        if e.kind == "auto_advance_decision":
+            row["target"] = e.data.get("target")
+            row["advance"] = e.data.get("advance")
+        proj.append(row)
+    return proj
+
+
+EXPECTED_WALK = [
+    {"kind": "state_transition", "actor": "fsm_engine", "from": "inferring_intent", "to": "awaiting_intent_confirmation"},
+    {"kind": "auto_advance_decision", "actor": "fsm_engine", "target": "intent", "advance": False},
+    {"kind": "state_transition", "actor": "fsm_engine", "from": "awaiting_intent_confirmation", "to": "awaiting_inference"},
+    {"kind": "state_transition", "actor": "fsm_engine", "from": "inferring_context", "to": "awaiting_context_confirmation"},
+    {"kind": "auto_advance_decision", "actor": "fsm_engine", "target": "context", "advance": False},
+    {"kind": "state_transition", "actor": "fsm_engine", "from": "awaiting_context_confirmation", "to": "awaiting_inference"},
+    {"kind": "state_transition", "actor": "fsm_engine", "from": "inferring_action", "to": "awaiting_confirmation"},
+    {"kind": "auto_advance_decision", "actor": "fsm_engine", "target": "action", "advance": False},
+    {"kind": "state_transition", "actor": "fsm_engine", "from": "awaiting_confirmation", "to": "executing"},
+    {"kind": "state_transition", "actor": "fsm_engine", "from": "executing", "to": "done"},
+]
+
+
+def test_full_inference_walk_event_log_frozen(fresh_db):
+    t = Thread(fsm_state=FSMState.INFERRING_INTENT)
+    store.insert_thread(t)
+    engine.transition(t.thread_id, fsm.TRIG_INFERENCE_DONE, data={"intent": "x"})
+    engine.transition(t.thread_id, fsm.TRIG_CONFIRMED)
+    store.update_thread_state(t.thread_id, fsm_state="inferring_context")
+    engine.transition(t.thread_id, fsm.TRIG_INFERENCE_DONE)
+    engine.transition(t.thread_id, fsm.TRIG_CONFIRMED)
+    store.update_thread_state(t.thread_id, fsm_state="inferring_action")
+    engine.transition(t.thread_id, fsm.TRIG_INFERENCE_DONE)
+    engine.transition(t.thread_id, fsm.TRIG_EXECUTE)
+    result = engine.transition(
+        t.thread_id, fsm.TRIG_EXECUTION_DONE, data={"requires_post_review": False},
+    )
+    assert result.next_state == FSMState.DONE
+    assert _project(t.thread_id) == EXPECTED_WALK
+
+
+def test_parent_event_id_chain_is_linked(fresh_db):
+    """Every event after the first links to its predecessor (the
+    optimistic-lock chain the extraction must not disturb)."""
+    t = Thread(fsm_state=FSMState.AWAITING_INTENT_CONFIRMATION)
+    store.insert_thread(t)
+    engine.transition(t.thread_id, fsm.TRIG_CONFIRMED)
+    engine.transition(t.thread_id, fsm.TRIG_DISMISSED_BY_USER)
+    events = store.list_events(t.thread_id)
+    # The dismiss event chains off the confirm transition's event.
+    assert events[1].parent_event_id == events[0].id
+
+
+def test_dismiss_path_frozen(fresh_db):
+    t = Thread(fsm_state=FSMState.PROPOSED)
+    store.insert_thread(t)
+    engine.transition(t.thread_id, fsm.TRIG_DISMISSED_BY_USER)
+    assert store.get_thread(t.thread_id).fsm_state == FSMState.DISMISSED
+    proj = _project(t.thread_id)
+    assert proj == [
+        {"kind": "state_transition", "actor": "fsm_engine", "from": "proposed", "to": "dismissed"},
+    ]

--- a/tests/unit/threads/test_types_frozen.py
+++ b/tests/unit/threads/test_types_frozen.py
@@ -253,12 +253,34 @@ class TestTask:
         assert task.subtype == "task"
         assert task.is_task
 
-    def test_methods_stub_in_stage_1(self):
+    def test_is_workitem_sibling_not_thread_subclass(self):
+        # The WorkItem inversion: Task is a sibling of Thread on WorkItem,
+        # NOT a Thread subclass, and carries no resolution FSM.
+        from work_buddy.threads.workitem import WorkItem
         task = Task()
-        with pytest.raises(NotImplementedError):
-            task.sync_to_markdown()
-        with pytest.raises(NotImplementedError):
-            task.master_list_position()
+        assert isinstance(task, WorkItem)
+        assert not isinstance(task, Thread)
+        assert not hasattr(task, "fsm_state")
+
+    def test_task_id_prefix(self):
+        assert Task().thread_id.startswith("t-")
+
+    def test_from_store_row_wraps_live_row(self):
+        # Phase-3 facade: a Task is built from a live task_metadata row;
+        # universal slots map across, the rest is read live from the store.
+        row = {
+            "task_id": "t-deadbeef",
+            "created_at": "2026-05-01T00:00:00+00:00",
+            "updated_at": "2026-05-02T00:00:00+00:00",
+            "risk_profile_json": None,
+            "archived_at": None,
+            "parent_id": None,
+        }
+        task = Task.from_store_row(row)
+        assert task.thread_id == "t-deadbeef"
+        assert task.subtype == "task"
+        assert task.risk_profile == {}
+        assert task.created_at == "2026-05-01T00:00:00+00:00"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/threads/test_work_item_events.py
+++ b/tests/unit/threads/test_work_item_events.py
@@ -1,0 +1,100 @@
+"""Phase-4 base event log: emit/list primitive + the additive wiring on
+the task mutation hook.
+
+The log is the WorkItem base's provenance record (separate store, no FK)
+so any subtype can emit — today Task, whose rows live outside the threads
+table. Emission is best-effort (never breaks a mutation) and additive
+(markdown stays source of truth).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from work_buddy.threads import work_item_events as wie
+
+
+@pytest.fixture
+def fresh_events_db(tmp_path: Path, monkeypatch):
+    db = tmp_path / "work_item_events.db"
+    monkeypatch.setattr(wie, "_db_path", lambda: db)
+    return db
+
+
+def test_emit_and_list_round_trip(fresh_events_db):
+    rid = wie.emit(
+        "t-abc12345", "task.state_changed",
+        subtype="task", actor="user", origin="task_mutation",
+        data={"state": "done", "reason": "toggled"},
+    )
+    assert isinstance(rid, int)
+    events = wie.list_events("t-abc12345")
+    assert len(events) == 1
+    e = events[0]
+    assert e["work_item_id"] == "t-abc12345"
+    assert e["kind"] == "task.state_changed"
+    assert e["subtype"] == "task"
+    assert e["actor"] == "user"
+    assert e["origin"] == "task_mutation"
+    assert e["data"] == {"state": "done", "reason": "toggled"}
+    assert e["timestamp"]
+
+
+def test_list_is_oldest_first(fresh_events_db):
+    wie.emit("t-x", "task.created", subtype="task")
+    wie.emit("t-x", "task.state_changed", subtype="task", data={"state": "focused"})
+    wie.emit("t-x", "task.state_changed", subtype="task", data={"state": "done"})
+    kinds = [e["kind"] for e in wie.list_events("t-x")]
+    assert kinds == ["task.created", "task.state_changed", "task.state_changed"]
+
+
+def test_events_are_scoped_per_work_item(fresh_events_db):
+    wie.emit("t-a", "task.created", subtype="task")
+    wie.emit("t-b", "task.created", subtype="task")
+    assert len(wie.list_events("t-a")) == 1
+    assert len(wie.list_events("t-b")) == 1
+    assert wie.list_events("t-missing") == []
+
+
+def test_emit_is_best_effort_never_raises(fresh_events_db, monkeypatch):
+    # If the DB layer blows up, emit must swallow it and return None —
+    # a missed audit event must never break the task mutation that fired it.
+    def boom():
+        raise RuntimeError("disk gone")
+
+    monkeypatch.setattr(wie, "get_connection", boom)
+    assert wie.emit("t-x", "task.created") is None  # no exception
+
+
+def test_list_is_best_effort_never_raises(fresh_events_db, monkeypatch):
+    monkeypatch.setattr(wie, "get_connection", lambda: (_ for _ in ()).throw(RuntimeError()))
+    assert wie.list_events("t-x") == []
+
+
+def test_task_mutation_hook_emits_a_work_item_event(fresh_events_db, monkeypatch):
+    # The additive wiring: _publish_task_event (fired by create/toggle/
+    # update/description) also records a durable WorkItem event. The
+    # dashboard publish + actor detection are best-effort, so this works
+    # without a running dashboard.
+    from work_buddy.obsidian.tasks import mutations
+
+    mutations._publish_task_event(
+        "task.state_changed", {"task_id": "t-hook01", "state": "done", "reason": "toggled"},
+    )
+    events = wie.list_events("t-hook01")
+    assert len(events) == 1
+    assert events[0]["kind"] == "task.state_changed"
+    assert events[0]["subtype"] == "task"
+    assert events[0]["origin"] == "task_mutation"
+    assert events[0]["data"]["state"] == "done"
+
+
+def test_hook_without_task_id_does_not_emit(fresh_events_db):
+    from work_buddy.obsidian.tasks import mutations
+
+    # A payload with no task_id (defensive) emits nothing rather than
+    # recording a junk row.
+    mutations._publish_task_event("task.something", {"no_id": True})
+    assert wie.list_events("") == []

--- a/tests/unit/threads/test_workitem_base.py
+++ b/tests/unit/threads/test_workitem_base.py
@@ -1,0 +1,120 @@
+"""Invariants of the WorkItem base — the guards that keep the inversion
+from eroding back into the v5 mistake (the base re-absorbing the FSM).
+
+R2: the base never branches on subtype and carries no FSM machinery.
+R3: the base must host a *hypothetical third subtype* with zero base
+changes — proof the cut is genuinely N-ary, not secretly bimodal.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from dataclasses import dataclass
+from typing import Optional
+
+from work_buddy.threads import workitem as workitem_mod
+from work_buddy.threads.models import Task, Thread
+from work_buddy.threads.workitem import WorkItem
+
+
+# ---------------------------------------------------------------------------
+# R2 — no leak: the base is FSM-agnostic and never branches on subtype
+# ---------------------------------------------------------------------------
+
+# Identifiers that would mean the FSM/resolution machinery leaked into the
+# base. Checked against *code* identifiers only (AST Name/Attribute), so
+# the module docstring's prose ("FSM", "Thread", …) is correctly ignored.
+_FSM_LEAK_IDENTIFIERS = {
+    "fsm_state",
+    "parent_event_id",
+    "current_focus_thread_id",
+    "parent_relationship",
+    "originating_scrape_id",
+    "TRANSITION_TABLE",
+    "INFERRING_INTENT",
+    "INFERRING_CONTEXT",
+    "INFERRING_ACTION",
+}
+
+
+def _code_identifiers(module) -> set[str]:
+    src = inspect.getsource(module)
+    tree = ast.parse(src)
+    ids: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            ids.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            ids.add(node.attr)
+    return ids
+
+
+def test_base_carries_no_fsm_machinery():
+    ids = _code_identifiers(workitem_mod)
+    leaked = _FSM_LEAK_IDENTIFIERS & ids
+    assert not leaked, f"FSM machinery leaked into WorkItem base: {leaked}"
+
+
+def test_base_never_branches_on_subtype():
+    """`if self.subtype == ...` is forbidden in the base. (`is_task`
+    *returns* the comparison — that's an accessor, not a branch — so we
+    specifically flag `If` nodes whose test inspects ``subtype``.)"""
+    tree = ast.parse(inspect.getsource(workitem_mod))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.If):
+            for sub in ast.walk(node.test):
+                name = getattr(sub, "id", None) or getattr(sub, "attr", None)
+                assert name != "subtype", (
+                    "WorkItem base branches on subtype — forbidden (R2)"
+                )
+
+
+def test_thread_and_task_are_both_workitems():
+    assert isinstance(Thread(), WorkItem)
+    assert isinstance(Task(), WorkItem)
+
+
+def test_only_thread_carries_the_fsm():
+    assert hasattr(Thread(), "fsm_state")
+    assert not hasattr(Task(), "fsm_state")
+    # And they are siblings, not a subclass chain.
+    assert not isinstance(Task(), Thread)
+    assert not isinstance(Thread(), Task)
+
+
+# ---------------------------------------------------------------------------
+# R3 — third-subtype probe: a hypothetical new WorkItem kind must work
+# with ZERO changes to the base. If this needs a base edit, the cut is
+# secretly bimodal and must be fixed before it ossifies.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ReminderProbe(WorkItem):
+    """A throwaway hypothetical third subtype — NOT shipped. Exists only
+    to prove the base hosts arbitrary subtypes (anti-A3-bimodal guard)."""
+
+    subtype: str = "reminder"
+    remind_at: Optional[str] = None
+
+
+def test_third_subtype_constructs_on_the_unchanged_base():
+    probe = _ReminderProbe(remind_at="2026-06-01T09:00:00+00:00")
+    assert isinstance(probe, WorkItem)
+    assert not isinstance(probe, (Thread, Task))
+    assert probe.subtype == "reminder"
+    assert probe.is_task is False
+    assert probe.remind_at == "2026-06-01T09:00:00+00:00"
+
+
+def test_third_subtype_inherits_universal_serialization():
+    probe = _ReminderProbe()
+    d = probe.to_dict()
+    # The base to_dict is the universal projection — it neither knows nor
+    # leaks the probe's own field; subtypes that want it serialized would
+    # override to_dict (as Thread does). The universal keys are present.
+    assert d["subtype"] == "reminder"
+    assert "thread_id" in d and "risk_profile" in d and "created_at" in d
+    assert "remind_at" not in d  # base owns only universal fields
+    assert "fsm_state" not in d  # no FSM anywhere near the base

--- a/work_buddy/obsidian/tasks/markdown_db.py
+++ b/work_buddy/obsidian/tasks/markdown_db.py
@@ -270,6 +270,52 @@ class TaskMarkdownDB(MarkdownDB):
         except Exception as exc:
             logger.warning("TaskMarkdownDB: set_sync_status failed: %s", exc)
 
+        # Ingest external (markdown-origin) edits into the WorkItem audit
+        # log so hand-edits in Obsidian are recorded, not just agent
+        # mutations. Best-effort.
+        self._emit_ingest_events(report)
+
+    def _emit_ingest_events(self, report: ReconcileReport) -> None:
+        """Emit WorkItem audit events for markdown-origin changes the
+        reconciler just applied — i.e. edits the user made directly in
+        Obsidian, *outside* work-buddy's mutation path.
+
+        Agent/code mutations go through ``mutations.py``, which writes both
+        surfaces atomically (so they leave no drift) and emits their own
+        ``origin='task_mutation'`` event. A *drift* therefore means the
+        markdown changed without a matching store write — an external edit —
+        so these events carry ``actor='user', origin='external_markdown'``.
+        This closes the audit gap for hand-edits (the deferred Phase-4 half).
+        Best-effort: a missed audit event must never undo a reconcile.
+        """
+        try:
+            from work_buddy.threads import work_item_events
+
+            for pk in report.created:
+                work_item_events.emit(
+                    pk, "task.ingested_created", subtype="task",
+                    actor="user", origin="external_markdown",
+                )
+            for pk in report.deleted:
+                work_item_events.emit(
+                    pk, "task.ingested_deleted", subtype="task",
+                    actor="user", origin="external_markdown",
+                )
+            for field, entries in report.drift.items():
+                for d in entries:
+                    if d.get("winner") == "markdown":
+                        work_item_events.emit(
+                            d["pk"], "task.ingested_changed", subtype="task",
+                            actor="user", origin="external_markdown",
+                            data={
+                                "field": field,
+                                "old": d.get("old"),
+                                "new": d.get("new"),
+                            },
+                        )
+        except Exception:
+            logger.exception("TaskMarkdownDB: ingest event emission failed")
+
 
 def reconcile_tasks() -> dict[str, Any]:
     """Reconcile the master task list against the SQLite store.

--- a/work_buddy/obsidian/tasks/markdown_db.py
+++ b/work_buddy/obsidian/tasks/markdown_db.py
@@ -285,7 +285,7 @@ class TaskMarkdownDB(MarkdownDB):
         ``origin='task_mutation'`` event. A *drift* therefore means the
         markdown changed without a matching store write — an external edit —
         so these events carry ``actor='user', origin='external_markdown'``.
-        This closes the audit gap for hand-edits (the deferred Phase-4 half).
+        This closes the audit gap for hand-edits.
         Best-effort: a missed audit event must never undo a reconcile.
         """
         try:

--- a/work_buddy/obsidian/tasks/mutations.py
+++ b/work_buddy/obsidian/tasks/mutations.py
@@ -69,6 +69,31 @@ def _publish_task_event(event_type: str, payload: dict[str, Any]) -> None:
     except Exception:
         logger.exception("tasks: event publish for %r failed", event_type)
 
+    # WorkItem base event log (additive, durable, best-effort). A Task is a
+    # WorkItem; recording its lifecycle here makes the backlog auditable —
+    # the fix for the "agent forgot to toggle" blind spot (every create /
+    # state-change / toggle / description edit lands a WorkItem event). The
+    # markdown master list stays the source of truth for task *content*;
+    # this log is provenance/history only. Never raises — a missed audit
+    # event must not break a task mutation.
+    task_id = payload.get("task_id")
+    if task_id:
+        try:
+            from work_buddy.threads import work_item_events
+
+            work_item_events.emit(
+                task_id,
+                event_type,
+                subtype="task",
+                actor=_detect_last_actor(),
+                origin="task_mutation",
+                data=payload,
+            )
+        except Exception:
+            logger.exception(
+                "tasks: work_item_events emit for %r failed", event_type,
+            )
+
 
 # ── Constants ───────────────────────────────────────────────────
 

--- a/work_buddy/threads/models.py
+++ b/work_buddy/threads/models.py
@@ -39,6 +39,13 @@ def _new_thread_id() -> str:
     return f"th-{uuid.uuid4().hex[:8]}"
 
 
+def _new_task_id() -> str:
+    """Stable opaque Task ID — same ``t-<hex8>`` shape as the live task
+    system's ``obsidian.tasks.mutations.generate_task_id`` (mirrored here
+    to avoid importing the heavy obsidian.tasks package at models load)."""
+    return f"t-{uuid.uuid4().hex[:8]}"
+
+
 def _new_event_id() -> int:
     """Event IDs come from the DB ``AUTOINCREMENT`` column. This helper
     exists for tests that need a deterministic shape; the canonical
@@ -337,38 +344,73 @@ class Thread(WorkItem):
 
 
 @dataclass
-class Task(Thread):
-    """A Thread with the master-task-list contract.
+class Task(WorkItem):
+    """The master-list-contract subtype of :class:`WorkItem`.
 
-    See DESIGN.md §5.3. Adds:
-    - markdown sync to the master task list
-    - persistence across terminal state (does not auto-archive)
-    - surface in the Tasks dashboard tab
+    A Task is a **sibling** of :class:`Thread` on ``WorkItem`` — NOT a
+    ``Thread`` subclass. This is the WorkItem inversion (design 08 §1):
+    the heavy resolution FSM stays on ``Thread``; ``Task`` has **no FSM**.
+    Its lifecycle is the task system's own state vocab (inbox / mit /
+    focused / snoozed / done) and it persists in the ``obsidian/tasks``
+    task_metadata store + the markdown master list — **never** in the
+    ``threads`` table.
 
-    Subtype is fixed at ``'task'``; do not mutate.
+    Phase 3 is a *transitional strangler facade*: this type wraps existing
+    task rows and reads through the live task store; the markdown sync
+    adapter + write-delegation are extracted in Phase 5. Field-ownership
+    follows ``TaskMarkdownDB.FIELDS`` — the Obsidian Tasks plugin owns its
+    in-markdown markers (checkbox / dates / recurrence / priority); this
+    facade never fights the plugin.
 
-    type only. Stage 2 wires the methods.
+    Subtype is fixed ``'task'`` and never mutated.
     """
 
     subtype: str = "task"
+    # ``t-`` prefix (overrides WorkItem's generic ``wi-``); matches the
+    # live task store's id shape so a Task wraps its existing row 1:1.
+    thread_id: str = field(default_factory=_new_task_id)
 
-    def sync_to_markdown(self) -> None:
-        """Write this Task's representation to the master task list.
+    @classmethod
+    def from_store_row(cls, row: dict[str, Any]) -> "Task":
+        """Build a Task facade from a live ``task_metadata`` row dict (the
+        shape returned by ``obsidian.tasks.store.get`` / ``.query``).
 
-        Stage 2 work; bridge integration lands then.
+        Maps the store's columns onto the WorkItem universal slots. Task
+        content with no WorkItem slot (state, urgency, contract, the
+        plugin-owned markers, …) stays in the store and is read live via
+        :meth:`live_row` — the facade does not duplicate it.
         """
-        raise NotImplementedError(
-            "Task.sync_to_markdown is wired in Stage 2.",
+
+        def _load_json(value: Any, default: Any) -> Any:
+            if value is None:
+                return default
+            if isinstance(value, (dict, list)):
+                return value
+            try:
+                return json.loads(value)
+            except (TypeError, ValueError):
+                return default
+
+        return cls(
+            thread_id=row["task_id"],
+            parent_id=row.get("parent_id"),
+            risk_profile=_load_json(row.get("risk_profile_json"), {}),
+            created_at=row.get("created_at") or _now_iso(),
+            updated_at=row.get("updated_at") or _now_iso(),
+            archived_at=row.get("archived_at"),
         )
 
-    def master_list_position(self) -> int:
-        """Return the 1-based position of this Task in the master list.
+    def live_row(self) -> Optional[dict[str, Any]]:
+        """Read this Task's authoritative row from the live task store.
 
-        Stage 2 work.
+        The markdown-backed store is the source of truth for task content
+        + state; the facade never caches it. Lazily imports the task store
+        so ``threads.models`` stays decoupled from ``obsidian.tasks`` at
+        import time. Returns ``None`` if the task is absent / deleted.
         """
-        raise NotImplementedError(
-            "Task.master_list_position is wired in Stage 2.",
-        )
+        from work_buddy.obsidian.tasks import store as _task_store
+
+        return _task_store.get(self.thread_id)
 
 
 # ---------------------------------------------------------------------------

--- a/work_buddy/threads/models.py
+++ b/work_buddy/threads/models.py
@@ -217,7 +217,7 @@ class Thread(WorkItem):
     resurface/order/search) and adds the resolution-FSM machinery
     below. Subtype is set at creation, never mutated; the only named
     subtype is ``Task`` (a sibling on ``WorkItem``, not a child of
-    ``Thread`` — see Phase 3 of the WorkItem plan).
+    ``Thread``).
     """
 
     # Re-declared only to pin the ``th-`` id prefix — WorkItem's own
@@ -348,16 +348,17 @@ class Task(WorkItem):
     """The master-list-contract subtype of :class:`WorkItem`.
 
     A Task is a **sibling** of :class:`Thread` on ``WorkItem`` — NOT a
-    ``Thread`` subclass. This is the WorkItem inversion (design 08 §1):
-    the heavy resolution FSM stays on ``Thread``; ``Task`` has **no FSM**.
+    ``Thread`` subclass. This is the WorkItem inversion: the heavy
+    resolution FSM stays on ``Thread``; ``Task`` has **no FSM**.
     Its lifecycle is the task system's own state vocab (inbox / mit /
     focused / snoozed / done) and it persists in the ``obsidian/tasks``
     task_metadata store + the markdown master list — **never** in the
     ``threads`` table.
 
-    Phase 3 is a *transitional strangler facade*: this type wraps existing
-    task rows and reads through the live task store; the markdown sync
-    adapter + write-delegation are extracted in Phase 5. Field-ownership
+    This type is a *transitional facade*: it wraps existing task rows and
+    reads through the live task store; the markdown sync adapter +
+    write-delegation are extracted when the facade is later collapsed onto
+    an owned adapter. Field-ownership
     follows ``TaskMarkdownDB.FIELDS`` — the Obsidian Tasks plugin owns its
     in-markdown markers (checkbox / dates / recurrence / priority); this
     facade never fights the plugin.

--- a/work_buddy/threads/models.py
+++ b/work_buddy/threads/models.py
@@ -21,6 +21,7 @@ from work_buddy.threads.enums import (
     ReasoningTier,
     SurfaceUrgency,
 )
+from work_buddy.threads.workitem import WorkItem
 
 
 # ---------------------------------------------------------------------------
@@ -201,51 +202,38 @@ class AutonomyPolicy:
 
 
 @dataclass
-class Thread:
-    """The universal entity for "context that may need an action."
+class Thread(WorkItem):
+    """The FSM-resolution subtype of :class:`WorkItem`.
 
-    Subtype is set at creation, never mutated; the only named
-    subtype is ``Task``.
+    Inherits the universal fields from ``WorkItem`` (id, lineage,
+    autonomy policy, context, risk profile, lifecycle timestamps,
+    resurface/order/search) and adds the resolution-FSM machinery
+    below. Subtype is set at creation, never mutated; the only named
+    subtype is ``Task`` (a sibling on ``WorkItem``, not a child of
+    ``Thread`` — see Phase 3 of the WorkItem plan).
     """
 
+    # Re-declared only to pin the ``th-`` id prefix — WorkItem's own
+    # default is the generic ``wi-``. The field keeps its (first)
+    # position from the base; only the default factory changes.
     thread_id: str = field(default_factory=_new_thread_id)
-    parent_id: Optional[str] = None
-    subtype: Optional[str] = None  # 'task' | None; never mutated
+
+    # --- Thread-specific (resolution-FSM) fields -----------------------
+    # The universal fields (parent_id, subtype, autonomy_policy,
+    # context_items, risk_profile, inciting_event_summary, created_at,
+    # updated_at, archived_at, resurface_at, order_index, search_blob)
+    # are inherited from WorkItem unchanged.
+
     fsm_state: FSMState = FSMState.PROPOSED
 
     # Last-known FSM-event id — used as the optimistic-lock target on
     # the next state transition. None for never-transitioned threads.
     parent_event_id: Optional[int] = None
 
-    autonomy_policy: AutonomyPolicy = field(default_factory=AutonomyPolicy)
-
-    # Attached ContextItems (live in their source; this is just a
-    # reference list).
-    context_items: tuple[ContextItem, ...] = ()
-
-    # Risk profile — per DESIGN.md §10.4 the thread carries
-    # contextual risk dimensions; intrinsic amplifiers live on the
-    # action template and are composed at execution time.
-    risk_profile: dict[str, Any] = field(default_factory=dict)
-
-    # Inciting-event metadata: what brought this Thread into being.
-    # Just a dict; canonical full-fidelity record lives in the event
-    # log's ``inciting_event`` row.
-    inciting_event_summary: dict[str, Any] = field(default_factory=dict)
-
-    created_at: str = field(default_factory=_now_iso)
-    updated_at: str = field(default_factory=_now_iso)
-    archived_at: Optional[str] = None
-
     # If this Thread had its current_action_item-equivalent set by a
     # parent (legacy ``current_action_item_id`` semantics, surfaced in
     # the bridge). Stored as a Thread ID pointing at a sub-Thread.
     current_focus_thread_id: Optional[str] = None
-
-    # Stage 4 fields (UX.md §8.2 + §10.2 + §13).
-    resurface_at: Optional[str] = None        # Later mechanic
-    order_index: int = 0                       # write-time linearization
-    search_blob: str = ""                      # denormalized search
 
     # parent-child relationship discriminator. 'decompose' is
     # the canonical fanout pattern (parent → action → N children, each
@@ -270,9 +258,7 @@ class Thread:
     def is_terminal(self) -> bool:
         return self.fsm_state.is_terminal
 
-    @property
-    def is_task(self) -> bool:
-        return self.subtype == "task"
+    # ``is_task`` is inherited from WorkItem (reads ``subtype`` only).
 
     @property
     def is_group_parent(self) -> bool:
@@ -288,26 +274,19 @@ class Thread:
         return self.parent_relationship == "group"
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "thread_id": self.thread_id,
-            "parent_id": self.parent_id,
-            "subtype": self.subtype,
+        # Universal fields come from the base projection; Thread adds its
+        # resolution-FSM keys. The combined output is the same 18-key dict
+        # as before the WorkItem extraction (key order is irrelevant to
+        # equality; the golden master asserts this).
+        d = self._universal_dict()
+        d.update({
             "fsm_state": self.fsm_state.value,
             "parent_event_id": self.parent_event_id,
-            "autonomy_policy": self.autonomy_policy.to_dict(),
-            "context_items": [c.to_dict() for c in self.context_items],
-            "risk_profile": self.risk_profile,
-            "inciting_event_summary": self.inciting_event_summary,
-            "created_at": self.created_at,
-            "updated_at": self.updated_at,
-            "archived_at": self.archived_at,
             "current_focus_thread_id": self.current_focus_thread_id,
-            "resurface_at": self.resurface_at,
-            "order_index": self.order_index,
-            "search_blob": self.search_blob,
             "parent_relationship": self.parent_relationship,
             "originating_scrape_id": self.originating_scrape_id,
-        }
+        })
+        return d
 
     @classmethod
     def from_row(cls, row: dict[str, Any]) -> Thread:

--- a/work_buddy/threads/work_item_events.py
+++ b/work_buddy/threads/work_item_events.py
@@ -1,0 +1,168 @@
+"""WorkItem base event log — durable, append-only audit of WorkItem
+lifecycle events, spanning subtypes.
+
+Phase 4 of the WorkItem foundation (design 08 §Phase 4). The base owns
+provenance/history for any WorkItem. ``Thread`` already has its rich
+``thread_events`` log — but that table's ``thread_id`` foreign-keys
+``threads(thread_id)``, and a ``Task`` does not live in the threads table.
+So this is the **additive** log for the other subtypes (today: ``Task``),
+deliberately a *separate* store keyed by an opaque ``work_item_id`` with
+**no foreign key**, so any subtype (Thread, Task, or a future kind) can
+emit into it. This is the additive emission path the plan recommended over
+a shadow threads row.
+
+Why it matters: it makes the task backlog auditable — every create / state
+change / toggle becomes a recorded WorkItem event, which is exactly what
+was missing when agents shipped work but "forgot to toggle" the task
+(the blind spot surfaced in the 2026-05-30 completeness audit).
+
+Design rules:
+- **Additive + best-effort.** ``emit()`` never raises into its caller — a
+  missed audit event must never break a task mutation or a reconcile.
+- **Markdown stays source of truth.** This log records *that* a change
+  happened (provenance/history); it is NOT authoritative task content.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _db_path() -> Path:
+    """Resolve the work-item events DB path. Tests monkeypatch this."""
+    from work_buddy.paths import resolve
+
+    return resolve("db/work_item_events")
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS work_item_events (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    work_item_id  TEXT NOT NULL,
+    subtype       TEXT,
+    kind          TEXT NOT NULL,
+    actor         TEXT NOT NULL DEFAULT 'agent',
+    origin        TEXT NOT NULL DEFAULT 'system',
+    data_json     TEXT NOT NULL DEFAULT '{}',
+    timestamp     TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_wie_work_item ON work_item_events(work_item_id);
+"""
+
+
+def get_connection() -> sqlite3.Connection:
+    """Open the events DB, ensuring the schema. ``CREATE … IF NOT EXISTS``
+    is idempotent + cheap; emit/list are low-frequency (task mutations, not
+    a render hot path), so per-connection ensure is fine and keeps tests —
+    which monkeypatch ``_db_path`` to a fresh tmp file each — working."""
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_SCHEMA)
+    return conn
+
+
+@dataclass(frozen=True)
+class WorkItemEvent:
+    work_item_id: str
+    kind: str
+    actor: str = "agent"
+    origin: str = "system"
+    subtype: Optional[str] = None
+    data: dict[str, Any] = field(default_factory=dict)
+    timestamp: str = field(default_factory=_now_iso)
+    id: Optional[int] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "work_item_id": self.work_item_id,
+            "subtype": self.subtype,
+            "kind": self.kind,
+            "actor": self.actor,
+            "origin": self.origin,
+            "data": self.data,
+            "timestamp": self.timestamp,
+        }
+
+
+def emit(
+    work_item_id: str,
+    kind: str,
+    *,
+    subtype: Optional[str] = None,
+    actor: str = "agent",
+    origin: str = "system",
+    data: Optional[dict[str, Any]] = None,
+) -> Optional[int]:
+    """Append a WorkItem event. **Best-effort: never raises into the
+    caller.** Returns the new row id, or ``None`` on failure."""
+    try:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "INSERT INTO work_item_events "
+                "(work_item_id, subtype, kind, actor, origin, data_json, timestamp) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    work_item_id,
+                    subtype,
+                    kind,
+                    actor,
+                    origin,
+                    json.dumps(data or {}),
+                    _now_iso(),
+                ),
+            )
+            conn.commit()
+            return cur.lastrowid
+        finally:
+            conn.close()
+    except Exception:  # noqa: BLE001 - audit must never break the caller
+        logger.exception(
+            "work_item_events: emit failed for %r/%r", work_item_id, kind,
+        )
+        return None
+
+
+def list_events(work_item_id: str) -> list[dict[str, Any]]:
+    """Return this work item's events oldest-first. Best-effort: returns
+    ``[]`` on any read failure."""
+    try:
+        conn = get_connection()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM work_item_events WHERE work_item_id = ? "
+                "ORDER BY id",
+                (work_item_id,),
+            ).fetchall()
+        finally:
+            conn.close()
+    except Exception:  # noqa: BLE001
+        logger.exception("work_item_events: list_events failed for %r", work_item_id)
+        return []
+
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        d = dict(r)
+        raw = d.pop("data_json", None)
+        try:
+            d["data"] = json.loads(raw) if raw else {}
+        except (TypeError, ValueError):
+            d["data"] = {}
+        out.append(d)
+    return out

--- a/work_buddy/threads/work_item_events.py
+++ b/work_buddy/threads/work_item_events.py
@@ -1,8 +1,7 @@
 """WorkItem base event log — durable, append-only audit of WorkItem
 lifecycle events, spanning subtypes.
 
-Phase 4 of the WorkItem foundation (design 08 §Phase 4). The base owns
-provenance/history for any WorkItem. ``Thread`` already has its rich
+The base owns provenance/history for any WorkItem. ``Thread`` already has its rich
 ``thread_events`` log — but that table's ``thread_id`` foreign-keys
 ``threads(thread_id)``, and a ``Task`` does not live in the threads table.
 So this is the **additive** log for the other subtypes (today: ``Task``),
@@ -14,7 +13,8 @@ a shadow threads row.
 Why it matters: it makes the task backlog auditable — every create / state
 change / toggle becomes a recorded WorkItem event, which is exactly what
 was missing when agents shipped work but "forgot to toggle" the task
-(the blind spot surfaced in the 2026-05-30 completeness audit).
+(the "agent forgot to toggle" blind spot, where work shipped but the task
+record was never closed).
 
 Design rules:
 - **Additive + best-effort.** ``emit()`` never raises into its caller — a

--- a/work_buddy/threads/workitem.py
+++ b/work_buddy/threads/workitem.py
@@ -1,12 +1,13 @@
 """WorkItem — the thin universal base for system-managed work units.
 
-See ``.data/designs/workflow-induction/design/08-workitem-implementation-plan.md`` §1.
+The universal base of the Thread/Task hierarchy: ``Thread`` and ``Task`` are
+its two sibling subtypes (neither subclasses the other).
 WorkItem carries only the *universal* slots — identity, lineage, attached
 context, lifecycle timestamps, and governance metadata (autonomy policy,
 risk profile) — and crucially **no resolution FSM**. Its two subtypes are:
 
 * ``Thread(WorkItem)`` — the FSM-resolution subtype (``threads/models.py``);
-* ``Task(WorkItem)``   — the master-list-contract subtype (Phase 3).
+* ``Task(WorkItem)``   — the master-list-contract subtype.
 
 Design rules this module must honour:
 

--- a/work_buddy/threads/workitem.py
+++ b/work_buddy/threads/workitem.py
@@ -105,6 +105,12 @@ class WorkItem:
         branch on it; the base itself never does."""
         return self.subtype == "task"
 
+    def to_dict(self) -> dict[str, Any]:
+        """Default serialization = the universal projection. Subtypes with
+        extra fields (e.g. ``Thread``) override this and merge their keys
+        on top of ``_universal_dict()``."""
+        return self._universal_dict()
+
     def _universal_dict(self) -> dict[str, Any]:
         """The universal-field projection shared by every subtype's
         ``to_dict``. Subtypes call this and merge their own keys, so the

--- a/work_buddy/threads/workitem.py
+++ b/work_buddy/threads/workitem.py
@@ -1,0 +1,126 @@
+"""WorkItem — the thin universal base for system-managed work units.
+
+See ``.data/designs/workflow-induction/design/08-workitem-implementation-plan.md`` §1.
+WorkItem carries only the *universal* slots — identity, lineage, attached
+context, lifecycle timestamps, and governance metadata (autonomy policy,
+risk profile) — and crucially **no resolution FSM**. Its two subtypes are:
+
+* ``Thread(WorkItem)`` — the FSM-resolution subtype (``threads/models.py``);
+* ``Task(WorkItem)``   — the master-list-contract subtype (Phase 3).
+
+Design rules this module must honour:
+
+* **No subtype branching.** The base never inspects ``self.subtype`` to
+  change behaviour (no ``if subtype == ...``). Subtype-specific behaviour
+  lives on the subtype, via overridden methods or injected data (e.g. the
+  FSM transition table). ``is_task`` is a plain accessor, not a branch.
+* **No storage assumption.** WorkItem is a pure in-memory dataclass.
+  ``Thread`` persists in the ``threads`` table; ``Task`` persists in the
+  task_metadata store. The base imposes neither.
+
+The id field is named ``thread_id`` (not ``work_item_id``) deliberately:
+~19 modules already import and use ``thread_id``; renaming is churn for a
+later cleanup, not part of the foundation. Subtypes override its default
+factory so the id prefix stays per-subtype (``th-`` / ``t-``); the base's
+own default is the generic ``wi-``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from work_buddy.threads.models import AutonomyPolicy, ContextItem
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _new_work_item_id() -> str:
+    """Generic base id. Subtypes override (Thread -> ``th-``, Task -> ``t-``)."""
+    return f"wi-{uuid.uuid4().hex[:8]}"
+
+
+def _default_autonomy_policy() -> "AutonomyPolicy":
+    # Lazy import: ``models.py`` imports this module at load time, so we
+    # cannot import ``AutonomyPolicy`` at module top (would cycle). The
+    # factory is only invoked at instance-construction time, by which
+    # point ``models`` is fully loaded.
+    from work_buddy.threads.models import AutonomyPolicy
+
+    return AutonomyPolicy()
+
+
+@dataclass
+class WorkItem:
+    """Thin universal base for any system-managed unit of work. No FSM.
+
+    See the module docstring for the design rules. Subtypes inherit these
+    universal fields and add their own (Thread: the resolution-FSM fields;
+    Task: nothing structural — it delegates persistence to the task store).
+    """
+
+    thread_id: str = field(default_factory=_new_work_item_id)
+    parent_id: Optional[str] = None
+    subtype: Optional[str] = None  # 'task' | None; never mutated
+
+    autonomy_policy: "AutonomyPolicy" = field(
+        default_factory=_default_autonomy_policy,
+    )
+
+    # Attached ContextItems (live in their source; this is just a
+    # reference list).
+    context_items: tuple["ContextItem", ...] = ()
+
+    # Contextual risk dimensions (DESIGN.md §10.4). Intrinsic amplifiers
+    # live on the action template and are composed at execution time.
+    risk_profile: dict[str, Any] = field(default_factory=dict)
+
+    # Inciting-event metadata: what brought this work item into being.
+    inciting_event_summary: dict[str, Any] = field(default_factory=dict)
+
+    created_at: str = field(default_factory=_now_iso)
+    updated_at: str = field(default_factory=_now_iso)
+    archived_at: Optional[str] = None
+
+    # Resurfacing / linearization / search (universal surfacing metadata).
+    resurface_at: Optional[str] = None        # Later mechanic
+    order_index: int = 0                       # write-time linearization
+    search_blob: str = ""                      # denormalized search
+
+    # NOTE(sovereignty): a per-WorkItem ``resurfacing_policy`` slot will
+    # land here when the attention/sovereignty governor is built (design
+    # 08 §6). It is deliberately NOT added now — an unused, unpersisted
+    # field would change serialization for zero current benefit and dent
+    # the "pure no-op extraction" guarantee. Add the field + its
+    # persistence + serialization together at that time.
+
+    @property
+    def is_task(self) -> bool:
+        """True iff this work item is a Task. A plain accessor — callers
+        branch on it; the base itself never does."""
+        return self.subtype == "task"
+
+    def _universal_dict(self) -> dict[str, Any]:
+        """The universal-field projection shared by every subtype's
+        ``to_dict``. Subtypes call this and merge their own keys, so the
+        base owns the serialization of the fields it owns."""
+        return {
+            "thread_id": self.thread_id,
+            "parent_id": self.parent_id,
+            "subtype": self.subtype,
+            "autonomy_policy": self.autonomy_policy.to_dict(),
+            "context_items": [c.to_dict() for c in self.context_items],
+            "risk_profile": self.risk_profile,
+            "inciting_event_summary": self.inciting_event_summary,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "archived_at": self.archived_at,
+            "resurface_at": self.resurface_at,
+            "order_index": self.order_index,
+            "search_blob": self.search_blob,
+        }


### PR DESCRIPTION
## Summary
- Introduce a thin `WorkItem` base; `Thread` and `Task` are now sibling subtypes —
  `Thread(WorkItem)` keeps the resolution FSM, `Task(WorkItem)` is the
  master-list-contract subtype (no FSM). Replaces the old unwired `Task(Thread)` stub.
- **Behavior-preserving.** The live task + thread systems run unchanged; `Task(WorkItem)`
  is a read-facade over the existing task store. Task data stays in `task_metadata` —
  **no data migration, no schema change** (verified against the live schema).
- New additive **WorkItem provenance log** (`work_item_events`): agent mutations *and*
  direct Obsidian hand-edits both record audit events — closing the "work shipped but
  the task was never closed" gap. Best-effort: can never break a task mutation.
- **Invariant guards** (no-subtype-branch leak test + a third-subtype probe) lock the
  inversion against erosion. Corrects the misleading `threads` knowledge unit.

## Not in this PR (deliberate)
- Collapsing the facade into an owned markdown adapter + making `Task(WorkItem)` the live
  write path is a follow-up PR. Everything works without it.

## Test plan
- [x] Full unit suite green (`pytest tests/unit/`) — incl. ~38 new tests + golden masters.
- [ ] After merge + sidecar/MCP reset: task create/toggle round-trips; an Obsidian
      hand-edit records an `external_markdown` event; a journal scan still walks a Thread.
- [ ] `/api/threads` + `/api/state` latency not regressed vs baseline.

Task: t-c0bbe01b / t-f822b87d