### PR TITLE
fix(ir): make vector .npz writes atomic and self-healing

### DIFF
--- a/knowledge/store/architecture/embedding-service.md
+++ b/knowledge/store/architecture/embedding-service.md
@@ -87,6 +87,20 @@ dev_notes: |-
 
   This is the structural twin of the knowledge-system three-signal design above. Future migration of `work_buddy/knowledge/index.py` onto this engine is the natural next step (gated on the brittleness harness to avoid wb_search regression); doing so would collapse the two parallel implementations.
 
+  ## Vector store durability: atomic writes + recovery sweep
+
+  The per-source/per-projection ``.npz`` vector files are a regenerable cache (the source docs live in ``work_buddy_ir.db`` plus the JSONL sessions), so the contract is resilience and self-heal, not durability:
+
+  - **Atomic writes.** ``work_buddy/ir/store.py::save_vectors`` writes through ``work_buddy/utils/npz_io.py::atomic_save_npz``: a sibling temp (``<name>.<pid>.tmp.npz``) written via an *open file object* (so numpy neither re-opens nor appends ``.npz``, and the fd can be ``fsync``'d), then ``os.replace``'d onto the canonical path with a short Windows-``PermissionError`` retry. A process killed mid-write can no longer truncate the canonical file into a 0-byte search outage. This matters on every write, not just the last one: the ``CHECKPOINT_ROWS`` loop in ``ir/dense.py`` calls ``save_vectors`` many times per large build.
+  - **Corrupt-tolerant reads.** ``load_vectors`` goes through ``safe_load_npz``, which returns ``None`` (never raises) for a missing, zero-byte, or truncated file — catching ``EOFError`` / ``zipfile.BadZipFile`` / ``ValueError`` / ``OSError`` (``BadZipFile`` is listed explicitly; it does not subclass the others). A corrupt file therefore degrades to BM25-only and the next build regenerates, instead of raising and taking the source dark behind an ``/ir/index`` 500. The read is pure — it never mutates the filesystem.
+  - **Startup recovery sweep.** ``recover_vector_store(cfg)`` runs in ``embedding/service.py::main()`` before serving. It quarantines a corrupt canonical file to ``<name>.corrupt`` (one forensic copy) and deletes orphaned ``*.tmp.npz`` temps whose writer PID is dead (``work_buddy/utils/process.py::is_process_alive``) or which are stale beyond ``ORPHAN_TEMP_MAX_AGE_S`` — while sparing a live writer's temp. The build runs in-process and the sweep runs before ``app.run``, so there is no in-process writer to race.
+
+  ``work_buddy/knowledge/persistence.py`` shares the same ``atomic_save_npz`` primitive (passing a fixed temp name, since its cache dir is not swept). The ``.npz`` durability primitives live in ``utils/npz_io.py`` so both vector caches use one implementation; its header-gated loaders stay local because they bail on a model/version mismatch before materializing arrays.
+
+  ## ``/ir/index`` error surfacing
+
+  A reachable embedding service that fails an ``/ir/index`` request surfaces the **real** error, not a generic "service unavailable". ``client._request`` catches ``HTTPError`` (a subclass of ``URLError``, so it must be caught first) separately from connection failures, logs the status + body, and — with ``return_http_error=True`` (passed only by ``ir_index``) — returns ``{"error", "status"}`` rather than collapsing a 500 to ``None``. The ``ir_index`` dispatch then distinguishes: ``None`` → service unreachable (remediation points at the sidecar via ``utils/service_hints.py::sidecar_restart_command``, since the embedding service is a sidecar-supervised child, not a standalone scheduled task); an error envelope → surface the real ``/ir/index`` error; otherwise the status/build result. Every *other* client caller still gets ``None`` on any failure — the flag defaults off, so their graceful-degradation contract is unchanged.
+
   ## Adding a new model
 
   Add an entry to `config.yaml` under `embedding.models` (or `_DEFAULT_MODELS` in `service.py` for the fallback). Required fields: HF name, dims, `eager` (bool). Eager-load only models on the critical path for interactive work; lazy-load large models (e.g. the 526 MB `leaf-ir` passage encoder) that are used only during indexing.
@@ -106,13 +120,14 @@ dev_notes: |-
   ## Key dev files
 
   - `work_buddy/embedding/service.py` — Flask service, `_DEFAULT_MODELS`, `ModelEntry`, lazy loader, `/embed` and `/similarity` handlers; `/ir/index` now also triggers a best-effort `dense.build_vectors` so hybrid search has vectors to score against.
-  - `work_buddy/embedding/client.py` — `embed`, `embed_for_ir`, `similarity_search`, `hybrid_search`, `ir_search`, `ir_index`. ``embed()`` and ``embed_for_ir()`` accept ``timeout_s`` for indexing callers that need to absorb a lazy-model cold load — see 'Lazy models' section above.
+  - `work_buddy/embedding/client.py` — `embed`, `embed_for_ir`, `similarity_search`, `hybrid_search`, `ir_search`, `ir_index`. ``embed()`` and ``embed_for_ir()`` accept ``timeout_s`` for indexing callers that need to absorb a lazy-model cold load — see 'Lazy models' section above. ``_request`` splits ``HTTPError`` from connection failures and takes ``return_http_error`` so ``ir_index`` can surface a real ``/ir/index`` error — see '``/ir/index`` error surfacing' above.
   - `work_buddy/knowledge/index.py` — knowledge search index; three-signal RRF fusion (custom path).
-  - `work_buddy/knowledge/persistence.py` — disk cache for content + alias vectors (hash-keyed, atomic writes, model+version headers).
+  - `work_buddy/knowledge/persistence.py` — disk cache for content + alias vectors (hash-keyed, model+version headers); atomic writes via ``utils/npz_io.atomic_save_npz``.
+  - `work_buddy/utils/npz_io.py` — shared atomic ``.npz`` write (``atomic_save_npz``), corrupt-tolerant load (``safe_load_npz``), and the temp-naming convention the recovery sweep parses. Used by both ``ir/store.py`` and ``knowledge/persistence.py``.
   - `work_buddy/ir/sources/base.py` — `Document`, `Projection`, `ProjectionSpec`, `Source` protocol, `get_projection_schema` helper.
   - `work_buddy/ir/dense.py` — kind-aware `encode_query` / `encode_documents`; pool-aware `score_dense`; projection-aware `build_vectors` with shared `_build_vectors_for_projection` inner loop.
   - `work_buddy/ir/engine.py` — `search` runs BM25 plus one ranking per declared projection (or one legacy ranking) and RRF-fuses; per-result `projection_scores` diagnostic.
-  - `work_buddy/ir/store.py` — `documents.projections` JSON column + in-place schema migration; `_npz_path` / `save_vectors` / `load_vectors` accept a `projection` arg.
+  - `work_buddy/ir/store.py` — `documents.projections` JSON column + in-place schema migration; `_npz_path` / `save_vectors` / `load_vectors` accept a `projection` arg. ``save_vectors`` is atomic and ``load_vectors`` is corrupt-tolerant (both via ``utils/npz_io``); ``recover_vector_store`` is the startup quarantine/orphan-temp sweep — see 'Vector store durability' above.
 ---
 
 ## Overview

--- a/tests/unit/test_ir_store_atomic.py
+++ b/tests/unit/test_ir_store_atomic.py
@@ -1,0 +1,282 @@
+"""Atomic + self-healing IR vector store.
+
+Pins the contract that a crash-truncated ``.npz`` can never take a search
+source dark:
+
+- ``save_vectors`` writes atomically — no leftover temp on success, and a
+  simulated crashed writer never corrupts the canonical file;
+- ``load_vectors`` returns ``None`` (never raises) on a missing / 0-byte /
+  truncated file, so callers degrade to BM25 and the next build regenerates;
+- ``recover_vector_store`` quarantines corrupt canonicals and reaps orphaned
+  write temps, while sparing a live writer's temp;
+- a reachable-but-failing ``/ir/index`` surfaces the *real* error instead of
+  the generic "service unavailable" (and never the phantom ``WB-Embedding``
+  scheduled task).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import time
+from urllib.error import HTTPError, URLError
+
+import numpy as np
+import pytest
+
+from work_buddy.ir.store import (
+    ORPHAN_TEMP_MAX_AGE_S,
+    _npz_path,
+    load_vectors,
+    recover_vector_store,
+    save_vectors,
+)
+from work_buddy.utils.npz_io import temp_path_for
+
+
+@pytest.fixture
+def tmp_ir_store(tmp_path, monkeypatch):
+    """Point the IR store (db + companion ``.npz`` files) at ``tmp_path``.
+
+    ``_npz_path`` derives from ``_db_path``, so patching the latter redirects the
+    vector files too — matching the ``tmp_ir_db`` convention in
+    ``test_ir_store_metadata_filter.py``.
+    """
+    db_file = tmp_path / "work_buddy_ir.db"
+    monkeypatch.setattr("work_buddy.ir.store._db_path", lambda cfg=None: db_file)
+    return tmp_path
+
+
+def _save(source: str = "conversation", n: int = 5, dim: int = 8):
+    # Integer values < 2048 are exact in float16, so the round-trip is lossless.
+    vectors = np.arange(n * dim, dtype=np.float32).reshape(n, dim)
+    doc_ids = [f"{source}:{i}" for i in range(n)]
+    save_vectors(vectors, doc_ids, source=source)
+    return vectors, doc_ids
+
+
+# ---------------------------------------------------------------------------
+# save_vectors / load_vectors
+# ---------------------------------------------------------------------------
+
+
+def test_save_load_roundtrip(tmp_ir_store):
+    vectors, doc_ids = _save()
+    npz = _npz_path(None, source="conversation")
+    assert npz.exists()
+    # Atomic write leaves no temp behind on success.
+    assert list(tmp_ir_store.glob("*.tmp.npz")) == []
+
+    loaded = load_vectors(source="conversation")
+    assert loaded is not None
+    lv, lids = loaded
+    assert lids == doc_ids
+    np.testing.assert_array_equal(lv, vectors)
+
+
+def test_load_missing_returns_none(tmp_ir_store):
+    assert load_vectors(source="conversation") is None
+
+
+def test_load_zero_byte_returns_none(tmp_ir_store):
+    npz = _npz_path(None, source="conversation")
+    npz.write_bytes(b"")
+    assert load_vectors(source="conversation") is None
+
+
+def test_load_truncated_returns_none(tmp_ir_store):
+    npz = _npz_path(None, source="conversation")
+    # A plausible-looking but truncated zip — surfaces as zipfile.BadZipFile,
+    # which is why the catch keeps it explicit.
+    npz.write_bytes(b"PK\x03\x04 truncated, not a real npz")
+    assert load_vectors(source="conversation") is None
+
+
+# ---------------------------------------------------------------------------
+# recover_vector_store — corrupt canonicals
+# ---------------------------------------------------------------------------
+
+
+def test_recover_quarantines_zero_byte(tmp_ir_store):
+    npz = _npz_path(None, source="conversation")
+    npz.write_bytes(b"")
+
+    summary = recover_vector_store(cfg={})
+
+    assert str(npz) in summary["quarantined"]
+    assert not npz.exists()
+    assert npz.with_name(npz.name + ".corrupt").exists()
+    # And the next read is clean.
+    assert load_vectors(source="conversation") is None
+
+
+def test_recover_quarantines_truncated(tmp_ir_store):
+    npz = _npz_path(None, source="conversation")
+    npz.write_bytes(b"PK\x03\x04 truncated")
+
+    summary = recover_vector_store(cfg={})
+
+    assert str(npz) in summary["quarantined"]
+    assert npz.with_name(npz.name + ".corrupt").exists()
+
+
+def test_recover_spares_healthy_canonical(tmp_ir_store):
+    _save()
+    npz = _npz_path(None, source="conversation")
+
+    summary = recover_vector_store(cfg={})
+
+    assert summary["quarantined"] == []
+    assert npz.exists()
+    assert load_vectors(source="conversation") is not None
+
+
+def test_recover_overwrites_prior_corrupt(tmp_ir_store):
+    npz = _npz_path(None, source="conversation")
+    corrupt = npz.with_name(npz.name + ".corrupt")
+    corrupt.write_bytes(b"older forensic copy")
+    npz.write_bytes(b"")
+
+    recover_vector_store(cfg={})
+
+    # Exactly one forensic copy is kept (the latest), not an accumulation.
+    assert corrupt.exists()
+    assert corrupt.read_bytes() == b""
+
+
+# ---------------------------------------------------------------------------
+# recover_vector_store — orphaned vs live temps
+# ---------------------------------------------------------------------------
+
+
+def test_recover_removes_orphan_temp_dead_pid(tmp_ir_store):
+    npz = _npz_path(None, source="conversation")
+    orphan = temp_path_for(npz, pid=2147480000)  # almost certainly not running
+    orphan.write_bytes(b"partial write")
+
+    summary = recover_vector_store(cfg={})
+
+    assert str(orphan) in summary["temps_removed"]
+    assert not orphan.exists()
+
+
+def test_recover_spares_live_temp(tmp_ir_store):
+    npz = _npz_path(None, source="conversation")
+    # This test process is alive, and the temp is fresh.
+    live = temp_path_for(npz, pid=os.getpid())
+    live.write_bytes(b"in progress")
+
+    summary = recover_vector_store(cfg={})
+
+    assert str(live) in summary["temps_kept"]
+    assert live.exists()
+
+
+def test_recover_removes_stale_temp_even_if_pid_alive(tmp_ir_store):
+    # PID-reuse guard: an alive PID with an old temp is still reaped.
+    npz = _npz_path(None, source="conversation")
+    stale = temp_path_for(npz, pid=os.getpid())
+    stale.write_bytes(b"old")
+    old = time.time() - (ORPHAN_TEMP_MAX_AGE_S + 60)
+    os.utime(stale, (old, old))
+
+    summary = recover_vector_store(cfg={})
+
+    assert str(stale) in summary["temps_removed"]
+    assert not stale.exists()
+
+
+def test_crash_leaves_canonical_intact(tmp_ir_store):
+    # A good canonical plus an orphan temp from a crashed writer: the canonical
+    # is untouched and still loads; only the orphan is reaped.
+    _vectors, doc_ids = _save()
+    npz = _npz_path(None, source="conversation")
+    orphan = temp_path_for(npz, pid=2147480000)
+    orphan.write_bytes(b"partial write")
+
+    assert load_vectors(source="conversation") is not None
+
+    summary = recover_vector_store(cfg={})
+
+    assert npz.exists()
+    assert str(orphan) in summary["temps_removed"]
+    loaded = load_vectors(source="conversation")
+    assert loaded is not None and loaded[1] == doc_ids
+
+
+# ---------------------------------------------------------------------------
+# /ir/index error surfacing (client + dispatch)
+# ---------------------------------------------------------------------------
+
+
+def _http_500(body: dict):
+    def fake_urlopen(req, timeout=30):
+        raise HTTPError(req.full_url, 500, "Internal Server Error", {},
+                        io.BytesIO(json.dumps(body).encode()))
+    return fake_urlopen
+
+
+def _conn_refused():
+    def fake_urlopen(req, timeout=30):
+        raise URLError("Connection refused")
+    return fake_urlopen
+
+
+def test_ir_index_surfaces_http_error(monkeypatch):
+    import work_buddy.embedding.client as c
+
+    monkeypatch.setattr(c, "urlopen",
+                        _http_500({"error": "EOFError: No data left in file"}))
+    result = c.ir_index("status", source="conversation")
+    assert result == {"error": "EOFError: No data left in file", "status": 500}
+
+
+def test_request_default_caller_still_none_on_http_error(monkeypatch):
+    # A non-ir_index caller (default return_http_error=False) keeps its
+    # byte-for-byte contract: an HTTP error still degrades to None.
+    import work_buddy.embedding.client as c
+
+    monkeypatch.setattr(c, "urlopen", _http_500({"error": "boom"}))
+    assert c._request("POST", "/embed", {"x": 1}) is None
+
+
+def test_ir_index_none_when_unreachable(monkeypatch):
+    import work_buddy.embedding.client as c
+
+    monkeypatch.setattr(c, "urlopen", _conn_refused())
+    assert c.ir_index("status", source="conversation") is None
+
+
+def test_dispatch_surfaces_real_error_not_generic(monkeypatch):
+    import work_buddy.embedding.client as c
+    import work_buddy.mcp_server.ops.context_ops  # noqa: F401 — registers the op
+    from work_buddy.mcp_server.op_registry import get_op
+
+    monkeypatch.setattr(c, "urlopen",
+                        _http_500({"error": "EOFError: No data left in file"}))
+    dispatch = get_op("op.wb.ir_index")
+    assert dispatch is not None
+
+    out = dispatch(action="status", source="conversation")
+    payload = json.loads(out)
+    assert "EOFError" in payload["error"]
+    assert "/ir/index failed" in payload["error"]
+    # The old, doubly-wrong message must be gone.
+    assert "WB-Embedding" not in out
+    assert "unavailable" not in out.lower()
+
+
+def test_dispatch_unreachable_points_at_sidecar(monkeypatch):
+    import work_buddy.embedding.client as c
+    import work_buddy.mcp_server.ops.context_ops  # noqa: F401
+    from work_buddy.mcp_server.op_registry import get_op
+
+    monkeypatch.setattr(c, "urlopen", _conn_refused())
+    dispatch = get_op("op.wb.ir_index")
+    assert dispatch is not None
+
+    out = dispatch(action="status", source="conversation")
+    payload = json.loads(out)
+    assert "sidecar" in payload["error"].lower()
+    assert "WB-Embedding" not in out

--- a/work_buddy/embedding/client.py
+++ b/work_buddy/embedding/client.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import time
 from typing import Any
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from pathlib import Path
@@ -39,8 +39,28 @@ def _base_url() -> str:
     return f"http://127.0.0.1:{port}"
 
 
-def _request(method: str, path: str, data: dict | None = None, timeout: int = 30) -> dict | None:
-    """Make a request to the embedding service."""
+def _request(
+    method: str,
+    path: str,
+    data: dict | None = None,
+    timeout: int = 30,
+    *,
+    return_http_error: bool = False,
+) -> dict | None:
+    """Make a request to the embedding service.
+
+    Returns the parsed JSON response on success. On failure:
+
+    - A genuine connection failure (service down / refused / timeout) returns
+      ``None`` — the universal "service unavailable" signal every caller already
+      degrades on.
+    - An HTTP error status (the service was reached but the endpoint failed,
+      e.g. ``/ir/index`` 500) is always logged with its body. By default it also
+      returns ``None`` (preserving the historical contract for all callers);
+      when ``return_http_error=True`` it instead returns
+      ``{"error": <message>, "status": <code>}`` so the caller can surface the
+      real error instead of masking it as "service unavailable".
+    """
     url = f"{_base_url()}{path}"
     body = json.dumps(data).encode("utf-8") if data else None
     req = Request(url, data=body, method=method)
@@ -49,6 +69,28 @@ def _request(method: str, path: str, data: dict | None = None, timeout: int = 30
     try:
         with urlopen(req, timeout=timeout) as resp:
             return json.loads(resp.read().decode("utf-8"))
+    except HTTPError as exc:
+        # HTTPError subclasses URLError, so it MUST be caught first — otherwise a
+        # 500's body (carrying the real error) is swallowed as a generic
+        # connection failure.
+        try:
+            raw = exc.read().decode("utf-8", errors="replace")
+        except Exception:
+            raw = ""
+        logger.warning(
+            "Embedding %s %s -> HTTP %s: %s", method, path, exc.code, raw[:500]
+        )
+        if not return_http_error:
+            return None
+        message = raw or f"HTTP {exc.code}"
+        if raw:
+            try:
+                parsed = json.loads(raw)
+                if isinstance(parsed, dict) and parsed.get("error"):
+                    message = parsed["error"]
+            except ValueError:
+                pass
+        return {"error": message, "status": exc.code}
     except (URLError, TimeoutError) as exc:
         logger.debug("Embedding service request failed: %s", exc)
         return None
@@ -205,7 +247,12 @@ def ir_index(
 ) -> dict | None:
     """Build or check the IR index via the embedding service.
 
-    Returns stats/status dict, or None if service unavailable.
+    Returns:
+        - the stats/status dict on success;
+        - ``{"error": <message>, "status": <code>}`` if the service was reachable
+          but the request failed (e.g. ``/ir/index`` returned 500 because a
+          vector file was corrupt) — so the caller surfaces the real error;
+        - ``None`` if the service is unreachable (connection refused / timeout).
     """
     payload: dict[str, Any] = {
         "action": action,
@@ -215,10 +262,14 @@ def ir_index(
     }
     # Index building can be slow (bulk encoding)
     timeout = 30 if action == "status" else 300
-    result = _request("POST", "/ir/index", payload, timeout=timeout)
+    result = _request(
+        "POST", "/ir/index", payload, timeout=timeout, return_http_error=True
+    )
     if result is None:
         return None
-    return result.get("result")
+    if "result" in result:
+        return result["result"]
+    return result  # HTTP-error envelope: {"error": ..., "status": ...}
 
 
 def similarity_search(

--- a/work_buddy/embedding/service.py
+++ b/work_buddy/embedding/service.py
@@ -812,6 +812,27 @@ def main():
     # Build model registry from config (cheap — just metadata)
     _init_registry(cfg)
 
+    # Recover the IR vector store before serving: quarantine any crash-corrupted
+    # .npz and clear orphaned write temps, so the first read after boot is clean
+    # instead of raising on a 0-byte file and taking a search source dark.
+    # Non-fatal — a sweep failure must not stop the service from coming up.
+    try:
+        from work_buddy.ir.store import recover_vector_store
+
+        summary = recover_vector_store(cfg)
+        if summary.get("quarantined") or summary.get("temps_removed"):
+            print(
+                "IR vector store recovery: "
+                f"quarantined={len(summary['quarantined'])} "
+                f"temps_removed={len(summary['temps_removed'])}",
+                file=sys.stderr,
+            )
+    except Exception as exc:
+        print(
+            f"IR vector store recovery raised (non-fatal): {exc}",
+            file=sys.stderr,
+        )
+
     # Surface LM Studio configuration drift at startup (loud but
     # non-fatal). Keeps the user informed when they've opted into
     # offloading but LM Studio isn't actually up, without blocking

--- a/work_buddy/health/components.py
+++ b/work_buddy/health/components.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import platform
 from dataclasses import dataclass, field
 
+from work_buddy.utils.service_hints import sidecar_restart_command
+
 # Detect once at import time — used to select platform-specific fix hints.
 _IS_WINDOWS = platform.system() == "Windows"
 _IS_MAC = platform.system() == "Darwin"
@@ -366,9 +368,7 @@ _register(ComponentDef(
 
 _SIDECAR_LOG_HINT = (
     "Check sidecar logs: <data_root>/logs/sidecar.log\n"
-    "Restart sidecar: "
-    + ("Start-ScheduledTask 'WB-Sidecar'" if _IS_WINDOWS
-       else "python -m work_buddy.sidecar &")
+    "Restart sidecar: " + sidecar_restart_command()
 )
 
 _register(ComponentDef(

--- a/work_buddy/ir/store.py
+++ b/work_buddy/ir/store.py
@@ -10,16 +10,33 @@ Vector storage uses a companion .npz file alongside the DB for efficiency
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import time
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from work_buddy.ir.sources.base import Document, Source
 from work_buddy.logging_config import get_logger
+from work_buddy.utils.npz_io import (
+    TEMP_GLOB,
+    TEMP_SUFFIX,
+    atomic_save_npz,
+    pid_from_temp_name,
+    safe_load_npz,
+)
+from work_buddy.utils.process import is_process_alive
 
 logger = get_logger(__name__)
+
+# A temp left by a writer whose PID is dead is an orphan; one whose PID is still
+# alive is a live write in progress and must be spared. PID reuse can make a
+# dead writer's PID resolve to an unrelated live process, so the recovery sweep
+# also deletes a temp older than this regardless of liveness — a real in-flight
+# build refreshes its temp on every checkpoint, well inside this window.
+ORPHAN_TEMP_MAX_AGE_S = 3600
 
 
 _SCHEMA = """\
@@ -347,8 +364,11 @@ def save_vectors(
     import numpy as np
 
     path = _npz_path(cfg, source=source, projection=projection)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    np.savez_compressed(
+    # Atomic temp + fsync + os.replace: a process killed mid-write can no longer
+    # truncate the canonical file into a 0-byte/corrupt search outage. The
+    # checkpoint loop in ir/dense.py calls this ~20x per large build, so every
+    # write — not just the final one — must be atomic.
+    atomic_save_npz(
         path,
         vectors=vectors.astype(np.float16),
         doc_ids=np.array(doc_ids, dtype=object),
@@ -363,16 +383,126 @@ def load_vectors(
     source: str | None = None,
     projection: str | None = None,
 ) -> tuple["np.ndarray", list[str]] | None:
-    """Load vectors from companion .npz file. Returns None if not found."""
+    """Load vectors from companion .npz file.
+
+    Returns ``None`` if the file is missing, empty, or corrupt. Callers degrade
+    to BM25-only and the next build regenerates (the vectors are a regenerable
+    cache), so a crash-truncated file self-heals instead of 500-ing. This read
+    is pure — it never mutates the filesystem; the startup recovery sweep
+    (:func:`recover_vector_store`) is what quarantines a corrupt file.
+    """
     import numpy as np
 
     path = _npz_path(cfg, source=source, projection=projection)
-    if not path.exists():
+    data = safe_load_npz(path)
+    if data is None:
         return None
-    data = np.load(path, allow_pickle=True)
     vectors = data["vectors"].astype(np.float32)  # Upcast for computation
     doc_ids = data["doc_ids"].tolist()
     return vectors, doc_ids
+
+
+def recover_vector_store(cfg: dict | None = None) -> dict[str, Any]:
+    """Quarantine corrupt vector files and remove orphaned temps.
+
+    Run once at embedding-service startup, before any read. The vector ``.npz``
+    files are a regenerable cache, so this favours self-heal over preservation:
+
+    - **Corrupt canonical** (0-byte, or an unreadable zip central directory):
+      renamed to ``<name>.corrupt`` — one forensic copy, overwriting any prior.
+      ``load_vectors`` already returns ``None`` for it, and the next build
+      cold-rebuilds; quarantining just keeps the first post-boot read clean and
+      preserves the bad file for diagnosis.
+    - **Orphaned temp** (a ``*.tmp.npz`` whose writer PID is dead, or which is
+      stale beyond :data:`ORPHAN_TEMP_MAX_AGE_S`): deleted. A temp whose PID is
+      still alive and recent is a live write in progress and is left untouched —
+      temps are never glob-deleted unconditionally.
+
+    Safe against a concurrent build: the build runs in-process inside the
+    embedding service and this sweep runs before the service serves, so there is
+    no in-process writer to race. A separate-process CLI build is guarded by the
+    PID-liveness + mtime checks.
+
+    Returns a summary of what it touched.
+    """
+    if cfg is None:
+        from work_buddy.config import load_config
+        cfg = load_config()
+
+    ir_dir = _db_path(cfg).parent
+    quarantined: list[str] = []
+    temps_removed: list[str] = []
+    temps_kept: list[str] = []
+
+    if not ir_dir.exists():
+        return {
+            "quarantined": quarantined,
+            "temps_removed": temps_removed,
+            "temps_kept": temps_kept,
+        }
+
+    # Canonical vector files: work_buddy_ir.<source>[.<projection>].npz. Exclude
+    # temps (which also end in .npz, via the .tmp.npz suffix); .corrupt files
+    # don't end in .npz so they're already excluded.
+    for path in sorted(ir_dir.glob("work_buddy_ir.*.npz")):
+        if path.name.endswith(TEMP_SUFFIX):
+            continue
+        corrupt = False
+        try:
+            if path.stat().st_size == 0:
+                corrupt = True
+            else:
+                # Validate the central directory without loading arrays.
+                with zipfile.ZipFile(path) as zf:
+                    zf.namelist()
+        except (zipfile.BadZipFile, OSError) as exc:
+            corrupt = True
+            logger.warning("Vector file %s failed validation: %s", path, exc)
+        if corrupt:
+            quarantine = path.with_name(path.name + ".corrupt")
+            try:
+                path.replace(quarantine)  # atomic; overwrites any prior .corrupt
+                quarantined.append(str(path))
+                logger.warning(
+                    "Quarantined corrupt vector file %s -> %s", path, quarantine
+                )
+            except OSError as exc:
+                logger.error("Could not quarantine %s: %s", path, exc)
+
+    # Orphaned temp files left by a dead (or hung / PID-reused) writer.
+    now = time.time()
+    for tmp in sorted(ir_dir.glob(TEMP_GLOB)):
+        pid = pid_from_temp_name(tmp.name)
+        try:
+            age = now - tmp.stat().st_mtime
+        except OSError:
+            age = float("inf")
+        recent = age < ORPHAN_TEMP_MAX_AGE_S
+        # Keep only a fresh temp whose writer is verifiably alive. An
+        # unparseable PID can't be liveness-checked, so fall back to mtime alone.
+        keep = recent and (pid is None or is_process_alive(pid))
+        if keep:
+            temps_kept.append(str(tmp))
+            continue
+        try:
+            tmp.unlink()
+            temps_removed.append(str(tmp))
+            logger.info(
+                "Removed orphaned temp %s (pid=%s, age=%.0fs)", tmp, pid, age
+            )
+        except OSError as exc:
+            logger.warning("Could not remove temp %s: %s", tmp, exc)
+
+    if quarantined or temps_removed:
+        logger.info(
+            "Vector store recovery: quarantined=%d temps_removed=%d temps_kept=%d",
+            len(quarantined), len(temps_removed), len(temps_kept),
+        )
+    return {
+        "quarantined": quarantined,
+        "temps_removed": temps_removed,
+        "temps_kept": temps_kept,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/work_buddy/knowledge/persistence.py
+++ b/work_buddy/knowledge/persistence.py
@@ -33,21 +33,22 @@ corrupt an existing cache. Reads are idempotent.
 
 Reads use ``with np.load(...) as data:`` so the underlying ZipFile handle
 is closed before the function returns. On Windows, leaking that handle
-makes the next ``tmp.replace(path)`` fail with ``[WinError 5] Access
-denied`` because the destination still has a live read handle. The
-``_atomic_replace`` helper additionally retries the rename a few times
-with brief backoff to absorb transient locks held by AV / file indexers.
+makes the next ``os.replace`` fail with ``[WinError 5] Access denied``
+because the destination still has a live read handle. The shared
+``atomic_save_npz`` helper (``work_buddy.utils.npz_io``) additionally retries
+the rename a few times with brief backoff to absorb transient locks held by
+AV / file indexers.
 """
 
 from __future__ import annotations
 
 import hashlib
-import time
 from pathlib import Path
 from typing import Any
 
 from work_buddy.logging_config import get_logger
 from work_buddy.paths import resolve
+from work_buddy.utils.npz_io import atomic_save_npz
 
 logger = get_logger(__name__)
 
@@ -59,26 +60,6 @@ CACHE_VERSION = 1
 # 16 hex chars = 8 bytes of SHA-256 prefix. Plenty of collision margin for a
 # corpus of a few hundred units.
 _HASH_LEN = 16
-
-# Brief retry schedule for tmp.replace(path). Windows occasionally refuses
-# the rename when AV / Defender / a file indexer momentarily holds the
-# destination open; backing off a few hundred ms is enough.
-_REPLACE_RETRY_DELAYS_S = (0.05, 0.1, 0.2)
-
-
-def _atomic_replace(tmp: Path, path: Path) -> None:
-    """Rename ``tmp`` over ``path``, retrying briefly on transient locks."""
-    last_err: Exception | None = None
-    for delay in (0.0, *_REPLACE_RETRY_DELAYS_S):
-        if delay:
-            time.sleep(delay)
-        try:
-            tmp.replace(path)
-            return
-        except PermissionError as e:  # WinError 5 surfaces as PermissionError
-            last_err = e
-    assert last_err is not None
-    raise last_err
 
 
 def _content_cache_path() -> Path:
@@ -169,20 +150,18 @@ def save_content_cache(
         # Empty 0-row array, but shape out the dim so load doesn't barf
         vectors_arr = np.zeros((0, 1), dtype=np.float16)
 
-    # savez_compressed auto-appends '.npz' when the path doesn't already
-    # end with it. Giving it a tmp name that ends in '.npz' (e.g.
-    # 'content.tmp.npz') keeps the on-disk name predictable so the rename
-    # targets the right file.
-    tmp = path.with_suffix(".tmp.npz")
-    np.savez_compressed(
-        tmp,
+    # Fixed temp name (single-process cache builder; this cache dir isn't swept,
+    # so no PID-namespacing is needed). atomic_save_npz writes via an open file
+    # object, so the '.tmp.npz' name is kept verbatim with no '.npz' re-append.
+    atomic_save_npz(
+        path,
+        tmp_path=path.with_suffix(".tmp.npz"),
         paths=paths_arr,
         hashes=hashes_arr,
         vectors=vectors_arr,
         model_key=np.array(model_key),
         version=np.array(CACHE_VERSION),
     )
-    _atomic_replace(tmp, path)
     logger.debug(
         "Saved knowledge content cache: %d units, %.2f MB",
         len(cache), path.stat().st_size / 1024 / 1024,
@@ -257,20 +236,18 @@ def save_alias_cache(
     else:
         vectors_arr = np.zeros((0, 1), dtype=np.float16)
 
-    # savez_compressed auto-appends '.npz' when the path doesn't already
-    # end with it. Giving it a tmp name that ends in '.npz' (e.g.
-    # 'content.tmp.npz') keeps the on-disk name predictable so the rename
-    # targets the right file.
-    tmp = path.with_suffix(".tmp.npz")
-    np.savez_compressed(
-        tmp,
+    # Fixed temp name (single-process cache builder; this cache dir isn't swept,
+    # so no PID-namespacing is needed). atomic_save_npz writes via an open file
+    # object, so the '.tmp.npz' name is kept verbatim with no '.npz' re-append.
+    atomic_save_npz(
+        path,
+        tmp_path=path.with_suffix(".tmp.npz"),
         paths=paths_arr,
         alias_texts=texts_arr,
         vectors=vectors_arr,
         model_key=np.array(model_key),
         version=np.array(CACHE_VERSION),
     )
-    _atomic_replace(tmp, path)
     logger.debug(
         "Saved knowledge alias cache: %d aliases, %.2f MB",
         len(cache), path.stat().st_size / 1024 / 1024,

--- a/work_buddy/mcp_server/ops/context_ops.py
+++ b/work_buddy/mcp_server/ops/context_ops.py
@@ -169,12 +169,28 @@ def _register() -> None:
         """Build or check the IR index via the embedding service."""
         import json
 
+        from work_buddy.utils.service_hints import sidecar_restart_command
+
         result = _ir_index_client(
             action, source=source, days=days, force=force,
         )
         if result is None:
+            # Genuine connection failure. The embedding service is supervised by
+            # the sidecar (not an independent scheduled task), so point there.
             return json.dumps({
-                "error": "Embedding service unavailable. Start it with: Start-ScheduledTask -TaskName 'WB-Embedding'"
+                "error": (
+                    "Embedding service unreachable. It's supervised by the "
+                    f"sidecar — restart with: {sidecar_restart_command()}. "
+                    "Or run /wb-setup-help to diagnose."
+                )
+            })
+        if "error" in result:
+            # Service was reachable but /ir/index failed — surface the real
+            # error (e.g. a corrupt vector file) instead of masking it.
+            status = result.get("status")
+            detail = f" (HTTP {status})" if status else ""
+            return json.dumps({
+                "error": f"/ir/index failed{detail}: {result['error']}"
             })
         return json.dumps(result, indent=2)
 

--- a/work_buddy/sidecar/pid.py
+++ b/work_buddy/sidecar/pid.py
@@ -6,49 +6,20 @@ Ported from ClaudeClaw's pid.ts — adapted for Python/Windows.
 import atexit
 import os
 import signal
-import sys
 import tempfile
 from pathlib import Path
 
 from work_buddy.logging_config import get_logger
 from work_buddy.paths import resolve
+from work_buddy.utils.process import is_process_alive
 
 logger = get_logger(__name__)
 
 PID_FILE = resolve("runtime/sidecar-pid")
 
-
-def _is_process_alive(pid: int) -> bool:
-    """Check whether a process with the given PID is still running.
-
-    Uses ctypes on Windows (os.kill signal-0 is unreliable there),
-    falls back to os.kill on other platforms.
-    """
-    if sys.platform == "win32":
-        import ctypes
-        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
-        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
-        handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
-        if not handle:
-            return False
-        try:
-            # OpenProcess can succeed on terminated processes whose handles
-            # haven't been fully released. Check the actual exit code:
-            # STILL_ACTIVE (259) means genuinely running.
-            exit_code = ctypes.c_ulong()
-            if kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
-                return exit_code.value == 259  # STILL_ACTIVE
-            return False  # couldn't query — treat as dead
-        finally:
-            kernel32.CloseHandle(handle)
-    else:
-        try:
-            os.kill(pid, 0)
-            return True
-        except PermissionError:
-            return True
-        except (OSError, ProcessLookupError):
-            return False
+# Process-liveness lives in work_buddy.utils.process (shared with the IR vector
+# store's orphan-temp sweep). Kept under the private name for internal callers.
+_is_process_alive = is_process_alive
 
 
 def check_existing_daemon() -> int | None:

--- a/work_buddy/utils/npz_io.py
+++ b/work_buddy/utils/npz_io.py
@@ -1,0 +1,190 @@
+"""Atomic, self-healing ``.npz`` read/write for work-buddy's vector caches.
+
+Numpy vector caches (the IR dense-vector store, the knowledge-index content /
+alias caches) are **regenerable**: the source of truth lives elsewhere (SQLite
++ JSONL sessions, the knowledge store), so the goal here is resilience, not
+durability. A write must never leave a corrupt canonical file, and a read of a
+corrupt file must degrade gracefully instead of raising.
+
+This module owns the two primitives that make that true, so every vector cache
+shares one implementation:
+
+- :func:`atomic_save_npz` — write to a sibling temp, ``fsync``, then
+  ``os.replace`` onto the canonical path. A crash mid-write leaves either the
+  intact old file or an orphaned temp, never a truncated canonical.
+- :func:`safe_load_npz` — return ``None`` (not raise) for a missing, empty, or
+  corrupt file, so callers fall back to a cold rebuild.
+
+## fsync without numpy's ``.npz`` rewrite
+
+``np.savez_compressed`` opens and closes its *own* handle when given a path, so
+the caller gets no file descriptor to ``fsync`` — and a path argument also
+triggers numpy's "append ``.npz`` if missing" rewrite. Passing an already-open
+binary file object avoids both: numpy writes through the caller's handle (no
+re-open, no rename), so the handle can be ``fsync``'d and the temp keeps the
+name it was given.
+
+## Temp naming and recovery
+
+Temps are named ``<canonical-without-.npz>.<pid>.tmp.npz`` so a recovery sweep
+(see ``work_buddy/ir/store.py::recover_vector_store``) can tell an orphan left
+by a dead writer from a temp a live writer is mid-write on. The trailing
+``.tmp.npz`` keeps numpy from appending another suffix.
+
+## Windows replace caveat
+
+``os.replace`` raises ``PermissionError`` (WinError 5) if the destination is
+still open by another process — typically a reader that leaked its ``NpzFile``
+handle. :func:`safe_load_npz` uses ``with np.load(...)`` and materializes every
+array inside the block so the handle is closed before return; :func:`atomic_replace`
+additionally retries the rename a few times to absorb transient AV / indexer
+locks.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import zipfile
+from pathlib import Path
+from typing import Any
+
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+# Brief retry schedule for the temp -> canonical rename. Windows occasionally
+# refuses the rename when AV / Defender / a file indexer momentarily holds the
+# destination open; backing off a few hundred ms is enough.
+_REPLACE_RETRY_DELAYS_S = (0.05, 0.1, 0.2)
+
+# Temp files are ``<canonical-without-.npz>.<pid>.tmp.npz``. The trailing
+# ``.tmp.npz`` both keeps numpy from appending a suffix and gives the recovery
+# sweep an unambiguous discriminator from canonical ``*.npz`` files.
+TEMP_SUFFIX = ".tmp.npz"
+TEMP_GLOB = f"*{TEMP_SUFFIX}"
+
+
+def atomic_replace(tmp: Path, path: Path) -> None:
+    """Rename ``tmp`` over ``path``, retrying briefly on transient locks."""
+    last_err: Exception | None = None
+    for delay in (0.0, *_REPLACE_RETRY_DELAYS_S):
+        if delay:
+            time.sleep(delay)
+        try:
+            tmp.replace(path)
+            return
+        except PermissionError as e:  # WinError 5 surfaces as PermissionError
+            last_err = e
+    assert last_err is not None
+    raise last_err
+
+
+def temp_path_for(path: Path, pid: int | None = None) -> Path:
+    """Sibling temp path for ``path``: ``<name-without-.npz>.<pid>.tmp.npz``.
+
+    ``path.with_suffix("")`` strips only the trailing ``.npz``, so multi-dot
+    canonical names (``work_buddy_ir.task_note.body.npz``) keep their inner
+    dots.
+    """
+    if pid is None:
+        pid = os.getpid()
+    base = path.with_suffix("")  # drop the trailing .npz
+    return base.parent / f"{base.name}.{pid}{TEMP_SUFFIX}"
+
+
+def pid_from_temp_name(name: str) -> int | None:
+    """Extract the writer PID from a temp file name, or ``None`` if unparseable.
+
+    ``work_buddy_ir.conversation.12345.tmp.npz`` -> ``12345``. A non-numeric
+    token (or a name not matching the convention) yields ``None``; the sweep
+    then falls back to its mtime-age guard.
+    """
+    if not name.endswith(TEMP_SUFFIX):
+        return None
+    stem = name[: -len(TEMP_SUFFIX)]  # strip ".tmp.npz"
+    token = stem.rsplit(".", 1)[-1]
+    return int(token) if token.isdigit() else None
+
+
+def atomic_save_npz(
+    path: Path,
+    *,
+    tmp_path: Path | None = None,
+    **arrays: Any,
+) -> Path:
+    """Save ``**arrays`` to ``path`` atomically (temp + fsync + replace).
+
+    Writes the compressed archive to a sibling temp, flushes and ``fsync``s it,
+    then ``os.replace``s it onto ``path`` — so a crash mid-write can never leave
+    a truncated canonical file.
+
+    Args:
+        path: Canonical destination path.
+        tmp_path: Override the temp path. Defaults to a PID-namespaced sibling
+            (see :func:`temp_path_for`) so a recovery sweep can identify
+            orphans. Single-process callers that don't need sweep-awareness may
+            pass a fixed name.
+        **arrays: Forwarded to ``np.savez_compressed`` (array name -> value).
+
+    Returns:
+        ``path`` (the canonical destination).
+    """
+    import numpy as np
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if tmp_path is None:
+        tmp_path = temp_path_for(path)
+
+    try:
+        # Pass an open file object (not a path) so numpy neither re-opens nor
+        # appends ".npz", and so we own the fd for fsync.
+        with open(tmp_path, "wb") as fh:
+            np.savez_compressed(fh, **arrays)
+            fh.flush()
+            os.fsync(fh.fileno())
+        atomic_replace(tmp_path, path)
+    finally:
+        # On success the temp was renamed away; on any failure (savez error or a
+        # replace that exhausted its retries) clean the partial/leftover temp so
+        # it doesn't masquerade as an orphan. The old canonical is untouched
+        # either way. A hard kill skips this finally — that orphan is what the
+        # recovery sweep cleans by dead-PID.
+        if tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError as exc:
+                logger.warning("Could not remove temp %s: %s", tmp_path, exc)
+
+    return path
+
+
+def safe_load_npz(path: Path) -> dict[str, "np.ndarray"] | None:
+    """Load an ``.npz`` file, returning ``None`` instead of raising on trouble.
+
+    Returns ``None`` if the file is missing, zero-byte, or fails to load/parse
+    (a truncated or corrupt archive). On success, returns a dict mapping each
+    archive key to a fully-materialized array.
+
+    Every array is read **inside** the ``with np.load(...)`` block so the
+    underlying ZipFile handle is closed before return — on Windows a leaked
+    handle makes a subsequent ``os.replace`` onto this path fail with WinError 5.
+    """
+    import numpy as np
+
+    if not path.exists():
+        return None
+    try:
+        if path.stat().st_size == 0:
+            logger.warning("Vector file %s is zero bytes; treating as absent.", path)
+            return None
+        with np.load(path, allow_pickle=True) as data:
+            # Materialize every array while the handle is open. np.load is lazy,
+            # so corruption can surface here on access rather than on np.load().
+            return {key: data[key] for key in data.files}
+    except (EOFError, zipfile.BadZipFile, ValueError, OSError) as exc:
+        # BadZipFile subclasses Exception (not OSError/ValueError), so it must
+        # be caught explicitly — a 0-byte or truncated archive surfaces as one.
+        logger.warning("Vector file %s is unreadable (%s); treating as absent.", path, exc)
+        return None

--- a/work_buddy/utils/process.py
+++ b/work_buddy/utils/process.py
@@ -1,0 +1,41 @@
+"""Process utilities for work-buddy.
+
+A cross-platform process-liveness primitive, shared by the sidecar's PID-file
+management and the IR vector store's orphan-temp recovery sweep.
+"""
+
+import os
+import sys
+
+
+def is_process_alive(pid: int) -> bool:
+    """Check whether a process with the given PID is still running.
+
+    Uses ctypes on Windows (``os.kill`` signal-0 is unreliable there),
+    falls back to ``os.kill`` on other platforms.
+    """
+    if sys.platform == "win32":
+        import ctypes
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return False
+        try:
+            # OpenProcess can succeed on terminated processes whose handles
+            # haven't been fully released. Check the actual exit code:
+            # STILL_ACTIVE (259) means genuinely running.
+            exit_code = ctypes.c_ulong()
+            if kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                return exit_code.value == 259  # STILL_ACTIVE
+            return False  # couldn't query — treat as dead
+        finally:
+            kernel32.CloseHandle(handle)
+    else:
+        try:
+            os.kill(pid, 0)
+            return True
+        except PermissionError:
+            return True
+        except (OSError, ProcessLookupError):
+            return False

--- a/work_buddy/utils/service_hints.py
+++ b/work_buddy/utils/service_hints.py
@@ -1,0 +1,24 @@
+"""User-facing remediation hints for work-buddy services.
+
+Single-sourced so the "how to restart" text can't drift between the health
+subsystem and ad-hoc error messages — a hardcoded copy can rot into naming a
+scheduled task that doesn't exist. The embedding, messaging, and dashboard
+services are children supervised by the sidecar daemon; restarting the sidecar
+is the correct remediation for any of them, and only the sidecar itself is a
+scheduled task.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def sidecar_restart_command() -> str:
+    """OS-aware shell command to restart the sidecar daemon.
+
+    Returns the bare command (no prose prefix) so callers can embed it in
+    whatever sentence fits their surface.
+    """
+    if sys.platform == "win32":
+        return "Start-ScheduledTask 'WB-Sidecar'"
+    return "python -m work_buddy.sidecar &"


### PR DESCRIPTION
## Summary

A process killed mid-write left a 0-byte/truncated `work_buddy_ir.<source>.npz`: `save_vectors` wrote `np.savez_compressed` straight to the canonical path, and `load_vectors` **raised** on a corrupt file. That raise surfaced as an `/ir/index` 500, which the client relabeled as the generic *"embedding service unavailable"* — masking the real error and taking the conversation search source dark. The 5-min rebuild cron couldn't self-heal it, because the incremental build also read the corrupt file and raised.

- **`work_buddy/utils/npz_io.py`** (new, shared): `atomic_save_npz` (PID-named temp + `fsync` + `os.replace` with Windows-`PermissionError` retry; writes via an open file object so numpy neither re-opens nor appends `.npz`) and `safe_load_npz` (returns `None` on missing/0-byte/corrupt; catches `EOFError`/`BadZipFile`/`ValueError`/`OSError`).
- **`ir/store.py`**: `save_vectors` → atomic; `load_vectors` → corrupt-tolerant + pure (returns `None`, no FS mutation); new `recover_vector_store` quarantines a corrupt canonical to `<name>.corrupt` and reaps orphaned `*.tmp.npz` (dead-PID or stale) while sparing a live writer. Hooked into `embedding/service.py::main()` before serving.
- **`knowledge/persistence.py`** shares `atomic_save_npz` (its `_atomic_replace` moves into `utils/npz_io`). **`utils/process.py`**: `is_process_alive` (moved from `sidecar/pid.py`) backs the sweep's PID check; `sidecar/pid.py` re-exports it.
- **`embedding/client.py`**: `_request` splits `HTTPError` from connection failures + adds `return_http_error` so `ir_index` surfaces the real `/ir/index` error; the dispatch points unreachable-service remediation at the sidecar via `utils/service_hints` (the service is sidecar-supervised, not a standalone scheduled task).

## Test plan

- [x] `tests/unit/test_ir_store_atomic.py` — round-trip, 0-byte/truncated → `None`, recovery sweep (orphan vs live temp, quarantine), `/ir/index` error surfacing
- [x] 285 passed / 0 failed across 18 files touching every changed module
- [x] Verified live: on service restart the sweep quarantined the stuck 0-byte `conversation.npz` and the index cold-rebuilt to ~12.4k vectors with searches up throughout

Task: t-78026f87

🤖 Generated with [Claude Code](https://claude.com/claude-code)