### PR TITLE
feat(inference): Local model fleet view (Settings > Inference)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -210,6 +210,21 @@ llm:
   #     context_length: 8192
   #     execution_mode: local
 
+inference:
+  # Static roster for the Settings > Inference "Local model fleet" section.
+  # The machine list is discovered live from the configured local-inference
+  # provider (e.g. LM Studio + LM Link); this roster only ENRICHES discovered
+  # machines, joined by device_id, with hardware specs the provider can't read
+  # remotely (peer GPU/VRAM/RAM). Leave empty to rely on discovery alone —
+  # discovered machines still render, with hardware shown as "unknown".
+  # fleet:
+  #   - device_id: "0123456789abcdef0123456789abcdef"   # provider's device identifier
+  #     role: "Remote compute node"
+  #     ram_gb: 64
+  #     gpus:                                            # a machine can have several
+  #       - name: "NVIDIA RTX 2080 Super Max-Q"
+  #         vram_gb: 8
+
 chats:
   specstory_days: 7
   claude_history_days: 7

--- a/knowledge/store/architecture/event-bus.md
+++ b/knowledge/store/architecture/event-bus.md
@@ -144,6 +144,7 @@ The dashboard updates in real time from server-pushed events delivered over Serv
 | ``cron.hot_reload`` | ``{old_count, new_count}`` | ``Scheduler._hot_reload`` (when fingerprints change) |
 | ``user_job.created`` | ``{name, file_path}`` | ``api_user_job_create`` (after successful write) |
 | ``inference.call_logged`` | ``{call_id, description, kind, model, execution_mode, status}`` (thin ping) | ``llm.provenance.record_inference_call`` — Settings › Inference refetches the cached ``/api/inference-activity`` |
+| ``fleet.changed`` | ``{reason}`` | ``dashboard.api.start_fleet_poller`` (25 s) — the Settings › Inference **fleet** section refetches the cached ``/api/fleet`` and morphs the cards. Published only when a machine's reachability or loaded-model set changes (external LM Studio loads/unloads have no other internal event). |
 
 ## Replay semantics
 

--- a/knowledge/store/architecture/inference.md
+++ b/knowledge/store/architecture/inference.md
@@ -29,6 +29,7 @@ Local-inference subsystems — everything that decides **when**, **where**, and 
 
 - **[Broker](architecture_inference_broker.md)** — ``work_buddy.inference.broker.LocalInferenceBroker``. Per-profile slot limits, priority classes (INTERACTIVE / WORKFLOW / BACKGROUND), split queue-wait vs inference timeouts, and per-call metrics. Every outbound local-inference call (embedding or LLM) routes through it so work-buddy — not LM Studio — is the scheduler of record.
 - **[Provenance](architecture_inference_provenance.md)** — ``work_buddy.llm.provenance.record_inference_call``. A stable ``call_id`` + plain-text description for every model call — local **and** cloud, completions **and** embeddings — written beside the cost ledger and surfaced as the Settings › Inference activity feed. Where the broker decides *when/where* a local call runs, provenance records *what* called a model and *why* across both providers; the two join by ``call_id`` so local rows carry their scheduler latency.
+- **[Fleet](architecture_inference_fleet.md)** — ``work_buddy.inference.fleet``. The per-machine "what's loaded on which box" view (reachability, loaded models, multi-GPU hardware) behind a provider-neutral seam with LM Studio as the first adapter. Adds the *machine* dimension the broker (when/where) and provenance (what/why) lack — the broker knows the profile, not which box ran it.
 
 ## What WILL live here (pending restructure)
 

--- a/knowledge/store/architecture/inference/fleet.md
+++ b/knowledge/store/architecture/inference/fleet.md
@@ -1,0 +1,119 @@
+---
+name: Local Model Fleet
+kind: system
+description: Per-machine "what's loaded on which box" view of the local-inference fleet — reachability, loaded models, and hardware (multi-GPU) — behind a provider-neutral seam with LM Studio as the first adapter.
+dev_notes: |-
+  ## Headless data-source map (LM Studio adapter)
+
+  - ``lms link status --json`` → machines + reachability + loaded-model names. The
+    local machine is the top-level ``deviceIdentifier``/``deviceName``, NOT in
+    ``peers[]`` — ``merge_fleet`` synthesizes the local row from those top-level fields.
+  - ``lms ps --json`` → loaded-model instance detail (quant, context, status),
+    device-attributed and cross-peer; joined by ``deviceIdentifier``.
+  - ``lms runtime survey --json`` → LOCAL machine hardware only; per-GPU dedicated
+    VRAM via ``gpuInfo[].dedicatedMemoryCapacityBytes`` (fallback
+    ``totalMemoryCapacityBytes``). There is NO headless path to remote-peer
+    hardware — that is why peer specs live in the roster.
+
+  ## Cache + poller
+
+  ``get_fleet_summary`` serves a ~20s background-refreshed cache (the three
+  subprocesses never run on a request thread). ``start_fleet_poller`` (25s,
+  started in ``service.main``) refreshes the cache and publishes ``fleet.changed``
+  only when the *material* fingerprint (per machine: reachability + sorted
+  loaded-model names) changes — volatile fields (last-used time, queued, context)
+  are excluded so the bus is not spammed. The fleet section subscribes to
+  ``fleet.changed``; it does NOT subscribe to ``inference.call_logged``.
+
+  ## Roster shape + merge semantics
+
+  Canonical roster hardware is ``gpus: [{name, vram_gb}]``; ``merge_fleet`` and the
+  ``fleet_roster`` capability accept a legacy scalar ``gpu``/``vram_gb`` as a
+  single-GPU fallback, and ``fleet_roster`` migrates an entry off the scalar keys
+  on edit. ``fleet_roster`` field semantics: ``None`` → omit (preserve), ``""``/``[]``
+  → clear, value → set — so partial updates preserve unspecified fields and the
+  dashboard form (which sends every field) is a full replace.
+
+  ## lms binary resolution
+
+  ``_resolve_lms_bin`` tries PATH then ``~/.lmstudio/bin/lms[.exe]`` (the
+  dashboard/sidecar PATH differs from an interactive shell). A missing binary or
+  unreadable link status → ``lms_available: false`` and the roster renders offline;
+  never raises.
+tags:
+- inference
+- fleet
+- lmstudio
+- lm-link
+- dashboard
+- gpu
+- vram
+- provider-neutral
+aliases:
+- local model fleet
+- fleet view
+- what's loaded on which machine
+- per-machine models
+parents:
+- architecture/inference
+---
+
+## What it is
+
+The Local model fleet is a per-machine view of the local-inference fleet: one
+card per machine (the local host + every reachable LM Link peer) showing
+reachability, the model(s) currently loaded (with quantization, status, and live
+context-vs-max), and hardware (GPUs + RAM). It answers "what's loaded on which
+box" — the per-machine question the [broker](architecture/inference/broker)
+can't, since the broker only knows the *profile* (model), not the machine. It
+renders as a section of the Settings › Inference sub-view, above the per-call
+[provenance](architecture/inference/provenance) feed.
+
+## Provider seam
+
+Provider-neutral. `merge_fleet(link_status, ps, local_hardware, roster)`
+(`work_buddy/inference/fleet.py`) is a pure function over already-parsed inputs
+and knows nothing about any backend. A provider adapter is the only place that
+talks to the backend; today that is LM Studio via the `lms` CLI. Swapping to
+vLLM / Ollama / llama.cpp is a new adapter — not a change to `merge_fleet`, the
+dashboard reader, the routes, or the capabilities.
+
+## Data layers
+
+- **Discovery (live):** machines + reachability + loaded models come from the
+  provider. The local machine is always present; remote peers appear when reachable.
+- **Hardware:** the local machine reports its own GPUs/RAM live. Remote-peer
+  hardware is NOT readable headless, so it comes from the static `inference.fleet`
+  config roster, joined by `device_id`. A rostered machine that isn't currently
+  discovered shows as offline rather than vanishing.
+- **Multi-GPU:** a machine carries a list of GPUs (`{name, vram_gb}`); the card
+  sums a total VRAM.
+
+## Config
+
+`inference.fleet` is a list of `{device_id, role, ram_gb, gpus: [{name, vram_gb}]}`.
+The roster only *enriches* discovered machines; zero config still renders
+discovered machines with hardware "unknown". It is managed end-to-end from the
+dashboard (the inline editor writes it) — users don't hand-edit it.
+
+## Surfaces
+
+- `GET /api/fleet` — the cached per-machine snapshot (read-only).
+- `POST /api/fleet/roster` — add/update or clear a machine's roster entry
+  (read-only-gated; the click is the consent; mirrors `/api/embeddings/vault`).
+- `fleet_status` capability — read the snapshot (answers "what's on which box /
+  can my laptop run model X").
+- `fleet_roster` capability — edit a machine's roster entry.
+- `fleet.changed` SSE event — published when a machine's reachability or
+  loaded-model set changes; the section morphs the cards in.
+
+## Key files
+
+- `work_buddy/inference/fleet.py` — dataclasses, pure `merge_fleet`, LM Studio
+  adapter, `read_fleet`.
+- `work_buddy/dashboard/api.py` — `get_fleet_summary` (background cache) +
+  `start_fleet_poller`.
+- `work_buddy/dashboard/service.py` — `/api/fleet` + `/api/fleet/roster` + index
+  pre-warm + poller start.
+- `work_buddy/dashboard/frontend/scripts/tabs/fleet.py` — the section + inline editor.
+- `work_buddy/mcp_server/ops/inference_ops.py` — `fleet_status` / `fleet_roster` ops.

--- a/knowledge/store/inference/fleet_roster.md
+++ b/knowledge/store/inference/fleet_roster.md
@@ -1,0 +1,58 @@
+---
+name: Fleet Roster
+kind: capability
+description: 'Add/update or clear a machine''s entry in the inference.fleet roster (config.local.yaml) — its role label and optional hardware specs. Enriches live-discovered fleet machines, joined by device_id.'
+capability_name: fleet_roster
+category: inference
+op: op.wb.fleet_roster
+schema_version: wb-capability/v1
+parameters:
+  action:
+    type: str
+    description: '"set" (add/update) or "remove" (clear the entry). Default "set".'
+    required: false
+  device_id:
+    type: str
+    description: The machine's provider device identifier (the join key). Required.
+    required: true
+  role:
+    type: str
+    description: Human label for the machine (e.g. "Remote compute node"). The primary field.
+    required: false
+  gpus:
+    type: list
+    description: 'List of {name, vram_gb} for a peer — machines can have several GPUs. Omit to leave unchanged; pass [] to clear. (The local machine reports its own live.)'
+    required: false
+  ram_gb:
+    type: float
+    description: Optional system RAM in GB for a peer.
+    required: false
+tags:
+- inference
+- fleet
+- roster
+- config
+aliases:
+- set machine role
+- edit fleet entry
+- fleet roster edit
+parents:
+- architecture/inference
+---
+
+Writes a machine's entry in the `inference.fleet` roster (persisted to
+`config.local.yaml`). The roster only *enriches* live-discovered fleet machines —
+joined by `device_id` — so `device_id` is the only required field; `role` is the
+primary human label and hardware specs are optional (peer hardware can't be
+auto-detected; the local machine reports its own live, so its roster specs are
+ignored for display).
+
+`action: "set"` adds or updates the entry; `action: "remove"` clears it (the
+machine still appears via live discovery). Backs the inline editor in the
+dashboard's Settings › Inference fleet section; the dashboard route
+(`POST /api/fleet/roster`) wraps this capability, gating on read-only mode and
+busting the fleet cache + publishing `fleet.changed` on success.
+
+Returns `{success, action, device_id, note}`, or `{success: false, errors_by_field}`
+on validation failure (e.g. a non-numeric VRAM value) so the form can highlight
+the offending input.

--- a/knowledge/store/inference/fleet_status.md
+++ b/knowledge/store/inference/fleet_status.md
@@ -1,0 +1,43 @@
+---
+name: Fleet Status
+kind: capability
+description: 'Local model fleet snapshot — per-machine reachability, currently loaded model(s) with live context utilization, and hardware (GPU/VRAM/RAM), across the local-inference fleet (LM Studio + LM Link).'
+capability_name: fleet_status
+category: inference
+op: op.wb.fleet_status
+schema_version: wb-capability/v1
+tags:
+- inference
+- fleet
+- lmstudio
+- lm-link
+- models
+- vram
+aliases:
+- model fleet
+- what's loaded on which machine
+- which box is running which model
+- fleet status
+- local model status
+- can my laptop run this model
+parents:
+- architecture/inference
+---
+
+Returns the **local model fleet** snapshot: one entry per machine in the
+local-inference fleet, with reachability, the model(s) currently loaded (with
+quantization, status, and live context length vs the model's trained max), and
+hardware (GPU / VRAM / RAM). Answers "what's running on which box" — the
+per-machine question the inference broker can't, since the broker only knows the
+*profile* (model), not the machine.
+
+Takes no parameters. Reads are live (the configured local-inference provider —
+LM Studio today — is enumerated via its CLI) and never raise: when the provider
+is unreachable, each machine degrades to `reachable: false` and `lms_available`
+is `false`. Remote-peer hardware comes from the `inference.fleet` config roster
+(the local machine reports its own hardware live); each machine's `hardware.source`
+records whether it was read `live` or came from the `roster`.
+
+Use this to decide where a model should run — e.g. whether a model that won't fit
+the local GPU should be routed to a higher-VRAM peer. The same snapshot backs the
+dashboard's Settings › Inference fleet section.

--- a/knowledge/store/services/dashboard.md
+++ b/knowledge/store/services/dashboard.md
@@ -50,6 +50,8 @@ Web dashboard for system observability + control. Served as a sidecar-managed Fl
 
 Primary consumer of the **control graph** (see ``architecture/control-graph`` for the aggregator; ``architecture/health`` for the four-layer mental model the graph fuses). The Settings panel has two sub-tabs: **Status** — the control-graph tree (domain → subsystem → component hierarchy with ``effective_state`` badges, preference toggles (Want / No thanks / Undecided, hidden for ``is_core`` components), Configure / Walk me through action buttons for fixable requirements, universal ``?`` help buttons that spawn interactive Claude Code sessions with structured briefs, a per-component ↻ reprobe button, and clickable bulk-state chips that jump to the first problem node of that state) — and **Activity**, a registry-driven set of cards (Obsidian bridge sparkline, sidecar event log, recent-notifications log). See the Card registry section below.
 
+The Settings panel also has **Embeddings** and **Inference** sub-views. Settings › Inference hosts the per-call provenance activity feed and, above it, a **Local model fleet** section — one card per machine (reachability, loaded models, multi-GPU hardware), load-on-open + manual refresh, live-updated via the ``fleet.changed`` SSE event. Reads serve from ``GET /api/fleet`` (cached per-machine snapshot); the inline roster editor writes via ``POST /api/fleet/roster`` (add/update or clear a machine's ``inference.fleet`` entry; ``_reject_read_only``-gated, mirrors ``/api/embeddings/vault``). See ``architecture/inference/fleet``.
+
 ## Modes and endpoints
 
 * **Dev mode:** ``python -m work_buddy.dashboard --dev`` (auto-reloads on file changes). **Not enabled in sidecar config** — use manually for local development only.

--- a/tests/unit/test_dashboard_fleet.py
+++ b/tests/unit/test_dashboard_fleet.py
@@ -1,0 +1,117 @@
+"""Tests for the dashboard fleet read-model cache, route, and frontend module."""
+from __future__ import annotations
+
+from work_buddy.dashboard import api
+
+
+def setup_function():
+    api._fleet_cache = None
+    api._fleet_cache_ts = 0.0
+    api._fleet_refreshing = False
+
+
+def test_get_fleet_summary_caches(monkeypatch):
+    calls = {"n": 0}
+
+    def _fake_build():
+        calls["n"] += 1
+        return {"machines": [], "lms_available": True}
+
+    monkeypatch.setattr(api, "_build_fleet_summary", _fake_build)
+    a = api.get_fleet_summary()
+    b = api.get_fleet_summary()
+    assert calls["n"] == 1 and a == b  # second read served from cache
+
+
+def test_route_shape(monkeypatch):
+    from work_buddy.dashboard.service import app
+    monkeypatch.setattr(
+        api, "_build_fleet_summary",
+        lambda: {"machines": [{"device_id": "x", "name": "X"}],
+                 "lms_available": True, "local_device_id": "x"},
+    )
+    resp = app.test_client().get("/api/fleet")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["lms_available"] is True
+    assert body["machines"][0]["device_id"] == "x"
+
+
+def test_frontend_fleet_section_is_independent_of_inference_sse():
+    """The fleet section must not subscribe to the inference SSE event and must
+    use the surgical morph mutator, not a wholesale innerHTML rewrite."""
+    from work_buddy.dashboard.frontend.scripts.tabs import fleet
+    src = fleet.script()
+    assert "window.fleetSurface" in src
+    assert "loadFleet" in src
+    assert "_wbMorphReplace" in src
+    # No SSE subscription inside the section itself — external model loads have no
+    # internal event; live updates come via the central dispatcher's fleet.changed.
+    assert "eventBus.on" not in src
+    assert "inference.call_logged" not in src
+
+
+def test_fleet_fingerprint_detects_material_change():
+    base = {"lms_available": True, "machines": [
+        {"device_id": "a", "reachable": True, "loaded_models": [{"model": "m1"}]},
+    ]}
+    same = {"lms_available": True, "machines": [
+        # volatile fields differ (queued/context) but material state identical
+        {"device_id": "a", "reachable": True, "loaded_models": [{"model": "m1"}]},
+    ]}
+    reach = {"lms_available": True, "machines": [
+        {"device_id": "a", "reachable": False, "loaded_models": [{"model": "m1"}]},
+    ]}
+    model = {"lms_available": True, "machines": [
+        {"device_id": "a", "reachable": True, "loaded_models": [{"model": "m2"}]},
+    ]}
+    assert api._fleet_fingerprint(base) == api._fleet_fingerprint(same)
+    assert api._fleet_fingerprint(base) != api._fleet_fingerprint(reach)
+    assert api._fleet_fingerprint(base) != api._fleet_fingerprint(model)
+
+
+def test_fleet_roster_route_success(monkeypatch):
+    from types import SimpleNamespace
+    from work_buddy.dashboard.service import app
+    import work_buddy.mcp_server.ops.inference_ops as iops
+
+    store = {"inference": {"fleet": []}}
+    monkeypatch.setattr("work_buddy.config.read_config_local", lambda: {k: v for k, v in store.items()})
+    monkeypatch.setattr("work_buddy.config.write_config_local", lambda k, v: store.__setitem__(k, v))
+    monkeypatch.setattr(
+        "work_buddy.mcp_server.registry.get_registry",
+        lambda: {"fleet_roster": SimpleNamespace(callable=iops._fleet_roster_dispatch)},
+    )
+    monkeypatch.setattr(api, "bust_fleet_cache", lambda: None)
+    monkeypatch.setattr("work_buddy.dashboard.events.publish_auto", lambda *a, **k: None)
+
+    resp = app.test_client().post("/api/fleet/roster",
+                                  json={"action": "set", "device_id": "X", "role": "r"})
+    assert resp.status_code == 200 and resp.get_json()["success"] is True
+    assert store["inference"]["fleet"][0]["role"] == "r"
+
+
+def test_fleet_roster_route_validation_400(monkeypatch):
+    from types import SimpleNamespace
+    from work_buddy.dashboard.service import app
+    import work_buddy.mcp_server.ops.inference_ops as iops
+
+    monkeypatch.setattr("work_buddy.config.read_config_local", lambda: {})
+    monkeypatch.setattr("work_buddy.config.write_config_local", lambda k, v: None)
+    monkeypatch.setattr(
+        "work_buddy.mcp_server.registry.get_registry",
+        lambda: {"fleet_roster": SimpleNamespace(callable=iops._fleet_roster_dispatch)},
+    )
+    resp = app.test_client().post("/api/fleet/roster", json={"action": "set", "device_id": ""})
+    assert resp.status_code == 400
+    assert "device_id" in resp.get_json()["errors_by_field"]
+
+
+def test_frontend_has_inline_editor_and_dispatcher_subscribes():
+    from work_buddy.dashboard.frontend.scripts.tabs import fleet
+    from work_buddy.dashboard.frontend.scripts.core import event_bus
+    src = fleet.script()
+    assert "showFleetForm" in src and "submitFleetForm" in src
+    assert "/api/fleet/roster" in src
+    # The central dispatcher (not the section) owns the SSE subscription.
+    assert "fleet.changed" in event_bus.script()

--- a/tests/unit/test_fleet_reader.py
+++ b/tests/unit/test_fleet_reader.py
@@ -1,0 +1,236 @@
+"""Tests for the provider-neutral local model fleet reader.
+
+The load-bearing piece is the pure ``merge_fleet`` function — fed already-parsed
+provider inputs (no subprocess, no IO), so every merge rule is unit-testable with
+plain dicts. Fixtures mirror real ``lms link status`` / ``lms ps`` /
+``lms runtime survey`` JSON shapes. Hardware is multi-GPU: each machine carries a
+list of GPUs.
+"""
+from __future__ import annotations
+
+from work_buddy.inference.fleet import (
+    _normalize_lms_survey,
+    merge_fleet,
+)
+
+
+# Real-shaped fixtures (ids shortened for readability) -----------------------
+
+LINK_STATUS = {
+    "status": "online",
+    "deviceIdentifier": "LOCAL",
+    "deviceName": "LAPTOP-LOCAL",
+    "peers": [
+        {"deviceIdentifier": "PEER8", "deviceName": "peer-a",
+         "status": "connected", "loadedModels": []},
+        {"deviceIdentifier": "PEER12", "deviceName": "peer-b",
+         "status": "connected", "loadedModels": ["text-embedding-x"]},
+    ],
+}
+
+PS = [
+    {"deviceIdentifier": "PEER12", "modelKey": "text-embedding-x",
+     "displayName": "Embed X", "type": "embedding",
+     "quantization": {"name": "Q8_0", "bits": 8}, "sizeBytes": 117852672,
+     "contextLength": 512, "maxContextLength": 512, "status": "idle", "queued": 0},
+]
+
+# Canonical roster shape — gpus is a list (machines can have several).
+ROSTER = [
+    {"device_id": "LOCAL", "gpus": [{"name": "GTX 1650", "vram_gb": 4}], "ram_gb": 16, "role": "host"},
+    {"device_id": "PEER8", "gpus": [{"name": "RTX 2080", "vram_gb": 8}], "ram_gb": 64, "role": "peer8"},
+    {"device_id": "PEER12", "gpus": [{"name": "RTX 5070 Ti", "vram_gb": 12}], "ram_gb": 32, "role": "peer12"},
+]
+
+# Normalized survey shape (what _normalize_lms_survey emits): per-GPU bytes.
+LOCAL_HW = {
+    "gpus": [{"name": "NVIDIA GeForce GTX 1650", "vram_bytes": 4294639616}],
+    "ram_bytes": 16541487104,
+}
+
+REAL_SURVEY = {
+    "status": "ok",
+    "engines": [{
+        "name": "llama.cpp-win-x86_64-nvidia-cuda12-avx2",
+        "hardwareSurvey": {
+            "gpuSurveyResult": {
+                "result": {"code": "success", "message": ""},
+                "gpuInfo": [{"name": "NVIDIA GeForce GTX 1650",
+                             "totalMemoryCapacityBytes": 4294639616}],
+            },
+        },
+        "memoryInfo": {"ramCapacity": 16541487104, "vramCapacity": 4294639616},
+    }],
+}
+
+
+def _by_id(snap, device_id):
+    return next(m for m in snap.machines if m.device_id == device_id)
+
+
+# merge_fleet -----------------------------------------------------------------
+
+def test_local_machine_synthesized_from_top_level():
+    # The local machine is the top-level identity of link status, NOT in peers[].
+    snap = merge_fleet(LINK_STATUS, PS, LOCAL_HW, ROSTER)
+    assert snap.local_device_id == "LOCAL"
+    assert snap.machines[0].is_local is True  # local sorts first
+    local = _by_id(snap, "LOCAL")
+    assert local.reachable is True
+    assert local.name == "LAPTOP-LOCAL"
+
+
+def test_local_hardware_is_live_from_survey():
+    snap = merge_fleet(LINK_STATUS, PS, LOCAL_HW, ROSTER)
+    hw = _by_id(snap, "LOCAL").hardware
+    assert hw.source == "live"
+    assert len(hw.gpus) == 1
+    assert hw.gpus[0].name == "NVIDIA GeForce GTX 1650"
+    assert hw.gpus[0].vram_gb == 4.0  # 4294639616 bytes -> 4.0 GiB
+    assert hw.total_vram_gb == 4.0
+    assert hw.ram_gb == 15.4  # 16541487104 bytes -> 15.4 GiB
+
+
+def test_peer_connected_with_zero_models():
+    snap = merge_fleet(LINK_STATUS, PS, LOCAL_HW, ROSTER)
+    peer8 = _by_id(snap, "PEER8")
+    assert peer8.reachable is True
+    assert peer8.loaded_models == []
+
+
+def test_model_joined_onto_remote_peer():
+    snap = merge_fleet(LINK_STATUS, PS, LOCAL_HW, ROSTER)
+    peer12 = _by_id(snap, "PEER12")
+    assert len(peer12.loaded_models) == 1
+    lm = peer12.loaded_models[0]
+    assert lm.model == "text-embedding-x"
+    assert lm.kind == "embedding"
+    assert lm.quant == "Q8_0"
+    assert lm.context_length == 512 and lm.max_context_length == 512
+
+
+def test_roster_enriches_peer_hardware():
+    snap = merge_fleet(LINK_STATUS, PS, LOCAL_HW, ROSTER)
+    hw = _by_id(snap, "PEER8").hardware
+    assert hw.source == "roster"
+    assert hw.gpus[0].name == "RTX 2080" and hw.gpus[0].vram_gb == 8
+    assert hw.total_vram_gb == 8 and hw.ram_gb == 64
+
+
+def test_multiple_gpus_sum_to_total():
+    roster = [{"device_id": "PEER8", "gpus": [
+        {"name": "RTX 4090", "vram_gb": 24},
+        {"name": "RTX 4090", "vram_gb": 24},
+    ], "role": "dual"}]
+    snap = merge_fleet(LINK_STATUS, [], LOCAL_HW, roster)
+    hw = _by_id(snap, "PEER8").hardware
+    assert len(hw.gpus) == 2
+    assert hw.total_vram_gb == 48
+
+
+def test_roster_back_compat_scalar_gpu():
+    # A legacy scalar gpu/vram_gb entry still renders as a single GPU.
+    roster = [{"device_id": "PEER8", "gpu": "RTX 2080", "vram_gb": 8, "role": "legacy"}]
+    snap = merge_fleet(LINK_STATUS, [], LOCAL_HW, roster)
+    hw = _by_id(snap, "PEER8").hardware
+    assert len(hw.gpus) == 1
+    assert hw.gpus[0].name == "RTX 2080" and hw.gpus[0].vram_gb == 8
+
+
+def test_discovered_but_unrostered_has_unknown_hardware():
+    snap = merge_fleet(LINK_STATUS, PS, LOCAL_HW, roster=[])
+    peer8 = _by_id(snap, "PEER8")
+    assert peer8.discovered is True and peer8.in_roster is False
+    assert peer8.hardware.source == "unknown"
+    assert peer8.hardware.gpus == []
+
+
+def test_offline_rostered_machine_is_shown_not_omitted():
+    # PEER12 is in the roster but absent from the live link status.
+    link = {
+        "status": "online", "deviceIdentifier": "LOCAL", "deviceName": "LAPTOP-LOCAL",
+        "peers": [{"deviceIdentifier": "PEER8", "deviceName": "peer-a",
+                   "status": "connected", "loadedModels": []}],
+    }
+    snap = merge_fleet(link, [], LOCAL_HW, ROSTER)
+    peer12 = _by_id(snap, "PEER12")
+    assert peer12.reachable is False
+    assert peer12.discovered is False and peer12.in_roster is True
+    assert peer12.hardware.source == "roster" and peer12.hardware.gpus[0].vram_gb == 12
+
+
+def test_lms_unavailable_degrades_to_offline_roster():
+    snap = merge_fleet({}, [], None, ROSTER, lms_available=False, error="lms down")
+    assert snap.lms_available is False and snap.error == "lms down"
+    assert len(snap.machines) == 3
+    assert all(not m.reachable for m in snap.machines)
+    assert all(m.in_roster and not m.discovered for m in snap.machines)
+
+
+def test_ps_detail_falls_back_to_bare_link_names():
+    # link status lists a loaded model name, but ps has no detail for it.
+    snap = merge_fleet(LINK_STATUS, ps=[], local_hardware=LOCAL_HW, roster=ROSTER)
+    peer12 = _by_id(snap, "PEER12")
+    assert [m.model for m in peer12.loaded_models] == ["text-embedding-x"]
+    assert peer12.loaded_models[0].quant is None  # bare — no ps detail
+
+
+def test_machine_ordering_local_then_reachable_then_offline():
+    link = {
+        "status": "online", "deviceIdentifier": "LOCAL", "deviceName": "LAPTOP-LOCAL",
+        "peers": [{"deviceIdentifier": "PEER8", "deviceName": "peer-a",
+                   "status": "connected", "loadedModels": []}],
+    }
+    snap = merge_fleet(link, [], LOCAL_HW, ROSTER)  # PEER12 offline (roster only)
+    order = [m.device_id for m in snap.machines]
+    assert order[0] == "LOCAL"          # local first
+    assert order[1] == "PEER8"          # reachable peer
+    assert order[2] == "PEER12"         # offline last
+
+
+def test_to_dict_is_json_serializable():
+    import json
+    snap = merge_fleet(LINK_STATUS, PS, LOCAL_HW, ROSTER)
+    d = snap.to_dict()
+    json.dumps(d)  # must not raise
+    hw = d["machines"][0]["hardware"]
+    assert hw["source"] == "live"
+    assert hw["gpus"][0]["name"] == "NVIDIA GeForce GTX 1650"
+
+
+# _normalize_lms_survey -------------------------------------------------------
+
+def test_normalize_survey_extracts_gpus_and_ram():
+    norm = _normalize_lms_survey(REAL_SURVEY)
+    assert norm["ram_bytes"] == 16541487104
+    assert norm["gpus"] == [{"name": "NVIDIA GeForce GTX 1650", "vram_bytes": 4294639616}]
+
+
+def test_normalize_survey_collects_multiple_gpus():
+    survey = {
+        "engines": [{
+            "hardwareSurvey": {"gpuSurveyResult": {
+                "result": {"code": "success"},
+                "gpuInfo": [
+                    {"name": "RTX 4090", "dedicatedMemoryCapacityBytes": 25757220864},
+                    {"name": "RTX 4090", "dedicatedMemoryCapacityBytes": 25757220864},
+                ],
+            }},
+            "memoryInfo": {"ramCapacity": 137438953472},
+        }],
+    }
+    norm = _normalize_lms_survey(survey)
+    assert len(norm["gpus"]) == 2
+    assert norm["gpus"][0]["vram_bytes"] == 25757220864
+
+
+def test_normalize_survey_tolerates_missing_pieces():
+    assert _normalize_lms_survey({}) is None
+    assert _normalize_lms_survey({"engines": []}) is None
+    # GPU probe failed but memory still present -> gpus empty, ram kept.
+    partial = {"engines": [{
+        "hardwareSurvey": {"gpuSurveyResult": {"result": {"code": "error"}}},
+        "memoryInfo": {"vramCapacity": 123, "ramCapacity": 456},
+    }]}
+    norm = _normalize_lms_survey(partial)
+    assert norm["gpus"] == [] and norm["ram_bytes"] == 456

--- a/tests/unit/test_fleet_roster_op.py
+++ b/tests/unit/test_fleet_roster_op.py
@@ -1,0 +1,145 @@
+"""Tests for the fleet_roster capability dispatch (config.local.yaml writer).
+
+Monkeypatches the config read/write seam so no real config file is touched.
+Hardware is multi-GPU: ``gpus`` is a list of {name, vram_gb}.
+"""
+from __future__ import annotations
+
+from work_buddy.mcp_server.ops.inference_ops import _fleet_roster_dispatch
+
+
+def _fake_config(monkeypatch, initial_fleet):
+    """Wire read_config_local/write_config_local to an in-memory store."""
+    store = {"inference": {"fleet": list(initial_fleet)}} if initial_fleet is not None else {}
+    monkeypatch.setattr(
+        "work_buddy.config.read_config_local",
+        lambda: {k: v for k, v in store.items()},
+    )
+    monkeypatch.setattr(
+        "work_buddy.config.write_config_local",
+        lambda key, val: store.__setitem__(key, val),
+    )
+    return store
+
+
+def _fleet(store):
+    return store["inference"]["fleet"]
+
+
+def test_set_new_entry_role_only(monkeypatch):
+    store = _fake_config(monkeypatch, [])
+    r = _fleet_roster_dispatch(action="set", device_id="DEV1", role="compute node")
+    assert r["success"] is True and r["action"] == "set"
+    assert _fleet(store) == [{"device_id": "DEV1", "role": "compute node"}]
+
+
+def test_set_gpus_list(monkeypatch):
+    store = _fake_config(monkeypatch, [])
+    r = _fleet_roster_dispatch(action="set", device_id="DEV1",
+                               gpus=[{"name": "RTX 4090", "vram_gb": "24"},
+                                     {"name": "RTX 4090", "vram_gb": 24}], ram_gb="64")
+    assert r["success"] is True
+    entry = _fleet(store)[0]
+    assert entry["gpus"] == [{"name": "RTX 4090", "vram_gb": 24},
+                             {"name": "RTX 4090", "vram_gb": 24}]
+    assert entry["ram_gb"] == 64
+
+
+def test_set_partial_preserves_existing_gpus(monkeypatch):
+    store = _fake_config(monkeypatch, [
+        {"device_id": "DEV1", "role": "old", "gpus": [{"name": "RTX 4090", "vram_gb": 24}]},
+    ])
+    r = _fleet_roster_dispatch(action="set", device_id="DEV1", role="new")  # gpus omitted
+    assert r["success"] is True
+    entry = _fleet(store)[0]
+    assert entry["role"] == "new"
+    assert entry["gpus"] == [{"name": "RTX 4090", "vram_gb": 24}]  # untouched
+
+
+def test_set_empty_gpus_clears(monkeypatch):
+    store = _fake_config(monkeypatch, [
+        {"device_id": "DEV1", "gpus": [{"name": "RTX 4090", "vram_gb": 24}]},
+    ])
+    r = _fleet_roster_dispatch(action="set", device_id="DEV1", gpus=[])
+    assert r["success"] is True
+    assert "gpus" not in _fleet(store)[0]
+
+
+def test_set_gpus_migrates_legacy_scalar(monkeypatch):
+    store = _fake_config(monkeypatch, [
+        {"device_id": "DEV1", "gpu": "OLD", "vram_gb": 8, "role": "r"},
+    ])
+    r = _fleet_roster_dispatch(action="set", device_id="DEV1",
+                               gpus=[{"name": "RTX 4090", "vram_gb": 24}])
+    assert r["success"] is True
+    entry = _fleet(store)[0]
+    assert entry["gpus"] == [{"name": "RTX 4090", "vram_gb": 24}]
+    assert "gpu" not in entry and "vram_gb" not in entry  # legacy keys removed
+    assert entry["role"] == "r"  # untouched
+
+
+def test_set_bad_gpu_vram_is_field_error(monkeypatch):
+    store = _fake_config(monkeypatch, [])
+    r = _fleet_roster_dispatch(action="set", device_id="DEV1",
+                               gpus=[{"name": "X", "vram_gb": "lots"}])
+    assert r["success"] is False and "gpus" in r["errors_by_field"]
+    assert _fleet(store) == []  # nothing written on validation failure
+
+
+def test_set_bad_ram_is_field_error(monkeypatch):
+    store = _fake_config(monkeypatch, [])
+    r = _fleet_roster_dispatch(action="set", device_id="DEV1", ram_gb="lots")
+    assert r["success"] is False and "ram_gb" in r["errors_by_field"]
+    assert _fleet(store) == []
+
+
+def test_set_skips_blank_gpu_rows(monkeypatch):
+    store = _fake_config(monkeypatch, [])
+    r = _fleet_roster_dispatch(action="set", device_id="DEV1",
+                               gpus=[{"name": "", "vram_gb": ""}, {"name": "RTX 4090"}])
+    assert r["success"] is True
+    assert _fleet(store)[0]["gpus"] == [{"name": "RTX 4090"}]
+
+
+def test_empty_role_clears_but_keeps_entry(monkeypatch):
+    store = _fake_config(monkeypatch, [
+        {"device_id": "DEV1", "role": "old", "gpus": [{"name": "X", "vram_gb": 8}]},
+    ])
+    r = _fleet_roster_dispatch(action="set", device_id="DEV1", role="")
+    assert r["success"] is True
+    entry = _fleet(store)[0]
+    assert "role" not in entry and entry["gpus"] == [{"name": "X", "vram_gb": 8}]
+
+
+def test_remove_existing(monkeypatch):
+    store = _fake_config(monkeypatch, [{"device_id": "DEV1", "role": "x"}])
+    r = _fleet_roster_dispatch(action="remove", device_id="DEV1")
+    assert r["success"] is True and _fleet(store) == []
+
+
+def test_remove_missing_is_ok(monkeypatch):
+    _fake_config(monkeypatch, [])
+    r = _fleet_roster_dispatch(action="remove", device_id="NOPE")
+    assert r["success"] is True and "No roster entry" in r["note"]
+
+
+def test_missing_device_id_errors(monkeypatch):
+    _fake_config(monkeypatch, [])
+    r = _fleet_roster_dispatch(action="set", device_id="")
+    assert r["success"] is False and "device_id" in r["errors_by_field"]
+
+
+def test_unknown_action_errors(monkeypatch):
+    _fake_config(monkeypatch, [])
+    r = _fleet_roster_dispatch(action="frobnicate", device_id="DEV1")
+    assert r["success"] is False and "error" in r
+
+
+def test_preserves_other_inference_keys(monkeypatch):
+    # A user may also have inference.profiles in local config — don't clobber it.
+    store = {"inference": {"profiles": {"p": 1}, "fleet": []}}
+    monkeypatch.setattr("work_buddy.config.read_config_local", lambda: {k: v for k, v in store.items()})
+    monkeypatch.setattr("work_buddy.config.write_config_local", lambda key, val: store.__setitem__(key, val))
+    r = _fleet_roster_dispatch(action="set", device_id="DEV1", role="x")
+    assert r["success"] is True
+    assert store["inference"]["profiles"] == {"p": 1}  # preserved

--- a/work_buddy/config.py
+++ b/work_buddy/config.py
@@ -77,6 +77,16 @@ DEFAULTS = {
         "specstory_days": 7,
         "claude_history_days": 7,
     },
+    "inference": {
+        # Static roster for the Local model fleet view. Discovery is live
+        # (the configured provider enumerates reachable machines); this
+        # roster only ENRICHES discovered machines — keyed by device_id —
+        # with hardware specs the provider can't read remotely. Each entry:
+        #   {device_id, role, ram_gb, gpus: [{name, vram_gb}, ...]}
+        # (a machine can have several GPUs). Empty is fine: discovered
+        # machines still render, with hardware shown as "unknown".
+        "fleet": [],
+    },
     "dashboard": {
         "read_only": False,  # disable mutating actions (investigate, palette execute, etc.)
         "external_url": "",  # Tailscale HTTPS URL (e.g. "https://machine.tailnet.ts.net")

--- a/work_buddy/dashboard/api.py
+++ b/work_buddy/dashboard/api.py
@@ -1527,6 +1527,127 @@ def get_inference_activity() -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Local model fleet (Settings › Inference — per-machine loaded models / hardware)
+# ---------------------------------------------------------------------------
+# Reads the local-inference fleet (machines, reachability, loaded models,
+# hardware) via the provider-neutral fleet reader, which shells out to the
+# provider CLI. The reads hit remote peers and can be slow, so — like the
+# embeddings/inference snapshots above — serve a cached copy and refresh on a
+# background thread; the subprocess work never runs on a request thread.
+_FLEET_CACHE_TTL = 20.0
+_fleet_cache: dict[str, Any] | None = None
+_fleet_cache_ts: float = 0.0
+_fleet_cache_lock = threading.Lock()
+_fleet_refreshing = False
+
+
+def _build_fleet_summary() -> dict[str, Any]:
+    """Compose the fleet snapshot (slow path — provider CLI subprocesses)."""
+    from work_buddy.inference.fleet import read_fleet
+    return read_fleet(load_config())
+
+
+def _kick_fleet_refresh() -> None:
+    """Rebuild the fleet snapshot on a background thread (single-flight).
+
+    Also the page-load pre-warm hook: the ``/`` route calls this so the first
+    Settings › Inference open serves a ready snapshot instead of the cold read.
+    """
+    global _fleet_refreshing
+    with _fleet_cache_lock:
+        if _fleet_refreshing:
+            return
+        _fleet_refreshing = True
+
+    def _refresh() -> None:
+        global _fleet_cache, _fleet_cache_ts, _fleet_refreshing
+        try:
+            fresh = _build_fleet_summary()
+            _fleet_cache = fresh
+            _fleet_cache_ts = time.time()
+        except Exception as exc:
+            logger.warning("Background fleet refresh failed: %s", exc)
+        finally:
+            _fleet_refreshing = False
+
+    threading.Thread(target=_refresh, name="fleet-refresh", daemon=True).start()
+
+
+def get_fleet_summary() -> dict[str, Any]:
+    """Fleet snapshot, served from a short-TTL background-refreshed cache."""
+    global _fleet_cache, _fleet_cache_ts
+    cache = _fleet_cache
+    if cache is not None:
+        if time.time() - _fleet_cache_ts >= _FLEET_CACHE_TTL:
+            _kick_fleet_refresh()  # stale — refresh for next open
+        return cache
+    # Cold start: build once synchronously (the lock makes concurrent first
+    # callers wait for the single build rather than each starting their own).
+    with _fleet_cache_lock:
+        if _fleet_cache is not None:
+            return _fleet_cache
+        _fleet_cache = _build_fleet_summary()
+        _fleet_cache_ts = time.time()
+        return _fleet_cache
+
+
+def bust_fleet_cache() -> None:
+    """Drop the snapshot so the next read rebuilds (call after a roster write)."""
+    global _fleet_cache
+    with _fleet_cache_lock:
+        _fleet_cache = None
+
+
+def _fleet_fingerprint(snapshot: dict[str, Any]) -> str:
+    """Material state of the fleet — reachability + loaded-model set per machine.
+
+    Deliberately excludes volatile fields (last-used time, queue depth, context)
+    so the poller only publishes ``fleet.changed`` on changes a user would care
+    about: a machine coming/going, or a model being loaded/unloaded.
+    """
+    parts = []
+    for m in snapshot.get("machines", []):
+        models = ",".join(sorted(
+            lm.get("model", "") for lm in m.get("loaded_models", [])
+        ))
+        parts.append(f"{m.get('device_id')}:{int(bool(m.get('reachable')))}:{models}")
+    return "|".join(parts) + f"|lms={snapshot.get('lms_available')}"
+
+
+def start_fleet_poller(interval: float = 25.0) -> "threading.Event":
+    """Daemon thread that refreshes the fleet snapshot and publishes ``fleet.changed``.
+
+    External model loads/unloads on peers produce no internal event, so the only
+    way to live-update the fleet section is to poll. This loop owns the cache
+    refresh (warming it for request-path reads) and publishes ``fleet.changed``
+    only when the *material* fingerprint changes — the dashboard section then
+    morphs in the fresh snapshot. Returns a ``threading.Event``; ``set()`` stops it.
+    """
+    stop = threading.Event()
+
+    def _loop() -> None:
+        global _fleet_cache, _fleet_cache_ts
+        last_fp: str | None = None
+        while not stop.is_set():
+            try:
+                snap = _build_fleet_summary()
+                _fleet_cache = snap
+                _fleet_cache_ts = time.time()
+                fp = _fleet_fingerprint(snap)
+                if last_fp is not None and fp != last_fp:
+                    from work_buddy.dashboard.events import publish_auto
+                    publish_auto("fleet.changed", {"reason": "state_changed"})
+                last_fp = fp
+            except Exception as exc:
+                logger.debug("fleet poller iteration failed: %s", exc)
+            stop.wait(interval)
+
+    threading.Thread(target=_loop, name="fleet-poller", daemon=True).start()
+    logger.info("Fleet poller started (interval=%.1fs)", interval)
+    return stop
+
+
+# ---------------------------------------------------------------------------
 # Command palette
 # ---------------------------------------------------------------------------
 

--- a/work_buddy/dashboard/frontend/html.py
+++ b/work_buddy/dashboard/frontend/html.py
@@ -546,6 +546,7 @@ def _html() -> str:
          inference.call_logged SSE event. Lazy-loaded on first switch (see
          switchSettingsSubtab). -->
     <div class="settings-subtab-panel" id="ssp-inference">
+        <div id="fleet-content"><div class="loading">Loading fleet...</div></div>
         <div id="inference-content"><div class="loading">Loading inference...</div></div>
     </div>
 </div>

--- a/work_buddy/dashboard/frontend/scripts/__init__.py
+++ b/work_buddy/dashboard/frontend/scripts/__init__.py
@@ -50,6 +50,7 @@ from .tabs import (
     conversations,
     costs,
     embeddings,
+    fleet,
     inference,
     jobs,
     memory,
@@ -131,6 +132,7 @@ SCRIPTS = [
     costs.script,
     embeddings.script,
     inference.script,
+    fleet.script,
     # page LAST — see ordering note above.
     page.script,
 ]
@@ -139,6 +141,7 @@ STYLES = [
     filters.styles,
     embeddings.styles,
     inference.styles,
+    fleet.styles,
     resolution.styles,
     threads.styles,
     threads_card.styles,

--- a/work_buddy/dashboard/frontend/scripts/core/event_bus.py
+++ b/work_buddy/dashboard/frontend/scripts/core/event_bus.py
@@ -259,6 +259,10 @@ def script() -> str:
     // the surface refetches the cross-provider activity feed and morphs it in.
     window.eventBus.on('inference.call_logged', () => _refreshSoon('inferenceSurface'));
 
+    // Fleet section (Settings › Inference): a machine's reachability or loaded-model
+    // set changed (published by the server-side fleet poller) — morph the cards in.
+    window.eventBus.on('fleet.changed', () => _refreshSoon('fleetSurface'));
+
     // Jobs tab: refresh on dashboard-side create (immediate, repaints the
     // pending banner) and on sidecar hot-reload (jobs appear in /api/state
     // for the first time, banner auto-clears).

--- a/work_buddy/dashboard/frontend/scripts/tabs/fleet.py
+++ b/work_buddy/dashboard/frontend/scripts/tabs/fleet.py
@@ -1,0 +1,357 @@
+"""Dashboard Settings › Inference — Local model fleet section.
+
+A per-machine view of the local-inference fleet: one card per machine showing
+reachability, the model(s) currently loaded (with live context utilization), and
+hardware (GPU / VRAM / RAM). It answers "what's running on which box" — distinct
+from the per-call provenance feed it sits above in the same Inference sub-view.
+
+Sourced from ``GET /api/fleet`` (background-cached). The machine roster +
+reachability + loaded models are discovered live from the local-inference
+provider; the local machine reports its own hardware, while remote-peer hardware
+comes from the ``inference.fleet`` config roster (a "config" provenance hint
+distinguishes the two).
+
+There is no internal event for external model loads/unloads, so this section is
+load-on-open plus a manual refresh — it deliberately does NOT subscribe to the
+provenance feed's SSE event (the one that keeps the per-call feed below it live).
+"""
+
+from __future__ import annotations
+
+
+def script() -> str:
+    return r"""
+// ---- Local model fleet (Settings › Inference section) ----
+
+function _fleetK(n) {
+    if (n == null) return '—';
+    if (n >= 1024) return Math.round(n / 1024) + 'k';
+    return String(n);
+}
+
+function _fleetGb(n) {
+    if (n == null) return null;
+    // Roster values are already GB; live values arrive pre-converted server-side.
+    return (Math.round(n * 10) / 10);
+}
+
+function _fleetReadOnly() { return (typeof WB_READ_ONLY_MODE !== 'undefined' && WB_READ_ONLY_MODE); }
+
+async function loadFleet() {
+    const container = document.getElementById('fleet-content');
+    if (!container) return;
+    window._fleetData = await fetchJSON('/api/fleet');
+    _fleetRender();
+}
+
+function _fleetRender() {
+    const container = document.getElementById('fleet-content');
+    if (!container) return;
+    window._wbMorphReplace(container, _fleetRenderInner(window._fleetData));
+}
+
+function _fleetReachBadge(m) {
+    if (m.reachable) return `<span class="idx-badge idx-ok">online</span>`;
+    return `<span class="idx-badge idx-muted-badge">offline</span>`;
+}
+
+function _fleetHardware(hw) {
+    const gpus = (hw && hw.gpus) || [];
+    const hasRam = hw && hw.ram_gb != null;
+    if (!hw || (gpus.length === 0 && !hasRam)) {
+        return `<div class="fleet-hw idx-muted">hardware unknown</div>`;
+    }
+    // Provenance hint: did the machine report this live, or is it from config?
+    let src = '';
+    if (hw.source === 'live') src = `<span class="fleet-hw-src" title="Read live from this machine">live</span>`;
+    else if (hw.source === 'roster') src = `<span class="fleet-hw-src fleet-hw-src-cfg" title="From the inference.fleet config roster (peer hardware isn't readable remotely)">config</span>`;
+    // One line per GPU; a total only when there's more than one to sum.
+    const gpuLines = gpus.map(g => {
+        const nm = g.name ? escapeHtml(g.name) : 'GPU';
+        const vr = (g.vram_gb != null) ? ` · ${_fleetGb(g.vram_gb)} GB` : '';
+        return `<div class="fleet-gpu">${nm}${vr}</div>`;
+    }).join('');
+    const total = (gpus.length > 1 && hw.total_vram_gb != null)
+        ? ` · ${_fleetGb(hw.total_vram_gb)} GB total` : '';
+    const head = gpus.length
+        ? `${gpus.length} GPU${gpus.length === 1 ? '' : 's'}${total}`
+        : 'hardware';
+    const ram = hasRam ? `<div class="fleet-gpu idx-muted">${_fleetGb(hw.ram_gb)} GB RAM</div>` : '';
+    return `<div class="fleet-hw">
+        <div class="fleet-hw-head">${head} ${src}</div>
+        ${gpuLines}${ram}
+    </div>`;
+}
+
+function _fleetModel(lm) {
+    const name = escapeHtml(lm.display_name || lm.model || '—');
+    const kind = lm.kind ? `<span class="idx-badge fleet-kind">${escapeHtml(lm.kind)}</span>` : '';
+    const quant = lm.quant ? `<span class="fleet-meta">${escapeHtml(lm.quant)}</span>` : '';
+    const statusCls = lm.status === 'idle' ? 'idx-muted-badge' : 'inf-st-run';
+    const status = lm.status ? `<span class="idx-badge ${statusCls}">${escapeHtml(lm.status)}</span>` : '';
+    const queued = (lm.queued != null && lm.queued > 0)
+        ? `<span class="fleet-meta">${lm.queued} queued</span>` : '';
+    // Context: how much of the model's trained max window the loaded instance
+    // uses. The numeric "loaded / max ctx" is always shown; the bar is only drawn
+    // where it's informative — i.e. LLMs with real headroom (a 4k-of-262k sliver
+    // signals lots of unused window / KV-cache room). For embedding models the
+    // window is fixed and equal to max, so a permanently-full bar is just noise.
+    let ctx = '';
+    if (lm.context_length != null && lm.max_context_length) {
+        const showBar = lm.kind !== 'embedding' && lm.context_length < lm.max_context_length;
+        const pct = Math.max(2, Math.min(100,
+            Math.round(lm.context_length / lm.max_context_length * 100)));
+        const bar = showBar
+            ? `<div class="fleet-ctx-bar"><div class="fleet-ctx-fill" style="width:${pct}%"></div></div>`
+            : '';
+        ctx = `
+            <div class="fleet-ctx" title="loaded context ${lm.context_length} of the model's ${lm.max_context_length} max">
+                ${bar}
+                <span class="fleet-meta">${_fleetK(lm.context_length)} / ${_fleetK(lm.max_context_length)} ctx</span>
+            </div>`;
+    }
+    return `
+        <div class="fleet-model">
+            <div class="fleet-model-row">
+                <span class="fleet-model-name" title="${escapeHtml(lm.model || '')}">${name}</span>
+                ${kind}${status}
+            </div>
+            <div class="fleet-model-row">${quant}${queued}${ctx}</div>
+        </div>`;
+}
+
+function _fleetCard(m) {
+    const local = m.is_local ? `<span class="idx-badge fleet-local">this machine</span>` : '';
+    const ro = _fleetReadOnly();
+    const editBtn = ro ? '' :
+        `<button class="fleet-edit" title="Edit role / hardware" onclick="showFleetForm('${escapeHtml(m.device_id)}')">&#9881;</button>`;
+    const role = m.role
+        ? `<div class="fleet-role idx-muted">${escapeHtml(m.role)}</div>`
+        : (ro ? '' : `<div class="fleet-role-empty" onclick="showFleetForm('${escapeHtml(m.device_id)}')">+ add a role label</div>`);
+    const models = (m.loaded_models && m.loaded_models.length)
+        ? m.loaded_models.map(_fleetModel).join('')
+        : `<div class="fleet-empty idx-muted">no models loaded</div>`;
+    const offlineCls = m.reachable ? '' : ' fleet-card-offline';
+    return `
+        <div class="fleet-card${offlineCls}">
+            <div class="fleet-card-head">
+                <span class="fleet-name">${escapeHtml(m.name || '—')}</span>
+                ${local}${_fleetReachBadge(m)}${editBtn}
+            </div>
+            ${role}
+            ${_fleetHardware(m.hardware)}
+            <div class="fleet-models">${models}</div>
+        </div>`;
+}
+
+// Inline roster editor — reuses the Jobs add-form styling (.jobs-add-form /
+// .job-form-*) so inputs/buttons match the rest of Settings. Role is primary;
+// hardware specs are optional and hidden for the local machine (detected live).
+function _fleetFormHtml() {
+    if (_fleetReadOnly()) return '';
+    return `
+    <div id="fleet-form" class="jobs-add-form" hidden>
+        <div class="fleet-form-title" id="fleet-form-title">Edit machine</div>
+        <div class="job-form-row">
+            <label>Role label
+                <input id="fleet-form-role" type="text" autocomplete="off" placeholder="e.g. Remote compute node" />
+                <small>A human label for this machine. The only field you usually need.</small>
+            </label>
+        </div>
+        <div id="fleet-form-specs">
+            <div class="fleet-form-note idx-muted">Remote-peer hardware can't be auto-detected — set it here and it shows on the card. No config file to edit.</div>
+            <div class="job-form-row">
+                <label>GPUs (one per line: name | VRAM in GB)
+                    <textarea id="fleet-form-gpus" rows="2" placeholder="NVIDIA RTX 4090 | 24"></textarea>
+                    <small>One line per GPU — a dual-GPU box gets two lines. VRAM is optional.</small>
+                </label>
+            </div>
+            <div class="job-form-row">
+                <label>RAM (GB)
+                    <input id="fleet-form-ram" type="number" step="any" min="0" autocomplete="off" />
+                </label>
+            </div>
+        </div>
+        <div id="fleet-form-error" class="job-form-error" hidden></div>
+        <div class="job-form-actions">
+            <button type="button" id="fleet-form-clear" class="fleet-clear-btn" onclick="clearFleetFromForm()" hidden>Clear roster entry</button>
+            <button type="button" class="jobs-form-cancel" onclick="hideFleetForm()">Cancel</button>
+            <button type="button" class="jobs-form-submit" onclick="submitFleetForm()">Save</button>
+        </div>
+    </div>`;
+}
+
+let _fleetEditingId = null;
+
+function showFleetForm(deviceId) {
+    if (_fleetReadOnly()) return;
+    const form = document.getElementById('fleet-form');
+    if (!form) return;
+    const m = ((window._fleetData && window._fleetData.machines) || []).find(x => x.device_id === deviceId);
+    if (!m) return;
+    _fleetEditingId = deviceId;
+    document.getElementById('fleet-form-title').textContent = `Edit ${m.name || deviceId}`;
+    document.getElementById('fleet-form-role').value = m.role || '';
+    // The local machine's hardware is detected live — hide the spec fields for it.
+    const specs = document.getElementById('fleet-form-specs');
+    specs.hidden = !!m.is_local;
+    const hw = m.hardware || {};
+    const rostered = hw.source === 'roster';
+    const gpus = (rostered && Array.isArray(hw.gpus)) ? hw.gpus : [];
+    document.getElementById('fleet-form-gpus').value = gpus.map(g =>
+        (g.vram_gb != null) ? `${g.name || ''} | ${g.vram_gb}` : (g.name || '')).join('\n');
+    document.getElementById('fleet-form-ram').value = (rostered && hw.ram_gb != null) ? hw.ram_gb : '';
+    document.getElementById('fleet-form-clear').hidden = !m.in_roster;
+    document.getElementById('fleet-form-error').hidden = true;
+    form.hidden = false;
+    form.scrollIntoView({behavior: 'smooth', block: 'nearest'});
+}
+
+function hideFleetForm() { const f = document.getElementById('fleet-form'); if (f) f.hidden = true; _fleetEditingId = null; }
+
+// Parse the "name | VRAM" textarea (one GPU per line) into [{name, vram_gb}].
+// VRAM stays a string here; the server validates/coerces it.
+function _fleetParseGpus(text) {
+    return (text || '').split('\n').map(s => s.trim()).filter(Boolean).map(line => {
+        const i = line.indexOf('|');
+        const name = (i >= 0 ? line.slice(0, i) : line).trim();
+        const vram = (i >= 0 ? line.slice(i + 1) : '').trim();
+        const g = {};
+        if (name) g.name = name;
+        if (vram) g.vram_gb = vram;
+        return g;
+    }).filter(g => g.name || g.vram_gb);
+}
+
+async function _fleetPost(payload) {
+    try {
+        const resp = await fetch('/api/fleet/roster', {method: 'POST',
+            headers: {'Content-Type': 'application/json'}, body: JSON.stringify(payload)});
+        return await resp.json();
+    } catch (e) { settingsToast(`Network error: ${e.message}`, 'error'); return null; }
+}
+
+async function submitFleetForm() {
+    if (_fleetReadOnly() || !_fleetEditingId) return;
+    const errEl = document.getElementById('fleet-form-error');
+    errEl.hidden = true;
+    const payload = {action: 'set', device_id: _fleetEditingId,
+                     role: document.getElementById('fleet-form-role').value.trim()};
+    if (!document.getElementById('fleet-form-specs').hidden) {
+        payload.gpus = _fleetParseGpus(document.getElementById('fleet-form-gpus').value);
+        payload.ram_gb = document.getElementById('fleet-form-ram').value.trim();
+    }
+    const result = await _fleetPost(payload);
+    if (!result || !result.success) {
+        errEl.textContent = (result && (result.error
+            || (result.errors_by_field && Object.values(result.errors_by_field).join(' ')))) || 'Save failed.';
+        errEl.hidden = false;
+        return;
+    }
+    settingsToast(result.note || 'Saved.', 'success');
+    hideFleetForm();
+    await loadFleet();
+}
+
+async function clearFleetFromForm() {
+    if (_fleetReadOnly() || !_fleetEditingId) return;
+    if (!confirm("Clear this machine's roster entry (role + hardware)? Discovered info stays.")) return;
+    const result = await _fleetPost({action: 'remove', device_id: _fleetEditingId});
+    if (!result || !result.success) { settingsToast((result && result.error) || 'Clear failed', 'error'); return; }
+    settingsToast(result.note || 'Cleared.', 'success');
+    hideFleetForm();
+    await loadFleet();
+}
+
+function _fleetRenderInner(data) {
+    if (!data) return `<div class="loading">Loading fleet...</div>`;
+    const header = `
+        <div class="fleet-header">
+            <div class="fleet-title-row">
+                <span class="emb-section-title">Local model fleet</span>
+                <button class="inf-help-btn" title="Refresh fleet" onclick="loadFleet()">↻</button>
+            </div>
+            <div class="idx-muted inf-intro">What's loaded on which machine right now — reachability, models, and hardware.</div>
+        </div>`;
+    let banner = '';
+    if (data.lms_available === false) {
+        banner = `<div class="fleet-banner">${escapeHtml(data.error || 'Local-inference provider not reachable.')} Showing configured machines as offline.</div>`;
+    }
+    const machines = data.machines || [];
+    const body = machines.length
+        ? `<div class="fleet-grid">${machines.map(_fleetCard).join('')}</div>`
+        : `<div class="empty-state">No machines found — configure a local-inference provider (e.g. LM Studio) and an inference.fleet roster.</div>`;
+    return `<div class="fleet-section">${header}${banner}${body}${_fleetFormHtml()}</div>`;
+}
+
+// Surface handle (manual refresh only — NOT wired to the provenance feed's SSE
+// event, since external model loads/unloads have no internal event to listen to).
+window.fleetSurface = {
+    refresh: function() { return loadFleet(); },
+    isMounted: function() {
+        return !!document.getElementById('fleet-content')
+            && (typeof WB_SETTINGS_SUBTAB === 'undefined' || WB_SETTINGS_SUBTAB === 'inference');
+    },
+};
+"""
+
+
+def styles() -> str:
+    return """
+/* Local model fleet section — reuses .idx-badge/.idx-ok/.idx-muted-badge/.inf-st-run
+   and .emb-section-title/.inf-intro/.inf-help-btn from the Embeddings/Inference views. */
+.fleet-section { margin-bottom: 26px; }
+.fleet-header { margin-bottom: 14px; }
+.fleet-title-row { display:flex; align-items:center; gap:8px; }
+
+.fleet-banner { margin: 8px 0 14px; padding: 8px 12px; border-radius: 8px;
+    background: color-mix(in srgb, var(--yellow, #d8a657) 16%, transparent);
+    color: var(--text-secondary); font-size: 0.85em; }
+
+.fleet-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 14px; }
+
+.fleet-card { border: 1px solid var(--border, var(--bg-tertiary)); border-radius: 10px;
+    background: var(--bg-secondary); padding: 14px 16px; display:flex; flex-direction:column; gap:8px; }
+.fleet-card-offline { opacity: 0.62; }
+
+.fleet-card-head { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+.fleet-name { font-weight: 700; color: var(--text-primary); }
+.fleet-local { background: color-mix(in srgb, var(--accent) 16%, transparent); color: var(--accent); }
+.fleet-role { font-size: 0.78em; }
+
+.fleet-hw { font-size: 0.82em; color: var(--text-secondary); font-variant-numeric: tabular-nums; }
+.fleet-hw-head { font-size: 0.78em; color: var(--text-muted); margin-bottom: 2px; }
+.fleet-gpu { color: var(--text-secondary); }
+.fleet-hw-src { margin-left: 6px; font-size: 0.82em; padding: 1px 6px; border-radius: 6px;
+    background: color-mix(in srgb, var(--green) 16%, transparent); color: var(--green); }
+.fleet-hw-src-cfg { background: color-mix(in srgb, var(--text-muted) 22%, transparent); color: var(--text-muted); }
+
+.fleet-models { display:flex; flex-direction:column; gap:8px; margin-top:4px; }
+.fleet-empty { font-size: 0.82em; font-style: italic; }
+.fleet-model { border-top: 1px solid var(--border, var(--bg-tertiary)); padding-top: 6px; }
+.fleet-model:first-child { border-top: none; padding-top: 0; }
+.fleet-model-row { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+.fleet-model-name { font-weight: 600; color: var(--text-primary); font-size: 0.88em;
+    max-width: 100%; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.fleet-kind { background: color-mix(in srgb, var(--text-muted) 20%, transparent); color: var(--text-muted); }
+.fleet-meta { font-size: 0.78em; color: var(--text-muted); font-variant-numeric: tabular-nums; }
+
+.fleet-ctx { display:flex; align-items:center; gap:6px; flex: 1 1 auto; min-width: 120px; }
+.fleet-ctx-bar { flex: 1 1 auto; height: 5px; border-radius: 3px; background: var(--bg-tertiary); overflow: hidden; }
+.fleet-ctx-fill { height: 100%; background: var(--accent); }
+
+/* Inline editor affordances (form itself reuses .jobs-add-form / .job-form-*) */
+.fleet-edit { margin-left: auto; background: none; border: none; cursor: pointer;
+    font-size: 1em; opacity: 0.6; padding: 2px 4px; color: var(--text-secondary); }
+.fleet-edit:hover { opacity: 1; color: var(--text-primary); }
+.fleet-role-empty { font-size: 0.78em; color: var(--text-muted); cursor: pointer;
+    border: 1px dashed var(--border, var(--bg-tertiary)); border-radius: 6px;
+    padding: 2px 8px; display: inline-block; }
+.fleet-role-empty:hover { color: var(--text-secondary); border-color: var(--text-muted); }
+.fleet-form-title { font-weight: 600; font-size: 13px; margin-bottom: 10px; color: var(--text-primary); }
+.fleet-form-note { font-size: 0.8em; margin: 2px 0 8px; }
+.fleet-clear-btn { margin-right: auto; border: 1px solid var(--red); border-radius: 4px;
+    padding: 6px 14px; font-size: 12px; font-weight: 600; cursor: pointer;
+    background: var(--bg-tertiary); color: var(--red); }
+.fleet-clear-btn:hover { background: color-mix(in srgb, var(--red) 14%, var(--bg-tertiary)); }
+"""

--- a/work_buddy/dashboard/frontend/scripts/tabs/settings.py
+++ b/work_buddy/dashboard/frontend/scripts/tabs/settings.py
@@ -58,6 +58,9 @@ function switchSettingsSubtab(st) {
     if (st === 'inference' && typeof loadInference === 'function') {
         loadInference();  // cheap (cached) — refresh on open; inference.call_logged SSE keeps it live
     }
+    if (st === 'inference' && typeof loadFleet === 'function') {
+        loadFleet();  // fleet section shares the Inference sub-view; load-on-open (no SSE)
+    }
 }
 
 // At-a-glance system cards (uptime / services healthy / jobs / last

--- a/work_buddy/dashboard/service.py
+++ b/work_buddy/dashboard/service.py
@@ -27,6 +27,7 @@ from work_buddy.dashboard.api import (
     get_chats_summary,
     get_contracts_summary,
     get_embeddings_summary,
+    get_fleet_summary,
     get_inference_activity,
     get_palette_commands,
     get_sessions_summary,
@@ -202,8 +203,12 @@ def index():
     # Pre-warm the embeddings snapshot on a background thread so the first
     # Settings › Embeddings open serves instantly instead of paying the cold aggregate.
     try:
-        from work_buddy.dashboard.api import _kick_embeddings_refresh
+        from work_buddy.dashboard.api import (
+            _kick_embeddings_refresh,
+            _kick_fleet_refresh,
+        )
         _kick_embeddings_refresh()
+        _kick_fleet_refresh()
     except Exception:
         pass
     resp = Response(render_page(), content_type="text/html; charset=utf-8")
@@ -1470,6 +1475,46 @@ def api_embeddings():
 def api_inference_activity():
     """Cross-provider inference-call provenance feed for Settings › Inference (cached)."""
     return jsonify(get_inference_activity())
+
+
+@app.get("/api/fleet")
+def api_fleet():
+    """Local model fleet snapshot for Settings › Inference (per-machine, cached)."""
+    return jsonify(get_fleet_summary())
+
+
+@app.post("/api/fleet/roster")
+def api_fleet_roster():
+    """Add/update or clear a machine's inference.fleet roster entry (Settings › Inference).
+
+    Thin wrapper around the ``fleet_roster`` capability (mirrors ``/api/embeddings/vault``).
+    The user clicking Save IS the consent; read-only mode blocks the write. On success
+    the fleet snapshot is busted and ``fleet.changed`` is published so the cards update
+    immediately.
+    """
+    blocked = _reject_read_only()
+    if blocked is not None:
+        return blocked
+
+    payload = request.get_json(silent=True) or {}
+    from work_buddy.mcp_server.registry import get_registry
+
+    cap = get_registry().get("fleet_roster")
+    if cap is None:
+        return jsonify({"success": False, "error": "fleet_roster capability not registered "
+                        "(reload MCP / rebuild the knowledge store)."}), 500
+    try:
+        result = cap.callable(**payload)
+    except TypeError as exc:
+        return jsonify({"success": False, "error": f"Invalid arguments: {exc}"}), 400
+
+    if result.get("success"):
+        from work_buddy.dashboard.api import bust_fleet_cache
+        bust_fleet_cache()
+        from work_buddy.dashboard.events import publish_auto
+        publish_auto("fleet.changed",
+                     {"reason": "roster_changed", "device_id": result.get("device_id")})
+    return jsonify(result), (200 if result.get("success") else 400)
 
 
 @app.post("/api/embeddings/vault")
@@ -4704,6 +4749,16 @@ def main():
     # liveness signal). The SSE endpoint also emits its own keepalive
     # comments; both are complementary.
     start_heartbeat(interval=10.0)
+
+    # Start the fleet poller: refreshes the local model fleet snapshot and
+    # publishes ``fleet.changed`` when a machine's reachability or loaded-model
+    # set changes (external LM Studio loads/unloads have no internal event, so
+    # the fleet section can only live-update via polling).
+    try:
+        from work_buddy.dashboard.api import start_fleet_poller
+        start_fleet_poller(interval=25.0)
+    except Exception as exc:
+        logger.warning("Fleet poller failed to start: %s", exc)
 
     # Start the cross-process bridge: pulls ``bus.event`` messages
     # from the messaging service (port 5123) and republishes them on

--- a/work_buddy/inference/fleet.py
+++ b/work_buddy/inference/fleet.py
@@ -1,0 +1,452 @@
+"""Local model fleet — per-machine "what's loaded on which box" snapshot.
+
+Answers a question the inference broker structurally cannot: which *machine*
+in the local-inference fleet currently holds which model, is it reachable, and
+what hardware does it have. The broker only knows the *profile* (model); it has
+no per-machine view.
+
+## Provider seam
+
+The fleet is provider-neutral. ``merge_fleet`` is a pure function over already-
+parsed inputs and knows nothing about any specific backend. A provider adapter
+(today: LM Studio via the ``lms`` CLI) is the only place that talks to the
+backend; swapping to vLLM / Ollama / llama.cpp later means writing a new adapter,
+not touching ``merge_fleet``, the dashboard reader, the route, or the capability.
+
+## Data layers
+
+- **Discovery (live):** the machine roster + reachability + loaded models come
+  from the provider. The local machine is always known; remote peers appear when
+  reachable.
+- **Hardware:** the local machine reports its own GPU/VRAM/RAM live. Remote-peer
+  hardware is not readable off the wire, so it comes from a static config
+  ``inference.fleet`` roster, joined by ``device_id``. A machine in the roster
+  but not currently discovered is shown as offline rather than omitted.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_BYTES_PER_GIB = 1024 ** 3
+
+
+# ---------------------------------------------------------------------------
+# Neutral data model (no provider knowledge)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LoadedModel:
+    """One model instance loaded on a machine."""
+
+    model: str
+    display_name: str | None = None
+    kind: str | None = None  # provider's instance type, e.g. "embedding" | "llm"
+    quant: str | None = None
+    size_bytes: int | None = None
+    context_length: int | None = None
+    max_context_length: int | None = None
+    status: str | None = None  # e.g. "idle" | "active"
+    queued: int | None = None
+
+
+@dataclass
+class Gpu:
+    """A single GPU on a machine."""
+
+    name: str | None = None
+    vram_gb: float | None = None
+
+
+@dataclass
+class Hardware:
+    """A machine's compute hardware (possibly multiple GPUs). ``source`` is provenance."""
+
+    gpus: list["Gpu"] = field(default_factory=list)
+    ram_gb: float | None = None
+    source: str = "unknown"  # "live" (read off the machine) | "roster" | "unknown"
+    total_vram_gb: float | None = None  # summed across gpus; derived below
+
+    def __post_init__(self) -> None:
+        if self.total_vram_gb is None:
+            vals = [g.vram_gb for g in self.gpus if g.vram_gb is not None]
+            self.total_vram_gb = round(sum(vals), 1) if vals else None
+
+
+@dataclass
+class FleetMachine:
+    device_id: str
+    name: str
+    is_local: bool = False
+    reachable: bool = False
+    role: str | None = None
+    hardware: Hardware = field(default_factory=Hardware)
+    loaded_models: list[LoadedModel] = field(default_factory=list)
+    in_roster: bool = False
+    discovered: bool = False  # present in the live provider read
+
+
+@dataclass
+class FleetSnapshot:
+    machines: list[FleetMachine] = field(default_factory=list)
+    local_device_id: str | None = None
+    provider: str = "lmstudio"
+    lms_available: bool = True
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Pure merge — unit-testable with plain dicts, zero provider/subprocess knowledge
+# ---------------------------------------------------------------------------
+
+def _gib(num_bytes: Any) -> float | None:
+    try:
+        return round(float(num_bytes) / _BYTES_PER_GIB, 1)
+    except (TypeError, ValueError):
+        return None
+
+
+def _num(val: Any) -> float | int | None:
+    """Coerce to int (when whole) / float, or None for blank/non-numeric."""
+    if val is None or (isinstance(val, str) and not val.strip()):
+        return None
+    try:
+        f = float(val)
+    except (TypeError, ValueError):
+        return None
+    return int(f) if f == int(f) else f
+
+
+def _roster_gpus(entry: dict[str, Any]) -> list[Gpu]:
+    """GPUs from a roster entry.
+
+    Canonical shape is a ``gpus`` list of ``{name, vram_gb}``; a legacy scalar
+    ``gpu``/``vram_gb`` is accepted as a single-GPU fallback so older/hand-written
+    configs still render.
+    """
+    out: list[Gpu] = []
+    raw = entry.get("gpus")
+    if isinstance(raw, list):
+        for g in raw:
+            if isinstance(g, dict):
+                name = g.get("name") or g.get("gpu")
+                name = name.strip() if isinstance(name, str) and name.strip() else None
+                out.append(Gpu(name=name, vram_gb=_num(g.get("vram_gb"))))
+            elif isinstance(g, str) and g.strip():
+                out.append(Gpu(name=g.strip()))
+    if not out and (entry.get("gpu") or entry.get("vram_gb") is not None):
+        nm = entry.get("gpu")
+        out.append(Gpu(
+            name=nm.strip() if isinstance(nm, str) and nm.strip() else None,
+            vram_gb=_num(entry.get("vram_gb")),
+        ))
+    return out
+
+
+def _loaded_model_from_ps(row: dict[str, Any]) -> LoadedModel:
+    quant = row.get("quantization")
+    quant_name = quant.get("name") if isinstance(quant, dict) else None
+    return LoadedModel(
+        model=row.get("modelKey") or row.get("identifier") or "?",
+        display_name=row.get("displayName"),
+        kind=row.get("type"),
+        quant=quant_name,
+        size_bytes=row.get("sizeBytes"),
+        context_length=row.get("contextLength"),
+        max_context_length=row.get("maxContextLength"),
+        status=row.get("status"),
+        queued=row.get("queued"),
+    )
+
+
+def merge_fleet(
+    link_status: dict[str, Any] | None,
+    ps: list[dict[str, Any]] | None,
+    local_hardware: dict[str, Any] | None,
+    roster: list[dict[str, Any]] | None,
+    *,
+    lms_available: bool = True,
+    error: str | None = None,
+) -> FleetSnapshot:
+    """Compose a fleet snapshot from already-parsed provider inputs.
+
+    Pure: deterministic, no IO. ``link_status`` is the live discovery (the
+    local machine is its top-level ``deviceIdentifier``/``deviceName``; remote
+    peers live under ``peers``). ``ps`` are loaded-model instances joined to
+    machines by ``deviceIdentifier``. ``local_hardware`` is the normalized
+    survey of the *local* machine only. ``roster`` enriches any machine
+    (local or remote) by ``device_id`` with hardware specs + role.
+    """
+    link_status = link_status or {}
+    ps = ps or []
+    roster = roster or []
+
+    roster_by_id: dict[str, dict[str, Any]] = {
+        str(e["device_id"]): e for e in roster if e.get("device_id")
+    }
+
+    # Group loaded-model instances by the machine they sit on.
+    ps_by_device: dict[str, list[LoadedModel]] = {}
+    for row in ps:
+        dev = row.get("deviceIdentifier")
+        if not dev:
+            continue
+        ps_by_device.setdefault(str(dev), []).append(_loaded_model_from_ps(row))
+
+    local_id = link_status.get("deviceIdentifier")
+    link_online = (link_status.get("status") or "").lower() == "online"
+
+    machines: list[FleetMachine] = []
+    discovered_ids: set[str] = set()
+
+    def _models_for(device_id: str, bare_names: list[str] | None) -> list[LoadedModel]:
+        """Prefer rich ``ps`` detail; fall back to bare names from link status."""
+        rich = ps_by_device.get(device_id, [])
+        if rich:
+            return rich
+        return [LoadedModel(model=n) for n in (bare_names or [])]
+
+    def _hardware_for(device_id: str, is_local: bool) -> Hardware:
+        # Local machine reports its own hardware live; prefer that.
+        if is_local and local_hardware:
+            gpus = [
+                Gpu(name=g.get("name"), vram_gb=_gib(g.get("vram_bytes")))
+                for g in (local_hardware.get("gpus") or [])
+            ]
+            return Hardware(
+                gpus=gpus,
+                ram_gb=_gib(local_hardware.get("ram_bytes")),
+                source="live",
+            )
+        entry = roster_by_id.get(device_id)
+        if entry:
+            return Hardware(
+                gpus=_roster_gpus(entry),
+                ram_gb=_num(entry.get("ram_gb")),
+                source="roster",
+            )
+        return Hardware(source="unknown")
+
+    def _build(device_id: str, name: str, *, is_local: bool, reachable: bool,
+               bare_names: list[str] | None) -> FleetMachine:
+        discovered_ids.add(device_id)
+        entry = roster_by_id.get(device_id) or {}
+        return FleetMachine(
+            device_id=device_id,
+            name=name or entry.get("name") or device_id[:12],
+            is_local=is_local,
+            reachable=reachable,
+            role=entry.get("role"),
+            hardware=_hardware_for(device_id, is_local),
+            loaded_models=_models_for(device_id, bare_names),
+            in_roster=device_id in roster_by_id,
+            discovered=True,
+        )
+
+    # Local machine (always first; the top-level identity of link status).
+    if local_id:
+        machines.append(_build(
+            str(local_id),
+            link_status.get("deviceName") or "",
+            is_local=True,
+            reachable=link_online,
+            bare_names=None,
+        ))
+
+    # Remote peers.
+    for peer in link_status.get("peers") or []:
+        dev = peer.get("deviceIdentifier")
+        if not dev:
+            continue
+        machines.append(_build(
+            str(dev),
+            peer.get("deviceName") or "",
+            is_local=False,
+            reachable=(peer.get("status") or "").lower() == "connected",
+            bare_names=peer.get("loadedModels"),
+        ))
+
+    # Rostered-but-not-discovered machines: show as offline, not omitted.
+    for device_id, entry in roster_by_id.items():
+        if device_id in discovered_ids:
+            continue
+        machines.append(FleetMachine(
+            device_id=device_id,
+            name=entry.get("name") or device_id[:12],
+            is_local=False,
+            reachable=False,
+            role=entry.get("role"),
+            hardware=_hardware_for(device_id, False),
+            loaded_models=[],
+            in_roster=True,
+            discovered=False,
+        ))
+
+    # Order: local first, then reachable, then offline; alphabetical within group.
+    machines.sort(key=lambda m: (
+        0 if m.is_local else 1,
+        0 if m.reachable else 1,
+        (m.name or "").lower(),
+    ))
+
+    return FleetSnapshot(
+        machines=machines,
+        local_device_id=str(local_id) if local_id else None,
+        lms_available=lms_available,
+        error=error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# LM Studio provider adapter — the ONLY place that runs `lms`
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _ProviderRead:
+    available: bool
+    link_status: dict[str, Any] | None
+    ps: list[dict[str, Any]]
+    local_hardware: dict[str, Any] | None
+    error: str | None
+
+
+def _resolve_lms_bin() -> str | None:
+    """Locate the ``lms`` CLI: PATH first, then LM Studio's default bin dir.
+
+    The dashboard/sidecar may run under a different PATH than an interactive
+    shell, so fall back to the documented install location.
+    """
+    found = shutil.which("lms")
+    if found:
+        return found
+    home = Path.home()
+    for cand in (
+        home / ".lmstudio" / "bin" / "lms.exe",
+        home / ".lmstudio" / "bin" / "lms",
+    ):
+        if cand.exists():
+            return str(cand)
+    return None
+
+
+def _run_lms_json(lms_bin: str, args: list[str], timeout: float = 12.0) -> Any:
+    """Run ``lms <args> --json`` and return parsed JSON, or None on any failure."""
+    try:
+        proc = subprocess.run(
+            [lms_bin, *args],
+            capture_output=True, text=True, timeout=timeout, check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("lms %s failed: %s", " ".join(args), exc)
+        return None
+    if proc.returncode != 0:
+        logger.debug("lms %s exited %s: %s", " ".join(args), proc.returncode, proc.stderr.strip())
+        return None
+    try:
+        return json.loads(proc.stdout or "")
+    except json.JSONDecodeError as exc:
+        logger.debug("lms %s returned non-JSON: %s", " ".join(args), exc)
+        return None
+
+
+def _normalize_lms_survey(survey: Any) -> dict[str, Any] | None:
+    """Flatten ``lms runtime survey --json`` to ``{gpus: [{name, vram_bytes}], ram_bytes}``.
+
+    Collects EVERY GPU the runtime surveyed (multi-GPU rigs report several), each
+    with its own dedicated VRAM. The survey is deeply nested and local-only.
+    Tolerant of missing engines, a failed GPU probe, or absent fields.
+    """
+    if not isinstance(survey, dict):
+        return None
+    engines = survey.get("engines") or []
+    if not engines:
+        return None
+    eng = engines[0]
+    mem = eng.get("memoryInfo") or {}
+    gpus: list[dict[str, Any]] = []
+    try:
+        gpu_res = eng["hardwareSurvey"]["gpuSurveyResult"]
+        if (gpu_res.get("result") or {}).get("code") == "success":
+            for g in (gpu_res.get("gpuInfo") or []):
+                if not isinstance(g, dict):
+                    continue
+                name = (g.get("name") or "").strip() or None
+                # Per-GPU dedicated VRAM is the reliable figure; memoryInfo.vramCapacity
+                # is ambiguous across multiple devices.
+                vram = g.get("dedicatedMemoryCapacityBytes") or g.get("totalMemoryCapacityBytes")
+                gpus.append({"name": name, "vram_bytes": vram})
+    except (KeyError, TypeError):
+        gpus = []
+    return {"gpus": gpus, "ram_bytes": mem.get("ramCapacity")}
+
+
+def _read_lmstudio() -> _ProviderRead:
+    """Run the three ``lms`` reads and return normalized provider inputs.
+
+    Never raises. ``available`` is False when the CLI is missing or its link
+    status can't be read; callers still render the static roster as offline.
+    """
+    lms_bin = _resolve_lms_bin()
+    if not lms_bin:
+        return _ProviderRead(
+            available=False, link_status=None, ps=[], local_hardware=None,
+            error="lms CLI not found (LM Studio not installed, or not on PATH).",
+        )
+
+    link = _run_lms_json(lms_bin, ["link", "status", "--json"])
+    if not isinstance(link, dict):
+        return _ProviderRead(
+            available=False, link_status=None, ps=[], local_hardware=None,
+            error="Could not read `lms link status` (LM Studio server / LM Link may be down).",
+        )
+
+    ps = _run_lms_json(lms_bin, ["ps", "--json"])
+    ps = ps if isinstance(ps, list) else []
+    survey = _run_lms_json(lms_bin, ["runtime", "survey", "--json"])
+    local_hardware = _normalize_lms_survey(survey)
+
+    return _ProviderRead(
+        available=True, link_status=link, ps=ps,
+        local_hardware=local_hardware, error=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def read_fleet(cfg: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Return the fleet snapshot as a JSON-serializable dict. Never raises.
+
+    Selects the local-inference provider adapter (LM Studio today) and merges
+    its live read with the static ``inference.fleet`` roster from config.
+    """
+    if cfg is None:
+        from work_buddy.config import load_config
+        cfg = load_config()
+    roster = cfg.get("inference", {}).get("fleet", []) or []
+
+    try:
+        read = _read_lmstudio()
+    except Exception as exc:  # pragma: no cover — defensive; adapter is tolerant
+        logger.warning("fleet provider read failed: %s", exc)
+        return merge_fleet(
+            {}, [], None, roster,
+            lms_available=False, error=f"fleet read failed: {exc}",
+        ).to_dict()
+
+    return merge_fleet(
+        read.link_status, read.ps, read.local_hardware, roster,
+        lms_available=read.available, error=read.error,
+    ).to_dict()

--- a/work_buddy/mcp_server/ops/inference_ops.py
+++ b/work_buddy/mcp_server/ops/inference_ops.py
@@ -1,0 +1,149 @@
+"""Inference-domain ops.
+
+Each op here is referenced by a capability declaration (a ``kind: "capability"``
+knowledge-store unit carrying a matching ``op`` field). Adding this module is
+enough to register its ops — ``load_builtin_ops`` auto-discovers every module in
+this package.
+"""
+
+from __future__ import annotations
+
+from work_buddy.mcp_server.op_registry import register_op
+
+
+def _fleet_status() -> dict:
+    """Local model fleet snapshot: per-machine reachability, loaded models, hardware."""
+    from work_buddy.inference.fleet import read_fleet
+    return read_fleet()
+
+
+def _fleet_roster_dispatch(
+    action: str = "set",
+    device_id: str = "",
+    role: str | None = None,
+    gpus: list | None = None,
+    ram_gb: float | None = None,
+) -> dict:
+    """Add/update (``set``) or clear (``remove``) a machine's ``inference.fleet`` entry.
+
+    Persists to ``config.local.yaml`` (the user-override layer; comments there are
+    machine-managed and not preserved). The fleet roster only *enriches* live-
+    discovered machines, joined by ``device_id`` — so only ``device_id`` is
+    required. ``role`` is the primary human label; hardware specs are optional
+    (peers can't be auto-detected; the local machine reports its own live, so its
+    roster specs are ignored for display). ``gpus`` is a list of
+    ``{name, vram_gb}`` — machines can have several. Returns ``{"success": bool,
+    ...}``; validation failures include ``errors_by_field`` for the dashboard form.
+    """
+    from work_buddy.config import read_config_local, write_config_local
+
+    did = (device_id or "").strip()
+    action = (action or "set").strip().lower()
+    if action not in ("set", "remove"):
+        return {"success": False, "error": f"unknown action {action!r} (expected set|remove)"}
+    if not did:
+        return {"success": False, "errors_by_field": {"device_id": "device_id is required."}}
+
+    local = read_config_local()
+    inf = dict(local.get("inference") or {})
+    fleet = [dict(e) for e in (inf.get("fleet") or [])]
+    idx = next((i for i, e in enumerate(fleet) if str(e.get("device_id")) == did), None)
+
+    if action == "remove":
+        existed = idx is not None
+        if existed:
+            fleet.pop(idx)
+            inf["fleet"] = fleet
+            write_config_local("inference", inf)
+        return {
+            "success": True, "action": "remove", "device_id": did,
+            "note": "Roster entry cleared." if existed else "No roster entry to clear.",
+        }
+
+    # ---- set ----
+    # Merge semantics per field: ``None`` (the default) means "omitted — leave
+    # untouched", an empty value clears it, and a value sets it. So a partial
+    # update (just the role) preserves existing hardware, and the dashboard form
+    # (which sends every editable field) is a full replace.
+    entry = dict(fleet[idx]) if idx is not None else {"device_id": did}
+
+    if role is not None:
+        s = role.strip()
+        if s:
+            entry["role"] = s
+        else:
+            entry.pop("role", None)
+
+    errors: dict[str, str] = {}
+
+    # ram_gb: scalar (None=omit, ""=clear, number=set)
+    if ram_gb is not None and not (isinstance(ram_gb, str) and not ram_gb.strip()):
+        try:
+            r = float(ram_gb)
+            entry["ram_gb"] = int(r) if r == int(r) else r
+        except (TypeError, ValueError):
+            errors["ram_gb"] = "ram_gb must be a number."
+    elif isinstance(ram_gb, str) and not ram_gb.strip():
+        entry.pop("ram_gb", None)
+
+    # gpus: list of {name, vram_gb} (None=omit, []=clear, [..]=set). Migrates away
+    # any legacy scalar gpu/vram_gb keys on this entry.
+    if gpus is not None:
+        if not isinstance(gpus, list):
+            errors["gpus"] = "gpus must be a list of {name, vram_gb}."
+        else:
+            normalized: list[dict] = []
+            for i, g in enumerate(gpus):
+                if not isinstance(g, dict):
+                    errors["gpus"] = "each GPU must be an object with name / vram_gb."
+                    break
+                name = g.get("name")
+                name = name.strip() if isinstance(name, str) and name.strip() else None
+                vram = None
+                v = g.get("vram_gb")
+                if v is not None and not (isinstance(v, str) and not v.strip()):
+                    try:
+                        fv = float(v)
+                        vram = int(fv) if fv == int(fv) else fv
+                    except (TypeError, ValueError):
+                        errors["gpus"] = f"VRAM for GPU {i + 1} must be a number."
+                        break
+                if not name and vram is None:
+                    continue  # skip blank rows
+                item = {}
+                if name:
+                    item["name"] = name
+                if vram is not None:
+                    item["vram_gb"] = vram
+                normalized.append(item)
+            if "gpus" not in errors:
+                if normalized:
+                    entry["gpus"] = normalized
+                else:
+                    entry.pop("gpus", None)
+                entry.pop("gpu", None)
+                entry.pop("vram_gb", None)
+
+    if errors:
+        return {"success": False, "errors_by_field": errors}
+
+    if idx is None:
+        fleet.append(entry)
+    else:
+        fleet[idx] = entry
+    inf["fleet"] = fleet
+    write_config_local("inference", inf)
+    return {
+        "success": True, "action": "set", "device_id": did,
+        "note": "Saved. The fleet view reflects it now.",
+    }
+
+
+def _register() -> None:
+    # replace=True so a hot ``mcp_registry_reload`` (which re-imports this module)
+    # doesn't raise on the already-registered op id.
+    register_op("op.wb.fleet_status", _fleet_status, replace=True)
+    register_op("op.wb.fleet_roster", _fleet_roster_dispatch, replace=True)
+
+
+_register()


### PR DESCRIPTION
## What
A **Local model fleet** view — a per-machine "what's loaded on which box" section in Settings › Inference, above the per-call provenance feed. One card per machine (local host + reachable LM Link peers): reachability, loaded model(s) with live context utilization, and hardware (multi-GPU). Fills the gap the inference broker structurally can't — the broker knows the *profile* (model), not which *machine* ran a call.

## How
- **Provider-neutral seam:** `merge_fleet()` is a pure function over parsed inputs; LM Studio (the `lms` CLI) is the first adapter behind it. Swapping to vLLM/Ollama/llama.cpp is a new adapter, nothing else.
- **Discovery-first:** machines + reachability + loaded models come live from the provider; a static `inference.fleet` roster only *enriches* discovered machines (by `device_id`) with hardware the provider can't read off remote peers. Multi-GPU: each machine carries a GPU list with a summed total VRAM.
- **Dashboard:** background-cached `GET /api/fleet`; `POST /api/fleet/roster` (read-only-gated) backs an inline roster editor reusing the vault-editor form pattern — no hand-edited YAML. Live updates via a new `fleet.changed` SSE event from a server-side poller (no frontend timer).
- **Capabilities:** `fleet_status` (read — "what's on which box / can my laptop run model X") and `fleet_roster` (edit the roster).

## Tests
61 passing: reader merge (local-not-in-`peers`, multi-GPU totals, scalar back-compat, `lms`-missing degradation), survey normalization, roster dispatch, dashboard cache/route, and frontend regressions.

## Docs
New `architecture/inference/fleet`; updated `architecture/event-bus`, `architecture/inference`, `services/dashboard`. Store validates clean.

## Notes
- A full MCP/sidecar restart surfaces the new `fleet_status`/`fleet_roster` capabilities via `wb_run` everywhere (dashboard routes already work).
- Peer GPU/VRAM/RAM isn't headless-discoverable (only the local box self-reports) — hence the roster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
