### PR TITLE
fix(knowledge): calibrate workflow_step_consistency to the directions convention + guard dangling bindings

### DIFF
--- a/knowledge/store/architecture/workflows.md
+++ b/knowledge/store/architecture/workflows.md
@@ -146,6 +146,16 @@ Starting a workflow grants blanket consent for all its steps (grant_workflow_con
 
 All slash commands (.claude/commands/wb-*.md) are thin launchers that load behavioral directions from the knowledge store via agent_docs. The slash command is the entry point; the knowledge store directions unit contains the behavioral content; the `kind: workflow` unit contains the DAG structure.
 
+## Reasoning-step instructions and directions binding
+
+A `reasoning` step's behavioral prose normally lives in the **bound directions unit** — the `kind: directions` unit whose `workflow:` frontmatter field targets this workflow — not in the step body. This keeps a single source: the directions unit (loaded by the slash command) is what the agent reads at runtime, so duplicating that prose into `## <step-id>` body sections only invites drift.
+
+A reasoning step is therefore well-formed when it is either (a) covered by such a bound directions unit, or (b) carries its own `## <step-id>` instruction in the workflow body. There is no legitimate *bare* reasoning step: if it has neither, it is either undocumented (write the `## <step-id>` prose) or miscategorized (the work is deterministic → make it a `code`/`auto_run` step).
+
+Two `docs_validate` checks enforce this:
+- `workflow_step_consistency` warns on a bare reasoning step **only** when no directions unit binds the workflow (a bound workflow's empty reasoning steps are intentional).
+- `directions_workflow_resolution` errors when a directions unit's `workflow:` does not resolve to a real `kind: workflow` unit — a dangling binding would silently defeat the suppression above, so the link must always point somewhere real (full path, e.g. `tasks/task-me`, not the bare slug).
+
 ## Step result visibility
 
 Steps can declare a `visibility` spec that controls what agents see inline vs on-demand. Full results are always in the DAG on disk — visibility only affects the MCP response.

--- a/knowledge/store/context/docs-edit.md
+++ b/knowledge/store/context/docs-edit.md
@@ -77,4 +77,4 @@ Edit the unit file at the `file` path the `resolve` step returned, using your na
 
 ## commit
 
-Auto-run. Re-reads the file and runs the kind-aware validation suite — DAG integrity, duplicate placeholders, required and kind-specific fields, capability op-resolution, and (for workflow units) step-DAG cycles / dangling dependencies and `## heading` ↔ step-id consistency — then reconciles the store cache and search index. If it returns `status: "error"`, fix the reported issues in the file and run `docs_edit` again; the reported `unit_errors` are scoped to the unit you edited.
+Auto-run. Re-reads the file and runs the kind-aware validation suite — DAG integrity, duplicate placeholders, required and kind-specific fields, capability op-resolution, directions→workflow binding resolution, and (for workflow units) step-DAG cycles / dangling dependencies and `## heading` ↔ step-id consistency — then reconciles the store cache and search index. If it returns `status: "error"`, fix the reported issues in the file and run `docs_edit` again; the reported `unit_errors` are scoped to the unit you edited.

--- a/knowledge/store/context/docs_validate.md
+++ b/knowledge/store/context/docs_validate.md
@@ -1,7 +1,7 @@
 ---
 name: Docs Validate
 kind: capability
-description: 'Validate the knowledge store: DAG integrity, command-to-store mappings, thinned command format, required fields, kind-specific fields, placeholder duplicates, and parent-child symmetry.'
+description: "Validate the knowledge store's structural integrity: DAG, command/store mappings, thinned-command format, store-path validity, required and kind-specific fields, directions fields, placeholder duplicates, parent-child symmetry, capability op-resolution, workflow step-DAG and reasoning-step consistency, and directions→workflow binding resolution."
 capability_name: docs_validate
 category: context
 op: op.wb.docs_validate
@@ -9,7 +9,7 @@ schema_version: wb-capability/v1
 parameters:
   checks:
     type: str
-    description: 'Comma-separated check names to run. Empty = all. Available: dag_integrity, command_mapping, thinned_commands, store_path_validity, required_fields, directions_fields, kind_specific_fields, placeholder_duplicate, parent_child_symmetry'
+    description: 'Comma-separated check names to run. Empty = all. Available: dag_integrity, command_mapping, thinned_commands, store_path_validity, required_fields, directions_fields, kind_specific_fields, placeholder_duplicate, parent_child_symmetry, capability_op_resolution, workflow_step_dag, workflow_step_consistency, directions_workflow_resolution'
     required: false
 tags:
 - context

--- a/knowledge/store/dev/stress-test.md
+++ b/knowledge/store/dev/stress-test.md
@@ -31,3 +31,7 @@ parents:
 - dev
 - dev
 ---
+
+## verify-result
+
+Inspect the `compute-primes` result. Confirm the subprocess returned without error and `prime_count` is plausible for the limit (π(1,000,000) = 78,498). Report pass/fail and `elapsed_seconds`. This validates that the gateway's subprocess-isolation path completed end-to-end and the server stayed responsive — not merely that primes were computed.

--- a/knowledge/store/tasks/task-me-directions.md
+++ b/knowledge/store/tasks/task-me-directions.md
@@ -5,7 +5,7 @@ description: How to run /wb-task-me — the re-runnable engage flow that answers
 summary: 'Re-runnable. Loads context, builds a clamp-to-now plan, presents top 1-2 recommendations. Slice-5a context-aware: skips tasks the agent and user both can''t satisfy now.'
 trigger: user runs /wb-task-me or asks what to work on right now
 command: wb-task-me
-workflow: task-me
+workflow: tasks/task-me
 capabilities:
 - task_me
 tags:

--- a/tests/unit/test_knowledge_validate.py
+++ b/tests/unit/test_knowledge_validate.py
@@ -14,6 +14,7 @@ from work_buddy.knowledge.file_store import workflow_body_heading_issues
 from work_buddy.knowledge.model import CapabilityUnit, DirectionsUnit, WorkflowUnit
 from work_buddy.knowledge.validate import (
     _check_capability_op_resolution,
+    _check_directions_workflow_resolution,
     _check_placeholder_duplicates,
     _check_workflow_step_consistency,
     _check_workflow_step_dag,
@@ -243,9 +244,85 @@ class TestWorkflowStepConsistencyCheck:
         assert len(errs) == 1
         assert errs[0]["severity"] == "warning"
 
+    def test_bare_reasoning_step_suppressed_when_directions_unit_binds(self):
+        # House convention: a reasoning step's behavior may live in the bound
+        # directions unit (whose ``workflow`` targets this workflow), not the
+        # step body — so a bare reasoning step there is intentional, not a miss.
+        wf = _wf("x", [{"id": "a", "step_type": "reasoning", "depends_on": []}])
+        directions = DirectionsUnit(
+            path="x-dir", name="X", description="d", workflow="x",
+        )
+        store = {"x": wf, "x-dir": directions}
+        assert _check_workflow_step_consistency(store) == []
+
+    def test_suppression_is_scoped_to_the_bound_workflow(self):
+        # A directions unit binding workflow "x" must NOT silence a bare
+        # reasoning step in an unrelated, unbound workflow "y".
+        wf_x = _wf("x", [{"id": "a", "step_type": "reasoning", "depends_on": []}])
+        wf_y = _wf("y", [{"id": "b", "step_type": "reasoning", "depends_on": []}])
+        directions = DirectionsUnit(
+            path="x-dir", name="X", description="d", workflow="x",
+        )
+        errs = _check_workflow_step_consistency(
+            {"x": wf_x, "y": wf_y, "x-dir": directions}
+        )
+        assert len(errs) == 1
+        assert errs[0]["path"] == "y"
+        assert errs[0]["severity"] == "warning"
+
+    def test_orphan_key_still_errors_even_when_directions_bound(self):
+        # Suppression only covers the bare-reasoning warning; an orphan
+        # ``step_instructions`` key is still dead text and must error.
+        wf = _wf(
+            "x",
+            [{"id": "a", "step_type": "reasoning", "depends_on": []}],
+            {"a": "do a", "ghost": "dead"},
+        )
+        directions = DirectionsUnit(
+            path="x-dir", name="X", description="d", workflow="x",
+        )
+        errs = _check_workflow_step_consistency({"x": wf, "x-dir": directions})
+        assert len(errs) == 1
+        assert "ghost" in errs[0]["message"]
+        assert errs[0].get("severity", "error") != "warning"
+
     def test_code_step_without_instructions_is_fine(self):
         wf = _wf("x", [{"id": "a", "step_type": "code", "depends_on": []}])
         assert _check_workflow_step_consistency({"x": wf}) == []
+
+
+class TestDirectionsWorkflowResolutionCheck:
+    """``directions_workflow_resolution`` — a directions unit's ``workflow``
+    field must resolve to a real ``kind: workflow`` unit; a dangling binding
+    is an error (it silently defeats the consistency-check suppression)."""
+
+    def test_resolved_binding_is_clean(self):
+        wf = _wf("tasks/task-me", [{"id": "a", "step_type": "code", "depends_on": []}])
+        directions = DirectionsUnit(
+            path="tasks/task-me-directions", name="D", description="d",
+            workflow="tasks/task-me",
+        )
+        store = {"tasks/task-me": wf, "tasks/task-me-directions": directions}
+        assert _check_directions_workflow_resolution(store) == []
+
+    def test_dangling_binding_is_error(self):
+        # The real bug this guards against: the bare slug instead of the path.
+        directions = DirectionsUnit(
+            path="tasks/task-me-directions", name="D", description="d",
+            workflow="task-me",  # missing the "tasks/" prefix → resolves to nothing
+        )
+        wf = _wf("tasks/task-me", [{"id": "a", "step_type": "code", "depends_on": []}])
+        errs = _check_directions_workflow_resolution(
+            {"tasks/task-me": wf, "tasks/task-me-directions": directions}
+        )
+        assert len(errs) == 1
+        assert errs[0]["check"] == "directions_workflow_resolution"
+        assert errs[0]["path"] == "tasks/task-me-directions"
+        assert errs[0].get("severity", "error") != "warning"
+
+    def test_directions_without_workflow_field_is_ignored(self):
+        directions = DirectionsUnit(path="d", name="D", description="d")
+        assert _check_directions_workflow_resolution({"d": directions}) == []
 
 
 class TestWorkflowBodyHeadingIssues:

--- a/work_buddy/knowledge/edit_flow.py
+++ b/work_buddy/knowledge/edit_flow.py
@@ -203,6 +203,7 @@ def commit_edit(
         "capability_op_resolution",
         "workflow_step_dag",
         "workflow_step_consistency",
+        "directions_workflow_resolution",
     ])
     reloaded = load_store()
 

--- a/work_buddy/knowledge/validate.py
+++ b/work_buddy/knowledge/validate.py
@@ -344,10 +344,21 @@ def _check_workflow_step_consistency(store: dict[str, PromptUnit]) -> list[dict[
     - An orphan ``step_instructions`` key (no matching step id) is dead text
       that will drift into ``content.full`` on the next codec round-trip —
       flagged as an error.
-    - A ``reasoning`` step with no instructions is usually an authoring miss
-      (the agent reaches the step with only its name) — flagged as a
-      non-blocking warning, since a few self-explanatory steps may omit them.
+    - A ``reasoning`` step with no instructions is flagged as a non-blocking
+      warning — *unless* the workflow has a bound directions unit. By the house
+      convention a reasoning step's behavioral prose lives in the directions
+      unit whose ``workflow`` field targets this workflow (the single source),
+      not the step body; those steps are intentionally instruction-less and
+      must not warn. A workflow with no bound directions unit and a bare
+      reasoning step is the real defect this check exists to surface: either
+      the instruction was never written, or the step is miscategorized and
+      should be a ``code`` step. (See ``architecture/workflows`` for the rule.)
     """
+    documented_workflows = {
+        u.workflow
+        for u in store.values()
+        if isinstance(u, DirectionsUnit) and u.workflow
+    }
     errors: list[dict[str, str]] = []
     for path, unit in sorted(store.items()):
         if not isinstance(unit, WorkflowUnit):
@@ -367,6 +378,10 @@ def _check_workflow_step_consistency(store: dict[str, PromptUnit]) -> list[dict[
                         "step; it will drift into content.full on round-trip"
                     ),
                 })
+        # A bound directions unit is the documented home for this workflow's
+        # reasoning-step behavior — its bare reasoning steps are intentional.
+        if path in documented_workflows:
+            continue
         for s in unit.steps or []:
             if not isinstance(s, dict):
                 continue
@@ -378,6 +393,39 @@ def _check_workflow_step_consistency(store: dict[str, PromptUnit]) -> list[dict[
                     "message": f"reasoning step {sid!r} has no instructions",
                     "severity": "warning",
                 })
+    return errors
+
+
+def _check_directions_workflow_resolution(store: dict[str, PromptUnit]) -> list[dict[str, str]]:
+    """Check 13: a directions unit's ``workflow`` field resolves to a real workflow.
+
+    ``DirectionsUnit.workflow`` names the workflow whose behavioral prose the
+    directions unit owns — it is the single source the
+    ``workflow_step_consistency`` suppression trusts. A value that does not
+    resolve to a ``kind: workflow`` unit in the store is a dangling reference:
+    the "Linked workflow" link renders to nothing in generated docs, and the
+    consistency suppression silently fails to recognise the binding (so the
+    bound workflow's bare reasoning steps would wrongly warn). Flagged as an
+    error — like ``parent_child_symmetry``, a broken cross-reference is not a
+    matter of degree.
+    """
+    workflow_paths = {
+        p for p, u in store.items() if isinstance(u, WorkflowUnit)
+    }
+    errors: list[dict[str, str]] = []
+    for path, unit in sorted(store.items()):
+        if not isinstance(unit, DirectionsUnit):
+            continue
+        target = unit.workflow
+        if target and target not in workflow_paths:
+            errors.append({
+                "check": "directions_workflow_resolution",
+                "path": path,
+                "message": (
+                    f"workflow {target!r} does not resolve to a kind:workflow "
+                    "unit in the store — dangling directions→workflow binding"
+                ),
+            })
     return errors
 
 
@@ -398,6 +446,7 @@ _CHECKS = [
     ("capability_op_resolution", _check_capability_op_resolution),
     ("workflow_step_dag", _check_workflow_step_dag),
     ("workflow_step_consistency", _check_workflow_step_consistency),
+    ("directions_workflow_resolution", _check_directions_workflow_resolution),
 ]
 
 
@@ -485,7 +534,8 @@ def docs_validate(
                  store_path_validity, required_fields, directions_fields,
                  kind_specific_fields, placeholder_duplicate,
                  parent_child_symmetry, capability_op_resolution,
-                 workflow_step_dag, workflow_step_consistency
+                 workflow_step_dag, workflow_step_consistency,
+                 directions_workflow_resolution
     """
     check_list = [c.strip() for c in checks.split(",") if c.strip()] if checks else None
     return validate_store(checks=check_list)


### PR DESCRIPTION
## Summary

`workflow_step_consistency` flagged 6 "reasoning step has no instructions" warnings, but 5 were false positives. By the house convention a reasoning step's behavioral prose lives in its **bound directions unit** (the `kind:directions` unit whose `workflow:` targets the workflow), not the step body — so those steps are intentionally instruction-less.

- **Teach the check the convention** — suppress the warning when a directions unit binds the workflow, so it measures the real defect ("behavior documented nowhere reachable") instead of "step body is empty".
- **Add `directions_workflow_resolution`** — errors when a directions unit's `workflow` doesn't resolve to a real `kind:workflow` unit (the reference the suppression trusts; a dangling one silently defeats it). Wired into the `docs_edit` author-time validation too.
- **Fix a real dangling binding it surfaced** — `tasks/task-me-directions` had `workflow: task-me` (bare slug) instead of `tasks/task-me`.
- **Write the one genuinely-missing instruction** — `dev/stress-test`'s `verify-result` (no directions unit binds it; it must stay a reasoning step to exercise the conductor's code→reasoning subprocess handback).
- **Document the convention** in `architecture/workflows`; sync the documented check lists in `context/docs_validate` and `context/docs-edit`.

Provenance: the 3 instruction-less workflows were **never authored** (verified against the pre-migration JSON and the initial release), not lost in the JSON→Markdown migration.

## Test plan

- [ ] `pytest tests/unit/test_knowledge_validate.py` — suppression scoping, orphan-key-still-errors-when-bound, and the resolution check (resolved / dangling / no-binding)
- [ ] `docs_validate` reports 0 warnings / 0 errors over the store
- [x] Verified live end-to-end through the MCP gateway: the new check **fires** on a reintroduced dangling binding (`failed:1`) and **clears** when fixed

Task: t-4e8baff5

🤖 Generated with [Claude Code](https://claude.com/claude-code)