### PR TITLE
feat(inference): thread broker Priority through the local LLM call path

### DIFF
--- a/knowledge/store/architecture/inference/broker.md
+++ b/knowledge/store/architecture/inference/broker.md
@@ -53,6 +53,8 @@ with broker.slot(
 
 On ``__exit__``, the ticket releases the slot and the call's metrics land in the ring buffer. Metrics are readable via ``broker.snapshot_metrics()``; current per-profile occupancy via ``broker.profile_status()``.
 
+``work_buddy.inference.parse_priority(value)`` maps a case-insensitive name string (``"interactive"`` / ``"workflow"`` / ``"background"``) — or a ``Priority`` / ``None`` passthrough — onto the enum. It exists for the MCP boundary, where capability params (``llm_call`` / ``llm_submit``) arrive as JSON strings and must map onto the enum before reaching the broker.
+
 ## Priority classes
 
 Three classes, fixed-priority admission across + FIFO within:

--- a/knowledge/store/architecture/llm-runner.md
+++ b/knowledge/store/architecture/llm-runner.md
@@ -147,9 +147,11 @@ Both LM-Studio-backed backends run inside ``LocalInferenceBroker.slot(...)`` bef
 - ``work_buddy.llm.backends.lmstudio_native.call_lmstudio_native`` — profile ``lmstudio_native:<model>``.
 - ``work_buddy.llm.backends.openai_compat.call_openai_compat`` — profile ``openai_compat:<model>``.
 
-Priority is set at the backend call site, not at the runner level. Both functions accept a ``priority`` kwarg (defaults to ``WORKFLOW``) and ``queue_wait_s`` (default 30s). Callers on user-facing paths should pass ``priority=Priority.INTERACTIVE``; batch classifiers / summarizers can pass ``Priority.BACKGROUND`` to yield to interactive work.
+Priority is threaded from the runner: ``LLMRunner.call(priority=...)`` forwards it through ``run_task`` and ``_run_profile`` to the backend's ``broker.slot(...)``. Both backend functions accept a ``priority`` kwarg (defaults to ``WORKFLOW``) and ``queue_wait_s`` (default 30s); the runner forwards ``priority`` and leaves ``queue_wait_s`` at the backend/config default. Callers on user-facing paths pass ``priority=Priority.INTERACTIVE``; batch classifiers / summarizers pass ``Priority.BACKGROUND`` to yield to interactive work. ``priority=None`` (the default) leaves the backend's ``WORKFLOW`` default in place.
 
-The Anthropic backend is NOT broker-wrapped — Anthropic is a cloud service, its own rate-limiting handles the admission layer, and the priority/slot vocabulary doesn't apply.
+The MCP-exposed ``llm_call`` / ``llm_submit`` capabilities take the priority as a string (``"interactive"`` / ``"workflow"`` / ``"background"``), mapped onto the enum by ``work_buddy.inference.parse_priority``. ``llm_submit`` validates it at submit time and carries the canonical name across the queue boundary so the sidecar-replayed ``llm_call`` admits at the requested priority.
+
+The Anthropic backend is NOT broker-wrapped — Anthropic is a cloud service, its own rate-limiting handles the admission layer, and the priority/slot vocabulary doesn't apply (the runner attaches ``priority`` only to the local-profile dispatch).
 
 ## Current internal callers
 

--- a/knowledge/store/status/llm_call.md
+++ b/knowledge/store/status/llm_call.md
@@ -39,6 +39,10 @@ parameters:
     type: int
     description: Cache TTL in minutes. None=config default, 0=no cache.
     required: false
+  priority:
+    type: str
+    description: "Local-inference admission priority for the broker: 'interactive', 'workflow' (default), or 'background'. Only applies to the local 'profile' path; ignored for cloud 'tier' (Anthropic isn't brokered). Lets background work yield to interactive work on the same LM Studio profile."
+    required: false
 tags:
 - llm
 - call

--- a/knowledge/store/status/llm_submit.md
+++ b/knowledge/store/status/llm_submit.md
@@ -35,6 +35,10 @@ parameters:
     type: int
     description: Cache TTL in minutes. None=config default, 0=no cache.
     required: false
+  priority:
+    type: str
+    description: "Local-inference admission priority for the broker: 'interactive', 'workflow' (default), or 'background'. Background submits should pass 'background' so they yield to interactive work on the same LM Studio profile."
+    required: false
 auto_retry: false
 tags:
 - llm

--- a/tests/unit/test_llm_backends_broker_wiring.py
+++ b/tests/unit/test_llm_backends_broker_wiring.py
@@ -245,3 +245,225 @@ def test_lmstudio_native_and_openai_compat_profiles_are_distinct(
     assert "lmstudio_native:shared-model" in profiles
     # Emphatic: they are NOT the same entry.
     assert len(profiles) == 2
+
+
+# ---------------------------------------------------------------------------
+# End-to-end priority threading
+#
+# The backend functions accept ``priority``; these tests pin that the
+# runner layers above them actually forward it:
+#   LLMRunner.call -> _call_one -> run_task -> _run_profile -> backend slot.
+# Without this threading every local LLM call is stuck at WORKFLOW and
+# callers can't make background work yield to interactive work.
+# ---------------------------------------------------------------------------
+
+
+def _fake_profile_info(model: str) -> dict:
+    """Minimal ``profile_info`` shape consumed by run_task / _run_profile."""
+    return {
+        "model": model,
+        "execution_mode": "local",
+        "backend_id": "test_profile",
+        "base_url": "http://fake/v1",
+        "api_key_env": None,
+        "provider": None,
+    }
+
+
+def _patch_profile_path(monkeypatch, backend_mod, model, response_json):
+    """Wire run_task's profile path to a mock backend HTTP endpoint.
+
+    Patches profile resolution (so no config.yaml is needed), cost
+    logging (so no cost file is written), and the backend module's httpx
+    client (so no network call happens).
+    """
+    monkeypatch.setattr(
+        "work_buddy.llm.profiles.resolve_profile",
+        lambda name: _fake_profile_info(model),
+    )
+    monkeypatch.setattr(
+        "work_buddy.llm.cost.log_call", lambda *a, **kw: None,
+    )
+    real_client = httpx.Client
+    monkeypatch.setattr(backend_mod.httpx, "Client", lambda *a, **kw: real_client(
+        *a, **kw, transport=httpx.MockTransport(
+            lambda r: httpx.Response(200, json=response_json)
+        ),
+    ))
+
+
+def test_run_task_threads_priority_to_openai_compat(monkeypatch):
+    """run_task(profile=..., backend_kind='openai_compat', priority=...)
+    forwards the priority all the way to the broker slot."""
+    import work_buddy.llm.backends.openai_compat as oa_mod
+    from work_buddy.llm.runner import run_task
+    from work_buddy.inference import get_broker
+
+    _patch_profile_path(monkeypatch, oa_mod, "fake-echo", _oa_fake_response())
+
+    result = run_task(
+        task_id="t",
+        system="s",
+        user="u",
+        profile="local_general",
+        backend_kind="openai_compat",
+        priority=Priority.BACKGROUND,
+        cache_ttl_minutes=0,
+    )
+    assert result.error is None
+    assert result.content == "hello from the fake"
+
+    m = get_broker().snapshot_metrics()[-1]
+    assert m["profile"] == "openai_compat:fake-echo"
+    assert m["priority"] == "BACKGROUND"
+    assert m["status"] == "ok"
+
+
+def test_run_task_threads_priority_to_lmstudio_native(monkeypatch):
+    """Same end-to-end threading for the native-chat backend, with a
+    distinct priority + profile prefix."""
+    import work_buddy.llm.backends.lmstudio_native as lms_mod
+    from work_buddy.llm.runner import run_task
+    from work_buddy.inference import get_broker
+
+    _patch_profile_path(monkeypatch, lms_mod, "fake-lms", _lms_fake_response())
+
+    result = run_task(
+        task_id="t",
+        system="s",
+        user="u",
+        profile="local_agent",
+        backend_kind="lmstudio_native",
+        priority=Priority.INTERACTIVE,
+        cache_ttl_minutes=0,
+    )
+    assert result.error is None
+    assert "lm studio echo" in result.content
+
+    m = get_broker().snapshot_metrics()[-1]
+    assert m["profile"] == "lmstudio_native:fake-lms"
+    assert m["priority"] == "INTERACTIVE"
+
+
+def test_run_task_defaults_to_workflow_priority(monkeypatch):
+    """Omitting priority leaves the backend default (WORKFLOW) intact —
+    the new param must not change existing behaviour."""
+    import work_buddy.llm.backends.openai_compat as oa_mod
+    from work_buddy.llm.runner import run_task
+    from work_buddy.inference import get_broker
+
+    _patch_profile_path(monkeypatch, oa_mod, "fake-echo", _oa_fake_response())
+
+    run_task(
+        task_id="t",
+        system="s",
+        user="u",
+        profile="local_general",
+        backend_kind="openai_compat",
+        cache_ttl_minutes=0,
+    )
+    m = get_broker().snapshot_metrics()[-1]
+    assert m["priority"] == "WORKFLOW"
+
+
+def test_llm_runner_call_threads_priority_end_to_end(monkeypatch):
+    """The public entry point LLMRunner.call(priority=...) threads the
+    priority through _call_one -> run_task -> _run_profile -> backend."""
+    import work_buddy.llm.backends.openai_compat as oa_mod
+    import work_buddy.llm.runner_v2 as runner_v2
+    from work_buddy.llm import LLMRunner, ModelTier
+    from work_buddy.llm.tiers import TierBinding
+    from work_buddy.inference import get_broker
+
+    _patch_profile_path(monkeypatch, oa_mod, "fake-echo", _oa_fake_response())
+
+    # Pin tier resolution so the test is independent of config.yaml's
+    # llm.tiers block.
+    binding = TierBinding(
+        tier=ModelTier.LOCAL_FAST,
+        backend="openai_compat",
+        profile="local_general",
+        model=None,
+        max_tokens=512,
+        temperature=0.0,
+        tool_support=False,
+    )
+    monkeypatch.setattr(runner_v2, "resolve_tier", lambda tier: binding)
+
+    resp = LLMRunner().call(
+        tier=ModelTier.LOCAL_FAST,
+        system="s",
+        user="u",
+        priority=Priority.BACKGROUND,
+        cache_ttl_minutes=0,
+    )
+    assert not resp.is_error()
+
+    m = get_broker().snapshot_metrics()[-1]
+    assert m["profile"] == "openai_compat:fake-echo"
+    assert m["priority"] == "BACKGROUND"
+
+
+# ---------------------------------------------------------------------------
+# MCP-boundary priority string -> Priority enum (parse_priority + llm_call)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_priority_maps_names_case_insensitively():
+    from work_buddy.inference import parse_priority
+
+    assert parse_priority("background") is Priority.BACKGROUND
+    assert parse_priority("WORKFLOW") is Priority.WORKFLOW
+    assert parse_priority("Interactive") is Priority.INTERACTIVE
+
+
+def test_parse_priority_passthrough_and_none():
+    from work_buddy.inference import parse_priority
+
+    assert parse_priority(None) is None
+    assert parse_priority(Priority.BACKGROUND) is Priority.BACKGROUND
+
+
+def test_parse_priority_rejects_unknown():
+    from work_buddy.inference import parse_priority
+
+    with pytest.raises(ValueError):
+        parse_priority("urgent")
+
+
+def test_llm_call_threads_string_priority_to_broker(monkeypatch):
+    """The llm_call MCP capability accepts a string priority and threads
+    it (mapped to the Priority enum) down to the backend broker slot."""
+    import work_buddy.llm.backends.openai_compat as oa_mod
+    from work_buddy.llm.call import llm_call
+    from work_buddy.inference import get_broker
+
+    _patch_profile_path(monkeypatch, oa_mod, "fake-echo", _oa_fake_response())
+
+    result = llm_call(
+        system="s",
+        user="u",
+        profile="local_general",
+        priority="background",
+        cache_ttl_minutes=0,
+    )
+    assert result["error"] is None
+
+    m = get_broker().snapshot_metrics()[-1]
+    assert m["profile"] == "openai_compat:fake-echo"
+    assert m["priority"] == "BACKGROUND"
+
+
+def test_llm_call_rejects_invalid_priority():
+    """A bad priority string is rejected at the capability boundary
+    before any backend call — no broker slot is taken."""
+    from work_buddy.llm.call import llm_call
+
+    result = llm_call(
+        system="s",
+        user="u",
+        profile="local_general",
+        priority="urgent",
+        cache_ttl_minutes=0,
+    )
+    assert result["error"] and "priority" in result["error"].lower()

--- a/tests/unit/test_llm_submit.py
+++ b/tests/unit/test_llm_submit.py
@@ -133,6 +133,55 @@ def test_llm_submit_preserves_output_schema(tmp_ops_dir):
     assert record["params"]["output_schema"] == schema
 
 
+def test_llm_submit_carries_priority_in_replay_params(tmp_ops_dir):
+    """A background submit stores the canonical priority string in the
+    replay params, so the sidecar-replayed llm_call admits at BACKGROUND."""
+    from work_buddy.llm.submit import llm_submit
+
+    response = llm_submit(
+        system="s", user="u", profile="local_general",
+        priority="BACKGROUND",  # case-insensitive
+    )
+    assert response["priority"] == "background"
+
+    record = json.loads(
+        (tmp_ops_dir / f"{response['operation_id']}.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert record["params"]["priority"] == "background"
+
+
+def test_llm_submit_omits_priority_when_absent(tmp_ops_dir):
+    """No priority → none in the response and the replay params don't
+    carry the key (the backend applies its WORKFLOW default)."""
+    from work_buddy.llm.submit import llm_submit
+
+    response = llm_submit(system="s", user="u", profile="local_general")
+    assert response["priority"] is None
+
+    record = json.loads(
+        (tmp_ops_dir / f"{response['operation_id']}.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert "priority" not in record["params"]
+
+
+def test_llm_submit_rejects_invalid_priority(tmp_ops_dir):
+    """An unknown priority fails fast at submit time — no op record is
+    written for the sidecar to replay."""
+    from work_buddy.llm.submit import llm_submit
+
+    response = llm_submit(
+        system="s", user="u", profile="local_general", priority="urgent",
+    )
+    assert "error" in response
+    assert "priority" in response["error"].lower()
+    # Nothing should have been queued.
+    assert not list(tmp_ops_dir.glob("op_*.json"))
+
+
 # ---------------------------------------------------------------------------
 # Gateway _is_queued helper
 # ---------------------------------------------------------------------------

--- a/work_buddy/inference/__init__.py
+++ b/work_buddy/inference/__init__.py
@@ -20,6 +20,7 @@ from work_buddy.inference.broker import (
     QueueWaitTimeout,
     SlotMetrics,
     get_broker,
+    parse_priority,
 )
 
 __all__ = [
@@ -31,4 +32,5 @@ __all__ = [
     "QueueWaitTimeout",
     "SlotMetrics",
     "get_broker",
+    "parse_priority",
 ]

--- a/work_buddy/inference/broker.py
+++ b/work_buddy/inference/broker.py
@@ -31,12 +31,23 @@ for local inference:
 
 Scope
 -----
-Wired only into ``work_buddy.embedding.providers.lmstudio`` for now —
-that's the call site that caused the recent dashboard-search outages
-(bulk encode holding the embedding service's thread + Python locks
-while an interactive search tried to run). Wiring into
-``work_buddy.llm.backends.{lmstudio_native,openai_compat}`` is a
-follow-on.
+Wired into every local-inference call site:
+
+* ``work_buddy.embedding.providers.lmstudio`` — bulk document encode
+  (profile prefix ``lmstudio:``). This is the call site that originally
+  motivated the broker: a bulk encode holding the embedding service's
+  thread + Python locks while an interactive search tried to run.
+* ``work_buddy.llm.backends.openai_compat`` (profile prefix
+  ``openai_compat:``) and ``work_buddy.llm.backends.lmstudio_native``
+  (profile prefix ``lmstudio_native:``) — every local LLM completion.
+
+The per-call-site profile prefix keeps slot limits independent even
+when all three point at the same LM Studio instance. Each caller
+declares a :class:`Priority` per call: the LLM path threads it from
+``LLMRunner.call(priority=...)`` down through ``run_task`` to the
+backend slot; the embedding path from ``encode(priority=...)``.
+Frontier/Anthropic calls are NOT brokered — Anthropic is a cloud
+service with its own rate limiting.
 
 The broker does NOT enforce ``inference_s`` directly — it passes
 the value along so the caller's ``httpx.Client(timeout=...)`` does
@@ -95,6 +106,30 @@ class Priority(enum.IntEnum):
 
     BACKGROUND = 2
     """Cron jobs, bulk index rebuilds. Yields to everything else."""
+
+
+def parse_priority(value: str | Priority | None) -> Priority | None:
+    """Coerce a string / enum / ``None`` into a :class:`Priority`.
+
+    Accepts a :class:`Priority` (returned as-is), ``None`` (returned as
+    ``None`` so the caller falls through to its own default), or a
+    case-insensitive name string (``"interactive"`` / ``"workflow"`` /
+    ``"background"``). Exists for the MCP boundary, where capability
+    params arrive as JSON strings and must map onto the enum before
+    reaching the broker.
+
+    Raises:
+        ValueError: the string does not name a known priority.
+    """
+    if value is None or isinstance(value, Priority):
+        return value
+    try:
+        return Priority[str(value).strip().upper()]
+    except KeyError:
+        valid = ", ".join(p.name.lower() for p in Priority)
+        raise ValueError(
+            f"Unknown priority {value!r}; expected one of: {valid}."
+        )
 
 
 class BrokerError(Exception):

--- a/work_buddy/llm/call.py
+++ b/work_buddy/llm/call.py
@@ -85,6 +85,7 @@ def llm_call(
     max_tokens: int = 1024,
     temperature: float = 0.0,
     cache_ttl_minutes: int | None = None,
+    priority: str | None = None,
 ) -> dict[str, Any]:
     """Make a single LLM API call with optional structured output.
 
@@ -107,11 +108,16 @@ def llm_call(
         max_tokens: Max response tokens.
         temperature: Sampling temperature.
         cache_ttl_minutes: Cache TTL. ``None`` = config default, ``0`` = skip.
+        priority: Local-inference admission priority for the broker —
+            ``"interactive"``, ``"workflow"`` (default), or
+            ``"background"``. Only meaningful on the local ``profile``
+            path; ignored for cloud ``tier`` (Anthropic isn't brokered).
 
     Returns:
         Dict with ``content`` (raw text), ``parsed`` (dict if schema used),
         ``model``, ``input_tokens``, ``output_tokens``, ``cached``, ``error``.
     """
+    from work_buddy.inference import parse_priority
     from work_buddy.llm.runner import ModelTier, run_task
 
     if tier is not None and profile is not None:
@@ -123,6 +129,20 @@ def llm_call(
             "output_tokens": 0,
             "cached": False,
             "error": "'tier' and 'profile' are mutually exclusive",
+        }
+
+    # Map the JSON-boundary priority string onto the broker enum.
+    try:
+        broker_priority = parse_priority(priority)
+    except ValueError as exc:
+        return {
+            "content": "",
+            "parsed": None,
+            "model": "",
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cached": False,
+            "error": str(exc),
         }
 
     # Resolve schema
@@ -158,6 +178,7 @@ def llm_call(
             max_tokens=max_tokens,
             temperature=temperature,
             cache_ttl_minutes=cache_ttl_minutes,
+            priority=broker_priority,
         )
     else:
         result = run_task(
@@ -169,6 +190,7 @@ def llm_call(
             max_tokens=max_tokens,
             temperature=temperature,
             cache_ttl_minutes=cache_ttl_minutes,
+            priority=broker_priority,
         )
 
     return {

--- a/work_buddy/llm/runner.py
+++ b/work_buddy/llm/runner.py
@@ -18,10 +18,13 @@ import os
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from work_buddy.config import load_config
 from work_buddy.logging_config import get_logger
+
+if TYPE_CHECKING:
+    from work_buddy.inference import Priority
 
 
 class ModelTier(str, Enum):
@@ -141,6 +144,7 @@ def run_task(
     allowed_tiers: list[ModelTier] | None = None,
     profile: str | None = None,
     backend_kind: str | None = None,
+    priority: Priority | None = None,
 ) -> TaskResult:
     """Run a single LLM task with optional caching.
 
@@ -173,6 +177,13 @@ def run_task(
             whose server-side JIT auto-load lets a cold request succeed
             without a prior model-load step. Only override when calling
             a profile intended for MCP tool use.
+        priority: Local-inference admission priority
+            (:class:`work_buddy.inference.Priority`), forwarded to the
+            local backend's ``broker.slot(...)`` so a background request
+            yields to interactive work on the same LM Studio profile.
+            Meaningful only on the local-profile path; the Anthropic path
+            is not brokered and ignores it. ``None`` lets the backend
+            apply its default (``WORKFLOW``).
 
     Returns:
         TaskResult with response content, token counts, and cache status.
@@ -296,6 +307,7 @@ def run_task(
             system_preview=system_preview,
             trace_id=trace_id,
             backend_kind=backend_kind,
+            priority=priority,
         )
 
     # Call Anthropic API — check dedicated subagent key first, then general key
@@ -508,6 +520,7 @@ def _run_profile(
     system_preview: str,
     trace_id: str | None,
     backend_kind: str | None = None,
+    priority: Priority | None = None,
 ) -> TaskResult:
     """Dispatch a profile-based request to the requested endpoint kind.
 
@@ -531,6 +544,10 @@ def _run_profile(
     warning when it disagrees with ``backend_kind``; the config value
     is not used for dispatch. Tier binding → dispatch kind is the one
     source of truth, authored at :mod:`work_buddy.llm.tiers`.
+
+    ``priority`` is forwarded to the chosen local backend's
+    ``broker.slot(...)`` admission call. Both local backends accept it
+    and default to ``WORKFLOW`` when it is ``None``.
     """
     provider = backend_kind or "openai_compat"
     config_provider = profile_info.get("provider")
@@ -567,6 +584,7 @@ def _run_profile(
                 max_tokens=max_tokens,
                 temperature=temperature,
                 api_key_env=profile_info["api_key_env"],
+                priority=priority,
             )
             # Normalize to the {content, input_tokens, output_tokens,
             # model} shape the rest of this function expects. The
@@ -593,6 +611,7 @@ def _run_profile(
                 temperature=temperature,
                 output_schema=output_schema,
                 api_key_env=profile_info["api_key_env"],
+                priority=priority,
             )
         else:
             return TaskResult(

--- a/work_buddy/llm/runner_v2.py
+++ b/work_buddy/llm/runner_v2.py
@@ -28,7 +28,7 @@ Scope / limitations for phase 1:
 from __future__ import annotations
 
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from work_buddy.llm.response import (
     ErrorKind,
@@ -38,6 +38,9 @@ from work_buddy.llm.response import (
 )
 from work_buddy.llm.tiers import ModelTier, TierBinding, resolve_tier, legacy_tier_for
 from work_buddy.logging_config import get_logger
+
+if TYPE_CHECKING:
+    from work_buddy.inference import Priority
 
 logger = get_logger(__name__)
 
@@ -198,6 +201,7 @@ class LLMRunner:
         escalate_to: list[ModelTier] | None = None,
         max_tokens: int | None = None,
         temperature: float | None = None,
+        priority: Priority | None = None,
         cache_ttl_minutes: int | None = None,
         trace_id: str | None = None,
     ) -> LLMResponse:
@@ -215,6 +219,12 @@ class LLMRunner:
             escalate_to: Ordered list of fallback tiers, tried in order
                 when escalation fires. Empty/None = no escalation.
             max_tokens, temperature: Override the tier defaults.
+            priority: Local-inference admission priority
+                (:class:`work_buddy.inference.Priority`). Threaded down to
+                the local backend's ``broker.slot(...)`` so background work
+                yields to interactive work on the same LM Studio profile.
+                ``None`` lets the backend apply its default (``WORKFLOW``).
+                Ignored for the Anthropic backend, which is not brokered.
             cache_ttl_minutes: Passed through to :func:`run_task`.
             trace_id: Passed through for debug correlation.
 
@@ -243,6 +253,7 @@ class LLMRunner:
                 output_schema=output_schema,
                 max_tokens=max_tokens if max_tokens is not None else binding.max_tokens,
                 temperature=temperature if temperature is not None else binding.temperature,
+                priority=priority,
                 cache_ttl_minutes=cache_ttl_minutes,
                 trace_id=trace_id,
             )
@@ -368,6 +379,7 @@ class LLMRunner:
         temperature: float,
         cache_ttl_minutes: int | None,
         trace_id: str | None,
+        priority: Priority | None = None,
     ) -> LLMResponse:
         """Dispatch one attempt to the right backend adapter.
 
@@ -375,6 +387,10 @@ class LLMRunner:
         :func:`run_task`. Local tiers use the profile path; frontier
         tiers translate through :func:`legacy_tier_for` to the legacy
         :class:`work_buddy.llm.runner.ModelTier`.
+
+        ``priority`` threads to the local backend's broker slot; it is
+        only meaningful on the local profile path (the Anthropic backend
+        is not brokered), so it is attached to the profile kwargs only.
         """
         from work_buddy.llm.runner import ModelTier as LegacyTier
         from work_buddy.llm.runner import run_task
@@ -432,6 +448,7 @@ class LLMRunner:
                 )
             kwargs["profile"] = binding.profile
             kwargs["backend_kind"] = binding.backend
+            kwargs["priority"] = priority
 
         try:
             result = run_task(**kwargs)

--- a/work_buddy/llm/submit.py
+++ b/work_buddy/llm/submit.py
@@ -41,6 +41,7 @@ def llm_submit(
     max_tokens: int = 1024,
     temperature: float = 0.0,
     cache_ttl_minutes: int | None = None,
+    priority: str | None = None,
 ) -> dict[str, Any]:
     """Queue an ``llm_call`` for async background execution.
 
@@ -54,6 +55,12 @@ def llm_submit(
         max_tokens: Max response tokens.
         temperature: Sampling temperature.
         cache_ttl_minutes: Cache TTL override.
+        priority: Local-inference admission priority for the broker —
+            ``"interactive"``, ``"workflow"`` (default), or
+            ``"background"``. Background submits should pass
+            ``"background"`` so they yield to interactive work on the
+            same LM Studio profile. Validated here so a bad value fails
+            fast at submit time rather than silently at replay time.
 
     Returns:
         ``{operation_id, status: "queued", profile, queue_reason,
@@ -70,6 +77,15 @@ def llm_submit(
                 "Cloud tier calls are already fast — use llm_call instead."
             ),
         }
+
+    # Validate the priority now so a typo fails fast at submit time
+    # rather than silently at replay time inside the sidecar.
+    from work_buddy.inference import parse_priority
+
+    try:
+        parsed_priority = parse_priority(priority)
+    except ValueError as exc:
+        return {"error": str(exc)}
 
     now = datetime.now(timezone.utc)
     op_id = f"op_{uuid.uuid4().hex[:8]}"
@@ -98,6 +114,10 @@ def llm_submit(
         replay_params["output_schema"] = output_schema
     if cache_ttl_minutes is not None:
         replay_params["cache_ttl_minutes"] = cache_ttl_minutes
+    # Carry the canonical name string across the JSON queue boundary;
+    # the replayed llm_call maps it back onto the broker enum.
+    if parsed_priority is not None:
+        replay_params["priority"] = parsed_priority.name.lower()
 
     record: dict[str, Any] = {
         "operation_id": op_id,
@@ -136,6 +156,7 @@ def llm_submit(
         "operation_id": op_id,
         "status": "queued",
         "profile": profile,
+        "priority": parsed_priority.name.lower() if parsed_priority else None,
         "queue_reason": "deferred_submit",
         "queued_at": now.isoformat(),
         "estimated_start_within_seconds": 10,


### PR DESCRIPTION
## Why

work-buddy offloads a lot of work to local models through LM Studio — and several very different things hit the *same* local model: an interactive dashboard search the user is actively waiting on, a workflow step mid-agent-turn, and background jobs like cron classifiers or poll-watchers. LM Studio has a small internal queue and doesn't expose its occupancy, so whoever calls first wins. Without admission control, a background poll can land ahead of the search the user is staring at, and they just see a stall.

The `LocalInferenceBroker` exists precisely to stop that: it makes work-buddy — not LM Studio — the scheduler of record, with three priority classes (`INTERACTIVE` > `WORKFLOW` > `BACKGROUND`) so interactive work preempts background work on a contended model.

The catch this PR fixes: the broker already wrapped every local LLM call, but every call was hard-pinned to `WORKFLOW`. Callers had no way to say *"this one is just a background poll — let it yield."* So the priority machinery was effectively inert on the LLM path: the interactive search and the background classifier queued at the **same** level and neither could preempt the other. The embedding path already threaded a priority end-to-end; the LLM path never grew the equivalent. The mechanism was built — the dial just wasn't connected to anything.

This PR connects the dial.

## What changed

- Thread an optional `priority` from `LLMRunner.call` → `run_task` → `_run_profile` → the local backends, all the way down to the broker slot. The default stays `WORKFLOW`, so nothing changes for existing callers unless they opt in. The Anthropic backend isn't brokered and ignores it.
- Expose it where callers actually live: `llm_call` and `llm_submit` take a string `priority` (`"interactive"` / `"workflow"` / `"background"`), mapped to the enum via the new `work_buddy.inference.parse_priority`. `llm_submit` validates it up front and carries it across the async queue boundary, so a background submit's sidecar-replayed call admits at `BACKGROUND` — and yields to the user's interactive work on the same model.
- Fix a stale premise along the way: the `broker.py` docstring and the `architecture/llm-runner` unit claimed the broker wasn't on the LLM path yet. It already was — only the priority threading was missing. The docs now describe the real behavior.

## Not in scope

- No broker API change (`get_broker().slot(...)` is untouched).
- `llm_with_tools` priority threading — deprecated path, deletion tracked by `t-a373609f`.

## Test plan

- [x] Unit (123 passed): end-to-end threading asserts the broker metric records the requested priority (`BACKGROUND` → `openai_compat`, `INTERACTIVE` → `lmstudio_native`); `parse_priority`; `llm_call`/`llm_submit` string-priority carry + validation; default-`WORKFLOW` regression.
- [x] Live: `llm_submit(priority="background")` → sidecar replay → real `gemma-4-e4b` round-trip; the op record carried `priority: "background"` and completed clean.
- [ ] Reviewer: confirm existing internal callers are unchanged (no behavior change unless `priority` is passed).

Task: t-aa9b4181

🤖 Generated with [Claude Code](https://claude.com/claude-code)