### PR TITLE
fix(inference): broker-admit local embedding encode so rebuilds yield to searches

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -224,6 +224,19 @@ inference:
   #     gpus:                                            # a machine can have several
   #       - name: "NVIDIA RTX 2080 Super Max-Q"
   #         vram_gb: 8
+  #
+  # Broker profiles — priority-aware admission for local inference so background
+  # index rebuilds yield to interactive searches on the shared GPU. A profile is
+  # a logical endpoint+model queue. All in-process ("local") embedding encode
+  # shares one `local:embedding` profile (the host GPU is one device); remote LM
+  # Studio peers get per-model `lmstudio:<model_id>` profiles. Profiles not
+  # listed auto-register with these defaults — listed here to make them tunable.
+  profiles:
+    "local:embedding":
+      max_concurrent: 1      # one encode at a time on the single GPU
+      max_queued: 64
+      default_queue_wait_s: 30
+      default_inference_s: 120
 
 chats:
   specstory_days: 7

--- a/knowledge/store/architecture/inference/broker.md
+++ b/knowledge/store/architecture/inference/broker.md
@@ -2,7 +2,7 @@
 name: Local Inference Broker
 kind: reference
 description: Admission-control + priority scheduling + per-call metrics for every local-inference call. Work-buddy is the scheduler of record for LM Studio / LM Link traffic, not LM Studio itself.
-summary: 'Process-global broker (``work_buddy.inference.get_broker()``) wraps every outbound local-inference call. Per-profile max_concurrent + max_queued. Three priority classes (INTERACTIVE, WORKFLOW, BACKGROUND) with priority-aware admission. Distinct error kinds: QueueFull, QueueWaitTimeout, InferenceTimeout. Metrics ring buffer (queued_at, admitted_at, started_http_at, first_token_at, finished_at + latency splits) for the dashboard.'
+summary: 'Process-global broker (``work_buddy.inference.get_broker()``) wraps every local-inference call — remote HTTP (LM Studio / OpenAI-compat) and in-process host-GPU embedding encode. Per-profile max_concurrent + max_queued. Three priority classes (INTERACTIVE, WORKFLOW, BACKGROUND) with priority-aware admission. Distinct error kinds: QueueFull, QueueWaitTimeout, InferenceTimeout. Metrics ring buffer (queued_at, admitted_at, started_http_at, first_token_at, finished_at + latency splits) for the dashboard.'
 entry_points:
 - work_buddy.inference.broker
 - work_buddy.inference
@@ -32,7 +32,7 @@ parents:
 
 LM Studio has an internal queue and concurrency slots (``Max Concurrent Predictions``, default 4), but its public API does NOT expose current slot occupancy. A naive caller hitting ``/v1/chat/completions`` or ``/v1/embeddings`` can sit inside LM Studio's hidden queue until the caller's timeout fires — and work-buddy would see "LM Studio is slow" with no way to tell whether the slow bit was queue-wait or actual inference. Worse: a background bulk encode can starve an interactive dashboard search because both hit the same server and the server has no notion of *our* priorities.
 
-The broker fixes that by making **work-buddy** the scheduler of record for local inference. Every outbound call (embedding provider, both LLM backends) routes through ``broker.slot(...)`` before the HTTP call is made.
+The broker fixes that by making **work-buddy** the scheduler of record for local inference. Every local-inference call routes through ``broker.slot(...)``: the LM Studio embedding provider and both LLM backends (outbound HTTP to a peer), **and** the in-process embedding encode on the host GPU — query and bulk-document — via ``work_buddy.inference.local_slot.local_embed_slot``. That last one is what lets a background index rebuild yield the local GPU to an interactive search; without it the default (no-offload) setup had no admission control between a rebuild and a live query.
 
 ## Public API
 
@@ -59,9 +59,9 @@ On ``__exit__``, the ticket releases the slot and the call's metrics land in the
 
 Three classes, fixed-priority admission across + FIFO within:
 
-- ``INTERACTIVE`` (0) — user-facing / UI-driven requests (dashboard search, agent response). Must not sit behind background work.
-- ``WORKFLOW`` (1) — agent-initiated work tied to a user task but not UI-facing. Default for LLM backend calls.
-- ``BACKGROUND`` (2) — cron jobs, bulk index rebuilds. Default for embedding provider calls. Yields to everything else.
+- ``INTERACTIVE`` (0) — user-facing / UI-driven requests (dashboard search, agent response, **query-side embedding encode**). Must not sit behind background work.
+- ``WORKFLOW`` (1) — agent-initiated work tied to a user task but not UI-facing. Default for LLM backend calls; also where a symmetric (no prompt-role) local embedding encode lands.
+- ``BACKGROUND`` (2) — cron jobs, bulk index rebuilds (LM Studio offload **and** in-process document encode). Yields to everything else.
 
 Lower numeric = higher priority. A queued INTERACTIVE ticket admits ahead of a queued BACKGROUND ticket on the same profile when a slot frees up.
 
@@ -74,13 +74,14 @@ Lower numeric = higher priority. A queued INTERACTIVE ticket admits ahead of a q
 
 ## Profile naming convention
 
-Each call site uses a prefix so slot limits stay independent:
+Each call site uses a prefix so slot limits stay independent. A profile is one logical queue on one device:
 
-- ``lmstudio:<model_id>`` — embedding provider (``work_buddy.embedding.providers.lmstudio.encode``).
+- ``lmstudio:<model_id>`` — embedding provider, per remote LM Studio peer/model (``work_buddy.embedding.providers.lmstudio.encode``).
 - ``lmstudio_native:<model>`` — LM Studio native-chat tool-call loop (``work_buddy.llm.backends.lmstudio_native.call_lmstudio_native``).
 - ``openai_compat:<model>`` — OpenAI-compatible chat-completions (``work_buddy.llm.backends.openai_compat.call_openai_compat``).
+- ``local:embedding`` — **all** in-process sentence-transformer embedding encode on the host GPU, regardless of model (``work_buddy.inference.local_slot.local_embed_slot``; used by the embedding service's ``/embed`` · ``/search`` · ``/similarity`` and ``work_buddy.ir.dense``). Deliberately a **single shared** profile: the local GPU is one device, so query (INTERACTIVE) and bulk-document (BACKGROUND) encode share one queue and the broker can let a search preempt a rebuild between batches.
 
-Same model id on the same physical LM Studio instance gets up to three independent logical profiles — so an active embedding bulk-encode can't starve a chat call (and vice versa), even though they talk to the same server.
+The ``lmstudio*`` / ``openai_compat`` prefixes give the same model id on the same physical LM Studio instance up to three independent logical profiles — so an active embedding bulk-encode can't starve a chat call (and vice versa), even though they talk to the same server. The ``local:embedding`` profile takes the opposite stance on purpose: one device → one queue, shared across models, so cross-priority preemption works.
 
 ## Per-profile config
 
@@ -115,7 +116,8 @@ Practical consequence: the broker exposes no HTTP state endpoint; per-call metri
 - ``work_buddy/inference/broker.py`` — the broker itself, ``SlotMetrics``, ``ProfileConfig``, error classes.
 - ``work_buddy/inference/__init__.py`` — public API re-exports (``get_broker``, ``Priority``, etc.).
 - ``work_buddy/inference/metrics_store.py`` — SQLite persistence for completed calls (the ``broker-metrics`` entry-TTL artifact); an embedding-service flusher daemon drains the ring into it so dashboard history survives restarts.
-- ``work_buddy/embedding/providers/lmstudio.py`` — first consumer; wraps bulk encode in ``broker.slot``.
+- ``work_buddy/embedding/providers/lmstudio.py`` — remote-offload consumer; wraps bulk encode in ``broker.slot``.
+- ``work_buddy/inference/local_slot.py`` — ``local_embed_slot`` helper + the ``local:embedding`` profile; admits in-process host-GPU encode (consumed by ``work_buddy/embedding/service.py`` encode endpoints and ``work_buddy/ir/dense.py``). Best-effort — degrades to a direct encode when the broker is unavailable.
 - ``work_buddy/llm/backends/lmstudio_native.py`` — LLM native-chat consumer.
 - ``work_buddy/llm/backends/openai_compat.py`` — OpenAI-compat consumer.
 - ``tests/unit/test_local_inference_broker.py`` — 12 tests covering admission, priority, queue capacity, timeouts, metrics, reconfigure.

--- a/tests/unit/test_llm_backends_broker_wiring.py
+++ b/tests/unit/test_llm_backends_broker_wiring.py
@@ -243,8 +243,13 @@ def test_lmstudio_native_and_openai_compat_profiles_are_distinct(
     profiles = set(get_broker().profile_status().keys())
     assert "openai_compat:shared-model" in profiles
     assert "lmstudio_native:shared-model" in profiles
-    # Emphatic: they are NOT the same entry.
-    assert len(profiles) == 2
+    # Emphatic: they are NOT the same entry. (Other profiles may also be
+    # registered — e.g. the config-declared `local:embedding` admission profile
+    # — so assert the two backend profiles are present + distinct rather than
+    # pinning the total count.)
+    assert len(
+        {"openai_compat:shared-model", "lmstudio_native:shared-model"} & profiles
+    ) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_local_embed_slot.py
+++ b/tests/unit/test_local_embed_slot.py
@@ -1,0 +1,119 @@
+"""Tests for ``local_embed_slot`` — broker admission for in-process embedding
+encode — and the ``/embed`` priority derivation.
+
+The broker's own priority/admission ordering is covered by
+``test_local_inference_broker.py``; these tests pin the *wiring*: that all local
+encode shares the one ``local:embedding`` profile, that admission degrades
+gracefully (never blocks the default encode path), and that the encode role
+maps to the right priority.
+"""
+from __future__ import annotations
+
+import pytest
+
+from work_buddy.inference import Priority, get_broker, local_embed_slot
+from work_buddy.inference import local_slot as local_slot_mod
+from work_buddy.inference.broker import _reset_broker_for_tests
+from work_buddy.inference.local_slot import LOCAL_EMBED_PROFILE
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    """Each test gets a fresh broker singleton."""
+    _reset_broker_for_tests()
+    yield
+    _reset_broker_for_tests()
+
+
+def test_acquires_slot_on_shared_profile():
+    """A successful slot yields a ticket on the local:embedding profile at the
+    requested priority, and records a metrics row."""
+    with local_embed_slot(Priority.BACKGROUND) as ticket:
+        assert ticket is not None
+        assert ticket.profile == LOCAL_EMBED_PROFILE
+        assert ticket.priority == Priority.BACKGROUND
+
+    rows = get_broker().snapshot_metrics()
+    assert any(
+        r["profile"] == LOCAL_EMBED_PROFILE and r["status"] == "ok" for r in rows
+    ), f"expected an ok metrics row on {LOCAL_EMBED_PROFILE}; got {rows}"
+
+
+def test_query_and_build_share_one_profile():
+    """Interactive query and background build encode use the SAME profile — the
+    whole point: the broker can only serialize+prioritize them on the one GPU if
+    they share a queue."""
+    with local_embed_slot(Priority.INTERACTIVE) as q:
+        q_profile = q.profile
+    with local_embed_slot(Priority.BACKGROUND) as b:
+        b_profile = b.profile
+    assert q_profile == b_profile == LOCAL_EMBED_PROFILE
+
+
+def test_default_priority_is_background():
+    with local_embed_slot() as ticket:
+        assert ticket.priority == Priority.BACKGROUND
+
+
+def test_degrades_to_none_when_broker_unavailable(monkeypatch):
+    """If the broker can't be obtained, the encode still runs (ticket is None)."""
+    def _boom():
+        raise RuntimeError("no broker in this rig")
+
+    monkeypatch.setattr(local_slot_mod, "get_broker", _boom)
+
+    ran = False
+    with local_embed_slot(Priority.INTERACTIVE) as ticket:
+        assert ticket is None
+        ran = True
+    assert ran, "body must still execute under graceful degradation"
+
+
+def test_degrades_to_none_on_admission_backpressure(monkeypatch):
+    """A queue-wait timeout / queue-full on admission must not break the encode
+    path — the slot yields None and the body proceeds."""
+    from work_buddy.inference.broker import QueueWaitTimeout
+
+    class _Boom:
+        def slot(self, **_kwargs):
+            raise QueueWaitTimeout("saturated", kind="queue_wait_timeout")
+
+    monkeypatch.setattr(local_slot_mod, "get_broker", lambda: _Boom())
+
+    ran = False
+    with local_embed_slot(Priority.BACKGROUND) as ticket:
+        assert ticket is None
+        ran = True
+    assert ran
+
+
+def test_body_exception_propagates():
+    """A failure inside the slot body propagates (admission is best-effort, but
+    we don't swallow the caller's encode error)."""
+    with pytest.raises(ValueError, match="boom"):
+        with local_embed_slot(Priority.BACKGROUND):
+            raise ValueError("boom")
+
+
+# ---------------------------------------------------------------------------
+# /embed priority derivation (role → priority)
+# ---------------------------------------------------------------------------
+
+def test_embed_priority_derives_from_prompt_name():
+    from work_buddy.embedding.service import _embed_priority
+
+    # Asymmetric roles map to scheduling intent.
+    assert _embed_priority({}, "query") == Priority.INTERACTIVE
+    assert _embed_priority({}, "document") == Priority.BACKGROUND
+    # Symmetric (no prompt) defaults to WORKFLOW — preempts background, yields
+    # to explicit interactive.
+    assert _embed_priority({}, None) == Priority.WORKFLOW
+
+
+def test_embed_priority_explicit_wins_and_bad_value_falls_through():
+    from work_buddy.embedding.service import _embed_priority
+
+    # Explicit priority overrides the role default.
+    assert _embed_priority({"priority": "background"}, "query") == Priority.BACKGROUND
+    # An unparseable explicit value falls through to the role derivation.
+    assert _embed_priority({"priority": "nonsense"}, "query") == Priority.INTERACTIVE

--- a/work_buddy/embedding/service.py
+++ b/work_buddy/embedding/service.py
@@ -415,6 +415,46 @@ def health():
 # (dashboard/api.py::_build_inference_activity).
 
 
+def _embed_priority(data: dict[str, Any], prompt_name: str | None) -> Any:
+    """Pick a broker priority for an encode request.
+
+    Explicit ``priority`` in the request body wins; otherwise derive from the
+    asymmetric prompt role — a ``"query"`` encode serves a live search
+    (INTERACTIVE), a ``"document"`` encode is part of a bulk index build
+    (BACKGROUND). Symmetric encodes (no ``prompt_name``, e.g. leaf-mt aliases)
+    default to WORKFLOW: they preempt background rebuilds but yield to explicit
+    interactive queries.
+    """
+    from work_buddy.inference import Priority, parse_priority
+
+    try:
+        explicit = parse_priority(data.get("priority"))
+    except ValueError:
+        explicit = None
+    if explicit is not None:
+        return explicit
+    if prompt_name == "query":
+        return Priority.INTERACTIVE
+    if prompt_name == "document":
+        return Priority.BACKGROUND
+    return Priority.WORKFLOW
+
+
+def _brokered_encode(model: Any, texts: list[str], *, priority: Any, **encode_kwargs: Any):
+    """Run ``model.encode`` under the shared local-device broker slot, so an
+    INTERACTIVE query preempts a BACKGROUND rebuild on the one GPU. Degrades to
+    a direct encode when the broker is unavailable (see ``local_embed_slot``).
+
+    ``priority`` may be a ``Priority`` or a name string ("interactive" / …).
+    """
+    from work_buddy.inference import parse_priority
+    from work_buddy.inference.local_slot import local_embed_slot
+
+    prio = parse_priority(priority) if isinstance(priority, str) else priority
+    with local_embed_slot(prio):
+        return model.encode(texts, **encode_kwargs)
+
+
 @app.route("/embed", methods=["POST"])
 def embed():
     """Embed one or more texts.
@@ -445,7 +485,9 @@ def embed():
     if prompt_name:
         encode_kwargs["prompt_name"] = prompt_name
 
-    vectors = model.encode(texts, **encode_kwargs)
+    vectors = _brokered_encode(
+        model, texts, priority=_embed_priority(data, prompt_name), **encode_kwargs,
+    )
 
     return Response(
         json.dumps({
@@ -498,7 +540,10 @@ def similarity():
             text_to_candidate.append((name, len(all_texts)))
             all_texts.append(phrase)
 
-    vectors = model.encode(all_texts, batch_size=32, show_progress_bar=False)
+    # Serving a live similarity query → INTERACTIVE (preempts background rebuilds).
+    vectors = _brokered_encode(
+        model, all_texts, priority="interactive", batch_size=32, show_progress_bar=False,
+    )
     query_vec = vectors[0]
     query_norm = np.linalg.norm(query_vec)
 
@@ -662,7 +707,9 @@ def search():
             # Cache hit — only encode the query
             cand_vectors = cached[1]
             text_to_name = cached[2]
-            query_vec = model.encode([query], batch_size=1, show_progress_bar=False)[0]
+            query_vec = _brokered_encode(
+                model, [query], priority="interactive", batch_size=1, show_progress_bar=False,
+            )[0]
         else:
             # Cache miss — encode all candidates, cache them, then encode query
             cand_texts = []
@@ -673,9 +720,13 @@ def search():
                     text_to_name.append((name, len(cand_texts)))
                     cand_texts.append(phrase)
 
-            cand_vectors = model.encode(cand_texts, batch_size=32, show_progress_bar=False)
+            cand_vectors = _brokered_encode(
+                model, cand_texts, priority="interactive", batch_size=32, show_progress_bar=False,
+            )
             _candidate_cache[model_key] = (fp, cand_vectors, text_to_name)
-            query_vec = model.encode([query], batch_size=1, show_progress_bar=False)[0]
+            query_vec = _brokered_encode(
+                model, [query], priority="interactive", batch_size=1, show_progress_bar=False,
+            )[0]
 
         query_norm = np.linalg.norm(query_vec)
         if query_norm > 0:

--- a/work_buddy/inference/__init__.py
+++ b/work_buddy/inference/__init__.py
@@ -22,9 +22,11 @@ from work_buddy.inference.broker import (
     get_broker,
     parse_priority,
 )
+from work_buddy.inference.local_slot import LOCAL_EMBED_PROFILE, local_embed_slot
 
 __all__ = [
     "InferenceTimeout",
+    "LOCAL_EMBED_PROFILE",
     "LocalInferenceBroker",
     "Priority",
     "ProfileConfig",
@@ -32,5 +34,6 @@ __all__ = [
     "QueueWaitTimeout",
     "SlotMetrics",
     "get_broker",
+    "local_embed_slot",
     "parse_priority",
 ]

--- a/work_buddy/inference/local_slot.py
+++ b/work_buddy/inference/local_slot.py
@@ -1,0 +1,78 @@
+"""Broker admission for in-process (local-device) embedding encodes.
+
+All local sentence-transformer encoding — bulk index builds AND interactive
+query/search encodes — runs on the one host GPU/CPU. This module funnels every
+such encode through a SINGLE broker profile (``local:embedding``) so the broker
+serializes them on that one device and an INTERACTIVE encode preempts a
+BACKGROUND index rebuild *between its batches*.
+
+Contrast with ``work_buddy.embedding.providers.lmstudio``, which uses a per-peer
+profile (``lmstudio:<model_id>``): a remote LM-Link peer is its own device, so it
+gets its own admission queue. The local GPU is one device → one profile.
+
+Why this exists: without it, the default (no-offload) configuration has **no**
+admission control between a cold rebuild and a live query — they contend on the
+GPU with nothing yielding, so an interactive search stalls behind a background
+rebuild. Wrapping encode work PER BATCH (never per whole build) is what lets a
+long rebuild actually yield between batches.
+"""
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+from typing import Any
+
+from work_buddy.inference.broker import (
+    Priority,
+    QueueFull,
+    QueueWaitTimeout,
+    get_broker,
+)
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# One profile for ALL local-device embedding encode. Query (INTERACTIVE) and
+# bulk-document (BACKGROUND) encode share it so the broker can let a query
+# preempt a rebuild on the single shared GPU.
+LOCAL_EMBED_PROFILE = "local:embedding"
+
+
+@contextlib.contextmanager
+def local_embed_slot(priority: Priority = Priority.BACKGROUND) -> Iterator[Any]:
+    """Admit one in-process embedding encode under the broker — best-effort.
+
+    Yields the broker ticket on admission, or ``None`` when admission is
+    skipped. Admission is **best-effort by design**: if the broker is
+    unreachable, or backpressure (``QueueWaitTimeout`` / ``QueueFull``) would
+    otherwise abort, the encode still proceeds without a slot — strictly no
+    worse than the pre-broker behavior, in which there was no admission at all.
+    The job here is to ADD yielding where there was none, never to BLOCK the
+    default encode path.
+
+    Usage (wrap the smallest unit of encode work, e.g. one batch)::
+
+        with local_embed_slot(Priority.BACKGROUND):
+            vecs = model.encode(batch, ...)
+    """
+    try:
+        slot_cm = get_broker().slot(profile=LOCAL_EMBED_PROFILE, priority=priority)
+    except Exception as exc:  # broker / config unavailable (bare CLI or test rig)
+        logger.debug(
+            "Inference broker unavailable (%s); encoding without admission.", exc,
+        )
+        yield None
+        return
+
+    try:
+        with slot_cm as ticket:
+            yield ticket
+    except (QueueWaitTimeout, QueueFull) as exc:
+        # Backpressure on admission must never break the default encode path.
+        # (model.encode does not raise broker errors, so this only ever fires
+        #  for an admission timeout/full on slot acquisition, not the body.)
+        logger.warning(
+            "Local embed admission skipped (%s) on profile %r; encoding without a slot.",
+            exc.kind, LOCAL_EMBED_PROFILE,
+        )
+        yield None

--- a/work_buddy/ir/dense.py
+++ b/work_buddy/ir/dense.py
@@ -51,15 +51,23 @@ def encode_query(query: str, kind: str = "passage") -> np.ndarray | None:
 
 
 def _encode_query_direct(query: str, kind: str = "passage") -> np.ndarray | None:
-    """Encode query in-process using the service's loaded model."""
+    """Encode query in-process using the service's loaded model.
+
+    Admitted at INTERACTIVE priority on the shared local-device broker profile so
+    a live search preempts a BACKGROUND index rebuild on the same GPU.
+    """
     try:
         from work_buddy.embedding.service import _get_model
+        from work_buddy.inference import Priority
+        from work_buddy.inference.local_slot import local_embed_slot
         if kind == "label":
             model = _get_model("leaf-mt")
-            vec = model.encode([query], show_progress_bar=False)
+            with local_embed_slot(Priority.INTERACTIVE):
+                vec = model.encode([query], show_progress_bar=False)
         else:
             model = _get_model("leaf-ir-query")
-            vec = model.encode([query], prompt_name="query", show_progress_bar=False)
+            with local_embed_slot(Priority.INTERACTIVE):
+                vec = model.encode([query], prompt_name="query", show_progress_bar=False)
         return np.array(vec, dtype=np.float32)
     except Exception as exc:
         logger.warning("In-service query encoding failed (kind=%s): %s", kind, exc)
@@ -422,6 +430,9 @@ def _encode_bulk_direct_impl(
         logger.info("Loading %s for bulk encoding (kind=%s)...", model_name, kind)
         model = SentenceTransformer(model_name)
 
+    from work_buddy.inference import Priority
+    from work_buddy.inference.local_slot import local_embed_slot
+
     all_vecs = []
     total = len(texts)
     for i in range(0, total, batch_size):
@@ -429,7 +440,11 @@ def _encode_bulk_direct_impl(
         encode_kwargs = {"batch_size": batch_size, "show_progress_bar": False}
         if prompt is not None:
             encode_kwargs["prompt_name"] = prompt
-        vecs = model.encode(batch, **encode_kwargs)
+        # Per-batch BACKGROUND admission: the build holds the shared GPU slot only
+        # for one batch, so an INTERACTIVE query is admitted *between* batches
+        # rather than waiting out the whole rebuild.
+        with local_embed_slot(Priority.BACKGROUND):
+            vecs = model.encode(batch, **encode_kwargs)
         all_vecs.append(vecs)
         done = min(i + batch_size, total)
         print(f"\r  Encoded {done}/{total} documents...", end="", file=sys.stderr)


### PR DESCRIPTION
## Problem

The inference broker only mediated the LM-Studio offload path; the default in-process sentence-transformer encode acquired **no broker slot**. On a single shared GPU a background index rebuild and an interactive search then contended with nothing enforcing priority — a query could stall behind a whole rebuild (the contention behind the dev-document scan-step timeout; measured query embeds spiking from ~30 ms to ~3.5 s under a concurrent rebuild).

## Fix

Route every local-device encode through **one shared `local:embedding` broker profile** so the broker can serialize + prioritize them on the one device:

- query / query-serving paths admit at **INTERACTIVE**;
- bulk document builds admit at **BACKGROUND**, *per batch*, so a rebuild yields between batches to a waiting search.

`/embed` derives priority from the prompt role (`query`→INTERACTIVE, `document`→BACKGROUND), so no client or knowledge-index changes are needed. Admission is **best-effort** — if the broker is unavailable or backpressured, the encode still proceeds (strictly no worse than the pre-broker behavior).

## Changes

- `work_buddy/inference/local_slot.py` — `local_embed_slot(priority)` graceful slot helper + the `local:embedding` profile.
- `work_buddy/embedding/service.py` — `/embed`, `/search`, `/similarity` now broker-admitted.
- `work_buddy/ir/dense.py` — in-service query encode (INTERACTIVE) + bulk build encode (BACKGROUND, per batch).
- `config.example.yaml` — ship the previously-undocumented `inference.profiles` block (absent profiles auto-register with the same defaults).
- `architecture/inference/broker` knowledge unit — document the `local:embedding` profile + that in-process host-GPU encode is now broker-admitted.

## Verification

- **93 unit tests pass** (`local_embed_slot` contract, graceful degradation, `/embed` priority derivation; broker / embedding / dense suites).
- **Live** (after restarting the embedding service): the `local:embedding` profile shows INTERACTIVE query encodes, BACKGROUND document encodes, and WORKFLOW symmetric encodes all admitting on the one shared profile, priorities per the role derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
