### PR TITLE
test(conftest): isolate task store DB and Obsidian bridge in unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,5 +83,7 @@ markers = [
     "unit: Pure logic tests — no filesystem, no network",
     "component: Tests with temp dirs, temp DBs, or service boundaries",
     "integration: CLI smoke tests and HTTP endpoint tests",
+    "real_task_store: opt out of the autouse task-store temp-DB isolation (see _isolate_task_store_and_vault)",
+    "real_obsidian_bridge: opt out of the autouse Obsidian-bridge neutralization (see _isolate_task_store_and_vault)",
 ]
 addopts = "-q --tb=short"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,68 @@ def _isolate_work_item_events(tmp_path, monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_task_store_and_vault(tmp_path, monkeypatch, request):
+    """Isolate the task metadata store and neutralize the Obsidian bridge.
+
+    Two real resources the per-test sandbox would otherwise leak into:
+
+    * **Task metadata store.** ``work_buddy.obsidian.tasks.store._db_path``
+      resolves (via ``paths.resolve("db/tasks")``) to the real
+      ``.data/db/task_metadata.db``. Any unmocked ``store.create`` /
+      ``mutations.create_task`` would write a real row. Redirected to a
+      per-test temp SQLite file.
+
+    * **Obsidian vault.** ``mutations.create_task`` writes the master task
+      list through the Obsidian *bridge* — an HTTP PUT to a *running*
+      Obsidian, which commits to the real ``tasks/master-task-list.md``.
+      The bridge bypasses ``vault_root`` entirely, so redirecting that
+      config value would not help. All bridge network I/O funnels through
+      ``bridge.urlopen``; replacing it with a connection-refusing stub
+      makes every bridge call behave as "Obsidian unreachable", so a
+      stray ``create_task`` reads ``None`` and bails via ``bridge_failure``
+      *before* it can write to the vault or the store — regardless of
+      whether Obsidian is actually running on the dev box.
+
+    Mirrors ``_isolate_work_item_events``. Best-effort imports so a module
+    move never breaks collection. The patch only swaps the attribute at
+    setup (it never calls ``urlopen`` itself), so tests that re-patch
+    ``bridge.urlopen`` / ``bridge._request_with_status`` in their own body
+    cleanly override it — e.g. ``test_bridge_typed_exceptions`` and
+    ``test_editor_conflict``.
+
+    Opt out per-test with ``@pytest.mark.real_task_store`` (drive the real
+    DB path) or ``@pytest.mark.real_obsidian_bridge`` (drive the real
+    bridge transport against the test's own mock/server). The two markers
+    are independent.
+    """
+    if request.node.get_closest_marker("real_task_store") is None:
+        try:
+            import work_buddy.obsidian.tasks.store as task_store
+        except Exception:  # pragma: no cover - defensive
+            pass
+        else:
+            monkeypatch.setattr(
+                task_store, "_db_path", lambda: tmp_path / "task_metadata.db",
+            )
+
+    if request.node.get_closest_marker("real_obsidian_bridge") is None:
+        try:
+            import work_buddy.obsidian.bridge as bridge
+        except Exception:  # pragma: no cover - defensive
+            pass
+        else:
+            def _refuse_bridge_connection(*_args, **_kwargs):
+                raise ConnectionRefusedError(
+                    "Obsidian bridge disabled in tests "
+                    "(_isolate_task_store_and_vault in tests/conftest.py). "
+                    "Mock the bridge, or mark @pytest.mark.real_obsidian_bridge "
+                    "to opt out."
+                )
+
+            monkeypatch.setattr(bridge, "urlopen", _refuse_bridge_connection)
+
+
 @pytest.fixture
 def tmp_agents_dir(tmp_path, monkeypatch):
     """Redirect agent_session to write into a temp directory.


### PR DESCRIPTION
## Summary
- Adds an autouse fixture `_isolate_task_store_and_vault` (mirroring `_isolate_work_item_events`) that closes two real-resource leaks: it redirects `store._db_path` to a per-test temp SQLite file, and replaces `bridge.urlopen` with a connection-refusing stub so every bridge call behaves as "Obsidian unreachable".
- This stops an unmocked `mutations.create_task` (or any task mutation) from writing a real row to `.data/db/task_metadata.db` and a real line to `tasks/master-task-list.md`. Neutralizing the bridge (not redirecting `vault_root`) is what actually stops the vault leak — `create_task` writes the vault over HTTP through the running Obsidian plugin, bypassing `vault_root`.
- Registers two independent opt-out markers (`real_task_store`, `real_obsidian_bridge`) for the rare test that genuinely needs a real store or the real transport.

Patching `urlopen` (rather than `_request*`) keeps blast radius minimal: the bridge-transport tests re-patch `urlopen` / `_request_with_status` in their own bodies and override the autouse stub.

## Test plan
- [x] Full `tests/unit/` suite green with the fixture active (pytest exit 0; only benign DeprecationWarnings).
- [x] Bridge/store-coupled files unaffected: `test_bridge_typed_exceptions`, `test_editor_conflict`, `test_journal_backlog_route`, `test_journal_backlog_pipeline` — 74 passed.
- [x] Acceptance probe: a deliberately-unmocked `mutations.create_task("probe-…")` produced 0 rows in the real `task_metadata.db` and no line in the real `master-task-list.md`.