### PR TITLE
fix(obsidian): gate vault direct-write fallback on Obsidian process state

### DIFF
--- a/knowledge/store/architecture/retry-queue.md
+++ b/knowledge/store/architecture/retry-queue.md
@@ -58,6 +58,12 @@ dev_notes: |-
   ## Why op-record `originating_session_id` is the consent reference
 
   The op record already carries `originating_session_id` (set by `_save_operation` from `WORK_BUDDY_SESSION_ID`). The sidecar's `_replay` binds a `replay_of(originating_session_id)` consent principal (and sets the `set_originating_session` contextvar for cost/artifact attribution). The consent layer resolves against the principal's session at check time, riding individual grants only. Net: zero schema changes, zero new persistence, full cross-session inheritance for replays with no workflow-grant time-travel.
+
+  ## Out-of-band enqueue seam (`enqueue_capability_for_retry`)
+
+  `work_buddy.mcp_server.tools.gateway.enqueue_capability_for_retry(capability, params, *, error, error_kind=None, originating_session_id=None) -> str | None` is the public seam for callers that do NOT dispatch through `wb_run` but still want transient-failure recovery — e.g. the Telegram capture handler, which runs in a separate sidecar process and calls the capability function directly. It creates a failed op record via `_save_operation` (carrying the capability's declared `retry_policy`, default `verify_first`) and enqueues it via `_enqueue_for_retry` with `error_class='transient'`, so the sidecar sweep replays the capability from the registry on backoff and re-reads vault state fresh each attempt.
+
+  The caller is responsible for only enqueuing genuinely transient failures — gate on `work_buddy.errors.classify_error(exc) == 'transient'` before calling. Returns the op_id, or `None` if persistence failed (the caller should then surface the original error rather than claim a queued retry). `originating_session_id` defaults to the op record's `session_id` (`WORK_BUDDY_SESSION_ID`), bound by the sweep as the `replay_of` consent principal — so a grant held by that session authorizes the replay without re-prompting. Consumer: `work_buddy/telegram/handlers.py::_do_capture`.
 ---
 
 ## Agent-facing quick rules

--- a/knowledge/store/notifications/telegram.md
+++ b/knowledge/store/notifications/telegram.md
@@ -21,11 +21,17 @@ aliases:
 parents:
 - notifications
 - notifications
+dev_notes: |
+  ## Capture retry wiring
+
+  `_do_capture` (work_buddy/telegram/handlers.py) calls `write_at_location` directly — the bot is a separate sidecar process, not the `wb_run` dispatch path, so it gets no automatic gateway enqueue and `@bridge_retry` is a no-op under the PTB event loop. On a failure where `work_buddy.errors.classify_error(exc) == "transient"` (e.g. `ObsidianEditorConflict`, `ObsidianStartupRace`), it enqueues the capture for the sidecar sweep via `work_buddy.mcp_server.tools.gateway.enqueue_capability_for_retry("vault_write_at_location", {...})`, defaulting `originating_session_id` to the op record's session so the `replay_of` consent principal authorizes the replay without re-prompting. Non-transient errors fall through to the generic handler. See `architecture/retry-queue` for the seam.
 ---
 
 Commands: /start (verify identity, register chat), /help, /capture <text> (append to journal Running Notes), /reply <short_id> <answer> (respond to pending request by 4-digit ID), /remote <prompt> (launch Claude Code remote session), /resume (resume existing session), /status (system health), /obs <query> (search and execute Obsidian command), /slash (list slash commands), /dashboard (return dashboard URL).
 
 Plain text messages (no command) are treated as captures and appended to the journal.
+
+Capture resilience: if a capture's write hits a transient failure (most commonly `editor_dirty` — the target journal is open in Obsidian with unsaved edits), the text is NOT dropped. It is queued on the retry queue and the bot replies `Attempted capture to <note> — queued …`; the sidecar sweep lands it automatically once the note is free. (See `architecture/retry-queue`.)
 
 Setup: (1) Create bot via @BotFather, (2) Set TELEGRAM_BOT_TOKEN env var, (3) Enable in config.yaml (telegram.enabled: true + sidecar.services.telegram.enabled: true), (4) Restart sidecar, (5) Send /start — first chat is auto-accepted. Chat ID is auto-persisted to .telegram_chat_id and merged with config.yaml allowed_chat_ids on startup.
 

--- a/knowledge/store/obsidian/vault-write-decision.md
+++ b/knowledge/store/obsidian/vault-write-decision.md
@@ -28,7 +28,7 @@ Work-buddy has two ways to write a vault file from Python. They look similar; pi
 
 | Helper | Behavior on bridge down | Use for |
 |---|---|---|
-| `work_buddy.obsidian.vault_writer.vault_write(path, abs_path, content, *, write_mode='replace', content_hint=None)` | Catches `ObsidianUnreachable`, falls back to atomic direct filesystem write. Re-raises `ObsidianEditorConflict`, `ObsidianPostWriteUncertain`, `ObsidianRefused`, `ObsidianServerError`. | Journals, knowledge units, capture, generic content the user typed (no plugin owns state for these files) |
+| `work_buddy.obsidian.vault_writer.vault_write(path, abs_path, content, *, write_mode='replace', content_hint=None)` | Direct filesystem fallback **only when the Obsidian process is down** (`ObsidianNotRunning` / `is_obsidian_running()` is False). Re-raises every other failure — other `ObsidianUnreachable` subclasses (`ObsidianStartupRace`, plugin missing / disabled), `ObsidianEditorConflict`, `ObsidianPostWriteUncertain`, `ObsidianRefused`, `ObsidianServerError`. | Journals, knowledge units, capture, generic content the user typed (no plugin owns state for these files) |
 | `work_buddy.obsidian.bridge.write_file_raw(path, content, *, write_mode='replace', content_hint=None)` | Raises typed `ObsidianError` subclasses; no fallback | Master task list (`tasks/master-task-list.md`), task notes, archives, contract files — anything the Obsidian Tasks plugin has live cache state for |
 
 ## Why the split is principled
@@ -37,8 +37,12 @@ The Tasks plugin maintains a runtime cache of every task in the vault. Mutations
 
 A direct `Path.write_text()` to the master task list bypasses ALL of that. The file on disk would be correct momentarily, but the plugin's in-memory cache would be stale until the next vault rescan, and any mutation the plugin then applied would be against pre-write state. Recurring tasks would lose their schedule, done-dates would be wrong, and so on.
 
-Non-task files have no equivalent plugin invariant, so falling back to a direct write is safe — the bridge is just a delivery mechanism. BUT: even for non-task files, the fallback only fires for `ObsidianUnreachable` (bridge can't even be reached, body not sent). For other failure types we re-raise:
+Non-task files have no equivalent plugin invariant, so a direct write is safe — **as long as no editor is holding the file**. The deciding predicate is the Obsidian **process** state, not bridge reachability: `vault_write` direct-writes only when `is_obsidian_running()` is False (`ObsidianNotRunning`). If Obsidian is running but the bridge is transiently unreachable (startup race / port not yet bound) or otherwise failing, an editor may have the note open. A direct write would update disk while the open editor keeps its old buffer, leaving the two diverged — and Obsidian then reports the file dirty on every subsequent bridge write, wedging it with a persistent `409 editor_dirty` until the user reloads the note. So those cases re-raise (transient) and the gateway / retry queue replays once the bridge recovers, rather than direct-writing.
 
+Per failure type:
+
+- `ObsidianNotRunning` → process is down, no editor can be open. Direct filesystem fallback is safe. FALL BACK.
+- `ObsidianStartupRace` / `ObsidianPluginMissing` / `ObsidianPluginDisabled` (other `ObsidianUnreachable`) → Obsidian is running; an editor may hold the note. RE-RAISE — don't diverge it.
 - `ObsidianPostWriteUncertain` → RE-RAISE. Body MAY have been sent; the gateway-side post-write-verify reads the file and decides. Filesystem fallback would risk overwriting a successful write.
 - `ObsidianEditorConflict` → RE-RAISE. The user has unsaved typing; a filesystem write would clobber it.
 - `ObsidianRefused` → RE-RAISE. Structural refusal (4xx other than 409). No retry will help; falling back to filesystem doesn't change the rejection reason.
@@ -63,7 +67,7 @@ Callers that do section-aware inserts (e.g. `vault_write_at_location`) should pa
 
 Both helpers route through `bridge.write_file_raw` when the bridge is up. That function raises `ObsidianEditorConflict` **immediately** on the first `409` from the plugin's pre-flight dirty-editor check. There is no in-bridge retry: retrying the same payload bytes after the user's typing auto-saves to disk would silently clobber those saved keystrokes. Re-reading + re-computing the payload is the *caller's* job — in practice, the gateway's retry queue (`architecture/retry-queue`).
 
-Capabilities with `retry_policy="verify_first"` or `"replay"` auto-enqueue on transient errors; the sidecar sweep re-invokes the whole capability from scratch on adaptive backoff (10 / 20 / 45 / 90 / 120s), so each attempt reads the file fresh. `vault_write_at_location`, `journal_write`, and the task mutation family all carry `verify_first` for this reason.
+Capabilities with `retry_policy="verify_first"` or `"replay"` auto-enqueue on transient errors; the sidecar sweep re-invokes the whole capability from scratch on adaptive backoff (10 / 20 / 45 / 90 / 120s), so each attempt reads the file fresh. `vault_write_at_location`, `journal_write`, and the task mutation family all carry `verify_first` for this reason. Out-of-band callers that don't dispatch through `wb_run` (e.g. the Telegram capture handler in the sidecar) enqueue the same way via `enqueue_capability_for_retry` (see `architecture/retry-queue`).
 
 `vault_write` deliberately does NOT fall back to a direct disk write on `ObsidianEditorConflict` — such a write would still be clobbered the moment the user saves. The conflict signal exists precisely to prevent that.
 
@@ -77,6 +81,7 @@ The legacy `EditorConflict` alias was removed in CP9. Callers must import `Obsid
 
 ## Anti-patterns
 
+- **Falling back to a direct write while Obsidian is running.** Even on a transient bridge flap (startup race / timeout), the note may be open in an editor; a direct disk write diverges the editor buffer from disk and wedges the note with a persistent 409 editor_dirty. Direct-write only when `is_obsidian_running()` is False.
 - **Retrying a write with the same payload after the user has been typing.** The whole reason `ObsidianEditorConflict` is raised at the first 409 is that a later retry with the original payload would clobber whatever the user auto-saved in the interim. Retry must go through the gateway / sidecar so each attempt re-computes the payload.
 - **Falling back to direct write on `ObsidianEditorConflict`.** The conflict signal exists precisely to prevent the disk-clobbers-editor scenario. Bypassing it re-introduces the bug.
 - **Falling back to direct write on `ObsidianPostWriteUncertain`.** Risks overwriting a successful-but-unacknowledged plugin write. Let the gateway's verify path decide.

--- a/tests/unit/test_capture_enqueue.py
+++ b/tests/unit/test_capture_enqueue.py
@@ -1,0 +1,81 @@
+"""Unit tests for ``enqueue_capability_for_retry`` — the public seam that lets
+out-of-band callers (e.g. the Telegram capture handler, which runs in a
+separate sidecar process and does NOT dispatch through ``wb_run``) enqueue a
+transiently-failed operation for the sidecar retry sweep instead of dropping
+it. The sweep replays the capability from the registry on backoff, so a
+capture blocked by a busy editor (409 editor_dirty) lands once the bridge frees
+up rather than being lost.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from work_buddy.mcp_server.tools.gateway import enqueue_capability_for_retry
+
+
+class _FakeEntry:
+    retry_policy = "verify_first"
+
+
+class _FakeRegistry:
+    def get(self, name):
+        return _FakeEntry()
+
+
+def _read_record(ops_dir, op_id):
+    return json.loads((ops_dir / f"{op_id}.json").read_text(encoding="utf-8"))
+
+
+def test_enqueue_creates_queued_op_record(tmp_path):
+    params = {
+        "content": "captured text",
+        "note": "latest_journal",
+        "section": "Running Notes",
+        "position": "top",
+        "source": None,
+    }
+    with patch(
+        "work_buddy.mcp_server.tools.gateway._get_operations_dir",
+        return_value=tmp_path,
+    ), patch(
+        "work_buddy.mcp_server.registry.get_registry",
+        return_value=_FakeRegistry(),
+    ):
+        op_id = enqueue_capability_for_retry(
+            "vault_write_at_location",
+            params,
+            error="editor_dirty: journal/2026-06-01.md",
+            error_kind="obsidian_editor_conflict",
+        )
+        assert op_id is not None
+        record = _read_record(tmp_path, op_id)
+
+    # Replays the exact capability + params the caller failed on.
+    assert record["name"] == "vault_write_at_location"
+    assert record["params"] == params
+    # Marked failed + queued so the sweep's _is_ready picks it up.
+    assert record["status"] == "failed"
+    assert record["queued"] is True
+    assert record["queue_reason"] == "retry"
+    assert record["error_class"] == "transient"
+    assert record["error_kind"] == "obsidian_editor_conflict"
+    # Carries the capability's declared replay policy.
+    assert record["retry_policy"] == "verify_first"
+    # A scheduled retry time is set in the future.
+    assert record["retry_at"]
+
+
+def test_enqueue_returns_none_when_persistence_fails(tmp_path):
+    """Best-effort: if the op record can't be persisted, return None so the
+    caller can surface the original error instead of claiming a queued retry."""
+    with patch(
+        "work_buddy.mcp_server.tools.gateway._save_operation",
+        side_effect=OSError("disk full"),
+    ):
+        op_id = enqueue_capability_for_retry(
+            "vault_write_at_location",
+            {"content": "x"},
+            error="boom",
+        )
+    assert op_id is None

--- a/tests/unit/test_editor_conflict.py
+++ b/tests/unit/test_editor_conflict.py
@@ -156,3 +156,86 @@ class TestVaultWriteDoesNotFallBackOnConflict:
                 vault_writer.vault_write(
                     "x.md", Path("/tmp/x.md"), "new content"
                 )
+
+
+class TestVaultWriteProcessGatedFallback:
+    """vault_write may only direct-write when Obsidian is genuinely DOWN.
+
+    When Obsidian is running but the bridge is transiently unavailable
+    (startup race / port flap), a direct filesystem write would diverge an
+    open editor's buffer from disk and wedge the note with a persistent 409
+    editor_dirty. The write must raise (transient) instead, so the retry queue
+    replays once the bridge recovers. The safety predicate is the pure process
+    check ``is_obsidian_running()`` — NOT ``is_available()`` (which reports
+    False during a startup race even though Obsidian is up).
+    """
+
+    def test_direct_write_when_obsidian_down(self, tmp_path):
+        from work_buddy.obsidian import vault_writer
+
+        p = tmp_path / "note.md"
+        with patch(
+            "work_buddy.obsidian.bridge.is_available", return_value=False
+        ), patch(
+            "work_buddy.obsidian.bridge.is_obsidian_running", return_value=False
+        ):
+            ok = vault_writer.vault_write("note.md", p, "fresh content")
+        assert ok is True
+        assert p.read_text(encoding="utf-8") == "fresh content"
+
+    def test_refuses_direct_write_when_unavailable_but_obsidian_running(self, tmp_path):
+        """Core regression: is_available()==False during a startup race while
+        Obsidian is up must NOT direct-write — it raises and leaves disk
+        untouched (no divergence created)."""
+        from work_buddy.obsidian import vault_writer
+        from work_buddy.obsidian.errors import ObsidianStartupRace
+
+        p = tmp_path / "note.md"
+        p.write_text("original", encoding="utf-8")
+        with patch(
+            "work_buddy.obsidian.bridge.is_available", return_value=False
+        ), patch(
+            "work_buddy.obsidian.bridge.is_obsidian_running", return_value=True
+        ):
+            with pytest.raises(ObsidianStartupRace):
+                vault_writer.vault_write("note.md", p, "should not land")
+        assert p.read_text(encoding="utf-8") == "original"
+
+    def test_startup_race_from_write_reraises(self, tmp_path):
+        """A non-NotRunning ObsidianUnreachable raised by write_file_raw
+        (startup race: Obsidian up, port not bound) re-raises rather than
+        direct-writing."""
+        from work_buddy.obsidian import vault_writer
+        from work_buddy.obsidian.errors import ObsidianStartupRace
+
+        p = tmp_path / "note.md"
+        p.write_text("original", encoding="utf-8")
+        with patch(
+            "work_buddy.obsidian.bridge.is_available", return_value=True
+        ), patch(
+            "work_buddy.obsidian.bridge.is_obsidian_running", return_value=True
+        ), patch(
+            "work_buddy.obsidian.bridge.write_file_raw",
+            side_effect=ObsidianStartupRace("port not bound"),
+        ):
+            with pytest.raises(ObsidianStartupRace):
+                vault_writer.vault_write("note.md", p, "should not land")
+        assert p.read_text(encoding="utf-8") == "original"
+
+    def test_not_running_from_write_falls_back(self, tmp_path):
+        """ObsidianNotRunning (process genuinely down) from write_file_raw is
+        safe to fall back: no editor can be open."""
+        from work_buddy.obsidian import vault_writer
+
+        p = tmp_path / "note.md"
+        with patch(
+            "work_buddy.obsidian.bridge.is_available", return_value=True
+        ), patch(
+            "work_buddy.obsidian.bridge.is_obsidian_running", return_value=False
+        ), patch(
+            "work_buddy.obsidian.bridge.write_file_raw",
+            side_effect=ObsidianNotRunning(),
+        ):
+            ok = vault_writer.vault_write("note.md", p, "fresh content")
+        assert ok is True
+        assert p.read_text(encoding="utf-8") == "fresh content"

--- a/tests/unit/test_journal_append.py
+++ b/tests/unit/test_journal_append.py
@@ -49,9 +49,12 @@ def test_append_preserves_order_across_midnight(tmp_path, monkeypatch):
     # Neutralize the consent decorator and bridge write so we exercise pure logic
     from work_buddy import journal as jmod
 
-    # Force the direct-write path (no bridge)
+    # Force the safe direct-write path: bridge unavailable AND Obsidian
+    # genuinely down (so vault_write's process guard permits the filesystem
+    # write rather than re-raising to protect a possibly-open editor).
     import work_buddy.obsidian.bridge as bridge_mod
     monkeypatch.setattr(bridge_mod, "is_available", lambda: False, raising=False)
+    monkeypatch.setattr(bridge_mod, "is_obsidian_running", lambda: False, raising=False)
 
     journal_file = _make_journal(tmp_path)
     entries = [
@@ -80,3 +83,32 @@ def test_append_preserves_order_across_midnight(tmp_path, monkeypatch):
     assert arrived_pos < meeting_pos < pm_one_pos < pm_late_pos
     # Post-midnight lands after PM late
     assert pm_late_pos < pm1_pos < pm2_pos
+
+
+def test_append_refuses_direct_write_when_obsidian_running(tmp_path, monkeypatch):
+    """Regression: a transient bridge outage while Obsidian is RUNNING must not
+    fall back to a direct filesystem write. A direct write would diverge an
+    open editor's buffer from disk and wedge the note with a persistent 409
+    editor_dirty. The write must raise (transient) so the retry queue replays
+    it; the file on disk must stay untouched (no divergence created).
+    """
+    from work_buddy.obsidian.errors import ObsidianStartupRace
+    import work_buddy.obsidian.bridge as bridge_mod
+
+    # Bridge reports unavailable (startup race / port flap) but the Obsidian
+    # process IS up — an editor may be holding the note.
+    monkeypatch.setattr(bridge_mod, "is_available", lambda: False, raising=False)
+    monkeypatch.setattr(bridge_mod, "is_obsidian_running", lambda: True, raising=False)
+
+    journal_file = _make_journal(tmp_path)
+    before = journal_file.read_text(encoding="utf-8")
+
+    with pytest.raises(ObsidianStartupRace):
+        _append_to_journal_locked(
+            [("2:15 PM", "must not land via direct write")],
+            journal_file,
+            "2026-04-16",
+        )
+
+    # Disk untouched — the open editor cannot have diverged.
+    assert journal_file.read_text(encoding="utf-8") == before

--- a/work_buddy/journal.py
+++ b/work_buddy/journal.py
@@ -676,70 +676,44 @@ def _append_to_journal_locked(
             "message": f"No entries inserted — all {len(entries)} entries skipped (no valid insertion points). Skipped times: {skipped}",
         }
 
-    # Write via Obsidian bridge if available (avoids Obsidian auto-save
-    # clobbering direct writes), fall back to direct file I/O.
-    #
-    # Post-CP6 typed-exception policy:
-    #   ObsidianUnreachable -> filesystem fallback (body not sent, safe).
-    #   ObsidianPostWriteUncertain -> RE-RAISE (gateway verifies; falling
-    #     back here would risk overwriting a successful write).
-    #   ObsidianEditorConflict -> RE-RAISE (filesystem write would
-    #     clobber the user's typing).
-    #   Other ObsidianError (Refused / ServerError) -> RE-RAISE.
-    #   Generic Exception -> log + filesystem fallback (legacy behavior;
-    #     keeps the journal write robust against transient non-bridge
-    #     issues).
+    # Single safe write path: bridge-first, with a direct-filesystem fallback
+    # that fires ONLY when Obsidian is genuinely down — so it can never diverge
+    # an open editor's buffer from disk (the failure mode that wedges a note
+    # with a persistent 409 editor_dirty). ``vault_write`` re-raises the typed
+    # signals — ObsidianEditorConflict / ObsidianPostWriteUncertain / startup
+    # race / refused / server-error — and ConsentRequired, so the gateway /
+    # retry queue handles each correctly. Those MUST propagate from here, not
+    # be swallowed into a direct write: a blanket ``except Exception`` that
+    # falls back to disk would diverge an open editor from disk and wedge the
+    # note with a persistent 409 editor_dirty.
     vault_rel_path = f"journal/{date_str}.md"
-    write_method = "direct"
-    try:
-        from work_buddy.obsidian.bridge import write_file_raw, is_available
-        from work_buddy.obsidian.errors import (
-            ObsidianEditorConflict,
-            ObsidianHTTPError,
-            ObsidianPostWriteUncertain,
-            ObsidianUnreachable,
+    from work_buddy.obsidian.vault_writer import vault_write
+
+    ok = vault_write(
+        vault_rel_path, journal_file, file_content, write_mode="replace",
+    )
+    if not ok:
+        # Only reachable when Obsidian was down AND the direct filesystem
+        # fallback itself hit an OSError. Surface as a failure rather than a
+        # false success.
+        logger.error(
+            "Journal write failed (direct fallback OSError): %s", vault_rel_path
         )
-        if is_available():
-            try:
-                ok = write_file_raw(vault_rel_path, file_content)
-            except ObsidianUnreachable as exc:
-                logger.info(
-                    "Bridge unreachable (%s); falling back to direct write",
-                    exc.error_kind,
-                )
-                journal_file.write_text(file_content, encoding="utf-8")
-            except (ObsidianEditorConflict, ObsidianPostWriteUncertain, ObsidianHTTPError):
-                # Re-raise — see policy comment above. The gateway/retry
-                # queue / verify-path handles each correctly.
-                raise
-            else:
-                if ok:
-                    write_method = "bridge"
-                else:
-                    # write_file_raw returned False without raising — should
-                    # not happen post-CP6 (failure paths all raise), but
-                    # keep the fallback as a defensive measure.
-                    logger.warning(
-                        "Bridge write returned False unexpectedly; "
-                        "falling back to direct write"
-                    )
-                    journal_file.write_text(file_content, encoding="utf-8")
-        else:
-            journal_file.write_text(file_content, encoding="utf-8")
-    except (
-        ObsidianEditorConflict, ObsidianPostWriteUncertain, ObsidianHTTPError,
-    ):
-        raise  # Outer re-raise — see policy.
-    except Exception as exc:
-        logger.warning("Bridge write failed (%s), falling back to direct write", exc)
-        journal_file.write_text(file_content, encoding="utf-8")
+        return {
+            "success": False,
+            "file": str(journal_file),
+            "entries_written": 0,
+            "message": (
+                f"Failed to write {date_str} journal "
+                f"({inserted_count} entries prepared)."
+            ),
+        }
 
     result = {
         "success": True,
         "file": str(journal_file),
         "entries_written": inserted_count,
-        "write_method": write_method,
-        "message": f"Appended {inserted_count} entries to Log section of {date_str} journal (via {write_method}).",
+        "message": f"Appended {inserted_count} entries to Log section of {date_str} journal.",
     }
     if skipped:
         result["skipped"] = skipped

--- a/work_buddy/mcp_server/tools/gateway.py
+++ b/work_buddy/mcp_server/tools/gateway.py
@@ -1026,6 +1026,61 @@ def _enqueue_for_retry(
     _update_operation(record)
 
 
+def enqueue_capability_for_retry(
+    capability: str,
+    params: dict[str, Any],
+    *,
+    error: str,
+    error_kind: str | None = None,
+    originating_session_id: str | None = None,
+) -> str | None:
+    """Persist a failed-op record for ``capability`` + ``params`` and enqueue
+    it for the sidecar retry sweep.
+
+    Public seam for callers that do NOT dispatch through ``wb_run`` (e.g. the
+    Telegram sidecar's capture handler) but still want transient-failure
+    recovery. The sweep replays the capability from the registry on backoff,
+    re-reading vault state fresh each attempt, so a transient bridge failure
+    (a busy editor, a startup race) lands the operation once the bridge frees
+    up instead of dropping it.
+
+    The op is enqueued with ``error_class="transient"`` unconditionally — the
+    caller is responsible for only invoking this for transient failures (see
+    ``work_buddy.errors.classify_error``). Returns the op_id, or ``None`` if
+    persistence failed (the caller should then surface the original error).
+    """
+    import logging
+
+    # Carry the capability's declared retry policy onto the record so the
+    # sweep's replay semantics match a normal gateway dispatch. Default to
+    # verify_first (re-read + verify) when the registry can't be consulted.
+    retry_policy = "verify_first"
+    try:
+        from work_buddy.mcp_server.registry import get_registry
+        entry = get_registry().get(capability)
+        if entry is not None and getattr(entry, "retry_policy", None):
+            retry_policy = entry.retry_policy
+    except Exception:
+        pass
+
+    try:
+        op_id = _save_operation(capability, params, retry_policy)
+        _enqueue_for_retry(
+            op_id,
+            error,
+            "transient",
+            originating_session_id=originating_session_id,
+            error_kind=error_kind,
+        )
+        return op_id
+    except Exception as exc:  # persistence is best-effort
+        logging.getLogger(__name__).warning(
+            "enqueue_capability_for_retry(%s) failed to persist: %s",
+            capability, exc,
+        )
+        return None
+
+
 def _is_queued(record: dict[str, Any]) -> bool:
     """Canonical read for 'is this op sitting in the sweep queue?'.
 

--- a/work_buddy/obsidian/vault_writer.py
+++ b/work_buddy/obsidian/vault_writer.py
@@ -308,15 +308,29 @@ def vault_write(
     the ``obsidian/vault-write-decision`` knowledge unit for the picking
     rule.
 
-    Post-CP6 fallback policy
-    ------------------------
+    Fallback safety predicate
+    -------------------------
+    A direct filesystem write is only safe when the Obsidian **process is
+    genuinely down** (``bridge.is_obsidian_running()`` is False) — then no
+    editor can be holding the note. If Obsidian is running, an open editor's
+    in-memory buffer would diverge from the freshly-written disk content (the
+    bridge's ``syncOpenEditorsToDisk`` only fires on writes *through* the
+    plugin), wedging the note with a persistent ``409 editor_dirty`` on every
+    later bridge write. So a transient bridge failure while Obsidian is up
+    must NOT direct-write — it re-raises so the gateway / retry queue replays.
+
     The bridge layer raises typed exceptions per the
     ``work_buddy.obsidian.errors`` hierarchy. Different failure types
     take different recovery paths:
 
-      ObsidianUnreachable (and subclasses)
-          Bridge can't be reached — body was NOT sent. Filesystem
-          fallback is safe (no double-write risk). FALL BACK.
+      ObsidianNotRunning
+          Obsidian process is down — no editor can hold the note, so a
+          direct filesystem write cannot diverge an open editor. FALL BACK.
+      ObsidianUnreachable (other subclasses: startup race, plugin
+      missing / disabled)
+          Obsidian IS running but the bridge is transiently/structurally
+          unreachable. An editor may hold the note. RE-RAISE — direct-writing
+          would diverge it. The retry queue replays once the bridge recovers.
       ObsidianPostWriteUncertain
           Body MAY have been sent and the plugin MAY have committed.
           Filesystem fallback would overwrite the plugin's write if
@@ -341,9 +355,11 @@ def vault_write(
     from work_buddy.consent import ConsentRequired
     from work_buddy.obsidian.errors import (
         ObsidianEditorConflict,
+        ObsidianNotRunning,
         ObsidianPostWriteUncertain,
         ObsidianRefused,
         ObsidianServerError,
+        ObsidianStartupRace,
         ObsidianUnreachable,
     )
 
@@ -351,7 +367,11 @@ def vault_write(
     vault_rel_path = vault_rel_path.replace("\\", "/")
 
     try:
-        from work_buddy.obsidian.bridge import write_file_raw, is_available
+        from work_buddy.obsidian.bridge import (
+            is_available,
+            is_obsidian_running,
+            write_file_raw,
+        )
         if is_available():
             log.info("Writing via bridge: %s", vault_rel_path)
             result = write_file_raw(
@@ -361,7 +381,7 @@ def vault_write(
             log.info("Bridge write result: %s", result)
             return result
         else:
-            log.info("Bridge not available, falling back to direct write")
+            log.info("Bridge not available; deciding fallback by process state")
     except ConsentRequired:
         raise
     except ObsidianEditorConflict:
@@ -372,16 +392,40 @@ def vault_write(
         raise  # Structural refusal — no point falling back.
     except ObsidianServerError:
         raise  # Plugin-side fault — filesystem would bypass plugin state.
-    except ObsidianUnreachable as exc:
-        # Body not sent (port refused / Obsidian not running). Filesystem
-        # fallback is safe — no double-write risk.
+    except ObsidianNotRunning:
+        # Obsidian process is genuinely down — no editor can be holding the
+        # note, so a direct filesystem write cannot diverge an open editor.
+        # Fall through to the safe direct write below.
         log.warning(
-            "Bridge unreachable (%s); falling back to direct filesystem write",
-            exc.error_kind,
+            "Obsidian not running; falling back to direct filesystem write: %s",
+            vault_rel_path,
+        )
+    except ObsidianUnreachable as exc:
+        # Obsidian IS running but the bridge is transiently unreachable
+        # (startup race / port not yet bound, plugin missing or disabled).
+        # An editor may be holding this note: a direct filesystem write would
+        # diverge its buffer from disk and wedge the bridge with a persistent
+        # 409 editor_dirty. Re-raise (transient) so the gateway / retry queue
+        # replays once the bridge recovers — do NOT direct-write.
+        log.warning(
+            "Bridge unreachable but Obsidian is running (%s); re-raising "
+            "instead of direct write to avoid diverging an open editor: %s",
+            exc.error_kind, vault_rel_path,
+        )
+        raise
+
+    # Reached only when is_available() returned False, OR ObsidianNotRunning
+    # was caught above. Guard the is_available()==False-but-process-up case:
+    # a startup race / port flap reports unavailable even though Obsidian is
+    # running with the note open, and direct-writing there would diverge the
+    # open editor. Only the genuine process-down case is safe to direct-write.
+    if is_obsidian_running():
+        raise ObsidianStartupRace(
+            f"bridge unavailable but Obsidian is running; refusing direct "
+            f"write to {vault_rel_path} (would diverge an open editor)"
         )
 
-    # Direct fallback (atomic). Reached only when bridge.is_available()
-    # returned False at the top, OR ObsidianUnreachable was caught above.
+    # Direct fallback (atomic). Reached only when Obsidian is down.
     try:
         log.info("Direct write: %s", abs_path)
         tmp = abs_path.with_suffix(".tmp")

--- a/work_buddy/telegram/handlers.py
+++ b/work_buddy/telegram/handlers.py
@@ -426,13 +426,60 @@ async def _do_capture(update: Update, text: str, state: "BotState") -> None:
         logger.info("Capture: note=%s section=%s position=%s text=%s",
                      note, section, position, text[:40])
 
-        result = write_at_location(
-            content=block,
-            note=note,
-            section=section,
-            position=position,
-            source=None,  # tag is already in the block header
-        )
+        try:
+            result = write_at_location(
+                content=block,
+                note=note,
+                section=section,
+                position=position,
+                source=None,  # tag is already in the block header
+            )
+        except Exception as exc:
+            # A transient bridge failure — a busy editor (409 editor_dirty), a
+            # startup race, a timeout — must not drop the capture. Enqueue it
+            # for the sidecar retry sweep, which replays vault_write_at_location
+            # on backoff and lands it once the bridge frees up. Anything
+            # non-transient falls through to the outer handler below.
+            from work_buddy.errors import classify_error
+            if classify_error(exc) != "transient":
+                raise
+            from work_buddy.mcp_server.tools.gateway import (
+                enqueue_capability_for_retry,
+            )
+            op_id = enqueue_capability_for_retry(
+                "vault_write_at_location",
+                {
+                    "content": block,
+                    "note": note,
+                    "section": section,
+                    "position": position,
+                    "source": None,
+                },
+                error=str(exc),
+                error_kind=getattr(exc, "error_kind", None),
+            )
+            # Lead the reply with the resolved note path (parallel to the
+            # success "Captured to <note>" line) for scannability. The typed
+            # ObsidianError carries the resolved vault-relative path; fall back
+            # to the resolver token if it doesn't.
+            target = getattr(exc, "path", None) or note
+            if op_id:
+                logger.info("Capture enqueued for retry (op=%s): %s", op_id, exc)
+                await _reply(
+                    update,
+                    f"Attempted capture to {target} — queued (Obsidian busy "
+                    "with unsaved edits). It'll land automatically once the "
+                    "note is free; no need to resend.",
+                )
+            else:
+                logger.error("Capture enqueue failed: %s", exc, exc_info=True)
+                await _reply(
+                    update,
+                    f"Attempted capture to {target} — couldn't queue it "
+                    f"({exc}). Reopen the note in Obsidian (or start today's), "
+                    "then resend.",
+                )
+            return
 
         logger.info("Capture result: status=%s note=%s",
                      result.get("status"), result.get("note"))


### PR DESCRIPTION
## Summary

- A capture/journal write that hit a **transient bridge failure while Obsidian was running** could fall back to a **direct filesystem write**, diverging the open editor's buffer from disk. The plugin then returned `409 editor_dirty` on every subsequent bridge write, wedging the note until the user reopened it — surfaced as `Capture error: editor_dirty` with the captured text **lost**.
- **Root cause:** `vault_write` (and a duplicated journal write path) fell back to a direct disk write whenever `is_available()` was False or any `ObsidianUnreachable` was caught. But `is_available()` returns False during a startup race / port flap, and `ObsidianStartupRace` subclasses `ObsidianUnreachable` — so a transient flap while Obsidian was up still direct-wrote and diverged the open editor.
- **`vault_write`:** fall back to a direct write **only when the Obsidian process is genuinely down** (`is_obsidian_running()` False / `ObsidianNotRunning`). Re-raise other `ObsidianUnreachable` subclasses so the gateway/retry queue replays instead of wedging an open editor.
- **`journal.py`:** consolidate the journal write onto `vault_write`; drop the broad `except Exception -> direct-write` fallback (the most dangerous divergence path).
- **Telegram capture:** route transient failures into the retry queue via a new public `enqueue_capability_for_retry` seam (the bot runs in a separate sidecar process, so it can't use the gateway's in-process auto-enqueue) and reply `Attempted capture to <note> — queued ...` instead of dropping the text.
- **Docs:** corrected `obsidian/vault-write-decision` fallback rule; documented capture resilience (`notifications/telegram`) and the out-of-band enqueue seam (`architecture/retry-queue`).

## Test plan

- [x] Unit: `vault_write` process-gated fallback predicate (down → direct write; up + flaky → raises, disk untouched); `journal` raises (no silent direct write) when Obsidian up + bridge flaky; `enqueue_capability_for_retry` creates a queued op record (20 passed).
- [x] Live: dirty-editor Telegram capture → `Capture enqueued for retry` → op `completed` on replay (no consent re-prompt) → text lands.
- [ ] Reviewer: confirm no other callers rely on the old "fall back on any `ObsidianUnreachable`" behavior.

## Known follow-up (out of scope)

A separate, pre-existing lost-update race remains: a whole-file capture write computed from a stale read can clobber a user's *concurrent* in-editor edits. Tracked as work-buddy task `t-bc54a87f` — proper fix is plugin-side (optimistic-concurrency base-precondition on the bridge PUT, or a true section-insert primitive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)