### PR TITLE
fix(dev-document): eliminate the scan-step auto_run timeout (batch query embeds + fix cache-save race)

### DIFF
--- a/knowledge/store/dev/dev-document.md
+++ b/knowledge/store/dev/dev-document.md
@@ -14,7 +14,7 @@ steps:
     callable: work_buddy.dev.document.scan_changes
     kwargs:
       base_ref: HEAD
-    timeout: 30
+    timeout: 90
   invokes: []
 - id: propose
   name: Propose knowledge-store edits (updates + new units)
@@ -104,7 +104,9 @@ parents:
 - dev
 - dev
 dev_notes: |-
-  The `scan` step uses grep-level matching intentionally — semantic search is the agent's job in `propose`. Don't 'improve' scan with embeddings; the split in responsibility keeps scan fast, deterministic, and cache-friendly, and forces the agent to actually load units instead of trusting a ranked list.
+  The `scan` step runs a hybrid matcher: BM25 + dense (embedding) retrieval over the knowledge store fused with Reciprocal Rank Fusion, with the scored substring-grep matcher (`_match_units_via_grep`) as a graceful lexical fallback. The semantic pass embeds every query — one structural query over changed paths/slugs, plus one per changed `.py` file's docstring — in a SINGLE batched call per model via `work_buddy.knowledge.search.search_many`, never one round-trip per query. This is the load-bearing design choice: on weak/contended GPUs the per-round-trip embedding overhead (not the in-process BM25/fusion) is the cost that scales with changeset size, so batching collapses ~2N round-trips to 2. If the embedding service is contended past `_QUERY_EMBED_TIMEOUT_S` (in `work_buddy/dev/document.py`), the dense signal drops and results fall back to BM25 (lexical) without failing the step; only a hard search failure falls all the way back to grep. **Footgun**: when changing the query fan-out, keep it batched — reintroducing a per-file `search()` loop brings back the O(changed_files) round-trip blowup that times the step out on large changesets.
+
+  The `auto_run` timeout is 90s, not the workflow default. The scan subprocess pays ~5-6s fixed startup + knowledge-index build before the first query runs; 90s is deliberate headroom for a step whose failure aborts the whole doc-sync flow (it is also chained inside `/wb-dev-pr`).
 
   The `apply` step is a code step with an `invokes` list, not an auto_run — this is the task-new pattern, applied here so the agent mediates each doc mutation (consent flows, error recovery, per-edit rationale all stay in agent hands).
 ---
@@ -138,8 +140,9 @@ Auto-run. The conductor calls `work_buddy.dev.document.scan_changes(base_ref="HE
 - `changed_files`: repo-relative paths of uncommitted + untracked files
 - `classified`: files grouped by bucket (module / knowledge / slash / tests / config / other)
 - `subsystem_slugs`: module keys derived from the changed paths (e.g. `obsidian/tasks`, `namespace_suggest`)
-- `candidate_units`: knowledge units whose text references a changed file or subsystem, ranked by match strength. **First-pass net only** — you must still do your own semantic searches in the next step.
+- `candidate_units`: knowledge units whose text references a changed file or subsystem, ranked by match strength (hybrid BM25 + semantic). **First-pass net only** — you must still do your own semantic searches in the next step.
 - `warnings`: non-fatal issues (empty diff, direct JSON edits).
+- `_source`: which matcher produced the candidates — `"rag"` (hybrid; degrades to lexical BM25 if the embedding service is busy) or `"grep_fallback"` (substring matcher, used only if the search could not run at all).
 
 ## propose
 

--- a/tests/unit/test_dev_document.py
+++ b/tests/unit/test_dev_document.py
@@ -129,11 +129,11 @@ def test_scan_candidates_shape_is_slimmed(fake_git):
 # RAG vs grep dispatch
 # ---------------------------------------------------------------------------
 
-def _fake_search_success(*args: Any, **kwargs: Any) -> dict[str, Any]:
-    """search() stub that returns a deterministic small result set."""
+def _one_result(query: str) -> dict[str, Any]:
+    """A deterministic search-mode result dict (the shape search_many emits)."""
     return {
         "mode": "search",
-        "query": kwargs.get("query", ""),
+        "query": query,
         "count": 2,
         "results": [
             {
@@ -154,23 +154,28 @@ def _fake_search_success(*args: Any, **kwargs: Any) -> dict[str, Any]:
     }
 
 
+def _fake_search_many_success(queries, *args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+    """search_many() stub: one deterministic result dict per query, in order."""
+    return [_one_result(q) for q in queries]
+
+
 def _fake_search_raises(*args: Any, **kwargs: Any) -> dict[str, Any]:
-    """search() stub that simulates an embedding-service failure."""
+    """search_many() stub that simulates a hard search failure."""
     raise RuntimeError("embedding service unhealthy")
 
 
 def test_scan_uses_rag_when_available(fake_git):
-    """When search() returns scored hits, the candidates carry _source: rag.
+    """When search_many returns scored hits, the candidates carry _source: rag.
 
-    The scan now makes 1 + N search() calls (one structural query, plus one
-    per Python file with a docstring). The mock's ``side_effect`` returns
-    the same response for every call.
+    The scan now makes a SINGLE batched search_many call carrying one
+    structural query plus one query per Python file with a docstring. The
+    stub returns one result dict per query.
     """
     fake_git["tracked"] = ["work_buddy/dashboard/forms.py"]
     fake_git["untracked"] = []
     # Stub _read_module_docstring to be deterministic — return empty so this
     # test exercises the structural-query-only path.
-    with patch("work_buddy.knowledge.search.search", side_effect=_fake_search_success), \
+    with patch("work_buddy.knowledge.search.search_many", side_effect=_fake_search_many_success), \
          patch("work_buddy.dev.document._read_module_docstring", return_value=""):
         result = dev_document.scan_changes()
     assert result["_source"] == "rag"
@@ -185,10 +190,10 @@ def test_scan_uses_rag_when_available(fake_git):
 
 
 def test_scan_falls_back_on_search_failure(fake_git):
-    """When search() raises on the structural query, scan falls back to grep."""
+    """When search_many raises outright, scan falls back to grep."""
     fake_git["tracked"] = ["work_buddy/obsidian/tasks/namespace_suggest.py"]
     fake_git["untracked"] = []
-    with patch("work_buddy.knowledge.search.search", side_effect=_fake_search_raises):
+    with patch("work_buddy.knowledge.search.search_many", side_effect=_fake_search_raises):
         result = dev_document.scan_changes()
     assert result["_source"] == "grep_fallback"
     # The fallback should still surface SOME candidates against the real
@@ -212,8 +217,10 @@ def test_scan_caps_at_20_candidates(fake_git):
     fake = {"mode": "search", "query": "x", "count": 50, "results": many}
     fake_git["tracked"] = ["work_buddy/dev/document.py"]
     fake_git["untracked"] = []
-    with patch("work_buddy.knowledge.search.search", return_value=fake), \
-         patch("work_buddy.dev.document._read_module_docstring", return_value=""):
+    with patch(
+        "work_buddy.knowledge.search.search_many",
+        side_effect=lambda queries, *a, **k: [fake for _ in queries],
+    ), patch("work_buddy.dev.document._read_module_docstring", return_value=""):
         result = dev_document.scan_changes()
     assert result["_source"] == "rag"
     assert len(result["candidate_units"]) <= 20
@@ -249,9 +256,11 @@ def test_scan_fuses_path_and_docstring_signals(fake_git):
     }
     fake_git["tracked"] = ["work_buddy/dev/document.py"]
     fake_git["untracked"] = []
+    # One batched call returns both rankings, in query order:
+    # [structural, docstring].
     with patch(
-        "work_buddy.knowledge.search.search",
-        side_effect=[structural, docstring],
+        "work_buddy.knowledge.search.search_many",
+        return_value=[structural, docstring],
     ), patch(
         "work_buddy.dev.document._read_module_docstring",
         return_value="some docstring text",
@@ -265,7 +274,7 @@ def test_scan_fuses_path_and_docstring_signals(fake_git):
 
 
 def test_scan_skips_files_without_docstrings(fake_git):
-    """Files with no docstring contribute no extra search call."""
+    """Files with no docstring contribute no extra query to the batch."""
     structural = {
         "mode": "search", "count": 1,
         "results": [{"path": "fake/A", "name": "A", "description": "a", "score": 0.9}],
@@ -273,17 +282,23 @@ def test_scan_skips_files_without_docstrings(fake_git):
     fake_git["tracked"] = ["work_buddy/dev/document.py"]
     fake_git["untracked"] = []
     mock_search = patch(
-        "work_buddy.knowledge.search.search",
-        return_value=structural,
+        "work_buddy.knowledge.search.search_many",
+        return_value=[structural],
     )
     with mock_search as m, patch(
         "work_buddy.dev.document._read_module_docstring",
         return_value="",
     ):
         dev_document.scan_changes()
-    # Only the structural query should have run.
+    # One batched call, carrying only the structural query (no docstrings).
     assert m.call_count == 1, (
-        f"Expected 1 search call (structural only); got {m.call_count}"
+        f"Expected 1 batched search_many call; got {m.call_count}"
+    )
+    called_queries = (
+        m.call_args.args[0] if m.call_args.args else m.call_args.kwargs["queries"]
+    )
+    assert len(called_queries) == 1, (
+        f"Expected only the structural query; got {len(called_queries)}"
     )
 
 

--- a/tests/unit/test_knowledge_index.py
+++ b/tests/unit/test_knowledge_index.py
@@ -298,6 +298,107 @@ class TestKnowledgeIndexSearch:
                 assert results[i]["score"] >= results[i + 1]["score"]
 
 
+class TestKnowledgeIndexSearchMany:
+    """The batched multi-query path: same results as a search() loop, but the
+    query-side embeddings are computed in one round-trip per model."""
+
+    @pytest.fixture
+    def idx(self):
+        store = _make_store()
+        idx = KnowledgeIndex()
+        idx.build(store, skip_dense=True)
+        return idx
+
+    def test_matches_search_loop_bm25_only(self, idx):
+        """With no dense signal, search_many == [search(q) for q in queries]."""
+        queries = [
+            "requires_consent decorator",
+            "telegram mobile notifications",
+            "xyzzyplugh",  # no match
+        ]
+        batched = idx.search_many(queries)
+        individual = [idx.search(q) for q in queries]
+        assert batched == individual
+
+    def test_empty_queries_returns_empty_list(self, idx):
+        assert idx.search_many([]) == []
+
+    def test_not_built_returns_empty_slot_per_query(self):
+        idx = KnowledgeIndex()
+        assert idx.search_many(["a", "b"]) == [[], []]
+
+    def test_untokenizable_query_gets_empty_slot(self, idx):
+        results = idx.search_many(["consent", "  "])
+        assert len(results) == 2
+        assert results[0]  # "consent" matches
+        assert results[1] == []  # whitespace tokenizes to nothing
+
+    def _give_content_vectors(self, idx, seed=0):
+        """Attach a synthetic normalized content matrix so the dense query
+        path is exercised without a real index build."""
+        import numpy as np
+        n = idx.size
+        mat = np.random.default_rng(seed).normal(size=(n, 768)).astype(np.float32)
+        idx._content_vectors = KnowledgeIndex._l2_normalize(mat)
+        idx._has_content = True
+        idx._alias_flat = None  # isolate the content signal
+
+    def test_query_embeddings_are_batched_into_one_call(self, idx, monkeypatch):
+        """The whole point: N queries → exactly ONE embed round-trip."""
+        import numpy as np
+        from work_buddy.embedding import client as embed_client
+
+        self._give_content_vectors(idx)
+
+        calls: list[list[str]] = []
+
+        def fake_embed_for_ir(texts, role="query", **kwargs):
+            calls.append(list(texts))
+            rng = np.random.default_rng(abs(hash(tuple(texts))) & 0xFFFF)
+            return [rng.normal(size=768).tolist() for _ in texts]
+
+        monkeypatch.setattr(embed_client, "embed_for_ir", fake_embed_for_ir)
+
+        queries = ["alpha query", "beta query", "gamma query"]
+        results = idx.search_many(queries)
+
+        assert len(calls) == 1, f"expected 1 batched embed call, got {len(calls)}"
+        assert calls[0] == queries, "the single call must carry every query"
+        assert len(results) == len(queries)
+
+    def test_degrades_to_bm25_when_embed_unavailable(self, idx, monkeypatch):
+        """Content vectors exist, but the service is down (embed → None):
+        results fall back to BM25 instead of failing."""
+        from work_buddy.embedding import client as embed_client
+
+        self._give_content_vectors(idx)
+        monkeypatch.setattr(
+            embed_client, "embed_for_ir",
+            lambda texts, role="query", **kw: None,
+        )
+
+        results = idx.search_many(["requires_consent decorator", "xyzzyplugh"])
+        # BM25 still resolves the first query; the nonsense query matches nothing.
+        assert results[0] and results[0][0]["path"] == "consent/system"
+        assert results[1] == []
+
+    def test_passes_embed_timeout_through(self, idx, monkeypatch):
+        """query_embed_timeout_s is forwarded to the embed client so a
+        contended service can be bounded."""
+        from work_buddy.embedding import client as embed_client
+
+        self._give_content_vectors(idx)
+        seen_timeout: list = []
+
+        def fake_embed_for_ir(texts, role="query", timeout_s=None, **kwargs):
+            seen_timeout.append(timeout_s)
+            return [[0.0] * 768 for _ in texts]
+
+        monkeypatch.setattr(embed_client, "embed_for_ir", fake_embed_for_ir)
+        idx.search_many(["q1", "q2"], query_embed_timeout_s=25)
+        assert seen_timeout == [25]
+
+
 class TestPlaceholderIndexSearch:
     """Searching for content from a referenced unit should surface the referrer."""
 

--- a/tests/unit/test_knowledge_index.py
+++ b/tests/unit/test_knowledge_index.py
@@ -629,6 +629,57 @@ class TestCacheIntegration:
         )
         assert "EDITED summary text" in embedded_texts[0]
 
+    def test_content_save_uses_per_pid_temp_not_a_fixed_name(self, monkeypatch):
+        """Regression: the content-cache save must NOT pin a single fixed temp name.
+
+        The gateway (warmup / agent_docs_rebuild) AND the dev-document scan
+        subprocess each rebuild the index in a fresh process and save here, so a
+        shared ``content.tmp.npz`` races — one process's temp->canonical rename
+        finds the temp already gone (WinError 2), the save fails, and the cache is
+        left cold. Passing no ``tmp_path`` lets ``atomic_save_npz`` default to a
+        per-PID temp that can't collide.
+        """
+        import numpy as np
+        from work_buddy.knowledge import persistence as persist
+
+        seen = {}
+        real = persist.atomic_save_npz
+
+        def spy(path, *, tmp_path=None, **arrays):
+            seen["tmp_path"] = tmp_path
+            return real(path, tmp_path=tmp_path, **arrays)
+
+        monkeypatch.setattr(persist, "atomic_save_npz", spy)
+        persist.save_content_cache(
+            {"u": (persist.content_hash("x"), np.zeros((1, 768), dtype=np.float32))},
+            "leaf-ir",
+        )
+        assert seen.get("tmp_path") is None, (
+            "save_content_cache must not pass a fixed tmp_path (would race across "
+            f"concurrent builders); got {seen.get('tmp_path')!r}"
+        )
+
+    def test_alias_save_uses_per_pid_temp_not_a_fixed_name(self, monkeypatch):
+        """Same per-PID-temp contract for the alias cache."""
+        import numpy as np
+        from work_buddy.knowledge import persistence as persist
+
+        seen = {}
+        real = persist.atomic_save_npz
+
+        def spy(path, *, tmp_path=None, **arrays):
+            seen["tmp_path"] = tmp_path
+            return real(path, tmp_path=tmp_path, **arrays)
+
+        monkeypatch.setattr(persist, "atomic_save_npz", spy)
+        persist.save_alias_cache(
+            {("u", "alias phrase"): np.zeros((1024,), dtype=np.float32)},
+            "leaf-mt",
+        )
+        assert seen.get("tmp_path") is None, (
+            f"save_alias_cache must not pass a fixed tmp_path; got {seen.get('tmp_path')!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Module-level helpers

--- a/work_buddy/dev/document.py
+++ b/work_buddy/dev/document.py
@@ -53,6 +53,15 @@ _EXT_BUCKETS: dict[str, str] = {
 # depth.
 _TOP_N = 20
 
+# Per-batch timeout for the query-side dense embeddings. The semantic pass
+# embeds every query (structural + per-file docstrings) in one batched call
+# per model; bounding each batch keeps the scan degrading to lexical-only
+# fast when the embedding service is contended, instead of consuming the
+# whole auto_run budget. Two batched calls (content + alias) fit comfortably
+# under the step's 90s budget even at this ceiling, with margin for the
+# ~5-6s fixed subprocess + index-build overhead.
+_QUERY_EMBED_TIMEOUT_S = 25
+
 
 def _run_git(*args: str) -> list[str]:
     """Run a git command in the repo root; return stdout lines (no blanks)."""
@@ -241,100 +250,96 @@ def _search_units_via_rag(
       query. Surfaces units that describe the *behavior* in domain language
       (e.g. ``architecture/workflows`` for changes to ``conductor.py``).
 
-    Each query produces its own ranked list; ``rrf_combine`` fuses them
-    rank-by-rank with equal voice. Concatenating the queries into one
-    string would dilute short structural signals under longer prosier
-    docstring text — running them separately and fusing keeps each
-    signal's discriminative power.
+    All queries are issued in ONE batched call (``search_many``) so their
+    query-side dense embeddings share a single round-trip per model rather
+    than one per query — the difference between fitting the scan's auto_run
+    budget and blowing it on a large changeset. Each query still produces
+    its own ranked list; ``rrf_combine`` fuses them rank-by-rank with equal
+    voice (concatenating queries into one string would dilute short
+    structural signals under longer prosier docstring text).
 
     Returns:
         A list of ``{path, name, description, score, why}`` dicts on
-        success, or ``None`` if the structural query failed (embedding
-        service unavailable, exception). ``None`` is the signal for
-        ``scan_changes`` to fall back to the scored grep path. Per-file
-        docstring queries that fail are logged and skipped — partial
-        rankings are better than no rankings.
+        success, or ``None`` if the batched search could not run at all
+        (exception) or the structural query errored. ``None`` is the signal
+        for ``scan_changes`` to fall back to the scored grep path. A
+        contended embedding service does NOT trigger ``None`` — ``search_many``
+        degrades to BM25 (lexical) and still returns ranked candidates;
+        per-docstring errors are logged and skipped.
     """
     if not (changed_files or slugs):
         return []
 
-    from work_buddy.knowledge.search import rrf_combine, search
+    from work_buddy.knowledge.search import rrf_combine, search_many
 
-    rankings: list[list[dict[str, Any]]] = []
-    sources_per_path: dict[str, list[str]] = {}  # for "why" labels
+    # Build the query set: one structural query + one per .py docstring.
+    # ``labels`` runs parallel to ``queries`` and feeds the "why" annotation.
+    queries: list[str] = []
+    labels: list[str] = []
 
-    # --- Source 1: structural query (paths + slugs). ---
     structural_query = _build_rag_query(changed_files, slugs)
     if structural_query.strip():
-        try:
-            result = search(
-                query=structural_query,
-                knowledge_scope="system",
-                top_n=_TOP_N,
-                depth="index",
-            )
-        except Exception as exc:  # noqa: BLE001 — fallback path is the recovery
-            logger.warning(
-                "RAG structural search failed (%s); falling back to grep.",
-                exc,
-            )
-            return None
-        if "error" in result:
-            logger.warning(
-                "RAG structural search returned error (%s); falling back to grep.",
-                result["error"],
-            )
-            return None
-        ranking = result.get("results") or []
-        if ranking:
-            rankings.append(ranking)
-            for hit in ranking:
-                sources_per_path.setdefault(hit["path"], []).append("paths")
+        queries.append(structural_query)
+        labels.append("paths")
 
-    # --- Source 2..N: per-file docstring queries. ---
     for f in changed_files:
         docstring = _read_module_docstring(f)
         if not docstring:
             continue
-        try:
-            result = search(
-                query=docstring,
-                knowledge_scope="system",
-                top_n=_TOP_N,
-                depth="index",
-            )
-        except Exception as exc:  # noqa: BLE001 — non-fatal: drop this signal
-            logger.warning(
-                "RAG docstring search for %s failed (%s); continuing without it.",
-                f, exc,
-            )
-            continue
+        queries.append(docstring)
+        labels.append(f"docstring({PurePosixPath(f.replace(chr(92), '/')).stem})")
+
+    if not queries:
+        return []
+
+    try:
+        results = search_many(
+            queries,
+            knowledge_scope="system",
+            top_n=_TOP_N,
+            depth="index",
+            query_embed_timeout_s=_QUERY_EMBED_TIMEOUT_S,
+        )
+    except Exception as exc:  # noqa: BLE001 — grep fallback is the recovery
+        logger.warning(
+            "RAG batched search failed (%s); falling back to grep.", exc,
+        )
+        return None
+
+    rankings: list[list[dict[str, Any]]] = []
+    sources_per_path: dict[str, list[str]] = {}  # for "why" labels
+
+    for label, result in zip(labels, results):
         if "error" in result:
+            # The structural query is load-bearing; if it errored, signal a
+            # grep fallback. A per-docstring error is non-fatal — skip it.
+            if label == "paths":
+                logger.warning(
+                    "RAG structural search returned error (%s); falling back to grep.",
+                    result["error"],
+                )
+                return None
             logger.warning(
-                "RAG docstring search for %s returned error (%s); skipping.",
-                f, result["error"],
+                "RAG docstring search (%s) returned error (%s); skipping.",
+                label, result["error"],
             )
             continue
         ranking = result.get("results") or []
         if ranking:
             rankings.append(ranking)
-            label = f"docstring({PurePosixPath(f.replace(chr(92), '/')).stem})"
             for hit in ranking:
                 sources_per_path.setdefault(hit["path"], []).append(label)
 
-    # If every source returned empty, surface that to the caller as an empty
-    # list (genuine "nothing matches"), not as a failure.  ``None`` is reserved
-    # for "the structural query couldn't even run" — that's where the grep
-    # fallback adds value.
+    # Every source empty → genuine "nothing matches", not a failure. ``None``
+    # is reserved for "the search couldn't run" — that's where grep adds value.
     if not rankings:
         return []
 
     fused = rrf_combine(rankings)
 
     # Slim each candidate and synthesize the "why" from which sources
-    # contributed.  This is materially more useful than the old single-source
-    # "matched: <slugs>" label — a reader can tell at a glance whether a
-    # candidate landed via path-mention or domain-language match.
+    # contributed — a reader can tell at a glance whether a candidate landed
+    # via path-mention or domain-language (docstring) match.
     out: list[dict[str, Any]] = []
     for hit in fused[:_TOP_N]:
         sources = sources_per_path.get(hit["path"], [])

--- a/work_buddy/knowledge/index.py
+++ b/work_buddy/knowledge/index.py
@@ -682,19 +682,162 @@ class KnowledgeIndex:
         if not q_tokens:
             return []
 
+        mask = self._candidate_mask(candidates)
+
+        # Dense signals — either may be None if a signal is unavailable
+        # (service down, model missing, no aliases). The query is embedded
+        # here (one round-trip per model); for multi-query callers that want
+        # to amortize that round-trip, see ``search_many``.
+        content_scores, alias_scores = self._score_dense(query, mask)
+
+        return self._combine_and_rank(
+            q_tokens, content_scores, alias_scores, mask,
+            top_n, meta_weight, content_weight,
+        )
+
+    def search_many(
+        self,
+        queries: list[str],
+        candidates: dict[str, KnowledgeUnit] | None = None,
+        top_n: int = 8,
+        meta_weight: float = 0.3,
+        content_weight: float = 0.7,
+        query_embed_timeout_s: int | None = None,
+    ) -> list[list[dict[str, Any]]]:
+        """Score multiple queries against the index, batching the embeddings.
+
+        Functionally equivalent to ``[self.search(q, ...) for q in queries]``,
+        but the query-side dense embeddings for ALL queries are computed in a
+        single round-trip per model (one ``embed_for_ir`` call for the content
+        signal, one ``embed`` call for the alias signal) instead of one round-
+        trip per query. On weak/contended hardware the per-round-trip overhead
+        dominates, so collapsing N round-trips to 1 is the difference between
+        fitting an auto_run budget and blowing it. BM25 and the score fusion
+        stay per-query and in-process (cheap).
+
+        Graceful degradation: if a batched embed call returns ``None`` (service
+        unavailable, or it exceeded ``query_embed_timeout_s``), that dense
+        signal is dropped for every query and results fall back to the
+        remaining signals (BM25 always available once built). A query with no
+        tokens yields an empty result list in its slot.
+
+        Args:
+            queries: Query strings. Result order matches input order.
+            candidates: If provided, restrict to these paths (shared mask).
+            top_n: Max results per query.
+            meta_weight / content_weight: BM25 signal weights.
+            query_embed_timeout_s: Per-batch embed timeout. Bound this below
+                the caller's overall budget so a contended service degrades to
+                lexical-only fast rather than stalling the whole call.
+
+        Returns:
+            One ``[{"path", "score"}, ...]`` list per input query, in order.
+        """
+        if not self.is_built:
+            return [[] for _ in queries]
+        if not queries:
+            return []
+
+        mask = self._candidate_mask(candidates)
+
+        # --- Batch the query-side embeddings: one round-trip per model. ---
+        content_qvecs: "list | None" = None
+        alias_qvecs: "list | None" = None
+
+        if self._content_vectors is not None:
+            try:
+                from work_buddy.embedding.client import embed_for_ir
+                content_qvecs = embed_for_ir(
+                    queries, role="query", timeout_s=query_embed_timeout_s,
+                )
+            except Exception as e:  # noqa: BLE001 — degrade to other signals
+                logger.debug("Batched content query embedding failed: %s", e)
+            if content_qvecs is not None and len(content_qvecs) != len(queries):
+                logger.warning(
+                    "Batched content embed returned %d vectors for %d queries; "
+                    "dropping content signal.", len(content_qvecs), len(queries),
+                )
+                content_qvecs = None
+
+        if self._alias_flat is not None and self._alias_flat.shape[0] > 0:
+            try:
+                from work_buddy.embedding.client import embed
+                alias_qvecs = embed(queries, timeout_s=query_embed_timeout_s)
+            except Exception as e:  # noqa: BLE001 — degrade to other signals
+                logger.debug("Batched alias query embedding failed: %s", e)
+            if alias_qvecs is not None and len(alias_qvecs) != len(queries):
+                logger.warning(
+                    "Batched alias embed returned %d vectors for %d queries; "
+                    "dropping alias signal.", len(alias_qvecs), len(queries),
+                )
+                alias_qvecs = None
+
+        # Surface graceful degradation: dense was expected (vectors exist) but
+        # the query-side embedding could not be obtained — results fall back to
+        # BM25 (lexical) for every query in this batch.
+        if self._content_vectors is not None and content_qvecs is None:
+            logger.info(
+                "search_many: content dense signal unavailable for %d queries; "
+                "degrading to lexical (BM25).", len(queries),
+            )
+
+        out: list[list[dict[str, Any]]] = []
+        for i, query in enumerate(queries):
+            q_tokens = _tokenize(query)
+            if not q_tokens:
+                out.append([])
+                continue
+            cqv = content_qvecs[i] if content_qvecs is not None else None
+            aqv = alias_qvecs[i] if alias_qvecs is not None else None
+            content_scores, alias_scores = self._score_dense_from_vecs(
+                cqv, aqv, mask,
+            )
+            out.append(self._combine_and_rank(
+                q_tokens, content_scores, alias_scores, mask,
+                top_n, meta_weight, content_weight,
+            ))
+        return out
+
+    def _candidate_mask(
+        self,
+        candidates: dict[str, KnowledgeUnit] | None,
+    ) -> "np.ndarray":
+        """Boolean mask over docs: True where searchable.
+
+        ``candidates is None`` means "search the whole index". Otherwise only
+        the given paths (that exist in the index) are searchable.
+        """
         import numpy as np
 
         n_docs = len(self._docs)
+        if candidates is None:
+            return np.ones(n_docs, dtype=bool)
+        mask = np.zeros(n_docs, dtype=bool)
+        for path in candidates:
+            idx = self._path_to_idx.get(path)
+            if idx is not None:
+                mask[idx] = True
+        return mask
 
-        # Candidate mask (restrict to subset if provided)
-        if candidates is not None:
-            mask = np.zeros(n_docs, dtype=bool)
-            for path in candidates:
-                idx = self._path_to_idx.get(path)
-                if idx is not None:
-                    mask[idx] = True
-        else:
-            mask = np.ones(n_docs, dtype=bool)
+    def _combine_and_rank(
+        self,
+        q_tokens: list[str],
+        content_scores: "np.ndarray | None",
+        alias_scores: "np.ndarray | None",
+        mask: "np.ndarray",
+        top_n: int,
+        meta_weight: float,
+        content_weight: float,
+    ) -> list[dict[str, Any]]:
+        """Fuse BM25 + (optional) dense signals and return the top_n ranking.
+
+        BM25 is computed here (in-process, cheap) from ``q_tokens``; the dense
+        signals are passed in pre-scored so this helper is shared by both the
+        single-query (``search``) and batched (``search_many``) paths.
+        """
+        import numpy as np
+
+        n_docs = len(self._docs)
 
         # --- BM25 scoring (weighted: content + metadata) ---
         bm25_scores = np.zeros(n_docs)
@@ -715,12 +858,7 @@ class KnowledgeIndex:
 
         bm25_scores[~mask] = 0.0
 
-        # --- Dense scoring: two independent signals, fused by rank ---
-        # Either may be None if the respective signal is unavailable (service
-        # down, model missing, no aliases in store). _rrf_fuse skips None/zero
-        # arrays, so fusion degrades gracefully.
-        content_scores, alias_scores = self._score_dense(query, mask)
-
+        # --- Fuse: BM25 + whichever dense signals are present ---
         signals: list = [bm25_scores]
         if content_scores is not None:
             signals.append(content_scores)
@@ -755,72 +893,108 @@ class KnowledgeIndex:
         query: str,
         mask: "np.ndarray",
     ) -> "tuple[np.ndarray | None, np.ndarray | None]":
-        """Score query against both dense indices.
+        """Embed a single query and score it against both dense indices.
 
-        Returns ``(content_scores, alias_scores)`` — either may be ``None``
-        if the respective signal is unavailable (service down, model missing,
-        no aliases in store). Callers should drop ``None`` arrays from fusion.
+        Convenience wrapper over ``_score_dense_from_vecs`` for single-query
+        callers: it performs the per-model query embedding (one round-trip
+        each) and then defers all the numpy to the shared scorer. Batched
+        callers embed once for many queries and call ``_score_dense_from_vecs``
+        directly — see ``search_many``.
 
-        Both arrays are normalized to [0, 1] per-query so that within-array
-        ranking is preserved; actual score magnitudes don't matter after RRF
-        since fusion is rank-based.
+        Returns ``(content_scores, alias_scores)`` — either may be ``None`` if
+        the respective signal is unavailable (service down, model missing, no
+        aliases in store). Callers should drop ``None`` arrays from fusion.
         """
         if self._content_vectors is None and self._alias_flat is None:
             return None, None
 
+        content_qvec = None
+        alias_qvec = None
+
+        if self._content_vectors is not None:
+            try:
+                from work_buddy.embedding.client import embed_for_ir
+                q_vecs = embed_for_ir([query], role="query")
+                if q_vecs and q_vecs[0]:
+                    content_qvec = q_vecs[0]
+            except Exception as e:
+                logger.debug("Content dense query embedding failed: %s", e)
+
+        if self._alias_flat is not None and self._alias_flat.shape[0] > 0:
+            try:
+                from work_buddy.embedding.client import embed
+                q_vecs = embed([query])
+                if q_vecs and q_vecs[0]:
+                    alias_qvec = q_vecs[0]
+            except Exception as e:
+                logger.debug("Alias dense query embedding failed: %s", e)
+
+        return self._score_dense_from_vecs(content_qvec, alias_qvec, mask)
+
+    def _score_dense_from_vecs(
+        self,
+        content_qvec: "list[float] | np.ndarray | None",
+        alias_qvec: "list[float] | np.ndarray | None",
+        mask: "np.ndarray",
+    ) -> "tuple[np.ndarray | None, np.ndarray | None]":
+        """Score pre-embedded query vectors against both dense indices.
+
+        Pure numpy — no embedding-service calls — so it works identically for
+        single-query and batched callers. ``content_qvec`` / ``alias_qvec``
+        may each be ``None`` (signal unavailable for this query), in which case
+        the corresponding score array is ``None``.
+
+        Both arrays are normalized to [0, 1] per-query so within-array ranking
+        is preserved; absolute magnitudes don't matter after rank fusion.
+        """
         import numpy as np
 
         content_scores: "np.ndarray | None" = None
         alias_scores: "np.ndarray | None" = None
 
-        # --- Content path: asymmetric query encoder (leaf-ir-query, 768-d) ---
-        if self._content_vectors is not None:
+        # --- Content path: 768-d asymmetric query vector vs content matrix ---
+        if self._content_vectors is not None and content_qvec is not None:
             try:
-                from work_buddy.embedding.client import embed_for_ir
-
-                q_vecs = embed_for_ir([query], role="query")
-                if q_vecs and q_vecs[0]:
-                    q_vec = np.array(q_vecs[0], dtype=np.float32)
-                    q_norm = np.linalg.norm(q_vec)
-                    if q_norm > 0:
-                        q_vec = q_vec / q_norm
-                        sims = self._content_vectors @ q_vec
-                        sims[~mask] = 0.0
-                        max_sim = sims.max()
-                        if max_sim > 0:
-                            sims = sims / max_sim
-                        content_scores = sims
+                q_vec = np.array(content_qvec, dtype=np.float32)
+                q_norm = np.linalg.norm(q_vec)
+                if q_norm > 0:
+                    q_vec = q_vec / q_norm
+                    sims = self._content_vectors @ q_vec
+                    sims[~mask] = 0.0
+                    max_sim = sims.max()
+                    if max_sim > 0:
+                        sims = sims / max_sim
+                    content_scores = sims
             except Exception as e:
-                logger.debug("Content dense query scoring failed: %s", e)
+                logger.debug("Content dense scoring failed: %s", e)
 
-        # --- Alias path: symmetric leaf-mt (1024-d), max-pool per doc ---
-        if self._alias_flat is not None and self._alias_flat.shape[0] > 0:
+        # --- Alias path: 1024-d symmetric query vector, max-pool per doc ---
+        if (
+            self._alias_flat is not None
+            and self._alias_flat.shape[0] > 0
+            and alias_qvec is not None
+        ):
             try:
-                from work_buddy.embedding.client import embed
-
-                q_vecs = embed([query])
-                if q_vecs and q_vecs[0]:
-                    q_vec = np.array(q_vecs[0], dtype=np.float32)
-                    q_norm = np.linalg.norm(q_vec)
-                    if q_norm > 0:
-                        q_vec = q_vec / q_norm
-                        # One dot product against ALL alias vectors.
-                        flat_sims = self._alias_flat @ q_vec
-                        # Max-pool per doc via slices.
-                        n_docs = len(self._docs)
-                        sims = np.zeros(n_docs, dtype=np.float32)
-                        for i, (start, end) in enumerate(self._alias_slices):
-                            if end > start and mask[i]:
-                                sims[i] = flat_sims[start:end].max()
-                        max_sim = sims.max()
-                        if max_sim > 0:
-                            sims = sims / max_sim
-                            alias_scores = sims
-                        # If no positive alias matches at all, leave as None —
-                        # adding an all-zero signal to fusion is a no-op but
-                        # explicit None is cleaner.
+                q_vec = np.array(alias_qvec, dtype=np.float32)
+                q_norm = np.linalg.norm(q_vec)
+                if q_norm > 0:
+                    q_vec = q_vec / q_norm
+                    # One dot product against ALL alias vectors.
+                    flat_sims = self._alias_flat @ q_vec
+                    # Max-pool per doc via slices.
+                    n_docs = len(self._docs)
+                    sims = np.zeros(n_docs, dtype=np.float32)
+                    for i, (start, end) in enumerate(self._alias_slices):
+                        if end > start and mask[i]:
+                            sims[i] = flat_sims[start:end].max()
+                    max_sim = sims.max()
+                    if max_sim > 0:
+                        sims = sims / max_sim
+                        alias_scores = sims
+                    # No positive alias match → leave as None (all-zero signal
+                    # would be a fusion no-op, but explicit None is cleaner).
             except Exception as e:
-                logger.debug("Alias dense query scoring failed: %s", e)
+                logger.debug("Alias dense scoring failed: %s", e)
 
         return content_scores, alias_scores
 

--- a/work_buddy/knowledge/persistence.py
+++ b/work_buddy/knowledge/persistence.py
@@ -150,12 +150,16 @@ def save_content_cache(
         # Empty 0-row array, but shape out the dim so load doesn't barf
         vectors_arr = np.zeros((0, 1), dtype=np.float16)
 
-    # Fixed temp name (single-process cache builder; this cache dir isn't swept,
-    # so no PID-namespacing is needed). atomic_save_npz writes via an open file
-    # object, so the '.tmp.npz' name is kept verbatim with no '.npz' re-append.
+    # PID-namespaced temp (the atomic_save_npz default — pass no tmp_path). This
+    # content cache is rebuilt + saved by MULTIPLE processes — the gateway warmup /
+    # agent_docs_rebuild AND the dev-document scan subprocess each build the index
+    # in a fresh process and save here — so a single fixed temp name races: one
+    # process's temp->canonical rename finds the temp already renamed/cleaned by
+    # the other (WinError 2), the save fails, and the cache is left cold (forcing
+    # the next cold process to re-embed the whole store). Per-PID temps don't
+    # collide; os.replace keeps the final write atomic whichever builder lands last.
     atomic_save_npz(
         path,
-        tmp_path=path.with_suffix(".tmp.npz"),
         paths=paths_arr,
         hashes=hashes_arr,
         vectors=vectors_arr,
@@ -236,12 +240,11 @@ def save_alias_cache(
     else:
         vectors_arr = np.zeros((0, 1), dtype=np.float16)
 
-    # Fixed temp name (single-process cache builder; this cache dir isn't swept,
-    # so no PID-namespacing is needed). atomic_save_npz writes via an open file
-    # object, so the '.tmp.npz' name is kept verbatim with no '.npz' re-append.
+    # PID-namespaced temp (the atomic_save_npz default — pass no tmp_path); see
+    # save_content_cache for why a single fixed temp name races across the gateway
+    # and the dev-document scan subprocess that both rebuild + save this cache.
     atomic_save_npz(
         path,
-        tmp_path=path.with_suffix(".tmp.npz"),
         paths=paths_arr,
         alias_texts=texts_arr,
         vectors=vectors_arr,

--- a/work_buddy/knowledge/search.py
+++ b/work_buddy/knowledge/search.py
@@ -84,6 +84,98 @@ def search(
     )
 
 
+def search_many(
+    queries: list[str],
+    *,
+    scope: str | None = None,
+    kind: str | None = None,
+    depth: str = "index",
+    top_n: int = 8,
+    knowledge_scope: str = "system",
+    category: str | None = None,
+    severity: str | None = None,
+    dev: bool = False,
+    query_embed_timeout_s: int | None = None,
+) -> list[dict[str, Any]]:
+    """Batched multi-query search — one result dict per query, in order.
+
+    Functionally equivalent to ``[search(q, ...) for q in queries]`` for the
+    search (query) mode, but the query-side dense embeddings for every query
+    are batched into a single round-trip per model (see
+    ``KnowledgeIndex.search_many``). Use this instead of a loop over
+    ``search()`` whenever you issue several queries against the same store in
+    one pass — the per-round-trip embedding overhead, not the in-process
+    BM25/fusion, is what dominates on weak or contended hardware.
+
+    Each returned dict has the same shape as ``search()``'s search-mode
+    response: ``{"mode": "search", "query", "count", "results"}`` where each
+    result carries ``path``, ``score``, and the unit's ``depth``-tiered fields.
+
+    Graceful degradation matches ``search()``: if the embedding service is
+    unavailable (or a batched embed exceeds ``query_embed_timeout_s``), the
+    dense signals drop and results fall back to BM25. ``query_embed_timeout_s``
+    bounds each batch so a contended service degrades fast rather than
+    stalling the whole call.
+    """
+    if depth not in ("index", "summary", "full"):
+        return [
+            {"error": f"Invalid depth: {depth!r}. Must be 'index', 'summary', or 'full'."}
+            for _ in queries
+        ]
+    if not queries:
+        return []
+
+    store = load_store(scope=knowledge_scope)
+
+    # Filter candidates once — shared across all queries.
+    candidates_units: dict[str, KnowledgeUnit] = {}
+    for p, u in store.items():
+        if scope and not p.startswith(scope.rstrip("/") + "/") and p != scope.rstrip("/"):
+            continue
+        if kind and u.kind != kind:
+            continue
+        candidates_units[p] = u
+    candidates_units = _apply_vault_filters(candidates_units, category, severity)
+
+    if not candidates_units:
+        return [
+            {"mode": "search", "query": q, "count": 0, "results": []}
+            for q in queries
+        ]
+
+    full_store = load_store(scope="all") if depth == "full" else None
+
+    from work_buddy.knowledge.index import ensure_index
+
+    idx = ensure_index(knowledge_scope=knowledge_scope)
+    scored_lists = idx.search_many(
+        queries=queries,
+        candidates=candidates_units,
+        top_n=top_n,
+        query_embed_timeout_s=query_embed_timeout_s,
+    )
+
+    out: list[dict[str, Any]] = []
+    for query, scored in zip(queries, scored_lists):
+        results = []
+        for item in scored:
+            unit = candidates_units.get(item["path"])
+            if unit is None:
+                continue
+            results.append({
+                "path": unit.path,
+                "score": item["score"],
+                **unit.tier(depth, store=full_store, dev=dev),
+            })
+        out.append({
+            "mode": "search",
+            "query": query,
+            "count": len(results),
+            "results": results,
+        })
+    return out
+
+
 def _lookup(
     path: str,
     depth: str,


### PR DESCRIPTION
Two fixes that together eliminate the `/wb-dev-document` scan-step auto_run timeout — one per independent cause we found.

## 1. Query-embed fan-out (`3a75782f`)

The scan issued one embedding round-trip **per changed file** (each `.py` docstring its own query, plus a structural query — ~2N sequential round-trips). On a contended GPU each round-trip balloons to seconds, so a ~20-file changeset blew the 30s auto_run budget and aborted the whole doc-sync workflow.

Collapsed into **one batched embed call per model** — `KnowledgeIndex.search_many` + a public `search_many()` wrapper; `_search_units_via_rag` makes a single batched call, with grep/BM25 as the graceful lexical fallback. Scan timeout 30→90s; the stale `dev_notes` (which wrongly said "don't use embeddings") rewritten to the batched-hybrid design.

## 2. Cache-save race (`3811b596`)

The *deeper* cause, surfaced live during this PR's own doc-sync: the knowledge content/alias caches saved to a single **fixed** temp name, on a false "single-process builder" assumption. The cache is actually built + saved by **multiple processes at once** — the gateway warm-up / `agent_docs_rebuild` AND the dev-document scan subprocess. They raced the temp→canonical rename (`[WinError 2]`), the save failed, and the cache was left **cold** — so every fresh scan re-embedded the whole store (~250s).

Fixed by passing no `tmp_path` → `atomic_save_npz`'s per-PID temp (`content.<pid>.tmp.npz`), the scheme the IR vector store already uses. Concurrent builders no longer collide.

## Verification

- **Unit:** 58 (scan suite) + 44 (cache suite, incl. 2 new per-PID-temp regression tests) — green.
- **Live, end-to-end:** the content cache went from `0.01 MB` (empty/racing) → **`0.58 MB` (persisted)**; the dev-document scan's index build dropped from a **90s timeout → 1.1s cache hit**; and the full scan that used to abort now completes — proven by `/wb-dev-pr`'s own doc-sync step in this PR.

## Known residual (deferred)

A genuinely cold cache (first run, model change, forced rebuild) still pays the ~250s embed once; its structural fix is the index-consolidation design (resident in-service index, no per-process rebuild). Tracked separately.

## Post-merge

`Ctrl+R` MCP restart to load the `search_many` code in the gateway (the 90s timeout is already live via `reload_capability_data`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
