### PR TITLE
feat(statusctl): shell-pollable consent/operation status CLI

### DIFF
--- a/knowledge/store/operations/status-cli.md
+++ b/knowledge/store/operations/status-cli.md
@@ -84,19 +84,28 @@ The verb may be omitted — `consent <id>` is shorthand for
 The loop the gateway timeout hands off to:
 
 1. A `wb_run` call returns `{"status":"timeout","request_id":…,"operation_id":…}`.
-2. Arm `Monitor` (or a bash loop) on `bash /tmp/wb/status consent wait <request_id> --timeout 300`.
-3. On exit 0 (granted), complete the sanctioned retry — `wb_run("retry", {"operation_id": …})` (or `obsidian_retry` for bridge ops). On exit 1 (denied) abort; on 2 (timeout) re-prompt or escalate.
+2. First do anything else you can safely do now — then arm `Monitor` (or a bash loop) on `bash /tmp/wb/status consent wait <request_id> --timeout -1`.
+3. On exit 0 (granted), complete the sanctioned retry — `wb_run("retry", {"operation_id": …})` (or `obsidian_retry` for bridge ops). On exit 1 (denied) abort; on 2 (expired) re-prompt or escalate.
 
 ```bash
-bash /tmp/wb/status consent wait "$REQUEST_ID" --timeout 300
+bash /tmp/wb/status consent wait "$REQUEST_ID" --timeout -1
 case $? in
   0) echo "granted — retry now" ;;
   1) echo "denied — abort" ;;
-  2) echo "timed out — re-prompt or escalate" ;;
+  2) echo "expired — re-prompt or escalate" ;;
   3) echo "unknown request id" ;;
   *) echo "error" ;;
 esac
 ```
+
+### How long to wait, and what it costs
+
+Waiting is **free** and **self-bounding**, so prefer a generous (or indefinite) timeout over a short one:
+
+- **Free:** run the `wait` in the background (the `Monitor` tool or `run_in_background` bash). Billing is per-token, not per-wall-clock-time — while the watcher sleeps between polls the model isn't invoked, so a wait of minutes or hours costs **zero tokens** until it resolves and re-invokes you. (Keep it silent — do not pass `--verbose` under the `Monitor` tool, or each progress line becomes a billed turn.)
+- **Self-bounding:** `--timeout -1` does not actually hang forever — a consent request carries a ~2h TTL, and `expired` is a terminal state, so the wait exits (code 2) when the request expires. So `-1` means "until the user decides or the request lapses," not "until the heat death of the universe."
+- Because it's free and self-bounding, the only reason to keep working instead of waiting is that you have other useful work in hand. Do that first, then wait.
+- **When a finite `--timeout` is the better choice:** `-1`'s free/self-bounding properties depend on running in the **background** (Monitor / `run_in_background`), where the model idles. Use a bounded `--timeout <seconds>` if you're running it in the **foreground** (where `-1` would tie up the turn for up to the full TTL), if you have your own deadline/SLA, or if you'd rather poll briefly and re-check later (the reschedule pattern) — e.g. escalate to another approver after N minutes.
 
 ## Guarantees and limits
 

--- a/knowledge/store/operations/status-cli.md
+++ b/knowledge/store/operations/status-cli.md
@@ -1,0 +1,138 @@
+---
+name: Status CLI (shell-pollable consent/operation status)
+kind: directions
+description: Read-only shell command for polling consent-request and operation status from tooling that cannot speak MCP (the Monitor tool, bash loops, cron)
+summary: '`bash /tmp/wb/status consent wait <request_id>` blocks until a timed-out consent prompt is approved/denied, then exits with a branchable code (0 granted, 1 denied, 2 timeout, 3 not found). Backed by python -m work_buddy.statusctl; read-only; generated per session by a SessionStart hook.'
+trigger: an agent or shell watcher needs to wait for a consent grant (after a gateway consent timeout) or poll operation completion without calling MCP
+tags:
+- consent
+- cli
+- monitor
+- polling
+- operations
+- shell
+aliases:
+- wb status
+- consent wait
+- consent status
+- op status
+- /tmp/wb/status
+- wait for consent
+- poll consent
+- statusctl
+parents:
+- operations
+---
+
+A read-only, shell-pollable window into two pieces of work-buddy state —
+**consent-request status** and **operation status** — for tooling that
+cannot speak the MCP gateway: the `Monitor` tool, `bash run_in_background`
+loops, cron scripts, one-off diagnostics.
+
+## Why this exists
+
+When a `wb_run` call trips a consent gate, the gateway sends one bundled
+notification, polls ~90s, then **times out and hands back** a result like
+`{"status":"timeout","request_id":"req_…","operation_id":"op_…"}`. The user
+can still approve on any surface afterward. The agent wants to *wait* for
+that approval and then retry — but a shell watcher has no sanctioned way to
+ask "is this consent granted yet?" without grovelling session-scoped consent
+SQLite directly. This command is that sanctioned poll target.
+
+## Commands
+
+Generated per session at `/tmp/wb/status` (the session id is baked in, so
+consent queries are automatically session-scoped). Backed by
+`python -m work_buddy.statusctl`.
+
+```
+bash /tmp/wb/status consent wait   <request_id> [--timeout 600]
+bash /tmp/wb/status consent status <request_id>          # one-shot
+bash /tmp/wb/status op      wait   <operation_id> [--timeout 600]
+bash /tmp/wb/status op      status <operation_id>         # one-shot
+bash /tmp/wb/status --help
+```
+
+The verb may be omitted — `consent <id>` is shorthand for
+`consent status <id>`. Add `--json` for the full status dict on stdout.
+
+### `wait` vs `status`
+
+- **`wait`** blocks in a single process, polling internally on a tiered
+  cadence (2s for the first 30s, 5s to a few minutes, then 15s), and exits
+  the moment the state resolves or `--timeout` (default 600s) elapses.
+  `--timeout 0` checks exactly once; a negative timeout waits indefinitely.
+  Prefer `wait` for a `Monitor` loop — it pays Python startup **once** for
+  the whole wait instead of re-spawning the interpreter every poll.
+- **`status`** prints the current state and exits 0 (state in the body).
+  Use `wait --timeout 0` instead when you want a single check *with* the
+  full exit-code vocabulary.
+
+### Exit codes (branch on `$?`)
+
+| code | meaning |
+|---|---|
+| 0 | granted / operation completed |
+| 1 | denied / operation failed |
+| 2 | timed out — no decision within the deadline, or the request expired |
+| 3 | not found (unknown id) |
+| 4 | internal error (e.g. no work-buddy interpreter found) |
+| 130 | interrupted (SIGINT) |
+
+## The wait-for-consent pattern
+
+The loop the gateway timeout hands off to:
+
+1. A `wb_run` call returns `{"status":"timeout","request_id":…,"operation_id":…}`.
+2. Arm `Monitor` (or a bash loop) on `bash /tmp/wb/status consent wait <request_id> --timeout 300`.
+3. On exit 0 (granted), complete the sanctioned retry — `wb_run("retry", {"operation_id": …})` (or `obsidian_retry` for bridge ops). On exit 1 (denied) abort; on 2 (timeout) re-prompt or escalate.
+
+```bash
+bash /tmp/wb/status consent wait "$REQUEST_ID" --timeout 300
+case $? in
+  0) echo "granted — retry now" ;;
+  1) echo "denied — abort" ;;
+  2) echo "timed out — re-prompt or escalate" ;;
+  3) echo "unknown request id" ;;
+  *) echo "error" ;;
+esac
+```
+
+## Guarantees and limits
+
+- **Strictly read-only.** It observes consent/operation state; it never
+  mints, caches, or consumes a grant. A `granted` verdict only means the
+  user approved — the actual retry goes back through the gateway, whose
+  `@requires_consent` gate re-checks the grant against the live principal.
+  If the grant has since expired, the gate re-prompts. This preserves the
+  invariant that grants do not time-travel through the retry queue.
+- **Session-scoped grant reads.** Consent grants live in a per-session
+  `consent.db`; the command resolves against the baked-in session id, so it
+  reads the agent's own grants, not another session's. Out-of-band grants
+  (approved on another surface) are detected even if the request record has
+  not yet flipped to `responded`.
+- **Operation records are global**, keyed by `operation_id` (not
+  session-scoped); a `running` record whose execution lease has lapsed is
+  reported as `stale` but a `wait` keeps polling until its own timeout.
+- **Startup cost.** Each invocation pays interpreter + package import
+  (hundreds of ms on some platforms, dominated by work-buddy's version
+  lookup at import). The blocking `wait` amortizes this across the whole
+  wait — another reason to prefer `wait` over re-spawning `status` in a
+  tight loop.
+- **Interpreter resolution.** The command finds a Python that can import
+  work-buddy via `$WORK_BUDDY_PYTHON` → a `python`/`python3` on PATH → common
+  conda env locations. Set `WORK_BUDDY_PYTHON` if your env is elsewhere.
+
+## Implementation
+
+- CLI: `work_buddy/statusctl/` (`cli.py` — argparse, tiered wait loop, exit
+  codes; lazy domain imports keep `op` queries off the consent stack).
+- Consent composer: `work_buddy/consent_status.py` — fuses
+  `consent.get_consent_request` (request lifecycle) and
+  `consent.list_consents` (the grant) into one verdict.
+- Operation reader: `work_buddy/operations_read.py` — mirrors the gateway's
+  on-disk operation layout without importing the gateway.
+- Shell wrapper template: `work_buddy/statusctl/bin/status.sh`, materialized
+  into `/tmp/wb/status` by `work_buddy/statusctl/install_commands.sh` on
+  SessionStart (registered in `config/global_settings.json`, mirroring the
+  messaging `check_messages.sh` hook).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
   - Components & health checks layer: handbook/architecture_health_components.md
   - Fixers layer: handbook/architecture_health_fixers.md
   - Requirements layer: handbook/architecture_health_requirements.md
+  - Hot-Path Discipline: handbook/architecture_hot-path-discipline.md
   - Inference: handbook/architecture_inference.md
   - Local Inference Broker: handbook/architecture_inference_broker.md
   - Knowledge System: handbook/architecture_knowledge-system.md
@@ -118,9 +119,13 @@ nav:
 - Calendar:
   - Calendar subsystem (provider-neutral): handbook/calendar.md
   - Calendar Coverage: handbook/calendar_calendar_coverage.md
+  - Calendar Create Event: handbook/calendar_calendar_create_event.md
+  - Calendar Delete Event: handbook/calendar_calendar_delete_event.md
   - Calendar Get Event: handbook/calendar_calendar_get_event.md
   - Calendar Health: handbook/calendar_calendar_health.md
   - Calendar List Events: handbook/calendar_calendar_list_events.md
+  - Calendar Update Event: handbook/calendar_calendar_update_event.md
+  - Google Calendar native (OAuth) setup: handbook/calendar_google-native-setup.md
 - Clarify:
   - Text-segmenter SubCall: handbook/clarify_text-segmenter.md
 - Context:
@@ -364,6 +369,7 @@ nav:
   - Agent Sessions: handbook/operations_agent-sessions.md
   - MCP Gateway: handbook/operations_mcp-gateway.md
   - Retry: handbook/operations_retry.md
+  - Status CLI (shell-pollable consent/operation status): handbook/operations_status-cli.md
 - Projects:
   - Projects: handbook/projects.md
   - Deleting a Project: handbook/projects_project-delete-directions.md
@@ -462,6 +468,7 @@ nav:
   - Task Create: handbook/tasks_task_create.md
   - Task Delete: handbook/tasks_task_delete.md
   - Task Namespace Suggest: handbook/tasks_task_namespace_suggest.md
+  - Task Note Readers: handbook/tasks_task_note_readers.md
   - Task Provenance: handbook/tasks_task_provenance.md
   - Task Read: handbook/tasks_task_read.md
   - Task Review Inbox: handbook/tasks_task_review_inbox.md

--- a/tests/integration/test_consent_wait_e2e.py
+++ b/tests/integration/test_consent_wait_e2e.py
@@ -1,0 +1,92 @@
+"""End-to-end: a shell-style consent `wait` resolves on approval.
+
+Substitutes for the human-driven live test (which needs a person clicking
+an approval surface): a background thread plays the role of the user,
+approving — or denying, or granting out-of-band — while the CLI's blocking
+`wait` polls the real consent stores (redirected to a temp dir). Proves the
+full loop the gateway timeout hands off to: poll the request_id → resolve →
+correct exit code.
+
+The real Monitor-driven live test is staged for morning review.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from work_buddy import consent
+from work_buddy.notifications import store
+from work_buddy.notifications.models import ResponseType, StandardResponse
+from work_buddy.statusctl import cli
+
+SESSION = "test-session-00000000"  # matches conftest's WORK_BUDDY_SESSION_ID
+
+
+def _make_request(operation="task_toggle"):
+    return consent.create_consent_request(
+        operation=operation, reason="e2e", requester="agent:e2e",
+    )["request_id"]
+
+
+def _approve_after(request_id, delay, value="once"):
+    def _go():
+        time.sleep(delay)
+        store.respond_to_notification(
+            request_id,
+            StandardResponse(
+                response_type=ResponseType.CHOICE.value, value=value,
+                surface="test",
+            ),
+        )
+    t = threading.Thread(target=_go, daemon=True)
+    t.start()
+    return t
+
+
+def _grant_after(request_id, delay, operation="task_toggle"):
+    def _go():
+        time.sleep(delay)
+        consent.grant_consent(operation, mode="always", session_id=SESSION)
+    t = threading.Thread(target=_go, daemon=True)
+    t.start()
+    return t
+
+
+def test_wait_resolves_on_response_approval(tmp_agents_dir):
+    rid = _make_request()
+    t = _approve_after(rid, 0.3, value="once")
+    rc = cli.main(["consent", "wait", rid, "--timeout", "15", "--poll-interval", "0.2"])
+    t.join(timeout=2)
+    assert rc == cli.EXIT_OK
+
+
+def test_wait_resolves_on_out_of_band_grant(tmp_agents_dir):
+    # Request stays pending (never "responded"); the grant lands directly.
+    rid = _make_request(operation="task_toggle")
+    t = _grant_after(rid, 0.3, operation="task_toggle")
+    rc = cli.main([
+        "consent", "wait", rid, "--session", SESSION,
+        "--timeout", "15", "--poll-interval", "0.2",
+    ])
+    t.join(timeout=2)
+    assert rc == cli.EXIT_OK
+
+
+def test_wait_returns_denied(tmp_agents_dir):
+    rid = _make_request()
+    t = _approve_after(rid, 0.3, value="deny")
+    rc = cli.main(["consent", "wait", rid, "--timeout", "15", "--poll-interval", "0.2"])
+    t.join(timeout=2)
+    assert rc == cli.EXIT_NEGATIVE
+
+
+def test_wait_times_out_when_never_answered(tmp_agents_dir):
+    rid = _make_request()
+    start = time.monotonic()
+    rc = cli.main(["consent", "wait", rid, "--timeout", "1", "--poll-interval", "0.2"])
+    elapsed = time.monotonic() - start
+    assert rc == cli.EXIT_TIMEOUT
+    assert elapsed >= 1.0  # actually waited the full deadline

--- a/tests/unit/test_consent_status.py
+++ b/tests/unit/test_consent_status.py
@@ -1,0 +1,116 @@
+"""Read-only consent-request status composer.
+
+Proves ``work_buddy.consent_status.consent_status`` fuses the request
+record (notification store) and the grant (session consent.db) into a
+single pending/granted/denied/expired/not_found verdict, and that it is
+strictly read-only (it never writes a grant or mutates the request).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from work_buddy import consent, consent_status
+from work_buddy.notifications import store
+from work_buddy.notifications.models import ResponseType, StandardResponse
+
+
+def _make_request(operation="task_toggle"):
+    rec = consent.create_consent_request(
+        operation=operation, reason="unit test", requester="agent:test",
+    )
+    return rec["request_id"]
+
+
+def _respond(request_id, value):
+    store.respond_to_notification(
+        request_id,
+        StandardResponse(
+            response_type=ResponseType.CHOICE.value, value=value, surface="test",
+        ),
+    )
+
+
+def test_not_found(tmp_agents_dir):
+    s = consent_status.consent_status("req_missing", session_id="agent-x")
+    assert s["state"] == "not_found"
+    assert s["terminal"] is False
+
+
+def test_pending(tmp_agents_dir):
+    rid = _make_request()
+    s = consent_status.consent_status(rid, session_id="agent-x")
+    assert s["state"] == "pending"
+    assert s["operation"] == "task_toggle"
+    assert s["terminal"] is False
+
+
+def test_granted_via_response(tmp_agents_dir):
+    rid = _make_request()
+    _respond(rid, "once")
+    s = consent_status.consent_status(rid, session_id="agent-x")
+    assert s["state"] == "granted"
+    assert s["response"] == "once"
+    assert s["terminal"] is True
+
+
+def test_denied(tmp_agents_dir):
+    rid = _make_request()
+    _respond(rid, "deny")
+    s = consent_status.consent_status(rid, session_id="agent-x")
+    assert s["state"] == "denied"
+    assert s["terminal"] is True
+
+
+def test_expired_by_ttl(tmp_agents_dir):
+    rid = _make_request()
+    n = store.get_notification(rid)
+    n.expires_at = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    store._write_notification(n)
+    s = consent_status.consent_status(rid, session_id="agent-x")
+    assert s["state"] == "expired"
+    assert s["terminal"] is True
+
+
+def test_cancelled_is_expired(tmp_agents_dir):
+    rid = _make_request()
+    store.cancel_notification(rid)
+    s = consent_status.consent_status(rid, session_id="agent-x")
+    assert s["state"] == "expired"
+
+
+def test_granted_via_grant_race(tmp_agents_dir):
+    # Pending request, but a grant already landed out-of-band → granted.
+    rid = _make_request(operation="task_toggle")
+    consent.grant_consent("task_toggle", mode="always", session_id="agent-race")
+    s = consent_status.consent_status(rid, session_id="agent-race")
+    assert s["state"] == "granted"
+    assert s["grant_seen"] is True
+
+
+def test_no_session_skips_grant_check(tmp_agents_dir):
+    # Without a session_id the grant cross-check is skipped; a pending
+    # request stays pending.
+    rid = _make_request()
+    s = consent_status.consent_status(rid, session_id=None)
+    assert s["state"] == "pending"
+    assert s["grant_seen"] is False
+
+
+def test_out_of_band_grant_after_expiry_is_granted(tmp_agents_dir):
+    # Request expired, but the user's approval grant landed → honour it.
+    rid = _make_request(operation="task_toggle")
+    n = store.get_notification(rid)
+    n.expires_at = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    store._write_notification(n)
+    consent.grant_consent("task_toggle", mode="always", session_id="agent-late")
+    s = consent_status.consent_status(rid, session_id="agent-late")
+    assert s["state"] == "granted"
+
+
+def test_read_only_does_not_mutate_request(tmp_agents_dir):
+    rid = _make_request()
+    before = store.get_notification(rid).to_dict()
+    consent_status.consent_status(rid, session_id="agent-x")
+    after = store.get_notification(rid).to_dict()
+    assert before == after

--- a/tests/unit/test_gateway_consent_wait_hint.py
+++ b/tests/unit/test_gateway_consent_wait_hint.py
@@ -1,9 +1,11 @@
-"""The gateway consent-timeout result advertises the shell `wait` command.
+"""The gateway consent-timeout message advertises the shell `wait` command.
 
-When ``_auto_consent_request`` times out, its result must carry a
-``wait_hint`` telling the agent how to wait for the user's decision from a
-shell watcher (the Monitor tool) and then retry — the discovery hook that
-makes the status CLI usable in the loop the gateway half-builds.
+When ``_auto_consent_request`` times out, its ``message`` must tell the
+agent how to wait for the user's decision from a shell watcher (the Monitor
+tool) and then retry — the discovery hook that makes the status CLI usable
+in the loop the gateway half-builds. The guidance lives in ``message``
+itself (not a separate field) so an agent acting on the message can't miss
+it.
 """
 
 from __future__ import annotations
@@ -23,7 +25,7 @@ class _FakeDispatcher:
         return None
 
 
-def test_timeout_result_includes_wait_hint(tmp_agents_dir, monkeypatch):
+def test_timeout_message_advertises_shell_wait(tmp_agents_dir, monkeypatch):
     from work_buddy.mcp_server.tools import gateway
     from work_buddy.notifications import dispatcher as disp
 
@@ -37,8 +39,10 @@ def test_timeout_result_includes_wait_hint(tmp_agents_dir, monkeypatch):
     )
 
     assert result["status"] == "timeout"
-    assert "request_id" in result and result["request_id"]
-    assert "wait_hint" in result
-    hint = result["wait_hint"]
-    assert result["request_id"] in hint
-    assert "/tmp/wb/status consent wait" in hint
+    assert result.get("request_id")
+    msg = result["message"]
+    # Wait guidance is folded into the message itself, with the request id,
+    # the free indefinite-wait suggestion, and the retry handoff.
+    assert "/tmp/wb/status consent wait" in msg
+    assert result["request_id"] in msg
+    assert "--timeout -1" in msg

--- a/tests/unit/test_gateway_consent_wait_hint.py
+++ b/tests/unit/test_gateway_consent_wait_hint.py
@@ -1,0 +1,44 @@
+"""The gateway consent-timeout result advertises the shell `wait` command.
+
+When ``_auto_consent_request`` times out, its result must carry a
+``wait_hint`` telling the agent how to wait for the user's decision from a
+shell watcher (the Monitor tool) and then retry — the discovery hook that
+makes the status CLI usable in the loop the gateway half-builds.
+"""
+
+from __future__ import annotations
+
+
+class _FakeDispatcher:
+    """Stands in for SurfaceDispatcher: delivery is a no-op and the poll
+    always times out (returns None)."""
+
+    def deliver(self, *a, **k):
+        return None
+
+    def poll_response(self, *a, **k):
+        return None  # simulate the user not responding within the window
+
+    def dismiss_others(self, *a, **k):
+        return None
+
+
+def test_timeout_result_includes_wait_hint(tmp_agents_dir, monkeypatch):
+    from work_buddy.mcp_server.tools import gateway
+    from work_buddy.notifications import dispatcher as disp
+
+    monkeypatch.setattr(
+        disp.SurfaceDispatcher, "from_config",
+        classmethod(lambda cls: _FakeDispatcher()),
+    )
+
+    result = gateway._auto_consent_request(
+        ["task_toggle"], "task_toggle", "op_test123", timeout=0,
+    )
+
+    assert result["status"] == "timeout"
+    assert "request_id" in result and result["request_id"]
+    assert "wait_hint" in result
+    hint = result["wait_hint"]
+    assert result["request_id"] in hint
+    assert "/tmp/wb/status consent wait" in hint

--- a/tests/unit/test_operations_read.py
+++ b/tests/unit/test_operations_read.py
@@ -1,0 +1,92 @@
+"""Read-only operation-record reader for shell-level pollers.
+
+Proves ``work_buddy.operations_read`` mirrors the gateway's on-disk
+operation layout without importing the gateway, and maps record states to
+the CLI's normalized vocabulary (including stale-lease detection).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from work_buddy import operations_read
+
+
+def _write_op(ops_dir, op_id, **fields):
+    rec = {
+        "operation_id": op_id,
+        "name": "do_thing",
+        "status": "running",
+        "error": None,
+        "error_kind": None,
+        "created_at": "2026-06-01T00:00:00+00:00",
+        "completed_at": None,
+        "locked_until": None,
+    }
+    rec.update(fields)
+    ops_dir.mkdir(parents=True, exist_ok=True)
+    (ops_dir / f"{op_id}.json").write_text(json.dumps(rec), encoding="utf-8")
+
+
+def test_load_missing_returns_none(tmp_agents_dir):
+    assert operations_read.load_operation("op_missing") is None
+
+
+def test_status_not_found(tmp_agents_dir):
+    s = operations_read.operation_status("op_missing")
+    assert s["state"] == "not_found"
+    assert s["terminal"] is False
+
+
+def test_status_completed(tmp_agents_dir):
+    ops = operations_read.operations_dir()
+    _write_op(ops, "op_done", status="completed",
+              completed_at="2026-06-01T01:00:00+00:00", result={"ok": True})
+    s = operations_read.operation_status("op_done")
+    assert s["state"] == "completed"
+    assert s["terminal"] is True
+    assert s["name"] == "do_thing"
+    assert s["completed_at"] == "2026-06-01T01:00:00+00:00"
+
+
+def test_status_failed(tmp_agents_dir):
+    ops = operations_read.operations_dir()
+    _write_op(ops, "op_fail", status="failed", error="boom", error_kind="x")
+    s = operations_read.operation_status("op_fail")
+    assert s["state"] == "failed"
+    assert s["terminal"] is True
+    assert s["error"] == "boom"
+    assert s["error_kind"] == "x"
+
+
+def test_status_running_with_live_lease_is_pending(tmp_agents_dir):
+    ops = operations_read.operations_dir()
+    future = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat()
+    _write_op(ops, "op_run", status="running", locked_until=future)
+    s = operations_read.operation_status("op_run")
+    assert s["state"] == "running"
+    assert s["terminal"] is False
+
+
+def test_status_running_with_expired_lease_is_stale(tmp_agents_dir):
+    ops = operations_read.operations_dir()
+    past = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+    _write_op(ops, "op_stale", status="running", locked_until=past)
+    s = operations_read.operation_status("op_stale")
+    assert s["state"] == "stale"
+    assert s["terminal"] is False  # not terminal — a long lease may be legit
+
+
+def test_running_no_lease_is_pending(tmp_agents_dir):
+    ops = operations_read.operations_dir()
+    _write_op(ops, "op_nolease", status="running", locked_until=None)
+    assert operations_read.operation_status("op_nolease")["state"] == "running"
+
+
+def test_unreadable_record_returns_none(tmp_agents_dir):
+    ops = operations_read.operations_dir()
+    ops.mkdir(parents=True, exist_ok=True)
+    (ops / "op_bad.json").write_text("{not json", encoding="utf-8")
+    assert operations_read.load_operation("op_bad") is None
+    assert operations_read.operation_status("op_bad")["state"] == "not_found"

--- a/tests/unit/test_statusctl_cli.py
+++ b/tests/unit/test_statusctl_cli.py
@@ -1,0 +1,152 @@
+"""The statusctl CLI: argv shorthand, exit-code mapping, wait loop.
+
+Domain reads are faked so these tests exercise the CLI's control flow and
+exit-code contract without touching the consent/operation stores.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from work_buddy.statusctl import cli
+
+
+@pytest.fixture
+def fake_consent(monkeypatch):
+    state = {"view": {"request_id": "req_x", "state": "pending",
+                      "terminal": False, "operation": "task_toggle"}}
+
+    def fake(request_id, *, session_id=None):
+        v = dict(state["view"])
+        v["request_id"] = request_id
+        return v
+
+    monkeypatch.setattr("work_buddy.consent_status.consent_status", fake)
+    return state
+
+
+@pytest.fixture
+def fake_op(monkeypatch):
+    state = {"view": {"operation_id": "op_x", "state": "running",
+                      "terminal": False, "name": "do_thing"}}
+
+    def fake(op_id):
+        v = dict(state["view"])
+        v["operation_id"] = op_id
+        return v
+
+    monkeypatch.setattr("work_buddy.operations_read.operation_status", fake)
+    return state
+
+
+# --- argv preprocessing -----------------------------------------------------
+
+def test_preprocess_injects_status_verb():
+    assert cli._preprocess(["consent", "req_1"]) == ["consent", "status", "req_1"]
+    assert cli._preprocess(["op", "op_1"]) == ["op", "status", "op_1"]
+
+
+def test_preprocess_leaves_explicit_verbs():
+    assert cli._preprocess(["consent", "wait", "req_1"]) == ["consent", "wait", "req_1"]
+    assert cli._preprocess(["consent", "status", "req_1"]) == ["consent", "status", "req_1"]
+
+
+def test_preprocess_handles_leading_option():
+    assert cli._preprocess(["--json", "consent", "req_1"]) == \
+        ["--json", "consent", "status", "req_1"]
+
+
+# --- one-shot status --------------------------------------------------------
+
+def test_oneshot_status_exits_zero(fake_consent, capsys):
+    fake_consent["view"]["state"] = "pending"
+    assert cli.main(["consent", "status", "req_1"]) == cli.EXIT_OK
+    assert "pending" in capsys.readouterr().out
+
+
+def test_oneshot_not_found_still_exits_zero(fake_consent, capsys):
+    fake_consent["view"]["state"] = "not_found"
+    assert cli.main(["consent", "req_1"]) == cli.EXIT_OK  # shorthand form
+    assert "not_found" in capsys.readouterr().out
+
+
+def test_oneshot_json_includes_exit_code(fake_consent, capsys):
+    fake_consent["view"]["state"] = "granted"
+    assert cli.main(["--json", "consent", "status", "req_1"]) == cli.EXIT_OK
+    data = json.loads(capsys.readouterr().out)
+    assert data["state"] == "granted"
+    assert data["exit_code"] == 0
+
+
+# --- wait: exit-code vocabulary ---------------------------------------------
+
+@pytest.mark.parametrize("state,code", [
+    ("granted", cli.EXIT_OK),
+    ("denied", cli.EXIT_NEGATIVE),
+    ("expired", cli.EXIT_TIMEOUT),
+    ("not_found", cli.EXIT_NOT_FOUND),
+])
+def test_consent_wait_exit_codes(fake_consent, state, code):
+    fake_consent["view"]["state"] = state
+    fake_consent["view"]["terminal"] = True
+    assert cli.main(["consent", "wait", "req_1", "--timeout", "0"]) == code
+
+
+def test_consent_wait_pending_times_out(fake_consent):
+    fake_consent["view"]["state"] = "pending"
+    assert cli.main(["consent", "wait", "req_1", "--timeout", "0"]) == cli.EXIT_TIMEOUT
+
+
+@pytest.mark.parametrize("state,code", [
+    ("completed", cli.EXIT_OK),
+    ("failed", cli.EXIT_NEGATIVE),
+    ("not_found", cli.EXIT_NOT_FOUND),
+])
+def test_op_wait_exit_codes(fake_op, state, code):
+    fake_op["view"]["state"] = state
+    fake_op["view"]["terminal"] = state in ("completed", "failed", "not_found")
+    assert cli.main(["op", "wait", "op_1", "--timeout", "0"]) == code
+
+
+def test_op_wait_running_times_out(fake_op):
+    fake_op["view"]["state"] = "running"
+    assert cli.main(["op", "wait", "op_1", "--timeout", "0"]) == cli.EXIT_TIMEOUT
+
+
+def test_op_stale_keeps_waiting_then_times_out(fake_op):
+    fake_op["view"]["state"] = "stale"
+    assert cli.main(["op", "wait", "op_1", "--timeout", "0"]) == cli.EXIT_TIMEOUT
+
+
+# --- wait: actually loops ---------------------------------------------------
+
+def test_wait_loops_until_resolved(monkeypatch):
+    seq = ["pending", "pending", "granted"]
+
+    def fake(request_id, *, session_id=None):
+        s = seq.pop(0) if len(seq) > 1 else seq[0]
+        return {"request_id": request_id, "state": s,
+                "terminal": s != "pending", "operation": "x"}
+
+    monkeypatch.setattr("work_buddy.consent_status.consent_status", fake)
+    monkeypatch.setattr(cli.time, "sleep", lambda *_: None)
+    rc = cli.main(["consent", "wait", "req_1", "--timeout", "30", "--poll-interval", "1"])
+    assert rc == cli.EXIT_OK
+
+
+# --- poll cadence -----------------------------------------------------------
+
+def test_next_interval_tiers():
+    assert cli._next_interval(0, None) == 2.0
+    assert cli._next_interval(60, None) == 5.0
+    assert cli._next_interval(600, None) == 15.0
+    assert cli._next_interval(600, 3.0) == 3.0  # override pins it
+
+
+# --- usage errors -----------------------------------------------------------
+
+def test_missing_domain_is_usage_error():
+    # argparse exits 2 on missing required subcommand
+    assert cli.main([]) == 2

--- a/tests/unit/test_statusctl_cli.py
+++ b/tests/unit/test_statusctl_cli.py
@@ -80,6 +80,28 @@ def test_oneshot_json_includes_exit_code(fake_consent, capsys):
     assert data["exit_code"] == 0
 
 
+@pytest.mark.parametrize("argv", [
+    ["--json", "consent", "status", "req_1"],          # before subcommand
+    ["consent", "status", "req_1", "--json"],          # trailing (the natural shell order)
+    ["consent", "req_1", "--json"],                     # shorthand + trailing
+])
+def test_json_flag_accepted_in_any_position(fake_consent, capsys, argv):
+    # Regression: --json after the subcommand was rejected by argparse
+    # because it was only on the top-level parser. It must work in either
+    # position — a trailing flag is how a Monitor loop / shell user writes it.
+    fake_consent["view"]["state"] = "granted"
+    assert cli.main(argv) == cli.EXIT_OK
+    assert json.loads(capsys.readouterr().out)["state"] == "granted"
+
+
+def test_wait_json_trailing_with_other_flags(fake_consent, capsys):
+    fake_consent["view"]["state"] = "granted"
+    fake_consent["view"]["terminal"] = True
+    rc = cli.main(["consent", "wait", "req_1", "--timeout", "0", "--json"])
+    assert rc == cli.EXIT_OK
+    assert json.loads(capsys.readouterr().out)["state"] == "granted"
+
+
 # --- wait: exit-code vocabulary ---------------------------------------------
 
 @pytest.mark.parametrize("state,code", [

--- a/work_buddy/consent_status.py
+++ b/work_buddy/consent_status.py
@@ -1,0 +1,208 @@
+"""Read-only consent-request status, fused for shell-level pollers.
+
+A consent request's lifecycle state lives in the shared notification store
+(:func:`work_buddy.consent.get_consent_request`), while the *grant* it
+produces lands in a session-scoped SQLite DB
+(:func:`work_buddy.consent.list_consents`). Neither alone answers the
+question a shell watcher actually asks — *"can I retry yet?"* — so this
+module fuses them into a single ``pending | granted | denied | expired |
+not_found`` verdict.
+
+Design constraints:
+
+* **Strictly read-only.** This never mints, caches, or consumes a grant.
+  A ``granted`` verdict only tells the caller the user approved; the actual
+  retry goes back through the gateway, whose ``@requires_consent`` gate
+  re-checks the grant against the live principal. If the grant has since
+  expired, the gate re-prompts. This preserves the invariant that grants
+  do not time-travel through the retry queue.
+* **Session-scoped grant reads.** The grant cross-check passes
+  ``agent_session_id`` explicitly so it resolves against the agent's own
+  ``consent.db`` rather than whatever session a shared cache last touched.
+* **Light imports.** ``work_buddy.consent`` is imported lazily inside the
+  functions so importing this module stays cheap for the CLI.
+
+The decision signal (request status + recorded response) is authoritative
+for *granted vs denied*. The grant cross-check is a best-effort second
+opinion that catches the race where an out-of-band approval has written
+the grant but the request record has not yet flipped to ``responded``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+# Verdicts
+PENDING = "pending"
+GRANTED = "granted"
+DENIED = "denied"
+EXPIRED = "expired"
+NOT_FOUND = "not_found"
+
+
+def consent_status(request_id: str, *, session_id: str | None = None) -> dict[str, Any]:
+    """Return a normalized, read-only status view of a consent request.
+
+    Parameters
+    ----------
+    request_id:
+        The consent request id (the ``request_id`` the gateway hands back
+        in a timeout result).
+    session_id:
+        The agent session whose ``consent.db`` to cross-check for the
+        grant. When ``None``, the grant cross-check is skipped and the
+        verdict rests on the request record alone (still correct for the
+        common responded/denied/expired cases).
+
+    Output shape (always includes ``state``)::
+
+        {
+          "request_id": str,
+          "state": "pending"|"granted"|"denied"|"expired"|"not_found",
+          "terminal": bool,            # True for granted/denied/expired
+          "operation": str | None,     # the gated operation, if discoverable
+          "response": str | None,      # the chosen option key, if responded
+          "responded_at": str | None,
+          "expires_at": str | None,
+          "grant_seen": bool,          # the operation has a live grant
+        }
+    """
+    from work_buddy.consent import get_consent_request
+
+    req = get_consent_request(request_id)
+    if req is None:
+        return _view(request_id, NOT_FOUND, operation=None)
+
+    operation = _extract_operation(req)
+    raw_status = req.get("status")
+    response_value = _response_value(req.get("response"))
+    responded_at = req.get("responded_at")
+    expires_at = req.get("expires_at")
+
+    # Best-effort grant cross-check (catches out-of-band approvals).
+    grant_seen = _grant_is_live(operation, session_id) if operation else False
+
+    # 1. Explicit terminal request states.
+    if raw_status in ("expired", "cancelled"):
+        # An out-of-band grant landing after the request expired still
+        # means the user approved — honour it.
+        state = GRANTED if grant_seen else EXPIRED
+        return _view(request_id, state, operation, response_value,
+                     responded_at, expires_at, grant_seen)
+
+    # 2. Responded → the user's recorded decision is authoritative.
+    if raw_status == "responded":
+        state = DENIED if response_value == "deny" else GRANTED
+        return _view(request_id, state, operation, response_value,
+                     responded_at, expires_at, grant_seen)
+
+    # 3. Not yet responded, but a grant is already visible (race / out-of-band).
+    if grant_seen:
+        return _view(request_id, GRANTED, operation, response_value,
+                     responded_at, expires_at, grant_seen)
+
+    # 4. Still pending — but the request record may be past its TTL without
+    #    having been swept yet (get_consent_request does not lazily expire).
+    if _is_past(expires_at):
+        return _view(request_id, EXPIRED, operation, response_value,
+                     responded_at, expires_at, grant_seen)
+
+    return _view(request_id, PENDING, operation, response_value,
+                 responded_at, expires_at, grant_seen)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TERMINAL = {GRANTED, DENIED, EXPIRED}
+
+
+def _view(
+    request_id: str,
+    state: str,
+    operation: str | None,
+    response: str | None = None,
+    responded_at: str | None = None,
+    expires_at: str | None = None,
+    grant_seen: bool = False,
+) -> dict[str, Any]:
+    return {
+        "request_id": request_id,
+        "state": state,
+        "terminal": state in _TERMINAL,
+        "operation": operation,
+        "response": response,
+        "responded_at": responded_at,
+        "expires_at": expires_at,
+        "grant_seen": grant_seen,
+    }
+
+
+def _extract_operation(req: dict[str, Any]) -> str | None:
+    """Pull the gated operation from the consent request record.
+
+    Prefers the structured ``custom_template.consent_meta.operation``;
+    falls back to the ``op:<operation>`` tag that
+    ``create_consent_request`` always attaches.
+    """
+    meta = (req.get("custom_template") or {}).get("consent_meta") or {}
+    op = meta.get("operation")
+    if op:
+        return op
+    for tag in req.get("tags") or []:
+        if isinstance(tag, str) and tag.startswith("op:"):
+            return tag[len("op:"):]
+    return None
+
+
+def _response_value(response: Any) -> str | None:
+    """Extract the chosen option key from a recorded response.
+
+    Handles the StandardResponse dict shape ``{"value": ...}`` and the
+    dashboard's nested ``{"value": {"value": "once"}}`` wrapping, mirroring
+    the gateway's own unwrapping.
+    """
+    if response is None:
+        return None
+    value: Any = response
+    if isinstance(value, dict) and "value" in value:
+        value = value["value"]
+    if isinstance(value, dict) and "value" in value:
+        value = value["value"]
+    return value if isinstance(value, str) else None
+
+
+def _grant_is_live(operation: str, session_id: str | None) -> bool:
+    """True when ``operation`` has a non-expired grant in the session DB.
+
+    Best-effort and defensive: any error reading the consent DB yields
+    ``False`` rather than propagating, so a status query never fails on a
+    grant-store hiccup.
+    """
+    if not session_id:
+        return False
+    try:
+        from work_buddy.consent import list_consents
+
+        grants = list_consents(agent_session_id=session_id)
+        entry = grants.get(operation)
+        if not entry:
+            return False
+        return not entry.get("expired", False)
+    except Exception:
+        return False
+
+
+def _is_past(iso_ts: str | None) -> bool:
+    """True when an ISO timestamp is in the past (UTC-aware)."""
+    if not iso_ts:
+        return False
+    try:
+        ts = datetime.fromisoformat(iso_ts)
+    except (ValueError, TypeError):
+        return False
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc) >= ts

--- a/work_buddy/mcp_server/tools/gateway.py
+++ b/work_buddy/mcp_server/tools/gateway.py
@@ -493,6 +493,13 @@ def _auto_consent_request(
                 f"mcp__work-buddy__wb_run(\"retry\", "
                 f"{{\"operation_id\": \"{op_id}\"}})"
             )
+        wait_hint = (
+            f"To wait for the user's decision from a shell watcher (e.g. the "
+            f"Monitor tool) instead of polling manually, run: "
+            f"bash /tmp/wb/status consent wait {nid} --timeout 300 "
+            f"(exit 0=granted, 1=denied, 2=timeout, 3=not found). On exit 0, "
+            f"run the retry above. See the operations/status-cli knowledge unit."
+        )
         return {
             "status": "timeout",
             "request_id": nid,
@@ -502,6 +509,7 @@ def _auto_consent_request(
                 f"the user can approve on any surface. Once approved, retry with: "
                 f"{retry_hint}"
             ),
+            "wait_hint": wait_hint,
         }
 
     # Extract choice from StandardResponse

--- a/work_buddy/mcp_server/tools/gateway.py
+++ b/work_buddy/mcp_server/tools/gateway.py
@@ -493,23 +493,28 @@ def _auto_consent_request(
                 f"mcp__work-buddy__wb_run(\"retry\", "
                 f"{{\"operation_id\": \"{op_id}\"}})"
             )
-        wait_hint = (
-            f"To wait for the user's decision from a shell watcher (e.g. the "
-            f"Monitor tool) instead of polling manually, run: "
-            f"bash /tmp/wb/status consent wait {nid} --timeout 300 "
-            f"(exit 0=granted, 1=denied, 2=timeout, 3=not found). On exit 0, "
-            f"run the retry above. See the operations/status-cli knowledge unit."
-        )
         return {
             "status": "timeout",
             "request_id": nid,
             "operation_id": op_id,
             "message": (
-                f"Consent request timed out, but still pending — "
-                f"the user can approve on any surface. Once approved, retry with: "
-                f"{retry_hint}"
+                f"Consent request timed out but is still pending — the user can "
+                f"approve on any surface (the request expires in ~2h). Before "
+                f"waiting, first do anything else you can and should safely do "
+                f"now. Then poll for their decision with a shell watcher (e.g. "
+                f"the Monitor tool): bash /tmp/wb/status consent wait {nid} "
+                f"--timeout <seconds> (exit 0=granted, 1=denied, 2=timed out or "
+                f"expired, 3=not found). Recommended: run it in the background "
+                f"with --timeout -1 — that waits at no token cost (the model "
+                f"isn't billed while it sleeps) until the request is "
+                f"granted/denied or self-expires at its ~2h TTL, so it never "
+                f"hangs forever. Use a finite --timeout instead if you want to "
+                f"bound the wait (you're not backgrounding it, you have your own "
+                f"deadline, or you'd rather re-check later). On exit 0, retry "
+                f"with: {retry_hint.rstrip('.')}. Or, once the user tells you "
+                f"they approved, just retry. See the operations/status-cli "
+                f"knowledge unit."
             ),
-            "wait_hint": wait_hint,
         }
 
     # Extract choice from StandardResponse

--- a/work_buddy/operations_read.py
+++ b/work_buddy/operations_read.py
@@ -1,0 +1,131 @@
+"""Read-only access to operation records for shell-level tooling.
+
+Operation records are durable JSON files written by the MCP gateway
+(:mod:`work_buddy.mcp_server.tools.gateway`) for every ``wb_run`` dispatch.
+This module exposes a read path that deliberately does **not** import the
+gateway — importing it pulls in the whole MCP/FastMCP stack, which would
+dominate the startup cost of a short-lived poller. The CLI in
+:mod:`work_buddy.statusctl` reads operation status through here so it can
+start in milliseconds.
+
+The on-disk layout is owned by the gateway. This module mirrors only its
+path resolution (``data_dir("agents")/"operations"/"<op_id>.json"``) and
+field names; keep it in sync with
+``gateway._get_operations_dir`` / ``gateway._load_operation`` /
+``gateway._complete_operation`` if those change.
+
+Everything here is strictly read-only: it observes operation records, it
+never creates, mutates, or completes them.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def operations_dir() -> Path:
+    """Return the global operations directory (mirrors the gateway).
+
+    Uses :func:`work_buddy.paths.data_dir`, the sanctioned path resolver,
+    so a custom ``paths.data_root`` is honoured. ``data_dir`` creates the
+    ``agents`` directory if absent — an idempotent no-op in any real
+    deployment where the gateway has already run.
+    """
+    from work_buddy.paths import data_dir
+
+    return data_dir("agents") / "operations"
+
+
+def load_operation(op_id: str) -> dict[str, Any] | None:
+    """Load an operation record by ID, or ``None`` if it does not exist.
+
+    Mirrors ``gateway._load_operation`` without importing the gateway.
+    Returns ``None`` (rather than raising) on a missing or unreadable
+    file so callers can treat "not found" and "unreadable" uniformly.
+    """
+    path = operations_dir() / f"{op_id}.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+# Terminal record states → CLI state vocabulary. ``running`` is the only
+# non-terminal state the gateway writes.
+_RECORD_STATE_MAP = {
+    "completed": "completed",
+    "failed": "failed",
+    "running": "running",
+}
+
+
+def operation_status(op_id: str) -> dict[str, Any]:
+    """Return a normalized, read-only status view of an operation.
+
+    Output shape (always includes ``state``)::
+
+        {
+          "operation_id": str,
+          "state": "running" | "completed" | "failed" | "stale" | "not_found",
+          "terminal": bool,          # True for completed/failed
+          "name": str | None,        # the capability/workflow name
+          "error": str | None,
+          "error_kind": str | None,
+          "created_at": str | None,
+          "completed_at": str | None,
+        }
+
+    ``stale`` marks a record still flagged ``running`` whose execution
+    lease (``locked_until``) has elapsed — the dispatching process likely
+    died. It is reported informationally; it is *not* treated as terminal,
+    so a ``wait`` keeps polling until the real timeout (a lease can be
+    legitimately long). Callers that want to abort on staleness can check
+    the field.
+    """
+    record = load_operation(op_id)
+    if record is None:
+        return {
+            "operation_id": op_id,
+            "state": "not_found",
+            "terminal": False,
+            "name": None,
+            "error": None,
+            "error_kind": None,
+            "created_at": None,
+            "completed_at": None,
+        }
+
+    raw = record.get("status")
+    state = _RECORD_STATE_MAP.get(raw, raw or "running")
+
+    if state == "running" and _lease_expired(record.get("locked_until")):
+        state = "stale"
+
+    return {
+        "operation_id": op_id,
+        "state": state,
+        "terminal": state in ("completed", "failed"),
+        "name": record.get("name"),
+        "error": record.get("error"),
+        "error_kind": record.get("error_kind"),
+        "created_at": record.get("created_at"),
+        "completed_at": record.get("completed_at"),
+    }
+
+
+def _lease_expired(locked_until: str | None) -> bool:
+    """True when an ISO ``locked_until`` lease is in the past."""
+    if not locked_until:
+        return False
+    try:
+        deadline = datetime.fromisoformat(locked_until)
+    except (ValueError, TypeError):
+        return False
+    if deadline.tzinfo is None:
+        deadline = deadline.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc) >= deadline

--- a/work_buddy/statusctl/__init__.py
+++ b/work_buddy/statusctl/__init__.py
@@ -1,0 +1,10 @@
+"""work-buddy status CLI — a read-only, shell-pollable window into
+consent-request and operation status for tooling that cannot speak MCP
+(the ``Monitor`` tool, ``bash`` background loops, cron).
+
+Invoke as ``python -m work_buddy.statusctl``. See :mod:`work_buddy.statusctl.cli`.
+"""
+
+from work_buddy.statusctl.cli import main
+
+__all__ = ["main"]

--- a/work_buddy/statusctl/__main__.py
+++ b/work_buddy/statusctl/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point: ``python -m work_buddy.statusctl``."""
+
+from work_buddy.statusctl.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/work_buddy/statusctl/bin/status.sh
+++ b/work_buddy/statusctl/bin/status.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# work-buddy status command — read-only consent/operation status for
+# shell-level pollers (the Monitor tool, bash background loops, cron) that
+# cannot speak MCP. Forwards to `python -m work_buddy.statusctl`.
+#
+# This is a TEMPLATE. The SessionStart hook
+# work_buddy/statusctl/install_commands.sh materializes it into
+# /tmp/wb/status, substituting %%SESSION%% and %%REPO%%. Do not run the
+# template directly; do not edit the generated copy.
+#
+# Usage:
+#   bash /tmp/wb/status consent wait   <request_id> [--timeout 600]
+#   bash /tmp/wb/status consent status <request_id>
+#   bash /tmp/wb/status op wait   <operation_id> [--timeout 600]
+#   bash /tmp/wb/status op status <operation_id>
+#   bash /tmp/wb/status --help
+#
+# The verb may be omitted: `consent <id>` == `consent status <id>`.
+#
+# Exit codes (branch on $? in a Monitor until-loop):
+#   0 granted / operation completed
+#   1 denied  / operation failed
+#   2 timed out (no decision within the deadline; or request expired)
+#   3 not found (unknown id)
+#   4 internal error / no interpreter
+#   130 interrupted (SIGINT)
+
+# Baked in at generation time so consent queries are session-scoped without
+# the caller passing --session.
+export WORK_BUDDY_SESSION_ID="%%SESSION%%"
+REPO="%%REPO%%"
+# Source-tree safety: ensure the package is importable even if not installed.
+export PYTHONPATH="${REPO}${PYTHONPATH:+:$PYTHONPATH}"
+
+# Resolve a Python interpreter that can import work-buddy. Resolution order:
+# explicit override → a `python`/`python3` on PATH → common conda env paths.
+_wb_can_import() { "$1" -c "import work_buddy.statusctl.cli" >/dev/null 2>&1; }
+
+WB_PY=""
+if [ -n "$WORK_BUDDY_PYTHON" ] && _wb_can_import "$WORK_BUDDY_PYTHON"; then
+    WB_PY="$WORK_BUDDY_PYTHON"
+fi
+if [ -z "$WB_PY" ]; then
+    for cand in python python3; do
+        if command -v "$cand" >/dev/null 2>&1 && _wb_can_import "$cand"; then
+            WB_PY="$cand"; break
+        fi
+    done
+fi
+if [ -z "$WB_PY" ]; then
+    for base in "$CONDA_PREFIX" "$HOME/miniforge3" "$HOME/anaconda3" "$HOME/miniconda3"; do
+        [ -n "$base" ] || continue
+        for exe in "$base/envs/work-buddy/python.exe" "$base/envs/work-buddy/bin/python"; do
+            if [ -x "$exe" ] && _wb_can_import "$exe"; then WB_PY="$exe"; break 2; fi
+        done
+    done
+fi
+if [ -z "$WB_PY" ]; then
+    echo "wb status: no Python with work-buddy installed was found." >&2
+    echo "Set WORK_BUDDY_PYTHON to your work-buddy env interpreter." >&2
+    exit 4
+fi
+
+exec "$WB_PY" -m work_buddy.statusctl "$@"

--- a/work_buddy/statusctl/cli.py
+++ b/work_buddy/statusctl/cli.py
@@ -1,0 +1,322 @@
+"""Read-only status CLI for shell-level pollers.
+
+Two domains, each with a one-shot ``status`` and a blocking ``wait``:
+
+    python -m work_buddy.statusctl consent status <request_id>
+    python -m work_buddy.statusctl consent wait   <request_id> [--timeout N]
+    python -m work_buddy.statusctl op      status <operation_id>
+    python -m work_buddy.statusctl op      wait   <operation_id> [--timeout N]
+
+The verb may be omitted — ``consent <request_id>`` is shorthand for
+``consent status <request_id>``.
+
+Design (see the knowledge unit ``operations/status-cli`` for the rationale):
+
+* **One blocking process, not a respawn-per-poll loop.** ``wait`` does the
+  tiered sleep-poll internally, so a ``Monitor`` until-loop runs a single
+  command instead of paying Python startup on every tick. This is the
+  ``kubectl wait`` / ``aws … wait`` shape.
+* **Distinct exit codes** so a shell loop can branch on ``$?`` without
+  parsing output:
+
+      0  granted / operation completed
+      1  denied  / operation failed
+      2  timed out (no decision within the deadline; or request expired)
+      3  not found (unknown id)
+      4  internal error
+      130 interrupted (SIGINT)
+
+  One-shot ``status`` always exits 0 and puts the state in the body (use
+  ``wait --timeout 0`` for a single check *with* the full exit-code
+  vocabulary).
+* **Strictly read-only.** It observes consent/operation state; it never
+  mints, consumes, or mutates anything. Acting on a ``granted`` result
+  (the retry) goes back through the gateway, which re-checks consent.
+* **Cheap startup.** Heavy reads are imported lazily inside handlers; an
+  ``op`` query never imports the consent stack and vice-versa.
+
+stdout carries the final result (text line, or JSON with ``--json``);
+progress and diagnostics go to stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+
+# Exit codes — the branchable verdict vocabulary.
+EXIT_OK = 0          # granted / completed
+EXIT_NEGATIVE = 1    # denied / failed
+EXIT_TIMEOUT = 2     # no decision within the deadline / expired
+EXIT_NOT_FOUND = 3   # unknown id
+EXIT_ERROR = 4       # internal error
+EXIT_INTERRUPT = 130  # SIGINT
+
+# Per-domain mapping of a resolved state → exit code, and which states are
+# terminal for the purpose of a ``wait`` (stop polling and return).
+_CONSENT_EXIT = {
+    "granted": EXIT_OK,
+    "denied": EXIT_NEGATIVE,
+    "expired": EXIT_TIMEOUT,
+    "not_found": EXIT_NOT_FOUND,
+}
+_CONSENT_TERMINAL = set(_CONSENT_EXIT)  # pending is the only non-terminal state
+
+_OP_EXIT = {
+    "completed": EXIT_OK,
+    "failed": EXIT_NEGATIVE,
+    "not_found": EXIT_NOT_FOUND,
+}
+# running/stale are non-terminal (keep waiting); not_found IS terminal — the
+# gateway only returns an operation_id after writing the record, so a missing
+# record means a bad id, not a not-yet-created one.
+_OP_TERMINAL = set(_OP_EXIT)
+
+_DEFAULT_TIMEOUT = 600  # seconds
+
+
+# ---------------------------------------------------------------------------
+# Poll cadence
+# ---------------------------------------------------------------------------
+
+def _next_interval(elapsed: float, override: float | None) -> float:
+    """Tiered poll interval: responsive early, lighter later.
+
+    Humans usually approve fast, so poll tightly for the first half-minute,
+    then back off. ``override`` pins a fixed interval when the caller asks.
+    """
+    if override is not None:
+        return override
+    if elapsed < 30:
+        return 2.0
+    if elapsed < 300:
+        return 5.0
+    return 15.0
+
+
+# ---------------------------------------------------------------------------
+# Wait loop (shared by both domains)
+# ---------------------------------------------------------------------------
+
+def _wait(check, terminal_states, timeout, poll_interval, *, on_poll=None):
+    """Poll ``check()`` until it returns a terminal state or the deadline.
+
+    Parameters
+    ----------
+    check:
+        Zero-arg callable returning a status view dict containing ``state``.
+    terminal_states:
+        States that end the wait immediately.
+    timeout:
+        Seconds. ``0`` checks exactly once; negative waits indefinitely.
+    poll_interval:
+        Fixed interval override, or ``None`` for the tiered schedule.
+    on_poll:
+        Optional callback(view, elapsed) for progress reporting.
+
+    Returns
+    -------
+    (view, timed_out): the last status view and whether the deadline hit
+    before a terminal state.
+    """
+    start = time.monotonic()
+    wait_forever = timeout is not None and timeout < 0
+    while True:
+        view = check()
+        elapsed = time.monotonic() - start
+        if on_poll is not None:
+            on_poll(view, elapsed)
+        if view["state"] in terminal_states:
+            return view, False
+        # Deadline check (after at least one poll, so timeout=0 = check once).
+        if not wait_forever and timeout is not None and elapsed >= timeout:
+            return view, True
+        interval = _next_interval(elapsed, poll_interval)
+        if not wait_forever and timeout is not None:
+            remaining = timeout - elapsed
+            if remaining <= 0:
+                return view, True
+            interval = min(interval, remaining)
+        time.sleep(interval)
+
+
+# ---------------------------------------------------------------------------
+# Domain handlers
+# ---------------------------------------------------------------------------
+
+def _resolve_session(explicit: str | None) -> str | None:
+    if explicit:
+        return explicit
+    import os
+    return os.environ.get("WORK_BUDDY_SESSION_ID") or None
+
+
+def _consent_check(request_id: str, session_id: str | None):
+    from work_buddy.consent_status import consent_status
+    return lambda: consent_status(request_id, session_id=session_id)
+
+
+def _op_check(operation_id: str):
+    from work_buddy.operations_read import operation_status
+    return lambda: operation_status(operation_id)
+
+
+def _emit(view: dict, *, as_json: bool, exit_code: int) -> int:
+    """Write the final result to stdout and return the exit code."""
+    if as_json:
+        out = dict(view)
+        out["exit_code"] = exit_code
+        print(json.dumps(out))
+    else:
+        state = view.get("state", "?")
+        extra = ""
+        if view.get("operation"):
+            extra = f" op={view['operation']}"
+        elif view.get("name"):
+            extra = f" name={view['name']}"
+        ident = view.get("request_id") or view.get("operation_id") or ""
+        print(f"{state} {ident}{extra}".rstrip())
+    return exit_code
+
+
+def _run_query(check, exit_map, terminal_states, args) -> int:
+    """Shared logic for status (one-shot) and wait (blocking)."""
+    as_json = args.json
+    is_wait = args.mode == "wait"
+
+    if not is_wait:
+        # One-shot: always exit 0, state in body.
+        view = check()
+        return _emit(view, as_json=as_json, exit_code=EXIT_OK)
+
+    def _progress(view, elapsed):
+        if args.verbose:
+            print(
+                f"[{int(elapsed)}s] {view['state']}",
+                file=sys.stderr, flush=True,
+            )
+
+    view, timed_out = _wait(
+        check, terminal_states, args.timeout, args.poll_interval,
+        on_poll=_progress,
+    )
+    if timed_out:
+        return _emit(view, as_json=as_json, exit_code=EXIT_TIMEOUT)
+    return _emit(view, as_json=as_json, exit_code=exit_map[view["state"]])
+
+
+def _handle_consent(args) -> int:
+    session_id = _resolve_session(args.session)
+    if args.mode == "wait" and session_id is None:
+        # Without a session the grant cross-check is skipped — a wait would
+        # only ever see request-record transitions, which is still correct
+        # for responded/denied/expired but misses out-of-band grants. Warn.
+        print(
+            "warning: no session id (WORK_BUDDY_SESSION_ID unset, --session "
+            "not given); out-of-band grants will not be detected.",
+            file=sys.stderr,
+        )
+    check = _consent_check(args.id, session_id)
+    return _run_query(check, _CONSENT_EXIT, _CONSENT_TERMINAL, args)
+
+
+def _handle_op(args) -> int:
+    check = _op_check(args.id)
+    return _run_query(check, _OP_EXIT, _OP_TERMINAL, args)
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+def _add_wait_flags(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "--timeout", type=float, default=_DEFAULT_TIMEOUT,
+        help="seconds to wait (default 600; 0 = check once; negative = forever)",
+    )
+    p.add_argument(
+        "--poll-interval", type=float, default=None, dest="poll_interval",
+        help="fixed poll interval in seconds (default: tiered 2/5/15s)",
+    )
+    p.add_argument(
+        "--verbose", action="store_true",
+        help="emit per-poll progress to stderr",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="statusctl",
+        description="Read-only consent/operation status for shell pollers.",
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="emit the full status dict as JSON on stdout",
+    )
+    domains = parser.add_subparsers(dest="domain", required=True)
+
+    for domain, ident_help in (
+        ("consent", "consent request id (req_…)"),
+        ("op", "operation id (op_…)"),
+    ):
+        d = domains.add_parser(domain, help=f"{domain} status queries")
+        verbs = d.add_subparsers(dest="mode", required=True)
+
+        s = verbs.add_parser("status", help="print current state and exit")
+        s.add_argument("id", help=ident_help)
+        if domain == "consent":
+            s.add_argument("--session", default=None,
+                           help="agent session id (default: $WORK_BUDDY_SESSION_ID)")
+
+        w = verbs.add_parser("wait", help="block until resolved or timeout")
+        w.add_argument("id", help=ident_help)
+        if domain == "consent":
+            w.add_argument("--session", default=None,
+                           help="agent session id (default: $WORK_BUDDY_SESSION_ID)")
+        _add_wait_flags(w)
+
+    return parser
+
+
+def _preprocess(argv: list[str]) -> list[str]:
+    """Allow the verb to be omitted: ``consent <id>`` → ``consent status <id>``.
+
+    Only rewrites when the token after the domain is neither a known verb
+    nor an option, so explicit forms and ``--help`` are untouched.
+    """
+    out = list(argv)
+    # Find the domain token (first non-option arg).
+    for i, tok in enumerate(out):
+        if tok in ("consent", "op"):
+            nxt = out[i + 1] if i + 1 < len(out) else None
+            if nxt is not None and nxt not in ("status", "wait") and not nxt.startswith("-"):
+                out.insert(i + 1, "status")
+            break
+        if not tok.startswith("-"):
+            break  # some other leading positional — leave alone
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    raw = sys.argv[1:] if argv is None else argv
+    parser = _build_parser()
+    try:
+        args = parser.parse_args(_preprocess(raw))
+    except SystemExit as exc:  # argparse exits 2 on usage error
+        return int(exc.code) if exc.code is not None else EXIT_ERROR
+
+    try:
+        if args.domain == "consent":
+            return _handle_consent(args)
+        if args.domain == "op":
+            return _handle_op(args)
+        parser.error(f"unknown domain: {args.domain}")
+        return EXIT_ERROR
+    except KeyboardInterrupt:
+        print("interrupted", file=sys.stderr)
+        return EXIT_INTERRUPT
+    except Exception as exc:  # pragma: no cover — defensive top-level guard
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_ERROR

--- a/work_buddy/statusctl/cli.py
+++ b/work_buddy/statusctl/cli.py
@@ -183,7 +183,7 @@ def _emit(view: dict, *, as_json: bool, exit_code: int) -> int:
 
 def _run_query(check, exit_map, terminal_states, args) -> int:
     """Shared logic for status (one-shot) and wait (blocking)."""
-    as_json = args.json
+    as_json = getattr(args, "json", False)
     is_wait = args.mode == "wait"
 
     if not is_wait:
@@ -247,13 +247,20 @@ def _add_wait_flags(p: argparse.ArgumentParser) -> None:
 
 
 def _build_parser() -> argparse.ArgumentParser:
+    # --json on a shared parent (default SUPPRESS so an unset level never
+    # overwrites a set one) added to BOTH the top parser and every leaf
+    # subparser, so `--json` is accepted before OR after the subcommand —
+    # a trailing flag is the natural shell order and must work.
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--json", action="store_true", default=argparse.SUPPRESS,
+        help="emit the full status dict as JSON on stdout",
+    )
+
     parser = argparse.ArgumentParser(
         prog="statusctl",
         description="Read-only consent/operation status for shell pollers.",
-    )
-    parser.add_argument(
-        "--json", action="store_true",
-        help="emit the full status dict as JSON on stdout",
+        parents=[common],
     )
     domains = parser.add_subparsers(dest="domain", required=True)
 
@@ -264,13 +271,15 @@ def _build_parser() -> argparse.ArgumentParser:
         d = domains.add_parser(domain, help=f"{domain} status queries")
         verbs = d.add_subparsers(dest="mode", required=True)
 
-        s = verbs.add_parser("status", help="print current state and exit")
+        s = verbs.add_parser("status", parents=[common],
+                             help="print current state and exit")
         s.add_argument("id", help=ident_help)
         if domain == "consent":
             s.add_argument("--session", default=None,
                            help="agent session id (default: $WORK_BUDDY_SESSION_ID)")
 
-        w = verbs.add_parser("wait", help="block until resolved or timeout")
+        w = verbs.add_parser("wait", parents=[common],
+                             help="block until resolved or timeout")
         w.add_argument("id", help=ident_help)
         if domain == "consent":
             w.add_argument("--session", default=None,

--- a/work_buddy/statusctl/install_commands.sh
+++ b/work_buddy/statusctl/install_commands.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# SessionStart hook: materialize the /tmp/wb/status helper command from its
+# template, baking in this session's id and the repo path. This gives
+# shell-level tooling (the Monitor tool, bash loops, cron) a sanctioned,
+# read-only poll target for consent-request and operation status — the
+# pieces that cannot speak MCP.
+#
+# Mirrors the messaging hook's /tmp/wb/* generation
+# (work_buddy/messaging/check_messages.sh) but is deliberately separate so
+# the status command does not depend on the messaging service's health.
+# Registered as a SessionStart hook in config/global_settings.json.
+
+INPUT=$(cat)
+
+# Extract session_id from the hook's stdin JSON (python, then python3).
+SESSION=$(echo "$INPUT" | python -c "import sys,json; print(json.load(sys.stdin).get('session_id',''))" 2>/dev/null)
+if [ -z "$SESSION" ]; then
+    SESSION=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id',''))" 2>/dev/null)
+fi
+if [ -z "$SESSION" ]; then
+    SESSION="${WORK_BUDDY_SESSION_ID:-}"
+fi
+
+# Locate the template (next to this script) and the repo root (two levels up:
+# work_buddy/statusctl/ -> work_buddy/ -> repo).
+BIN_SRC="$(cd "$(dirname "$0")" && pwd)/bin"
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+
+mkdir -p /tmp/wb
+if [ -f "$BIN_SRC/status.sh" ]; then
+    sed \
+        -e "s|%%SESSION%%|$SESSION|g" \
+        -e "s|%%REPO%%|$REPO|g" \
+        "$BIN_SRC/status.sh" > /tmp/wb/status
+    chmod +x /tmp/wb/status
+fi
+
+exit 0


### PR DESCRIPTION
## What

A read-only, shell-pollable window into **consent-request** and **operation** status, for tooling that cannot speak the MCP gateway — the `Monitor` tool, `bash run_in_background` loops, cron. Backs task **t-6beb03d5**.

The motivating loop: when a `wb_run` consent gate times out (~90s) and hands back a `request_id`, an agent can now arm a background watcher:

```
bash /tmp/wb/status consent wait <request_id> --timeout -1
```

which blocks (at no token cost) until the user approves/denies on any surface, exits with a branchable code, and the agent then runs the sanctioned retry. Closes the loop the gateway already half-built.

## Design

- **One blocking process per wait, not respawn-per-poll.** `wait` does the tiered sleep-poll internally (2s → 5s → 15s), so a `Monitor` loop runs a single command. The `kubectl wait` / `aws … wait` shape.
- **Distinct exit codes** for shell branching: `0` granted/completed · `1` denied/failed · `2` timed out/expired · `3` not found · `4` error · `130` SIGINT.
- **Strictly read-only.** Never mints, caches, or consumes a grant. A `granted` verdict only means the user approved; the retry re-checks consent through the gate, so an expired grant re-prompts — preserving the no-time-travel-through-the-retry-queue invariant.
- **Session-scoped grant reads** (`agent_session_id` passed explicitly — principal-correct).
- **Self-bounding indefinite wait:** the consent request's ~2h TTL makes `expired` terminal, so even `--timeout -1` exits on its own.

## Pieces

- `work_buddy/statusctl/` — argparse CLI (`consent|op` × `status|wait`), tiered wait loop, lazy imports (an `op` query never imports the consent stack).
- `work_buddy/consent_status.py` — read-only composer fusing the request record + the session grant into one verdict.
- `work_buddy/operations_read.py` — light operation-record reader that does not import the MCP gateway (keeps CLI startup off the heavy stack).
- `work_buddy/statusctl/bin/status.sh` + `install_commands.sh` — `/tmp/wb/status` materialized per session, mirroring the messaging `check_messages.sh` hook.
- Gateway: the consent-timeout `message` now folds in the wait guidance (recommends a free, self-bounding backgrounded `--timeout -1`; offers a finite `--timeout` for foreground/deadline/reschedule; op-aware retry hint).
- Knowledge unit `operations/status-cli` + handbook nav.

## Verification

- **Unit + integration:** reader, composer, CLI exit-code mapping (both `--json` orders), gateway message, and an end-to-end simulated-approval test (`tests/integration/test_consent_wait_e2e.py`). All green; no regressions across the existing consent suite.
- **Live (`/wb-dev-live-testing`):** verified against the real running system with Telegram approvals — composer reads a real approval as `granted` with correct session routing; the blocking `wait` polled 512s on the tiered cadence then exited 0 on a fresh approval in one run; honest timeout (exit 2, no false positive); the folded gateway message renders live.
- **Bug found + fixed in live testing:** trailing `--json` (`consent wait <id> --json`) was rejected by argparse because it was top-level-only — the natural shell order failed. Fixed via a shared-parent parser; 4 regression tests added.

## Notes for reviewers

- **Hook registration is machine-local** (lives in the gitignored, hard-linked `config/global_settings.json`, exactly like `check_messages.sh`). The hook *scripts* are tracked and ship; the registration is not — a pre-existing distribution characteristic, not specific to this PR. Worth deciding separately whether to add a tracked setup-wizard step.
- **Follow-ups surfaced** (filed as real tasks during live testing): the SessionStart hook doesn't auto-fire until the Desktop app restarts (it caches hooks at startup); `once` grants didn't auto-revoke after `obsidian_retry` (pre-existing retry-path behavior); and an optional cold-start win by lazy-loading `work_buddy/__init__.py`'s version lookup (~178ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
