### PR TITLE
feat(inference): dashboard panel for LocalInferenceBroker state + persisted metrics

### DIFF
--- a/knowledge/store/architecture/artifact-system.md
+++ b/knowledge/store/architecture/artifact-system.md
@@ -110,7 +110,7 @@ The lifecycle is itself composed of three orthogonal pieces — separating them 
 
 `SessionTagged` extracts the creating session id from a record. Accepts either a single field name (filesystem `session_id`, agent-sessions) or an ordered list of candidate columns (messaging `sender_session` / `recipient_session`, first non-null wins). Justifies the `list_by_session(sid)` operation on the Artifact composer.
 
-## Fifteen registered artifacts
+## Sixteen registered artifacts
 
 Each consumer registers one `Artifact` from its own module at import time (or in `work_buddy.artifacts.default_registrations` for the four backends without a natural consumer module: filesystem, logs-global, service-logs, agents-logs). `sweep_all` and `artifact_registry_dump` lazily import all consumer modules so the registry is fully populated by the first cleanup tick.
 
@@ -127,6 +127,7 @@ Each consumer registers one `Artifact` from its own module at import time (or in
 | `logs-global` | DirectoryTreeStorage(LOG_FILES) | MtimeWindow(_mtime, 7d) + Delete | — | Default registration. `.data/logs/`. |
 | `notifications` | DirectoryTreeStorage(JSON_FILES) | PerRecordTtl(expires_at) + Delete + retention(keep PENDING/DELIVERED) | — | NEW: previously had no scheduled pruner; ~370 expired records were piling up. |
 | `llm-queue` | SqliteRowsStorage | PerRecordTtl(completed_at, 30d) + Delete + retention(keep pending/in_flight) | — | NEW: previously had no DELETE path at all; rows accumulated indefinitely. |
+| `broker-metrics` | SqliteRowsStorage | PerRecordTtl(completed_at, 7d) + Delete | — | Persisted ``LocalInferenceBroker`` call metrics; flushed out-of-band by an embedding-service daemon so the dashboard Inference panel keeps history across restarts. |
 | `conversation-observability` | SqliteRowsStorage | NeverExpires + Delete | — | Durable session-derived activity (commits / writes / summaries); retained indefinitely, manual delete only. |
 | `summarization` | SqliteRowsStorage | NeverExpires + Delete | — | Content-summary store; retained indefinitely, manual delete only. |
 | `service-logs` | DirectoryTreeStorage(LOG_FILES) | MtimeWindow(_mtime, 7d) + Delete + retention(pin live `<name>.log`) | — | Default registration. `.data/runtime/service_logs/` (sidecar child stdout/stderr). The daemon rolls an oversized *live* log aside at startup (`_roll_oversize_log`, dateext naming); this artifact reaps the rolled backups by age while pinning the live log. |
@@ -138,7 +139,7 @@ Each consumer registers one `Artifact` from its own module at import time (or in
 
 One tick now does everything in a single uniform pass:
 * per-type TTL on filesystem blobs (via the registered `filesystem` Artifact)
-* per-record TTL on SQLite tables (messaging, llm-queue) and JSON caches
+* per-record TTL on SQLite tables (messaging, llm-queue, broker-metrics) and JSON caches
 * time-window cutoffs on the chrome ledger and escalations log
 * mtime+activity checks on session dirs and global logs; mtime reaping of rolled service-log and agents-log backups (live logs pinned)
 * rollup-then-delete on the claude-code-usage DB
@@ -160,7 +161,7 @@ Metadata captures: creating session id, tags, description, expiry, original arti
 * `artifact_list(type?, since?, tags?, session?, include_expired?, limit?)` — filesystem-typed list with filters.
 * `artifact_get(id)` — filesystem-typed read; metadata + inline content for files <50 KB.
 * `artifact_delete(id)` — filesystem-typed delete.
-* `artifact_cleanup(dry_run?, name?)` — sweep registered artifacts. With no `name`, sweeps all 15. With `name="llm-cache"` etc., scopes to a single artifact. Note: `name` is deliberately distinct from `artifact_save`'s `type` field (which means filesystem subtype).
+* `artifact_cleanup(dry_run?, name?)` — sweep registered artifacts. With no `name`, sweeps all 16. With `name="llm-cache"` etc., scopes to a single artifact. Note: `name` is deliberately distinct from `artifact_save`'s `type` field (which means filesystem subtype).
 * `artifact_registry()` — returns the cross-backend introspection map: every artifact's name, storage_kind, lifecycle_kind, provenance_kind, capabilities (i.e. its declared `StorageTrait` set), exposed_operations. Replaces grep'ing paths.py for resource definitions.
 * `commit_record(...)` — record commit metadata as a filesystem artifact (specialised convenience).
 
@@ -212,6 +213,7 @@ Consumer modules where Artifacts are registered at import time:
 * `work_buddy/messaging/models.py` (messages)
 * `work_buddy/notifications/store.py` (notifications)
 * `work_buddy/llm/queue.py` (llm-queue)
+* `work_buddy/inference/metrics_store.py` (broker-metrics)
 
 Other entry points:
 * `work_buddy/paths.py` — `RESOURCES` (path registry) + `PRUNERS` (now empty, deprecated)

--- a/knowledge/store/architecture/event-bus.md
+++ b/knowledge/store/architecture/event-bus.md
@@ -143,6 +143,7 @@ The dashboard updates in real time from server-pushed events delivered over Serv
 | ``llm.call_logged`` | ``{model, task_id, input_tokens, output_tokens, estimated_cost_usd, execution_mode, cached}`` | ``llm.cost.log_call`` |
 | ``cron.hot_reload`` | ``{old_count, new_count}`` | ``Scheduler._hot_reload`` (when fingerprints change) |
 | ``user_job.created`` | ``{name, file_path}`` | ``api_user_job_create`` (after successful write) |
+| ``broker.state`` | ``{available, in_flight_total, n_recent}`` (thin ping) | dashboard ``start_broker_state_poller`` (subscriber-gated, ~2 s) — Settings › Inference refetches the cached ``/api/broker`` |
 
 ## Replay semantics
 

--- a/knowledge/store/architecture/inference/broker.md
+++ b/knowledge/store/architecture/inference/broker.md
@@ -102,18 +102,19 @@ Unregistered profiles auto-register on first use with conservative defaults (max
 
 ``SlotMetrics`` rows in a 1000-entry ring buffer, one per slot admission. Fields: ``id, profile, priority, queued_at, admitted_at, started_http_at, first_token_at, finished_at, status, error_kind, error_detail``, plus computed splits ``queue_wait_ms, service_time_ms, total_latency_ms``. ``status`` is one of ``queued / running / ok / queue_full / queue_wait_timeout / inference_timeout / error``. Read via ``broker.snapshot_metrics(limit=...)``.
 
-Dashboard visualization is tracked in a separate task — task ``t-6bd54103``.
+Completed calls are also persisted out-of-band to a SQLite store (``work_buddy/inference/metrics_store.py``, registered as the ``broker-metrics`` artifact with a 7-day per-record TTL) by a flusher daemon in the embedding service, so dashboard history survives a process restart that wipes the in-memory ring. The Settings › Inference dashboard panel visualizes per-profile occupancy, a recent-calls feed, and a latency summary — merging the live ring with the persisted store. See ``services/dashboard`` for the panel and ``architecture/event-bus`` for the ``broker.state`` push that keeps it live.
 
 ## Important limitation: process-global singleton
 
 The broker is one instance **per Python process**. The MCP gateway, the embedding service, and the dashboard each have their own broker — they do NOT share state. Reading ``get_broker().snapshot_metrics()`` from process A returns only calls originating in A.
 
-Practical consequence: the dashboard panel needs an HTTP endpoint on the embedding service (``/broker/state``) to fetch the embedding-service broker's view. Cross-process aggregation is not supported in v1. Tracked as a future improvement in ``t-6bd54103``.
+Practical consequence: the dashboard panel reads broker state through an HTTP endpoint on the embedding service (``GET /broker/state``), which serves that process's broker — the high-traffic local-inference path. Cross-process aggregation (merging the MCP-gateway broker's view) is not supported; both the panel and the persisted metrics store scope to the embedding-service broker.
 
 ## Key files
 
 - ``work_buddy/inference/broker.py`` — the broker itself, ``SlotMetrics``, ``ProfileConfig``, error classes.
 - ``work_buddy/inference/__init__.py`` — public API re-exports (``get_broker``, ``Priority``, etc.).
+- ``work_buddy/inference/metrics_store.py`` — SQLite persistence for completed calls (the ``broker-metrics`` entry-TTL artifact); an embedding-service flusher daemon drains the ring into it so dashboard history survives restarts.
 - ``work_buddy/embedding/providers/lmstudio.py`` — first consumer; wraps bulk encode in ``broker.slot``.
 - ``work_buddy/llm/backends/lmstudio_native.py`` — LLM native-chat consumer.
 - ``work_buddy/llm/backends/openai_compat.py`` — OpenAI-compat consumer.

--- a/tests/unit/test_broker_metrics_store.py
+++ b/tests/unit/test_broker_metrics_store.py
@@ -1,0 +1,107 @@
+"""Tests for the persistent broker-metrics store + its entry-TTL artifact.
+
+The store persists completed ``LocalInferenceBroker`` calls so the dashboard
+Inference panel survives restarts. Covers: terminal-only persistence, idempotent
+re-flush, monotonic→wall conversion + ISO ``completed_at`` (the TTL contract),
+newest-first reads, and end-to-end TTL pruning via the artifact registry.
+"""
+from __future__ import annotations
+
+import time
+from datetime import datetime
+
+import pytest
+
+from work_buddy.inference import metrics_store
+
+
+@pytest.fixture(autouse=True)
+def _tmp_db(monkeypatch, tmp_path):
+    """Point the store at a throwaway DB and force a fresh schema per test."""
+    db = tmp_path / "broker_metrics.db"
+    monkeypatch.setattr(metrics_store, "_db_path", lambda: db)
+    metrics_store._schema_ready.clear()
+    yield db
+    metrics_store._schema_ready.clear()
+
+
+def _row(rid: str, *, status: str = "ok", finished: float | None = 999.0,
+         queued: float = 998.0) -> dict:
+    """A broker.snapshot_metrics()-shaped row (monotonic timestamps)."""
+    return {
+        "id": rid, "profile": "lmstudio:m", "priority": "BACKGROUND", "status": status,
+        "error_kind": None, "error_detail": None,
+        "queued_at": queued, "finished_at": finished,
+        "queue_wait_ms": 0.0, "service_time_ms": 200.0, "total_latency_ms": 200.0,
+    }
+
+
+def test_only_terminal_rows_persist():
+    rows = [
+        _row("ok1", status="ok"),
+        _row("err", status="error"),
+        _row("qf", status="queue_full"),
+        _row("qwt", status="queue_wait_timeout"),
+        _row("it", status="inference_timeout"),
+        _row("running", status="running", finished=None),
+        _row("queued", status="queued", finished=None),
+    ]
+    written = metrics_store.persist_terminal_rows(rows, mono_now=1000.0, wall_now=1_000_000.0)
+    assert written == 5
+    ids = {r["id"] for r in metrics_store.read_recent()}
+    assert ids == {"ok1", "err", "qf", "qwt", "it"}
+
+
+def test_insert_or_ignore_dedup():
+    r = _row("dup")
+    assert metrics_store.persist_terminal_rows([r], 1000.0, 1_000_000.0) == 1
+    # Re-flushing the same (immutable) terminal row is a no-op.
+    assert metrics_store.persist_terminal_rows([r], 1000.0, 1_000_000.0) == 0
+    assert len([x for x in metrics_store.read_recent() if x["id"] == "dup"]) == 1
+
+
+def test_monotonic_to_wall_and_iso_completed_at():
+    mono, wall = 5000.0, 2_000_000.0
+    # finished 30s before mono_now, queued 30.2s before.
+    metrics_store.persist_terminal_rows(
+        [_row("t", finished=mono - 30.0, queued=mono - 30.2)], mono, wall
+    )
+    row = metrics_store.read_recent()[0]
+    assert abs(row["finished_at_wall"] - (wall - 30.0)) < 1e-6
+    assert abs(row["queued_at_wall"] - (wall - 30.2)) < 1e-6
+    # completed_at must be ISO-parseable — PerRecordTtl reads it via fromisoformat;
+    # an epoch string would silently never expire.
+    parsed = datetime.fromisoformat(row["completed_at"])
+    assert abs(parsed.timestamp() - (wall - 30.0)) < 1.0
+
+
+def test_read_recent_is_newest_first():
+    metrics_store.persist_terminal_rows([
+        _row("a", finished=100.0, queued=99.0),
+        _row("b", finished=200.0, queued=199.0),
+        _row("c", finished=300.0, queued=299.0),
+    ], mono_now=1000.0, wall_now=1_000_000.0)
+    assert [r["id"] for r in metrics_store.read_recent()] == ["c", "b", "a"]
+
+
+def test_ttl_prune_drops_old_keeps_recent():
+    mono, wall = 5000.0, time.time()
+    metrics_store.persist_terminal_rows([
+        _row("old", finished=mono - 8 * 86400, queued=mono - 8 * 86400 - 0.2),
+        _row("fresh", finished=mono - 1 * 86400, queued=mono - 1 * 86400 - 0.2),
+    ], mono, wall)
+    # Re-register so the artifact's SqliteRowsStorage points at the tmp DB.
+    metrics_store._register_broker_metrics_artifact()
+    from work_buddy.artifacts.registry import sweep_all
+
+    sweep_all(dry_run=False, name="broker-metrics")
+    ids = {r["id"] for r in metrics_store.read_recent()}
+    assert "fresh" in ids
+    assert "old" not in ids  # 8 days > 7-day TTL
+
+
+def test_artifact_is_registered():
+    from work_buddy.artifacts import list_artifact_names
+
+    metrics_store._register_broker_metrics_artifact()
+    assert "broker-metrics" in list_artifact_names()

--- a/tests/unit/test_dashboard_broker.py
+++ b/tests/unit/test_dashboard_broker.py
@@ -1,0 +1,84 @@
+"""Tests for the dashboard's broker data layer + the broker.state SSE event.
+
+Data layer mirrors the embeddings-snapshot pattern (background-refreshed cache),
+with one difference: the build does a cross-process HTTP call, so a cold miss
+fast-fails to ``{available: False}`` instead of blocking. The poller publishes a
+thin ``broker.state`` ping; the SSE stream must deliver it.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import time
+
+from work_buddy.dashboard import api
+from work_buddy.dashboard.events import EventBus
+from work_buddy.dashboard.service import _sse_stream
+
+
+def setup_function():
+    api._broker_cache = None
+    api._broker_cache_ts = 0.0
+    api._broker_refreshing = False
+
+
+def test_build_wraps_available(monkeypatch):
+    state = {"profiles": {}, "recent": [], "latency": {"n": 0}, "now_monotonic": 1.0}
+    monkeypatch.setattr("work_buddy.embedding.client.broker_state", lambda: state)
+    out = api._build_broker_summary()
+    assert out["available"] is True
+    assert out["recent"] == []
+    assert out["latency"] == {"n": 0}
+
+
+def test_build_unavailable(monkeypatch):
+    monkeypatch.setattr("work_buddy.embedding.client.broker_state", lambda: None)
+    assert api._build_broker_summary() == {"available": False}
+
+
+def test_refresh_then_get_serves_cache(monkeypatch):
+    calls = {"n": 0}
+
+    def _bs():
+        calls["n"] += 1
+        return {"profiles": {}, "recent": [{"id": "a"}], "latency": {"n": 0}}
+
+    monkeypatch.setattr("work_buddy.embedding.client.broker_state", _bs)
+    fresh = api.refresh_broker_cache()
+    assert fresh["available"] is True
+    again = api.get_broker_summary()
+    assert again == fresh
+    assert calls["n"] == 1  # second read served from the cache, no new client call
+
+
+def test_cold_get_fast_fails(monkeypatch):
+    # No cache: return the immediate "no data yet" envelope WITHOUT a blocking
+    # synchronous build. (Kick is stubbed so no background thread is spawned.)
+    monkeypatch.setattr(api, "_kick_broker_refresh", lambda: None)
+    assert api.get_broker_summary() == {"available": False}
+
+
+def test_broker_state_event_delivered_over_sse():
+    bus = EventBus()
+    gen = _sse_stream(bus, idle_timeout=0.05)
+    next(gen)  # ": connected" — registers the subscriber
+
+    def _pub():
+        time.sleep(0.02)
+        bus.publish("broker.state", {"available": True, "in_flight_total": 1, "n_recent": 3})
+
+    threading.Thread(target=_pub, daemon=True).start()
+
+    deadline = time.time() + 1.0
+    seen = None
+    while time.time() < deadline:
+        chunk = next(gen)
+        if chunk.startswith(b"data: "):
+            seen = chunk
+            break
+    assert seen is not None, "no broker.state data frame arrived"
+    parsed = json.loads(seen[len(b"data: "):-2].decode("utf-8"))
+    assert parsed["event_type"] == "broker.state"
+    assert parsed["payload"]["in_flight_total"] == 1
+    assert parsed["payload"]["n_recent"] == 3
+    gen.close()

--- a/tests/unit/test_dashboard_inference_frontend.py
+++ b/tests/unit/test_dashboard_inference_frontend.py
@@ -1,0 +1,66 @@
+"""Smoke tests for the Settings › Inference sub-view wiring.
+
+The JS is a Python string assembled into the single-page app. We verify the
+sub-view renders, the sub-tab guard accepts ``'inference'`` (a silent
+rewrite-to-status would otherwise hide the panel), and the broker.state SSE
+handler routes through the surface mutator without a wholesale-loader call.
+"""
+from __future__ import annotations
+
+from work_buddy.dashboard.frontend import render_page
+from work_buddy.dashboard.frontend.scripts.core.event_bus import script as _event_bus_script
+from work_buddy.dashboard.frontend.scripts.tabs.inference import script as _inference_script
+from work_buddy.dashboard.frontend.scripts.tabs.settings import script as _settings_script
+
+
+def test_inference_subview_in_page():
+    page = render_page()
+    assert 'id="ssp-inference"' in page
+    assert 'id="inference-content"' in page
+    assert "switchSettingsSubtab('inference')" in page
+
+
+def test_settings_guard_accepts_inference():
+    # Regression against the line-42 guard that silently rewrites unknown
+    # sub-tabs to 'status' — if 'inference' isn't whitelisted, the panel never shows.
+    src = _settings_script()
+    assert "st !== 'inference'" in src
+    assert "loadInference()" in src
+
+
+def test_inference_surface_contract():
+    src = _inference_script()
+    assert "window.inferenceSurface" in src
+    assert "function loadInference" in src
+    assert "isMounted" in src
+    # Newest-first ordering of the oldest-first ring snapshot.
+    assert ".slice().reverse()" in src
+
+
+def test_inference_legibility_affordances():
+    """The UX addendum: verdict, humanized labels, teaching help, units."""
+    src = _inference_script()
+    # Health verdict (the "see it, don't guess" signal).
+    assert "_infHealth" in src
+    assert "Contended" in src and "Healthy" in src
+    # Humanized profile labels (raw key → role).
+    assert "_infRole" in src
+    assert "Embedding offload" in src
+    # Inline teaching help.
+    assert "_infToggleHelp" in src
+    assert "Priority" in src and "Latency splits" in src
+    # Units + window explanation.
+    assert "Queue wait (ms)" in src
+    assert "the table below lists recent calls" in src
+    # Recent calls scroll viewport (Event Log pattern) so many rows fit.
+    assert "inf-table-scroll" in src
+
+
+def test_broker_state_handler_clean():
+    src = _event_bus_script()
+    assert "eventBus.on('broker.state'" in src
+    assert "_refreshSoon('inferenceSurface')" in src
+    # The dispatcher must not introduce any wholesale-loader call (mirrors the
+    # invariant in test_dashboard_event_bus_frontend.py).
+    for forbidden in ("loadSettings(", "loadInference(", "staticLoaders[", "_smartRefresh"):
+        assert forbidden not in src

--- a/tests/unit/test_embedding_broker_state.py
+++ b/tests/unit/test_embedding_broker_state.py
@@ -1,0 +1,206 @@
+"""Tests for the embedding service's ``GET /broker/state`` endpoint.
+
+The endpoint snapshots the process-global ``LocalInferenceBroker`` for the
+dashboard's Inference sub-view. It enriches the recent-calls rows with a
+relative ``age_s`` and computes the latency percentile window SERVER-SIDE (all
+``SlotMetrics`` timestamps are ``time.monotonic()``), over the FULL ring filtered
+to successful, finished-in-window calls — not the 50-row table slice.
+
+We monkeypatch ``work_buddy.inference.get_broker`` (the name the handler imports
+function-locally) to a broker we seed with controlled metrics, so timestamps and
+statuses are deterministic.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from work_buddy.embedding.service import app
+from work_buddy.inference.broker import (
+    LocalInferenceBroker,
+    Priority,
+    ProfileConfig,
+    SlotMetrics,
+)
+
+
+@pytest.fixture
+def client():
+    return app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def _empty_persisted(monkeypatch):
+    """Default: no persisted history, so the live-ring tests stay deterministic.
+
+    The endpoint merges the live ring with ``metrics_store.read_recent()``;
+    stubbing it to ``[]`` isolates the in-memory behavior. Merge/restart tests
+    override it explicitly.
+    """
+    monkeypatch.setattr(
+        "work_buddy.inference.metrics_store.read_recent", lambda limit=200: []
+    )
+
+
+def _ok_row(
+    profile: str, latency_s: float, finished_ago_s: float, now: float, rid: str = "ok",
+) -> SlotMetrics:
+    """A finished, successful call with a controlled total latency + recency.
+
+    ``rid`` must be unique per row: the endpoint merges live+persisted and dedups
+    by call id (real ids are unique uuids), so duplicate ids would collapse.
+    """
+    finished = now - finished_ago_s
+    queued = finished - latency_s
+    return SlotMetrics(
+        id=rid,
+        profile=profile,
+        priority=Priority.WORKFLOW,
+        queued_at=queued,
+        admitted_at=queued,
+        started_http_at=queued,
+        finished_at=finished,
+        status="ok",
+    )
+
+
+def test_empty_broker(client, monkeypatch):
+    monkeypatch.setattr("work_buddy.inference.get_broker", lambda: LocalInferenceBroker())
+    resp = client.get("/broker/state")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["profiles"] == {}
+    assert data["recent"] == []
+    assert data["latency"]["n"] == 0
+    assert data["latency"]["p50"] is None
+    assert data["latency"]["p95"] is None
+    assert data["latency"]["p99"] is None
+    assert data["latency"]["window_s"] == 300.0
+
+
+def test_shape_window_and_null_handling(client, monkeypatch):
+    b = LocalInferenceBroker()
+    b.configure_profile(ProfileConfig(name="p1", max_concurrent=2, max_queued=16))
+    now = time.monotonic()
+
+    # 3 successful, in-window calls: 100 / 200 / 300 ms (unique ids).
+    for i, lat in enumerate((0.1, 0.2, 0.3)):
+        b._record(_ok_row("p1", lat, finished_ago_s=1.0, now=now, rid=f"ok{i}"))
+    # A successful call that finished 400s ago: present in the table, but OUTSIDE
+    # the 5-min latency window (forces full-ring-scan vs 50-slice correctness).
+    b._record(_ok_row("p1", 0.999, finished_ago_s=400.0, now=now, rid="ok_old"))
+    # An in-flight call: no finished_at → null latency splits, but a real age.
+    b._record(SlotMetrics(
+        id="run", profile="p1", priority=Priority.INTERACTIVE,
+        queued_at=now - 2.0, admitted_at=now - 2.0, status="running",
+    ))
+    # A terminal error: excluded from the percentile set.
+    b._record(SlotMetrics(
+        id="err", profile="p1", priority=Priority.BACKGROUND,
+        queued_at=now - 5.0, admitted_at=now - 5.0, finished_at=now - 4.0,
+        status="error", error_kind="ValueError", error_detail="boom",
+    ))
+
+    monkeypatch.setattr("work_buddy.inference.get_broker", lambda: b)
+    data = client.get("/broker/state").get_json()
+
+    # Profiles: occupancy-card contract.
+    p1 = data["profiles"]["p1"]
+    assert p1["max_concurrent"] == 2
+    assert set(p1["waiting"]) == {"INTERACTIVE", "WORKFLOW", "BACKGROUND"}
+
+    # Recent: all 6 seeded rows, newest-first ordering handled client-side; each
+    # row carries age_s. The in-flight row has null latency splits but a real age.
+    assert len(data["recent"]) == 6
+    assert all("age_s" in r for r in data["recent"])
+    running = next(r for r in data["recent"] if r["status"] == "running")
+    assert running["total_latency_ms"] is None
+    assert running["service_time_ms"] is None
+    assert running["age_s"] is not None and running["age_s"] >= 0
+
+    # Latency window: only the 3 in-window ok rows count.
+    lat = data["latency"]
+    assert lat["n"] == 3
+    assert lat["p50"] == 200.0  # nearest-rank over [100, 200, 300]
+    assert lat["p95"] == 300.0
+    assert lat["p99"] == 300.0
+
+
+def test_single_ok_row_percentiles(client, monkeypatch):
+    """n==1 must not blow up (nearest-rank handles it; statistics.quantiles wouldn't)."""
+    b = LocalInferenceBroker()
+    now = time.monotonic()
+    b._record(_ok_row("p1", 0.15, finished_ago_s=1.0, now=now))
+    monkeypatch.setattr("work_buddy.inference.get_broker", lambda: b)
+    lat = client.get("/broker/state").get_json()["latency"]
+    assert lat["n"] == 1
+    assert lat["p50"] == 150.0 and lat["p95"] == 150.0 and lat["p99"] == 150.0
+
+
+def _persisted(rid: str, *, status: str, finished_ago_s: float, latency_ms: float, wall: float) -> dict:
+    """A persisted-store row (wall-clock), as ``metrics_store.read_recent`` returns."""
+    finished = wall - finished_ago_s
+    return {
+        "id": rid, "profile": "lmstudio:m", "priority": "BACKGROUND", "status": status,
+        "error_kind": None, "error_detail": None,
+        "queued_at_wall": finished - latency_ms / 1000.0, "finished_at_wall": finished,
+        "queue_wait_ms": 0.0, "service_time_ms": latency_ms, "total_latency_ms": latency_ms,
+        "completed_at": "",
+    }
+
+
+def test_persisted_survives_restart(client, monkeypatch):
+    """Empty live ring + populated persisted store → recent/latency from history.
+
+    This is the "survives a sidecar reset" proof: the broker singleton is fresh
+    (ring wiped), but the panel still shows prior calls from the persisted store.
+    """
+    monkeypatch.setattr("work_buddy.inference.get_broker", lambda: LocalInferenceBroker())
+    wall = time.time()
+    persisted = [
+        _persisted("h1", status="ok", finished_ago_s=10.0, latency_ms=150.0, wall=wall),
+        _persisted("h2", status="ok", finished_ago_s=5.0, latency_ms=250.0, wall=wall),
+    ]
+    monkeypatch.setattr(
+        "work_buddy.inference.metrics_store.read_recent", lambda limit=200: persisted
+    )
+    data = client.get("/broker/state").get_json()
+    assert {r["id"] for r in data["recent"]} == {"h1", "h2"}
+    assert all(r["age_s"] is not None for r in data["recent"])
+    assert data["latency"]["n"] == 2
+    assert data["latency"]["p50"] == 150.0  # nearest-rank over [150, 250]
+    assert data["latency"]["p95"] == 250.0
+
+
+def test_merge_live_wins(client, monkeypatch):
+    """Same id present live (running) + persisted (ok) → live wins (freshest)."""
+    b = LocalInferenceBroker()
+    now = time.monotonic()
+    b._record(SlotMetrics(
+        id="x", profile="lmstudio:m", priority=Priority.INTERACTIVE,
+        queued_at=now - 1.0, admitted_at=now - 1.0, status="running",
+    ))
+    monkeypatch.setattr("work_buddy.inference.get_broker", lambda: b)
+    monkeypatch.setattr(
+        "work_buddy.inference.metrics_store.read_recent",
+        lambda limit=200: [_persisted("x", status="ok", finished_ago_s=0.8,
+                                       latency_ms=200.0, wall=time.time())],
+    )
+    data = client.get("/broker/state").get_json()
+    rows = [r for r in data["recent"] if r["id"] == "x"]
+    assert len(rows) == 1  # deduped by id
+    assert rows[0]["status"] == "running"  # live wins over persisted
+    assert data["latency"]["n"] == 0  # the live row is in-flight, not ok
+
+
+def test_recent_ordering_oldest_first(client, monkeypatch):
+    """`recent` is returned oldest-first; the frontend `.reverse()` makes it newest-first."""
+    b = LocalInferenceBroker()
+    now = time.monotonic()
+    b._record(_ok_row("p1", 0.1, finished_ago_s=2.9, now=now, rid="old"))
+    b._record(_ok_row("p1", 0.1, finished_ago_s=1.9, now=now, rid="mid"))
+    b._record(_ok_row("p1", 0.1, finished_ago_s=0.9, now=now, rid="new"))
+    monkeypatch.setattr("work_buddy.inference.get_broker", lambda: b)
+    data = client.get("/broker/state").get_json()
+    assert [r["id"] for r in data["recent"]] == ["old", "mid", "new"]

--- a/work_buddy/artifacts/registry.py
+++ b/work_buddy/artifacts/registry.py
@@ -44,6 +44,7 @@ _CONSUMER_MODULES: tuple[str, ...] = (
     "work_buddy.llm.queue",
     "work_buddy.conversation_observability",
     "work_buddy.summarization",
+    "work_buddy.inference.metrics_store",
 )
 
 _consumers_loaded = False

--- a/work_buddy/dashboard/api.py
+++ b/work_buddy/dashboard/api.py
@@ -1421,6 +1421,94 @@ def get_embeddings_summary() -> dict[str, Any]:
         return _embeddings_cache
 
 
+# Broker (Inference sub-view) snapshot cache. Unlike the embeddings snapshot
+# (local store reads), building this does a cross-process HTTP call to the
+# embedding service's ``/broker/state`` — so a slow/down service must NOT block
+# the request. Broker state is live, so the TTL is short; the dashboard poller
+# refreshes it on a cadence and a panel open serves whatever is cached.
+_BROKER_CACHE_TTL = 2.5
+_broker_cache: dict[str, Any] | None = None
+_broker_cache_ts: float = 0.0
+_broker_cache_lock = threading.Lock()
+_broker_refreshing = False
+
+
+def _build_broker_summary() -> dict[str, Any]:
+    """Compose the Inference sub-view snapshot from the embedding-service broker.
+
+    Wraps the cross-process read in an availability envelope: the service being
+    unreachable is the normal "no data yet" state, not an error. The panel
+    renders a graceful empty state on ``available: False``.
+    """
+    from work_buddy.embedding.client import broker_state
+
+    state = broker_state()
+    if state is None:
+        return {"available": False}
+    return {"available": True, **state}
+
+
+def _kick_broker_refresh() -> None:
+    """Rebuild the broker snapshot on a background thread (single-flight).
+
+    Also the page-load pre-warm + poller hook.
+    """
+    global _broker_refreshing
+    with _broker_cache_lock:
+        if _broker_refreshing:
+            return
+        _broker_refreshing = True
+
+    def _refresh() -> None:
+        global _broker_cache, _broker_cache_ts, _broker_refreshing
+        try:
+            fresh = _build_broker_summary()
+            _broker_cache = fresh
+            _broker_cache_ts = time.time()
+        except Exception as exc:
+            logger.warning("Background broker refresh failed: %s", exc)
+        finally:
+            _broker_refreshing = False
+
+    threading.Thread(
+        target=_refresh, name="broker-refresh", daemon=True,
+    ).start()
+
+
+def get_broker_summary() -> dict[str, Any]:
+    """Inference sub-view snapshot, served from a short-TTL background-refreshed cache.
+
+    Cold start does NOT build synchronously: the build does a cross-process HTTP
+    call, and a slow/down embedding service would otherwise block the first
+    ``/api/broker`` request for the full client timeout. Instead it kicks a
+    background refresh and returns an immediate ``{available: False}``; the next
+    read (or the poller's refresh) serves real data.
+    """
+    cache = _broker_cache
+    if cache is not None:
+        if time.time() - _broker_cache_ts >= _BROKER_CACHE_TTL:
+            _kick_broker_refresh()  # stale — refresh for next read
+        return cache
+    # Cold start: kick a background build, return a fast "no data yet" envelope
+    # rather than blocking on the network round-trip.
+    _kick_broker_refresh()
+    return {"available": False}
+
+
+def refresh_broker_cache() -> dict[str, Any]:
+    """Synchronously rebuild the broker snapshot and update the cache; return it.
+
+    Called by the dashboard's broker-state poller, which is already a background
+    daemon, so a blocking cross-process read here is fine — and it keeps the
+    cache that ``/api/broker`` serves current with what the poller just pushed.
+    """
+    global _broker_cache, _broker_cache_ts
+    fresh = _build_broker_summary()
+    _broker_cache = fresh
+    _broker_cache_ts = time.time()
+    return fresh
+
+
 # ---------------------------------------------------------------------------
 # Command palette
 # ---------------------------------------------------------------------------

--- a/work_buddy/dashboard/frontend/html.py
+++ b/work_buddy/dashboard/frontend/html.py
@@ -532,6 +532,8 @@ def _html() -> str:
                 onclick="switchSettingsSubtab('activity')">Activity</button>
         <button class="settings-subtab-btn" data-st="embeddings"
                 onclick="switchSettingsSubtab('embeddings')">Embeddings</button>
+        <button class="settings-subtab-btn" data-st="inference"
+                onclick="switchSettingsSubtab('inference')">Inference</button>
     </div>
     <!-- Status sub-view: the control graph (component state, preferences,
          requirements). Default sub-tab. The toolbar lives inside this
@@ -560,6 +562,12 @@ def _html() -> str:
          Replaces the former top-level Indexes tab. -->
     <div class="settings-subtab-panel" id="ssp-embeddings">
         <div id="embeddings-content"><div class="loading">Loading embeddings...</div></div>
+    </div>
+    <!-- Inference sub-view: LocalInferenceBroker occupancy cards + recent-calls
+         feed + latency summary. Read-only; live-updated via the broker.state
+         SSE event. Lazy-loaded on first switch (see switchSettingsSubtab). -->
+    <div class="settings-subtab-panel" id="ssp-inference">
+        <div id="inference-content"><div class="loading">Loading inference...</div></div>
     </div>
 </div>
 

--- a/work_buddy/dashboard/frontend/scripts/__init__.py
+++ b/work_buddy/dashboard/frontend/scripts/__init__.py
@@ -49,6 +49,7 @@ from .tabs import (
     conversations,
     costs,
     embeddings,
+    inference,
     jobs,
     memory,
     projects,
@@ -124,12 +125,14 @@ SCRIPTS = [
     palette.script,
     costs.script,
     embeddings.script,
+    inference.script,
     # page LAST — see ordering note above.
     page.script,
 ]
 
 STYLES = [
     embeddings.styles,
+    inference.styles,
     resolution.styles,
     threads.styles,
     threads_card.styles,

--- a/work_buddy/dashboard/frontend/scripts/core/event_bus.py
+++ b/work_buddy/dashboard/frontend/scripts/core/event_bus.py
@@ -255,6 +255,11 @@ def script() -> str:
 
     window.eventBus.on('llm.call_logged', () => _refreshSoon('costsSurface'));
 
+    // Inference sub-view: the broker-state poller pings this on a cadence; the
+    // surface refetches the cached /api/broker and morphs in the change. The
+    // ping is thin — the snapshot rides the HTTP read, not the SSE frame.
+    window.eventBus.on('broker.state', () => _refreshSoon('inferenceSurface'));
+
     // Jobs tab: refresh on dashboard-side create (immediate, repaints the
     // pending banner) and on sidecar hot-reload (jobs appear in /api/state
     // for the first time, banner auto-clears).
@@ -285,6 +290,7 @@ def script() -> str:
         'component.health_changed':        'settingsSurface.refresh (morphdom)',
         'component.preference_changed':    'settingsSurface.refresh (morphdom)',
         'llm.call_logged':                 'costsSurface.refresh (morphdom)',
+        'broker.state':                    'inferenceSurface.refresh (morphdom)',
         'user_job.created':                'jobsSurface.refresh (morphdom)',
         'user_job.deleted':                'jobsSurface.refresh (morphdom)',
         'cron.hot_reload':                  'jobsSurface.refresh (morphdom)',

--- a/work_buddy/dashboard/frontend/scripts/tabs/inference.py
+++ b/work_buddy/dashboard/frontend/scripts/tabs/inference.py
@@ -1,0 +1,388 @@
+"""Dashboard Settings › Inference sub-view JS.
+
+Read-only observability for the ``LocalInferenceBroker`` (the embedding-service
+process's view — the high-traffic local-inference path). The panel is designed to
+answer one question at a glance — *is local inference healthy, and if not, where's
+the bottleneck?* — and to teach its own vocabulary rather than dump raw counters:
+
+* **Health verdict** — ✓ Healthy / ◐ Busy / ⚠ Contended, computed from slot
+  occupancy + whether interactive work is waiting. This is the "see it, don't
+  guess" signal the feature exists for.
+* **Occupancy cards** — one per profile, rendered as a *state* (Idle / Active /
+  Queued) with a slot gauge and any waiting work spelled out in words. Profile
+  keys are humanized (``lmstudio:`` → "Embedding offload"); the raw key is a tooltip.
+* **Latency** — p50/p95/p99 over the last 5 min, with the window↔table distinction
+  spelled out; collapses to a single number (not three identical ones) when n ≤ 1.
+* **Recent calls** — last 50, newest-first, units + split definitions in the
+  header tooltips; filter chips appear only once there are enough rows to matter.
+* **"?" help** — explains priority classes, slots/queue, and the latency splits.
+
+Data via ``GET /api/broker``; liveness via the ``broker.state`` SSE ping →
+``inferenceSurface.refresh`` → morphdom merge (no frontend timer). Reuses the
+shared ``.idx-badge`` / ``.idx-ok|warn|err`` / ``.data-table`` / ``.idx-r`` /
+``.idx-muted`` primitives from the Embeddings sub-view; inference-specific classes
+are defined here. All latency cells are null-coalesced (in-flight / queue_full /
+timeout rows carry null splits).
+"""
+
+from __future__ import annotations
+
+
+def script() -> str:
+    return r"""
+// ---- Inference (Settings sub-view) ----
+
+// View state, preserved across re-renders (SSE refresh re-runs _infRender).
+let _infPriorityFilter = 'All';
+let _infStatusFilter = 'All';
+let _infHelpOpen = false;
+
+// Profile-key prefix → human role. Keys look like "lmstudio:<model>" /
+// "lmstudio_native:<model>" / "openai_compat:<model>".
+const _INF_ROLE = {
+    'lmstudio': 'Embedding offload',
+    'lmstudio_native': 'LLM (native)',
+    'openai_compat': 'LLM (OpenAI-compat)',
+};
+
+function _infMs(n) { return (n == null) ? '—' : Math.round(n).toLocaleString(); }
+
+function _infAge(s) {
+    if (s == null) return '—';
+    if (s < 60) return Math.round(s) + 's';
+    if (s < 3600) return Math.round(s / 60) + 'm';
+    if (s < 86400) return Math.round(s / 3600) + 'h';
+    return Math.round(s / 86400) + 'd';  // persisted rows can be days old after a restart
+}
+
+function _infRole(profileKey) {
+    const key = profileKey || '';
+    const i = key.indexOf(':');
+    if (i < 0) return { role: key || '—', model: '' };
+    const prefix = key.slice(0, i);
+    return { role: _INF_ROLE[prefix] || prefix, model: key.slice(i + 1) };
+}
+
+function _infWaiting(w) {
+    w = w || {};
+    return (w.INTERACTIVE || 0) + (w.WORKFLOW || 0) + (w.BACKGROUND || 0);
+}
+
+function _infWaitWords(w) {
+    w = w || {};
+    const parts = [];
+    if (w.INTERACTIVE) parts.push(`${w.INTERACTIVE} interactive`);
+    if (w.WORKFLOW) parts.push(`${w.WORKFLOW} workflow`);
+    if (w.BACKGROUND) parts.push(`${w.BACKGROUND} background`);
+    return parts.length ? parts.join(', ') + ' waiting' : '';
+}
+
+// Status → badge class. ok=green, queued/running=accent, the caller-visible wait
+// failures + inference_timeout=orange(warn), error=red.
+function _infStatusBadge(status) {
+    let cls = 'idx-warn';
+    if (status === 'ok') cls = 'idx-ok';
+    else if (status === 'queued' || status === 'running') cls = 'inf-st-run';
+    else if (status === 'error') cls = 'idx-err';
+    return `<span class="idx-badge ${cls}">${escapeHtml(status || '—')}</span>`;
+}
+
+function _infPriBadge(priority) {
+    const p = priority || '—';
+    return `<span class="idx-badge inf-pri-${escapeHtml(p)}">${escapeHtml(p)}</span>`;
+}
+
+function _infStatusGroup(status) {
+    if (status === 'ok') return 'ok';
+    if (status === 'queued' || status === 'running') return 'queued';
+    return 'errored';
+}
+
+// Health verdict from occupancy: interactive work waiting is the bad signal the
+// whole feature exists to surface.
+function _infHealth(data) {
+    const profs = Object.values(data.profiles || {});
+    let inFlight = 0, interWait = 0, totalWait = 0;
+    for (const p of profs) {
+        inFlight += (p.in_flight || 0);
+        const w = p.waiting || {};
+        interWait += (w.INTERACTIVE || 0);
+        totalWait += _infWaiting(w);
+    }
+    if (interWait > 0) {
+        return { cls: 'inf-verdict-warn', icon: '⚠',
+                 text: 'Contended — interactive work is waiting behind other jobs' };
+    }
+    if (inFlight > 0 || totalWait > 0) {
+        return { cls: 'inf-verdict-busy', icon: '◐',
+                 text: 'Busy — calls in flight; nothing you are waiting on is queued' };
+    }
+    return { cls: 'inf-verdict-ok', icon: '✓', text: 'Healthy — idle, nothing queued' };
+}
+
+const _INF_HELP_HTML = `
+<div class="inf-help">
+    <div><b>Priority</b> — INTERACTIVE (you're waiting on it) preempts WORKFLOW (agent work),
+        which preempts BACKGROUND (cron / bulk jobs) on a busy model.</div>
+    <div><b>Slots</b> — each profile runs up to <i>max_concurrent</i> calls at once; extra calls
+        queue, up to the per-priority cap.</div>
+    <div><b>Latency splits</b> — <i>Queue wait</i>: time waiting for a free slot ·
+        <i>Service</i>: the model call itself · <i>Total</i>: end-to-end.</div>
+    <div><b>Contended</b> means an interactive call is stuck waiting — that's when local
+        inference feels slow.</div>
+</div>`;
+
+function _infToggleHelp() { _infHelpOpen = !_infHelpOpen; _infRender(); }
+
+async function loadInference() {
+    const container = document.getElementById('inference-content');
+    if (!container) return;
+    window._infLast = await fetchJSON('/api/broker');
+    _infRender();
+}
+
+function _infRender() {
+    const container = document.getElementById('inference-content');
+    if (!container) return;
+    const data = window._infLast;
+    if (!data) {
+        window._wbMorphReplace(container, `<div class="empty-state">Inference broker state unavailable.</div>`);
+        return;
+    }
+    let html = _infRenderHeader(data);
+    if (!data.available) {
+        html += `<div class="empty-state">No data from the embedding-service broker — it may be `
+              + `offline or still starting. Recent activity reappears once it's reachable.</div>`;
+    } else if (!Object.keys(data.profiles || {}).length && !(data.recent || []).length) {
+        html += `<div class="empty-state">Idle — nothing has run through the broker yet. Occupancy, `
+              + `recent calls, and latency appear here as local inference runs (persisted ~7 days).</div>`;
+    } else {
+        html += _infRenderCards(data) + _infRenderLatency(data) + _infRenderRecent(data);
+    }
+    window._wbMorphReplace(container, html);
+}
+
+function _infRenderHeader(data) {
+    const v = data.available
+        ? _infHealth(data)
+        : { cls: 'inf-verdict-off', icon: '○', text: 'Embedding service offline — no live broker data' };
+    return `
+        <div class="inf-header">
+            <div class="inf-verdict ${v.cls}">
+                <span class="inf-verdict-icon">${v.icon}</span>
+                <span class="inf-verdict-text">${escapeHtml(v.text)}</span>
+                <button class="inf-help-btn" title="What am I looking at?" onclick="_infToggleHelp()">?</button>
+            </div>
+            <div class="idx-muted inf-intro">work-buddy schedules local model calls by priority so the work
+                you're waiting on isn't stuck behind background jobs. Recent activity from the embedding-service
+                broker — live-updating, and persisted ~7 days so it survives restarts.</div>
+            ${_infHelpOpen ? _INF_HELP_HTML : ''}
+        </div>`;
+}
+
+function _infRenderCards(data) {
+    const profiles = data.profiles || {};
+    const names = Object.keys(profiles).sort();
+    if (!names.length) return '';
+    const cards = names.map(name => {
+        const p = profiles[name];
+        const { role, model } = _infRole(name);
+        const max = (p.max_concurrent == null) ? 1 : p.max_concurrent;
+        const inf = p.in_flight || 0;
+        const waiting = _infWaiting(p.waiting);
+        const pct = max ? Math.min(100, (inf / max) * 100) : 0;
+        let st = { label: 'Idle', cls: 'inf-st-idle' };
+        if (waiting > 0) st = { label: 'Queued', cls: 'idx-warn' };
+        else if (inf > 0) st = { label: 'Active', cls: 'inf-st-run' };
+        const waitWords = _infWaitWords(p.waiting);
+        return `
+        <div class="inf-card" title="${escapeHtml(name)}">
+            <div class="inf-card-head">
+                <span class="inf-card-role">${escapeHtml(role)}</span>
+                <span class="idx-badge ${st.cls}">${st.label}</span>
+            </div>
+            <div class="inf-card-model idx-muted">${escapeHtml(model || name)}</div>
+            <div class="inf-gauge" title="${inf} of ${max} concurrency slots in use">
+                <div class="inf-gauge-fill" style="width:${pct}%"></div>
+            </div>
+            <div class="idx-muted inf-gauge-label">${inf} of ${max} slot${max === 1 ? '' : 's'} busy</div>
+            ${waitWords ? `<div class="inf-wait-words">${escapeHtml(waitWords)}</div>` : ''}
+            <div class="idx-muted inf-card-foot" title="Max calls queued per priority class before new calls are rejected">queue cap ${(p.max_queued == null) ? '—' : p.max_queued}</div>
+        </div>`;
+    }).join('');
+    return `
+        <div class="inf-section">
+            <div class="emb-section-head">
+                <span class="emb-section-title">Occupancy</span>
+                <span class="idx-muted">slots in use + anything waiting, per profile</span>
+            </div>
+            <div class="inf-cards">${cards}</div>
+        </div>`;
+}
+
+function _infRenderLatency(data) {
+    const lat = data.latency || {};
+    const win = lat.window_s ? Math.round(lat.window_s / 60) : 5;
+    const n = lat.n || 0;
+    const cell = (label, v) =>
+        `<div class="inf-lat-cell"><div class="inf-lat-num">${_infMs(v)}<span class="inf-lat-unit">ms</span></div>`
+        + `<div class="inf-lat-label">${label}</div></div>`;
+    let body;
+    if (n === 0) {
+        body = `<div class="idx-muted">No successful calls in the last ${win} min.</div>`;
+    } else if (n === 1) {
+        body = `<div class="inf-lat">${cell('total', lat.p50)}</div>`
+             + `<div class="idx-muted inf-lat-note">Only 1 call in the window — needs more for meaningful percentiles.</div>`;
+    } else {
+        body = `<div class="inf-lat">${cell('p50', lat.p50)}${cell('p95', lat.p95)}${cell('p99', lat.p99)}</div>`;
+    }
+    return `
+        <div class="inf-section">
+            <div class="emb-section-head">
+                <span class="emb-section-title">Latency</span>
+                <span class="idx-muted">end-to-end time of successful calls · last ${win} min · ${n} call${n === 1 ? '' : 's'} (the table below lists recent calls)</span>
+            </div>
+            ${body}
+        </div>`;
+}
+
+function _infChip(group, value, label, active) {
+    return `<button class="inf-chip${active ? ' active' : ''}" onclick="${group}('${value}')">${escapeHtml(label)}</button>`;
+}
+
+function _infRenderRecent(data) {
+    // Newest-first: snapshot_metrics returns oldest-first.
+    const allRows = (data.recent || []).slice().reverse();
+    // Filter chips only earn their space once there are enough rows to scan.
+    const showFilters = allRows.length > 5;
+    let rows = allRows;
+    if (showFilters) {
+        rows = rows.filter(r =>
+            (_infPriorityFilter === 'All' || r.priority === _infPriorityFilter)
+            && (_infStatusFilter === 'All' || _infStatusGroup(r.status) === _infStatusFilter));
+    }
+
+    let filterBar = '';
+    if (showFilters) {
+        const priChips = ['All', 'INTERACTIVE', 'WORKFLOW', 'BACKGROUND']
+            .map(p => _infChip('_infSetPriority', p, p, _infPriorityFilter === p)).join('');
+        const stChips = ['All', 'ok', 'queued', 'errored']
+            .map(s => _infChip('_infSetStatus', s, s, _infStatusFilter === s)).join('');
+        filterBar = `<div class="inf-filters"><span class="inf-filter-label">priority</span>${priChips}`
+                  + `<span class="inf-filter-label">status</span>${stChips}</div>`;
+    }
+
+    const body = rows.length ? rows.map(r => `
+        <tr>
+            <td class="idx-muted" title="time since this call was queued">${_infAge(r.age_s)}</td>
+            <td class="inf-prof" title="${escapeHtml(r.profile || '')}">${escapeHtml(_infRole(r.profile).role)}</td>
+            <td>${_infPriBadge(r.priority)}</td>
+            <td>${_infStatusBadge(r.status)}${r.error_detail ? ` <span class="idx-muted" title="${escapeHtml(r.error_detail)}">ⓘ</span>` : ''}</td>
+            <td class="idx-r">${_infMs(r.queue_wait_ms)}</td>
+            <td class="idx-r">${_infMs(r.service_time_ms)}</td>
+            <td class="idx-r">${_infMs(r.total_latency_ms)}</td>
+        </tr>`).join('')
+        : `<tr><td colspan="7" class="idx-muted">no calls match the current filter</td></tr>`;
+
+    return `
+        <div class="inf-section">
+            <div class="emb-section-head">
+                <span class="emb-section-title">Recent calls</span>
+                <span class="idx-muted">last ${allRows.length}, newest first — live + persisted (~7 days)</span>
+            </div>
+            ${filterBar}
+            <div class="inf-table-scroll">
+                <table class="data-table">
+                    <thead><tr>
+                        <th title="time since the call was queued">Age</th>
+                        <th>Profile</th><th>Priority</th><th>Status</th>
+                        <th class="idx-r" title="time spent waiting for a free slot">Queue wait (ms)</th>
+                        <th class="idx-r" title="time in the actual model call">Service (ms)</th>
+                        <th class="idx-r" title="end-to-end: queue wait + service">Total (ms)</th>
+                    </tr></thead>
+                    <tbody>${body}</tbody>
+                </table>
+            </div>
+        </div>`;
+}
+
+function _infSetPriority(p) { _infPriorityFilter = p; _infRender(); }
+function _infSetStatus(s) { _infStatusFilter = s; _infRender(); }
+
+// Surface handle for the event-bus dispatcher (broker.state → _refreshSoon).
+window.inferenceSurface = {
+    refresh: function() { return loadInference(); },
+    isMounted: function() {
+        return !!document.getElementById('inference-content')
+            && (typeof WB_SETTINGS_SUBTAB === 'undefined' || WB_SETTINGS_SUBTAB === 'inference');
+    },
+};
+"""
+
+
+def styles() -> str:
+    return """
+/* Inference sub-view — reuses .idx-badge/.idx-ok|warn|err/.data-table/.idx-r/.idx-muted
+   from the Embeddings sub-view; only inference-specific classes below. */
+.inf-section { margin-bottom: 22px; }
+
+/* Header: health verdict + orientation + help */
+.inf-header { margin-bottom: 20px; }
+.inf-verdict { display:flex; align-items:center; gap:8px; font-size:1.05em; font-weight:600;
+    padding:10px 14px; border-radius:8px; border-left:4px solid var(--text-muted);
+    background: var(--bg-tertiary); color: var(--text-primary); }
+.inf-verdict-icon { font-size:1.1em; }
+.inf-verdict-ok   { border-left-color: var(--green);  background: color-mix(in srgb, var(--green) 10%, var(--bg-tertiary)); }
+.inf-verdict-busy { border-left-color: var(--accent); background: color-mix(in srgb, var(--accent) 10%, var(--bg-tertiary)); }
+.inf-verdict-warn { border-left-color: var(--yellow); background: color-mix(in srgb, var(--yellow) 14%, var(--bg-tertiary)); }
+.inf-verdict-off  { border-left-color: var(--text-muted); color: var(--text-secondary); }
+.inf-help-btn { margin-left:auto; width:22px; height:22px; border-radius:50%; cursor:pointer;
+    border:1px solid var(--text-muted); background:transparent; color: var(--text-secondary);
+    font-weight:700; line-height:1; flex:0 0 auto; }
+.inf-help-btn:hover { color: var(--text-primary); border-color: var(--text-primary); }
+.inf-intro { margin-top:8px; font-size:0.85em; max-width:70ch; }
+.inf-help { margin-top:10px; padding:12px 14px; border-radius:8px; background: var(--bg-tertiary);
+    font-size:0.85em; color: var(--text-secondary); display:flex; flex-direction:column; gap:6px; }
+.inf-help b { color: var(--text-primary); }
+
+/* Occupancy cards */
+.inf-cards { display:flex; flex-wrap:wrap; gap:12px; }
+.inf-card { background: var(--bg-tertiary); border:1px solid var(--border, var(--bg-tertiary));
+    border-radius:8px; padding:12px 14px; min-width:210px; flex:0 1 250px; }
+.inf-card-head { display:flex; align-items:center; justify-content:space-between; gap:8px; }
+.inf-card-role { font-weight:600; color: var(--text-primary); }
+.inf-card-model { font-size:0.78em; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; margin:2px 0 8px; }
+.inf-gauge { height:6px; border-radius:3px; background: color-mix(in srgb, var(--text-muted) 25%, transparent); overflow:hidden; }
+.inf-gauge-fill { height:100%; background: var(--accent); border-radius:3px; transition:width .3s ease; }
+.inf-gauge-label { font-size:0.8em; margin-top:4px; }
+.inf-wait-words { font-size:0.82em; color: var(--yellow); font-weight:600; margin-top:6px; }
+.inf-card-foot { margin-top:6px; font-size:0.78em; }
+.inf-st-idle { background: color-mix(in srgb, var(--text-muted) 22%, transparent); color: var(--text-muted); }
+.inf-st-run  { background: color-mix(in srgb, var(--accent) 16%, transparent); color: var(--accent); }
+
+/* Priority color coding (shared by waiting words context + table badges) */
+.inf-pri-INTERACTIVE { background: color-mix(in srgb, var(--green) 16%, transparent); color: var(--green); }
+.inf-pri-WORKFLOW { background: color-mix(in srgb, var(--accent) 16%, transparent); color: var(--accent); }
+.inf-pri-BACKGROUND { background: color-mix(in srgb, var(--text-muted) 22%, transparent); color: var(--text-muted); }
+
+/* Latency summary */
+.inf-lat { display:flex; gap:28px; }
+.inf-lat-cell { text-align:center; }
+.inf-lat-num { font-size:1.8em; font-weight:700; color: var(--text-primary); font-variant-numeric:tabular-nums; }
+.inf-lat-unit { font-size:0.5em; color: var(--text-muted); margin-left:3px; }
+.inf-lat-label { font-size:0.8em; color: var(--text-muted); margin-top:2px; }
+.inf-lat-note { font-size:0.8em; margin-top:6px; }
+
+/* Filter chips */
+.inf-filters { display:flex; align-items:center; gap:6px; margin-bottom:8px; flex-wrap:wrap; }
+.inf-filter-label { font-size:0.75em; color: var(--text-muted); margin-left:8px; }
+.inf-filter-label:first-child { margin-left:0; }
+.inf-chip { font-size:0.78em; padding:2px 10px; border-radius:12px; cursor:pointer;
+    border:1px solid var(--border, var(--bg-tertiary)); background: var(--bg-tertiary); color: var(--text-secondary); }
+.inf-chip.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+.inf-prof { font-variant-numeric:tabular-nums; }
+
+/* Recent-calls scroll viewport (mirrors the Activity Event Log's .log-container) */
+.inf-table-scroll { max-height: 360px; overflow-y: auto; border:1px solid var(--border, var(--bg-tertiary)); border-radius:8px; }
+.inf-table-scroll thead th { position: sticky; top: 0; background: var(--bg-secondary); z-index: 1; }
+"""

--- a/work_buddy/dashboard/frontend/scripts/tabs/settings.py
+++ b/work_buddy/dashboard/frontend/scripts/tabs/settings.py
@@ -39,7 +39,7 @@ let WB_MATCHED_SET = null;
 let WB_SETTINGS_SUBTAB = 'status';
 
 function switchSettingsSubtab(st) {
-    if (st !== 'status' && st !== 'activity' && st !== 'embeddings') st = 'status';
+    if (st !== 'status' && st !== 'activity' && st !== 'embeddings' && st !== 'inference') st = 'status';
     WB_SETTINGS_SUBTAB = st;
     document.querySelectorAll('.settings-subtab-btn').forEach(b =>
         b.classList.toggle('active', b.dataset.st === st));
@@ -54,6 +54,9 @@ function switchSettingsSubtab(st) {
     }
     if (st === 'embeddings' && typeof loadEmbeddings === 'function') {
         loadEmbeddings();  // cheap (cached, pre-warmed) — refresh on each open
+    }
+    if (st === 'inference' && typeof loadInference === 'function') {
+        loadInference();  // cheap (cached) — refresh on open; broker.state SSE keeps it live
     }
 }
 

--- a/work_buddy/dashboard/service.py
+++ b/work_buddy/dashboard/service.py
@@ -24,6 +24,7 @@ from flask import Flask, Response, jsonify, request, send_file
 
 from work_buddy.config import load_config
 from work_buddy.dashboard.api import (
+    get_broker_summary,
     get_chats_summary,
     get_contracts_summary,
     get_embeddings_summary,
@@ -1463,6 +1464,12 @@ def api_contracts():
 def api_embeddings():
     """System (IR/knowledge) + User (vaults) status for Settings › Embeddings."""
     return jsonify(get_embeddings_summary())
+
+
+@app.get("/api/broker")
+def api_broker():
+    """LocalInferenceBroker snapshot for Settings › Inference (read-only, cached)."""
+    return jsonify(get_broker_summary())
 
 
 @app.post("/api/embeddings/vault")
@@ -4661,6 +4668,50 @@ def _prewarm_costs() -> None:
     get_claude_code_usage_summary()
 
 
+def start_broker_state_poller(interval: float = 2.0) -> threading.Event:
+    """Poll the embedding-service broker and push a thin ``broker.state`` ping.
+
+    The broker's per-call metrics live in the embedding-service process; the SSE
+    event bus lives here in the dashboard process. This daemon (mirroring
+    ``events.start_heartbeat``) refreshes the dashboard's broker cache and
+    publishes a lightweight ``broker.state`` event so the Settings › Inference
+    sub-view refetches the (cached) ``/api/broker`` and morphs the change in —
+    the actual snapshot rides the cached HTTP read, not the SSE frame.
+
+    Gated on having at least one SSE subscriber, so an idle or closed dashboard
+    does zero cross-process work. Returns a ``threading.Event``; ``set()`` stops
+    the loop within ``interval`` seconds.
+    """
+    from work_buddy.dashboard.api import refresh_broker_cache
+    from work_buddy.dashboard.events import get_bus, publish
+
+    stop = threading.Event()
+
+    def _loop() -> None:
+        while not stop.is_set():
+            try:
+                if get_bus().subscriber_count() > 0:
+                    summary = refresh_broker_cache()
+                    profiles = summary.get("profiles") or {}
+                    in_flight = sum(
+                        p.get("in_flight", 0) for p in profiles.values()
+                    )
+                    publish("broker.state", {
+                        "available": bool(summary.get("available")),
+                        "in_flight_total": in_flight,
+                        "n_recent": len(summary.get("recent") or []),
+                    })
+            except Exception as exc:  # pragma: no cover - best-effort daemon
+                logger.debug("broker-state poller tick failed: %s", exc)
+            stop.wait(interval)
+
+    threading.Thread(
+        target=_loop, name="broker-state-poller", daemon=True,
+    ).start()
+    logger.info("Broker-state poller started (interval=%.1fs)", interval)
+    return stop
+
+
 def main():
     import sys
 
@@ -4704,6 +4755,10 @@ def main():
     # service-health monitor) reach the dashboard via this bridge.
     from work_buddy.dashboard.messaging_bridge import start_messaging_bridge
     start_messaging_bridge()
+
+    # Push live broker (LocalInferenceBroker) state to the Settings › Inference
+    # sub-view. Subscriber-gated, so it idles when no dashboard is connected.
+    start_broker_state_poller(interval=2.0)
 
     from work_buddy.web.access_log_filter import install_probe_log_filter
     install_probe_log_filter(["/health"])

--- a/work_buddy/embedding/client.py
+++ b/work_buddy/embedding/client.py
@@ -105,6 +105,17 @@ def is_available() -> bool:
     return available
 
 
+def broker_state() -> dict | None:
+    """Fetch the embedding service's ``LocalInferenceBroker`` snapshot.
+
+    Returns the ``/broker/state`` payload (``profiles`` / ``recent`` /
+    ``latency`` / ``now_monotonic``), or ``None`` when the service is
+    unreachable — the universal "service unavailable" signal callers already
+    degrade on. Used by the dashboard's Inference panel (read-only).
+    """
+    return _request("GET", "/broker/state", timeout=5)
+
+
 def wait_until_available(
     timeout_s: float = 30.0,
     interval_s: float = 0.5,

--- a/work_buddy/embedding/service.py
+++ b/work_buddy/embedding/service.py
@@ -409,6 +409,118 @@ def health():
     })
 
 
+# Latency-summary window: percentiles are computed over successful calls that
+# finished within this many seconds of "now". 5 minutes matches the panel's
+# "recent activity" framing.
+_BROKER_LATENCY_WINDOW_S = 300.0
+
+# How many recent calls the table feeds (the panel scrolls them). Bounded well
+# under the broker's 1000-entry ring so the rendered DOM stays reasonable.
+_BROKER_RECENT_LIMIT = 200
+
+
+@app.route("/broker/state", methods=["GET"])
+def broker_state():
+    """Snapshot of this process's ``LocalInferenceBroker`` for the dashboard panel.
+
+    Read-only. The broker is a process-global singleton, so this returns the
+    embedding-service process's view — the high-traffic local-inference path.
+    Cross-process aggregation (MCP server + embedding service) is out of scope.
+
+    Serves a **merge of the live in-memory ring and the persisted store**: the
+    ring (``snapshot_metrics``) carries the freshest rows, including in-flight
+    calls; ``metrics_store`` carries history that survives restarts. Everything
+    is unified to **wall-clock** here — the ring's ``SlotMetrics`` timestamps are
+    ``time.monotonic()`` (process-relative), so they're converted with a single
+    ``(mono_now, wall_now)`` pair, and the persisted rows are already wall-clock.
+    A browser can't window monotonic floats, so per-row ``age_s`` and the
+    latency-percentile window are still computed HERE.
+    """
+    # Function-local import: this module deliberately keeps ``work_buddy.*``
+    # imports out of the module top (every route here defers them; see the
+    # rationale in ``work_buddy/embedding/providers/lmstudio.py``).
+    import math
+
+    from work_buddy.inference import get_broker, metrics_store
+
+    broker = get_broker()
+    mono_now = time.monotonic()
+    wall_now = time.time()
+
+    def _to_wall(ts: float | None) -> float | None:
+        return None if ts is None else wall_now - (mono_now - ts)
+
+    def _norm_live(r: dict) -> dict:
+        # Reshape an in-memory ring row to the persisted-row shape (wall-clock).
+        return {
+            "id": r.get("id"),
+            "profile": r.get("profile"),
+            "priority": r.get("priority"),
+            "status": r.get("status"),
+            "error_kind": r.get("error_kind"),
+            "error_detail": r.get("error_detail"),
+            "queue_wait_ms": r.get("queue_wait_ms"),
+            "service_time_ms": r.get("service_time_ms"),
+            "total_latency_ms": r.get("total_latency_ms"),
+            "queued_at_wall": _to_wall(r.get("queued_at")),
+            "finished_at_wall": _to_wall(r.get("finished_at")),
+        }
+
+    # Merge persisted history with the live ring, keyed on call id. Live wins:
+    # it's the freshest (a row may be `running` live but absent/older in the
+    # store) and includes in-flight calls the flusher hasn't persisted yet.
+    merged: dict[str, dict] = {}
+    for row in metrics_store.read_recent(limit=_BROKER_RECENT_LIMIT):
+        merged[row["id"]] = row
+    for row in broker.snapshot_metrics():
+        merged[row["id"]] = _norm_live(row)
+
+    for row in merged.values():
+        queued = row.get("queued_at_wall")
+        row["age_s"] = (wall_now - queued) if queued is not None else None
+
+    # Newest-first for the "last N", then reverse back to oldest-first so the
+    # frontend's `.reverse()` renders newest-first (preserves the existing
+    # contract — see tabs/inference.py).
+    rows = sorted(
+        merged.values(), key=lambda r: r.get("queued_at_wall") or 0.0, reverse=True
+    )
+    recent = rows[:_BROKER_RECENT_LIMIT]
+    recent.reverse()
+
+    # Percentiles over successful, finished-in-window calls (wall-clock). Dedup
+    # by id already happened in `merged`, so no double-count of a row present in
+    # both sources.
+    latencies = sorted(
+        r["total_latency_ms"]
+        for r in merged.values()
+        if r.get("status") == "ok"
+        and r.get("finished_at_wall") is not None
+        and r.get("total_latency_ms") is not None
+        and (wall_now - r["finished_at_wall"]) <= _BROKER_LATENCY_WINDOW_S
+    )
+
+    def _pct(p: float) -> float | None:
+        # Nearest-rank percentile; well-defined for n in {0, 1}.
+        if not latencies:
+            return None
+        rank = max(1, math.ceil(p / 100.0 * len(latencies)))
+        return round(latencies[rank - 1], 1)
+
+    return jsonify({
+        "profiles": broker.profile_status(),
+        "recent": recent,
+        "latency": {
+            "p50": _pct(50),
+            "p95": _pct(95),
+            "p99": _pct(99),
+            "window_s": _BROKER_LATENCY_WINDOW_S,
+            "n": len(latencies),
+        },
+        "now_wall": wall_now,
+    })
+
+
 @app.route("/embed", methods=["POST"])
 def embed():
     """Embed one or more texts.
@@ -866,6 +978,32 @@ def _vault_matrix_evictor_loop() -> None:
             print(f"vault matrix evictor error (non-fatal): {exc}", file=sys.stderr)
 
 
+_BROKER_PERSIST_INTERVAL_S = 15  # how often completed broker calls flush to disk
+
+
+def _broker_metrics_persist_loop() -> None:
+    """Background thread: flush completed broker calls to the persistent store.
+
+    The broker's metrics ring is in-memory and wiped on every process restart.
+    This drains it periodically into ``inference.metrics_store`` — out-of-band,
+    so the broker itself stays a pure in-memory object — giving the dashboard's
+    Inference panel history that survives restarts. ``INSERT OR IGNORE`` on the
+    immutable call id makes re-flushing the same ring rows a cheap no-op.
+    """
+    from work_buddy.inference import get_broker, metrics_store
+
+    while True:
+        try:
+            time.sleep(_BROKER_PERSIST_INTERVAL_S)
+            metrics_store.persist_terminal_rows(
+                get_broker().snapshot_metrics(),
+                time.monotonic(),
+                time.time(),
+            )
+        except Exception as exc:
+            print(f"broker metrics persist error (non-fatal): {exc}", file=sys.stderr)
+
+
 def main():
     """Entry point — init registry, start serving, load models in background.
 
@@ -949,6 +1087,13 @@ def main():
     threading.Thread(
         target=_vault_matrix_evictor_loop,
         name="vault-matrix-evictor",
+        daemon=True,
+    ).start()
+    # Persist completed broker calls so the dashboard Inference panel keeps
+    # history across restarts (the broker's metrics ring is in-memory only).
+    threading.Thread(
+        target=_broker_metrics_persist_loop,
+        name="broker-metrics-persist",
         daemon=True,
     ).start()
 

--- a/work_buddy/inference/metrics_store.py
+++ b/work_buddy/inference/metrics_store.py
@@ -1,0 +1,216 @@
+"""Persistent store for ``LocalInferenceBroker`` call metrics.
+
+The broker keeps only an in-memory 1000-entry ring, wiped on every process
+restart (a sidecar reset restarts the embedding-service child). This module
+persists COMPLETED calls to a small SQLite table so the dashboard's Inference
+panel survives restarts instead of blanking until the ring refills.
+
+Design constraints:
+
+* **The broker stays pure.** Persistence is written out-of-band by a flusher
+  daemon in the embedding service (``service.py:_broker_metrics_persist_loop``),
+  which passes ``broker.snapshot_metrics()`` rows in. This module never imports
+  the broker — so listing it in ``artifacts.registry._CONSUMER_MODULES`` (so the
+  cleanup tick discovers the artifact) stays cheap and side-effect-free.
+* **Wall-clock at persist time.** ``SlotMetrics`` timestamps are
+  ``time.monotonic()`` (process-relative). They are converted to epoch
+  wall-clock here using a ``(mono_now, wall_now)`` reference pair captured by the
+  caller, and ``completed_at`` is stored as a UTC ISO string — the format the
+  ``broker-metrics`` artifact's ``PerRecordTtl`` parses (epoch would silently
+  never expire).
+* **Terminal rows only.** A terminal ``SlotMetrics`` is immutable once stamped,
+  so ``INSERT OR IGNORE`` keyed on ``id`` is correct and idempotent across
+  flushes. In-flight rows (``queued`` / ``running``) are skipped — persisting one
+  would freeze a stale snapshot under OR-IGNORE.
+
+Aged out by the ``broker-metrics`` artifact (7-day per-record TTL) on the
+unified cleanup tick.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from work_buddy.paths import resolve
+
+logger = logging.getLogger(__name__)
+
+# Immutable, persist-eligible statuses. (queued / running are in-flight.)
+_TERMINAL_STATUSES = frozenset(
+    {"ok", "error", "queue_full", "queue_wait_timeout", "inference_timeout"}
+)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS broker_metrics (
+    id                TEXT PRIMARY KEY,
+    profile           TEXT NOT NULL,
+    priority          TEXT,
+    status            TEXT NOT NULL,
+    error_kind        TEXT,
+    error_detail      TEXT,
+    queued_at_wall    REAL,
+    finished_at_wall  REAL,
+    queue_wait_ms     REAL,
+    service_time_ms   REAL,
+    total_latency_ms  REAL,
+    completed_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_broker_metrics_finished
+    ON broker_metrics(finished_at_wall);
+"""
+
+# DB paths whose schema is ensured this process; keyed on resolved path so a
+# test pointing at a fresh DB still creates the table exactly once.
+_schema_ready: set[str] = set()
+
+
+def _db_path() -> Path:
+    return resolve("db/broker-metrics")
+
+
+def get_connection() -> sqlite3.Connection:
+    """Open (creating + migrating once per path) the broker-metrics DB."""
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path), timeout=10)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    key = str(path)
+    if key not in _schema_ready:
+        conn.executescript(_SCHEMA)
+        _schema_ready.add(key)
+    return conn
+
+
+def _to_wall(ts: float | None, mono_now: float, wall_now: float) -> float | None:
+    """Convert a process-relative ``time.monotonic()`` value to epoch wall-clock."""
+    if ts is None:
+        return None
+    return wall_now - (mono_now - ts)
+
+
+def persist_terminal_rows(
+    rows: list[dict[str, Any]], mono_now: float, wall_now: float
+) -> int:
+    """Insert completed broker calls into the store; return the count newly written.
+
+    ``rows`` is ``broker.snapshot_metrics()`` output (monotonic timestamps). Only
+    terminal-status, finished rows are persisted. Idempotent across flushes via
+    ``INSERT OR IGNORE`` on the immutable ``id``. Never raises — persistence is
+    best-effort observability.
+    """
+    terminal = [
+        r for r in rows
+        if r.get("status") in _TERMINAL_STATUSES and r.get("finished_at") is not None
+    ]
+    if not terminal:
+        return 0
+    try:
+        conn = get_connection()
+        try:
+            written = 0
+            for r in terminal:
+                finished_wall = _to_wall(r.get("finished_at"), mono_now, wall_now)
+                completed_at = datetime.fromtimestamp(
+                    finished_wall, tz=timezone.utc
+                ).isoformat()
+                cur = conn.execute(
+                    "INSERT OR IGNORE INTO broker_metrics "
+                    "(id, profile, priority, status, error_kind, error_detail, "
+                    " queued_at_wall, finished_at_wall, queue_wait_ms, "
+                    " service_time_ms, total_latency_ms, completed_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        r.get("id"),
+                        r.get("profile"),
+                        r.get("priority"),
+                        r.get("status"),
+                        r.get("error_kind"),
+                        r.get("error_detail"),
+                        _to_wall(r.get("queued_at"), mono_now, wall_now),
+                        finished_wall,
+                        r.get("queue_wait_ms"),
+                        r.get("service_time_ms"),
+                        r.get("total_latency_ms"),
+                        completed_at,
+                    ),
+                )
+                written += cur.rowcount or 0
+            conn.commit()
+            return written
+        finally:
+            conn.close()
+    except Exception as exc:  # pragma: no cover - best-effort
+        logger.warning("broker-metrics persist failed: %s", exc)
+        return 0
+
+
+def read_recent(limit: int = 200) -> list[dict[str, Any]]:
+    """Most-recent persisted calls, newest-first (ordered by the indexed column)."""
+    try:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "SELECT * FROM broker_metrics "
+                "ORDER BY finished_at_wall DESC LIMIT ?",
+                (int(limit),),
+            )
+            return [dict(row) for row in cur.fetchall()]
+        finally:
+            conn.close()
+    except Exception as exc:  # pragma: no cover - best-effort
+        logger.warning("broker-metrics read failed: %s", exc)
+        return []
+
+
+def _init_schema_safe() -> None:
+    try:
+        get_connection().close()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("broker-metrics schema init skipped: %s", exc)
+
+
+def _register_broker_metrics_artifact() -> None:
+    """Register the entry-TTL artifact so the cleanup tick prunes old rows.
+
+    7-day per-record TTL keyed on ``completed_at`` (UTC ISO). No retention
+    predicate — every persisted row is terminal, hence TTL-eligible.
+    ``vacuum_on_delete=False``: the table is tiny and pruned frequently, so a
+    VACUUM (which locks the DB) on every tick is not worth it.
+    """
+    try:
+        from work_buddy.artifacts import (
+            Artifact,
+            Delete,
+            Lifecycle,
+            PerRecordTtl,
+            register_artifact,
+            SqliteRowsStorage,
+        )
+
+        register_artifact(Artifact(
+            name="broker-metrics",
+            storage=SqliteRowsStorage(
+                db_path=_db_path(),
+                table="broker_metrics",
+                id_column="id",
+                vacuum_on_delete=False,
+            ),
+            lifecycle=Lifecycle(
+                trigger=PerRecordTtl(
+                    ttl_field="completed_at",
+                    default_ttl_days=7,
+                ),
+                action=Delete(),
+            ),
+        ))
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("Failed to register broker-metrics artifact: %s", exc)
+
+
+_init_schema_safe()
+_register_broker_metrics_artifact()

--- a/work_buddy/paths.py
+++ b/work_buddy/paths.py
@@ -71,6 +71,7 @@ RESOURCES: dict[str, str] = {
     "db/llm_queue":              "db/llm_call_queue.db",  # LLM-call priority queue
     "db/work_item_events":       "db/work_item_events.db",  # WorkItem audit/provenance log
     "db/vault-index":            "db/vault-index.db",  # Vault semantic-index chunk store
+    "db/broker-metrics":         "db/broker_metrics.db",  # Persisted LocalInferenceBroker call metrics
 
     # Logs
     "logs/gateway-debug":        "logs/gateway_debug.log",


### PR DESCRIPTION
## Summary
- Read-only **Settings › Inference** sub-view for the `LocalInferenceBroker`: per-profile occupancy, a recent-calls feed, a p50/p95/p99 latency summary, and a Healthy/Busy/Contended health verdict with an inline explainer — so slow or contended local inference is visible, not guessed at.
- Live updates via a subscriber-gated `broker.state` SSE ping (no frontend timer); data served by `GET /broker/state` (embedding service) → background-cached `GET /api/broker` (dashboard).
- Call metrics are **persisted** to a SQLite store (`broker-metrics` artifact, 7-day per-record TTL) by an embedding-service flusher; the endpoint merges the live ring with the persisted store, so history survives a restart that wipes the in-memory ring. Broker API unchanged.

## Test plan
- [x] Unit — 104 passed: endpoint shape/window/null-handling, restart-survival + live/persisted merge, metrics store (terminal-only persist, dedup, monotonic→wall + ISO `completed_at`, TTL prune), `broker.state` SSE delivery, frontend assembly/regressions, artifact protocol/backends.
- [x] Live — IR-index build → broker call persisted within ~2s → sidecar reset → `/broker/state` still served the call from the persisted store (ring empty, `profiles: {}`).

Task: t-6bd54103