### PR TITLE
feat(index): consolidated index package — flag-gated, inert (knowledge/vault/IR unification)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -238,6 +238,22 @@ inference:
       default_queue_wait_s: 30
       default_inference_s: 120
 
+# Consolidated index (work_buddy/index/) — one SQLite+FTS5+vector store across all
+# partitions (knowledge, vault chunks, conversation, projects, chrome, summary,
+# task_note). INERT until `enabled: true` (default OFF): the live knowledge/vault/IR
+# indexes stay the hot path; this builds into a SEPARATE db (db/index-consolidated),
+# served warm in-service and broker-scheduled. Per-partition `rrf_k` is the single
+# source for the RRF constant (was hardcoded ×7). Enabling + re-pointing callers is a
+# deliberate, reviewed step — see .data/designs/index-consolidation/.
+index:
+  enabled: false
+  db_path: null            # null → paths.resolve("db/index-consolidated")
+  partitions:
+    knowledge:
+      rrf_k: 20            # smaller per-partition default (A/B: k=60≈k=15 at top-k)
+    # conversation: { rrf_k: 60, recency: true }
+    # vault:        { rrf_k: 60 }
+
 chats:
   specstory_days: 7
   claude_history_days: 7

--- a/tests/unit/test_index_build.py
+++ b/tests/unit/test_index_build.py
@@ -1,0 +1,192 @@
+"""Tests for index/build.py (IndexBuilder) + index/partition.py (registry/accessors).
+
+A FakePartition supplies items/docs; a FakeEncoder returns deterministic vectors.
+tmp_path IndexStore; no real embedding service.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from work_buddy.index.build import IndexBuilder
+from work_buddy.index.model import Document, ItemRef, Projection, ProjectionKind, ProjectionSpec
+from work_buddy.index.partition import (
+    PartitionRegistry,
+    get_change_key,
+    get_projection_schema,
+    hydrate,
+)
+from work_buddy.index.resident import ResidentCacheRegistry
+from work_buddy.index.store import IndexStore
+
+
+class FakeEncoder:
+    def __init__(self, dim=4, down=False):
+        self.dim = dim
+        self.down = down
+
+    def encode_query(self, texts, kind, model_key=None):
+        return None if self.down else np.ones((len(texts), self.dim), dtype=np.float32)
+
+    def encode_documents(self, texts, kind, model_key=None):
+        return None if self.down else np.ones((len(texts), self.dim), dtype=np.float32)
+
+
+class FakePartition:
+    name = "fake"
+    change_key = "hash"
+
+    def __init__(self, items):
+        # items: {item_id: {"hash": str, "docs": [(suffix, name, proj_text)]}}
+        self.items = items
+
+    def field_weights(self):
+        return {"title": 3.0, "body": 1.0}
+
+    def projection_schema(self):
+        return {"content": ProjectionSpec(kind=ProjectionKind.PASSAGE)}
+
+    def discover(self):
+        return [ItemRef(item_id=iid, content_hash=v["hash"]) for iid, v in self.items.items()]
+
+    def parse(self, item_id):
+        out = []
+        for suffix, name, proj_text in self.items[item_id]["docs"]:
+            out.append(Document(
+                doc_id=f"fake:{suffix}", partition="fake",
+                fields={"name": name, "body": f"{name} body"},
+                display_text=name,
+                projections={"content": Projection(text=proj_text)},
+            ))
+        return out
+
+    def hydrate(self, hits, **opts):
+        return hits
+
+
+@pytest.fixture
+def store(tmp_path):
+    return IndexStore(tmp_path / "build-index.db")
+
+
+def _builder(store, partition, encoder=None):
+    return IndexBuilder(
+        store, encoder or FakeEncoder(), partition,
+        residents=ResidentCacheRegistry(), use_lock=False,
+    )
+
+
+class TestBuild:
+    def test_build_indexes_docs_and_vectors(self, store):
+        part = FakePartition({
+            "i1": {"hash": "h1", "docs": [("a", "alpha", "alpha passage")]},
+            "i2": {"hash": "h2", "docs": [("b", "beta", "beta passage")]},
+        })
+        stats = _builder(store, part).build()
+        assert stats["changed"] == 2
+        assert stats["doc_count"] == 2
+        assert stats["version"] == 1
+        assert store.vector_count("fake", "content") == 2
+        # lexical works
+        assert "fake:a" in store.search_lexical("alpha", partition="fake")
+
+    def test_incremental_no_change(self, store):
+        part = FakePartition({"i1": {"hash": "h1", "docs": [("a", "alpha", "p")]}})
+        _builder(store, part).build()
+        stats2 = _builder(store, part).build()
+        assert stats2["changed"] == 0
+        assert stats2["deleted"] == 0
+        assert stats2["version"] == 1  # unchanged → no bump
+
+    def test_changed_item_reindexed(self, store):
+        part = FakePartition({"i1": {"hash": "h1", "docs": [("a", "alpha", "p")]}})
+        _builder(store, part).build()
+        # mutate the item's hash + content
+        part.items["i1"] = {"hash": "h2", "docs": [("a", "alphaedited", "p2")]}
+        stats = _builder(store, part).build()
+        assert stats["changed"] == 1
+        assert stats["version"] == 2
+        assert "fake:a" in store.search_lexical("alphaedited", partition="fake")
+        assert store.search_lexical("alpha", partition="fake") == {} or \
+            "fake:a" not in store.search_lexical("alphaXYZ", partition="fake")
+
+    def test_deleted_item_pruned(self, store):
+        part = FakePartition({
+            "i1": {"hash": "h1", "docs": [("a", "alpha", "p")]},
+            "i2": {"hash": "h2", "docs": [("b", "beta", "p")]},
+        })
+        _builder(store, part).build()
+        assert store.doc_count("fake") == 2
+        del part.items["i2"]
+        stats = _builder(store, part).build()
+        assert stats["deleted"] == 1
+        assert store.doc_count("fake") == 1
+        assert store.vector_count("fake", "content") == 1  # cascade
+
+    def test_force_reindexes_all(self, store):
+        part = FakePartition({"i1": {"hash": "h1", "docs": [("a", "alpha", "p")]}})
+        _builder(store, part).build()
+        stats = _builder(store, part).build(force=True)
+        assert stats["changed"] == 1  # forced despite unchanged hash
+
+    def test_encode_unavailable_still_indexes_lexical(self, store):
+        part = FakePartition({"i1": {"hash": "h1", "docs": [("a", "alpha", "p")]}})
+        stats = _builder(store, part, encoder=FakeEncoder(down=True)).build()
+        assert stats["doc_count"] == 1            # docs indexed
+        assert store.vector_count("fake", "content") == 0  # no vectors (service down)
+        assert "fake:a" in store.search_lexical("alpha", partition="fake")  # lexical OK
+
+    def test_pooled_projection_build(self, store):
+        class PooledPartition(FakePartition):
+            def projection_schema(self):
+                return {"aliases": ProjectionSpec(kind=ProjectionKind.LABEL, pool="max")}
+
+            def parse(self, item_id):
+                return [Document(
+                    doc_id="fake:a", partition="fake", fields={"name": "alpha"},
+                    projections={"aliases": Projection(text=["a1", "a2", "a3"])},
+                )]
+        part = PooledPartition({"i1": {"hash": "h1", "docs": [("a", "alpha", "")]}})
+        _builder(store, part).build()
+        # 3 alias sub-vectors for the one doc
+        loaded = store.load_all_vectors("fake", "aliases")
+        assert loaded is not None and loaded[0].shape[0] == 3
+        assert store.vector_count("fake", "aliases") == 1  # distinct docs
+
+    def test_build_with_lock_completes(self, store):
+        part = FakePartition({"i1": {"hash": "h1", "docs": [("a", "alpha", "p")]}})
+        b = IndexBuilder(store, FakeEncoder(), part, residents=ResidentCacheRegistry(), use_lock=True)
+        assert b.build()["doc_count"] == 1
+
+
+class TestPartitionRegistry:
+    def test_lazy_register_and_get(self):
+        reg = PartitionRegistry()
+        calls = {"n": 0}
+
+        def factory():
+            calls["n"] += 1
+            return FakePartition({})
+
+        reg.register("fake", factory)
+        assert calls["n"] == 0          # lazy — not built at register
+        p = reg.get("fake")
+        assert calls["n"] == 1
+        assert reg.get("fake") is p     # cached
+        assert reg.names() == ["fake"]
+
+    def test_unknown_raises(self):
+        with pytest.raises(KeyError):
+            PartitionRegistry().get("missing")
+
+    def test_accessors(self):
+        part = FakePartition({})
+        assert get_change_key(part) == "hash"
+        assert "content" in get_projection_schema(part)
+        # a partition without optional methods
+        class Bare:
+            name = "bare"
+            change_key = "mtime"
+        assert get_projection_schema(Bare()) == {}
+        assert hydrate(Bare(), ["x"]) == ["x"]  # default passthrough

--- a/tests/unit/test_index_encode.py
+++ b/tests/unit/test_index_encode.py
@@ -1,0 +1,142 @@
+"""Tests for index/encode.py — dense scoring, model resolution, provider routing.
+
+No real embedding service: a FakeProvider records calls + returns deterministic vectors.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from work_buddy.index.encode import (
+    BrokeredEncoder,
+    ProviderRouter,
+    resolve_model,
+    score_dense,
+)
+from work_buddy.index.model import PoolStrategy, ProjectionKind
+from work_buddy.inference.broker import Priority
+
+
+class FakeProvider:
+    name = "fake"
+
+    def __init__(self, dim=4, name="fake"):
+        self.name = name
+        self.dim = dim
+        self.calls = []  # (texts, model_id, prompt_name, priority)
+
+    def encode(self, texts, *, model_id, prompt_name=None, priority=Priority.BACKGROUND):
+        self.calls.append((list(texts), model_id, prompt_name, priority))
+        if not texts:
+            return np.zeros((0, self.dim), dtype=np.float32)
+        return np.ones((len(texts), self.dim), dtype=np.float32)
+
+
+class _NoneProvider:
+    name = "down"
+
+    def encode(self, texts, *, model_id, prompt_name=None, priority=Priority.BACKGROUND):
+        return None  # simulates an unavailable backend
+
+
+# ---------------------------------------------------------------------------
+# score_dense
+# ---------------------------------------------------------------------------
+
+class TestScoreDense:
+    def test_cosine_ranking(self):
+        q = np.array([1.0, 0.0], dtype=np.float32)
+        matrix = np.array([[1.0, 0.0], [0.0, 1.0], [0.7, 0.7]], dtype=np.float32)
+        ids = ["aligned", "orthogonal", "diag"]
+        scores = score_dense(q, matrix, ids, pool=PoolStrategy.MAX)
+        assert scores["aligned"] == 1.0          # best (normalized)
+        assert "orthogonal" not in scores         # cosine 0 → dropped (not positive)
+        assert 0 < scores["diag"] < 1.0
+
+    def test_max_pool_over_repeated_doc(self):
+        q = np.array([1.0, 0.0], dtype=np.float32)
+        # doc 'x' has two sub-vectors: one orthogonal, one aligned → max should win
+        matrix = np.array([[0.0, 1.0], [1.0, 0.0]], dtype=np.float32)
+        ids = ["x", "x"]
+        scores = score_dense(q, matrix, ids, pool=PoolStrategy.MAX)
+        assert scores["x"] == 1.0
+
+    def test_mean_pool(self):
+        q = np.array([1.0, 0.0], dtype=np.float32)
+        matrix = np.array([[1.0, 0.0], [1.0, 0.0]], dtype=np.float32)  # both aligned
+        ids = ["x", "x"]
+        scores = score_dense(q, matrix, ids, pool=PoolStrategy.MEAN)
+        assert scores["x"] == 1.0
+
+    def test_empty(self):
+        assert score_dense(np.array([1.0]), None, []) == {}
+        assert score_dense(np.zeros(3), np.ones((2, 3)), ["a", "b"]) == {}  # zero query
+
+
+# ---------------------------------------------------------------------------
+# resolve_model
+# ---------------------------------------------------------------------------
+
+class TestResolveModel:
+    def test_label_is_symmetric(self):
+        assert resolve_model(ProjectionKind.LABEL, "query") == ("leaf-mt", None)
+        assert resolve_model(ProjectionKind.LABEL, "document") == ("leaf-mt", None)
+
+    def test_passage_is_asymmetric(self):
+        assert resolve_model(ProjectionKind.PASSAGE, "query") == ("leaf-ir-query", "query")
+        assert resolve_model(ProjectionKind.PASSAGE, "document") == ("leaf-ir", "document")
+
+    def test_model_key_override(self):
+        assert resolve_model(ProjectionKind.PASSAGE, "query", model_key="custom") == ("custom", None)
+        # leaf-ir family override keeps the asymmetric query/doc split
+        assert resolve_model(ProjectionKind.LABEL, "query", model_key="leaf-ir") == ("leaf-ir-query", "query")
+
+
+# ---------------------------------------------------------------------------
+# BrokeredEncoder + ProviderRouter
+# ---------------------------------------------------------------------------
+
+class TestBrokeredEncoder:
+    def _encoder(self, provider):
+        router = ProviderRouter(providers={"local": provider}, cfg={})
+        return BrokeredEncoder(router=router), provider
+
+    def test_query_uses_interactive_priority(self):
+        enc, prov = self._encoder(FakeProvider())
+        out = enc.encode_query(["hello"], ProjectionKind.PASSAGE)
+        assert out.shape == (1, 4)
+        texts, model_id, prompt, priority = prov.calls[-1]
+        assert priority == Priority.INTERACTIVE
+        assert model_id == "leaf-ir-query"
+        assert prompt == "query"
+
+    def test_documents_use_background_and_batch(self):
+        enc, prov = self._encoder(FakeProvider())
+        texts = [f"doc {i}" for i in range(70)]  # > 2 batches at 32
+        out = enc.encode_documents(texts, ProjectionKind.PASSAGE, batch_size=32)
+        assert out.shape == (70, 4)
+        assert len(prov.calls) == 3  # 32 + 32 + 6
+        assert all(c[3] == Priority.BACKGROUND for c in prov.calls)
+        assert prov.calls[0][1] == "leaf-ir"  # document side
+
+    def test_label_documents_use_leaf_mt(self):
+        enc, prov = self._encoder(FakeProvider())
+        enc.encode_documents(["alias one", "alias two"], ProjectionKind.LABEL)
+        assert prov.calls[-1][1] == "leaf-mt"
+        assert prov.calls[-1][2] is None
+
+    def test_documents_degrade_to_none_when_provider_down(self):
+        enc, _ = self._encoder(_NoneProvider())
+        assert enc.encode_documents(["x"], ProjectionKind.PASSAGE) is None
+
+    def test_router_falls_back_to_local_on_none(self):
+        local = FakeProvider(name="local")
+        down = _NoneProvider()
+        # config routes leaf-ir to the (down) lmstudio provider
+        router = ProviderRouter(
+            providers={"local": local, "lmstudio": down},
+            cfg={"embedding": {"models": {"leaf-ir": {"provider": "lmstudio"}}}},
+        )
+        out = router.encode(["x"], model_id="leaf-ir", priority=Priority.BACKGROUND)
+        assert out is not None and out.shape == (1, 4)  # fell back to local
+        assert local.calls  # local was invoked

--- a/tests/unit/test_index_fusion.py
+++ b/tests/unit/test_index_fusion.py
@@ -1,0 +1,112 @@
+"""Tests for index/fusion.py (RRF, parity with ir.store) + index/recency.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from work_buddy.index.fusion import RRF_K, rrf_fuse
+from work_buddy.index.recency import apply_recency_bias, recency_weight
+from work_buddy.index.model import Hit
+
+
+# ---------------------------------------------------------------------------
+# RRF + parity with the IR engine's implementation
+# ---------------------------------------------------------------------------
+
+class TestRrfFuse:
+    def test_default_k(self):
+        assert RRF_K == 60
+
+    def test_single_ranking_preserves_order(self):
+        r = {"a": 0.9, "b": 0.5, "c": 0.1}
+        fused = rrf_fuse([r])
+        ranked = sorted(fused, key=fused.get, reverse=True)
+        assert ranked == ["a", "b", "c"]
+
+    def test_shared_doc_ranks_higher(self):
+        # b appears in both rankings → should fuse to the top.
+        r1 = {"a": 0.9, "b": 0.5}
+        r2 = {"b": 0.9, "c": 0.5}
+        fused = rrf_fuse([r1, r2])
+        top = max(fused, key=fused.get)
+        assert top == "b"
+
+    def test_empty_rankings(self):
+        assert rrf_fuse([]) == {}
+        assert rrf_fuse([{}, {}]) == {}
+
+    def test_k_changes_spread_not_order(self):
+        r1 = {"a": 0.9, "b": 0.5}
+        r2 = {"b": 0.9, "a": 0.5}
+        f60 = rrf_fuse([r1, r2], k=60)
+        f15 = rrf_fuse([r1, r2], k=15)
+        # symmetric → both tie; but the key property: same key set, valid scores
+        assert set(f60) == set(f15) == {"a", "b"}
+
+    def test_parity_with_ir_store(self):
+        """Verbatim-lift parity: index.fusion.rrf_fuse == ir.store.rrf_fuse."""
+        from work_buddy.ir.store import rrf_fuse as ir_rrf
+        cases = [
+            [{"a": 0.9, "b": 0.5, "c": 0.1}],
+            [{"a": 0.9, "b": 0.5}, {"b": 0.8, "c": 0.4, "d": 0.2}],
+            [{}, {"x": 1.0}],
+            [{"p": 0.3, "q": 0.3, "r": 0.3}],  # ties
+        ]
+        for ks in (60, 20, 15, 1):
+            for c in cases:
+                assert rrf_fuse(c, k=ks) == ir_rrf(c, k=ks), (c, ks)
+
+
+# ---------------------------------------------------------------------------
+# Recency
+# ---------------------------------------------------------------------------
+
+class TestRecencyWeight:
+    def test_none_timestamp_no_penalty(self):
+        assert recency_weight(None) == 1.0
+
+    def test_zero_half_life_disabled(self):
+        assert recency_weight(1000.0, half_life_days=0, now_epoch=1_000_000.0) == 1.0
+
+    def test_fresh_is_near_one(self):
+        now = 1_000_000.0
+        assert recency_weight(now, now_epoch=now) == pytest.approx(1.0)
+
+    def test_one_half_life_is_midpoint(self):
+        now = 0.0
+        ts = -14 * 86400.0  # 14 days old, half_life=14
+        w = recency_weight(ts, half_life_days=14.0, floor=0.15, now_epoch=now)
+        # decay = 0.5 → floor + (1-floor)*0.5 = 0.15 + 0.425 = 0.575
+        assert w == pytest.approx(0.575, abs=1e-3)
+
+    def test_very_old_approaches_floor(self):
+        now = 0.0
+        ts = -3650 * 86400.0  # ~10 years
+        w = recency_weight(ts, half_life_days=14.0, floor=0.15, now_epoch=now)
+        assert w == pytest.approx(0.15, abs=1e-3)
+
+    def test_monotonic_decreasing_with_age(self):
+        now = 0.0
+        weights = [recency_weight(-d * 86400.0, now_epoch=now) for d in (0, 7, 14, 60)]
+        assert weights == sorted(weights, reverse=True)
+
+
+class TestApplyRecencyBias:
+    def test_mutates_and_resorts(self):
+        now = 0.0
+        hits = [Hit(doc_id="old", score=0.9), Hit(doc_id="new", score=0.6)]
+        ts = {"old": -100 * 86400.0, "new": now}  # old is heavily decayed
+        out = apply_recency_bias(hits, ts, half_life_days=14.0, floor=0.15, now_epoch=now)
+        # 'new' should now outrank 'old' despite lower raw score
+        assert out[0].doc_id == "new"
+        # signals recorded
+        assert "recency_weight" in out[0].signals
+        assert out[0].signals["raw_score"] == 0.6
+
+    def test_empty(self):
+        assert apply_recency_bias([], {}) == []
+
+    def test_disabled_half_life_noop(self):
+        hits = [Hit(doc_id="a", score=0.5)]
+        out = apply_recency_bias(hits, {"a": 0.0}, half_life_days=0, now_epoch=1.0)
+        assert out[0].score == 0.5  # untouched

--- a/tests/unit/test_index_model.py
+++ b/tests/unit/test_index_model.py
@@ -1,0 +1,183 @@
+"""Unit tests for the consolidated index value types + config (work_buddy/index/).
+
+No embedding service / DB needed — pure value-type + config behavior.
+"""
+
+from __future__ import annotations
+
+from work_buddy.index.model import (
+    Document,
+    Hit,
+    ItemRef,
+    PoolStrategy,
+    Projection,
+    ProjectionKind,
+    ProjectionSpec,
+    Query,
+    content_hash,
+    make_doc_id,
+)
+from work_buddy.index.config import (
+    DEFAULT_RRF_K,
+    IndexConfig,
+    PartitionConfig,
+    load_index_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Enums: string-equal to the IR engine's Literal values (interop, no 3.11 floor)
+# ---------------------------------------------------------------------------
+
+class TestEnums:
+    def test_projection_kind_is_str_equal(self):
+        assert ProjectionKind.LABEL == "label"
+        assert ProjectionKind.PASSAGE == "passage"
+        # usable as a plain string (dict keys, JSON, IR interop)
+        assert {"k": ProjectionKind.PASSAGE}["k"] == "passage"
+        assert f"{ProjectionKind.LABEL}" in ("label", "ProjectionKind.LABEL")
+
+    def test_pool_strategy_is_str_equal(self):
+        assert PoolStrategy.NONE == "none"
+        assert PoolStrategy.MAX == "max"
+        assert PoolStrategy.MEAN == "mean"
+
+    def test_projection_spec_defaults(self):
+        spec = ProjectionSpec(kind=ProjectionKind.PASSAGE)
+        assert spec.pool == PoolStrategy.NONE
+        assert spec.model_key is None
+        # frozen
+        import dataclasses
+        try:
+            spec.kind = ProjectionKind.LABEL  # type: ignore[misc]
+            assert False, "ProjectionSpec must be frozen"
+        except dataclasses.FrozenInstanceError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# content_hash + doc id
+# ---------------------------------------------------------------------------
+
+class TestHashingAndIds:
+    def test_content_hash_deterministic_and_16_chars(self):
+        h1 = content_hash("hello world")
+        h2 = content_hash("hello world")
+        assert h1 == h2
+        assert len(h1) == 16
+        assert content_hash("hello world") != content_hash("hello worlD")
+
+    def test_content_hash_handles_empty(self):
+        assert isinstance(content_hash(""), str)
+        assert len(content_hash("")) == 16
+
+    def test_make_doc_id(self):
+        assert make_doc_id("knowledge", "tasks/triage") == "knowledge:tasks/triage"
+
+
+# ---------------------------------------------------------------------------
+# Document
+# ---------------------------------------------------------------------------
+
+class TestDocument:
+    def test_defaults(self):
+        d = Document(doc_id="knowledge:x", partition="knowledge", fields={"name": "X"})
+        assert d.display_text == ""
+        assert d.metadata == {}
+        assert d.projections == {}
+        assert d.content_hash == ""
+        assert d.timestamp is None
+
+    def test_ensure_hash_populates_and_is_stable(self):
+        d = Document(
+            doc_id="knowledge:x", partition="knowledge",
+            fields={"name": "Alpha", "body": "beta gamma"},
+            projections={"content": Projection(text="beta gamma")},
+        )
+        h = d.ensure_hash()
+        assert h and d.content_hash == h
+        # idempotent
+        assert d.ensure_hash() == h
+        # changing a field changes the hashable text (fresh doc → different hash)
+        d2 = Document(
+            doc_id="knowledge:x", partition="knowledge",
+            fields={"name": "Alpha", "body": "beta DELTA"},
+            projections={"content": Projection(text="beta gamma")},
+        )
+        assert d2.ensure_hash() != h
+
+    def test_hashable_text_is_order_independent_over_fields(self):
+        a = Document(doc_id="p:1", partition="p", fields={"a": "1", "b": "2"})
+        b = Document(doc_id="p:1", partition="p", fields={"b": "2", "a": "1"})
+        assert a.hashable_text() == b.hashable_text()
+
+
+# ---------------------------------------------------------------------------
+# Query / Hit / ItemRef
+# ---------------------------------------------------------------------------
+
+class TestQueryHitItemRef:
+    def test_query_defaults(self):
+        q = Query(text="find me")
+        assert q.top_k == 10
+        assert q.method == "hybrid"
+        assert q.filters == {}
+        assert q.scope is None
+        assert q.recency is False
+        assert q.rrf_k is None
+
+    def test_hit_defaults(self):
+        h = Hit(doc_id="p:1", score=0.5)
+        assert h.signals == {}
+        assert h.metadata == {}
+
+    def test_itemref(self):
+        ref = ItemRef(item_id="f.md", mtime=123.0)
+        assert ref.content_hash is None
+        ref2 = ItemRef(item_id="f.md", content_hash="abc")
+        assert ref2.mtime == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+class TestConfig:
+    def test_load_defaults_when_absent(self):
+        cfg = load_index_config({})  # no index: block
+        assert cfg.enabled is False
+        assert cfg.db_path is None
+        assert cfg.partitions == {}
+
+    def test_load_disabled_by_default_even_with_block(self):
+        cfg = load_index_config({"index": {}})
+        assert cfg.enabled is False
+
+    def test_partition_fallback_for_unlisted(self):
+        cfg = load_index_config({"index": {"enabled": True}})
+        assert cfg.enabled is True
+        pc = cfg.partition("knowledge")
+        assert pc.name == "knowledge"
+        assert pc.rrf_k == DEFAULT_RRF_K
+
+    def test_partition_overrides(self):
+        cfg = load_index_config({
+            "index": {
+                "enabled": True,
+                "partitions": {"knowledge": {"rrf_k": 15, "recency": True}},
+            }
+        })
+        pc = cfg.partition("knowledge")
+        assert pc.rrf_k == 15
+        assert pc.recency is True
+        # unlisted still gets defaults
+        assert cfg.partition("conversation").rrf_k == DEFAULT_RRF_K
+
+    def test_malformed_block_degrades_to_off(self):
+        cfg = load_index_config({"index": "not a dict"})
+        assert cfg.enabled is False
+
+    def test_resolved_db_path_default(self):
+        cfg = load_index_config({})
+        p = cfg.resolved_db_path()
+        assert p.name == "index-consolidated.db"

--- a/tests/unit/test_index_partitions.py
+++ b/tests/unit/test_index_partitions.py
@@ -1,0 +1,206 @@
+"""Tests for the partition adapters: KnowledgePartition + IRSourcePartition + bootstrap."""
+
+from __future__ import annotations
+
+from work_buddy.index.model import ProjectionKind, PoolStrategy
+from work_buddy.index.partitions.ir_source import IRSourcePartition
+from work_buddy.knowledge.model import DirectionsUnit, SystemUnit, VaultUnit
+from work_buddy.knowledge.partition import KnowledgePartition
+
+
+def _synthetic_store():
+    return {
+        "consent/system": SystemUnit(
+            path="consent/system", name="Consent System",
+            description="Session-scoped approval grants",
+            content={"summary": "SQLite consent with TTL.", "full": "The consent system uses SQLite."},
+            tags=["consent", "permissions"], aliases=["approval", "grants"],
+        ),
+        "personal/pattern-a": VaultUnit(
+            path="personal/pattern-a", name="Pattern A", description="a personal pattern",
+            category="work_pattern", severity="HIGH",
+            content={"summary": "fixture", "full": "personal fixture body"},
+            tags=["metacognition"],
+        ),
+        "vault/writer": DirectionsUnit(
+            path="vault/writer", name="Vault Writer", description="section-aware writes",
+            trigger="agent writes to a vault note",
+            content={"summary": "insert at a section", "full": "resolver logic"},
+            tags=["vault"],
+        ),
+    }
+
+
+class TestKnowledgePartition:
+    def _part(self):
+        store = _synthetic_store()
+        return KnowledgePartition(store_loader=lambda: store), store
+
+    def test_discover_yields_ref_per_unit_with_hash(self):
+        part, store = self._part()
+        refs = list(part.discover())
+        assert {r.item_id for r in refs} == set(store)
+        assert all(r.content_hash for r in refs)
+        # stable across calls
+        refs2 = list(part.discover())
+        assert {r.item_id: r.content_hash for r in refs} == {r.item_id: r.content_hash for r in refs2}
+
+    def test_parse_builds_document_with_projections_and_scope(self):
+        part, _ = self._part()
+        docs = part.parse("consent/system")
+        assert len(docs) == 1
+        d = docs[0]
+        assert d.doc_id == "knowledge:consent/system"
+        assert d.partition == "knowledge"
+        assert d.fields["name"] == "Consent System"
+        # content projection (passage) + aliases projection (label, list)
+        assert "content" in d.projections
+        assert "approval" in d.projections["aliases"].text
+        assert d.metadata["scope"] == "system"
+        assert d.metadata["kind"]  # SystemUnit kind populated
+
+    def test_personal_unit_scope(self):
+        part, _ = self._part()
+        d = part.parse("personal/pattern-a")[0]
+        assert d.metadata["scope"] == "personal"
+
+    def test_no_aliases_no_alias_projection(self):
+        part, _ = self._part()
+        d = part.parse("vault/writer")[0]
+        assert "aliases" not in d.projections  # DirectionsUnit fixture has none
+
+    def test_projection_schema(self):
+        part, _ = self._part()
+        sch = part.projection_schema()
+        assert sch["content"].kind == ProjectionKind.PASSAGE
+        assert sch["aliases"].kind == ProjectionKind.LABEL
+        assert sch["aliases"].pool == PoolStrategy.MAX
+
+    def test_hydrate_returns_tiered_units(self):
+        from work_buddy.index.model import Hit
+        part, _ = self._part()
+        hits = [Hit(doc_id="knowledge:consent/system", score=0.9)]
+        out = part.hydrate(hits, depth="index")
+        assert out and out[0]["path"] == "consent/system"
+        assert out[0]["score"] == 0.9
+        assert "name" in out[0]  # tiered fields present
+
+
+class _FakeIRDoc:
+    def __init__(self, doc_id, fields, dense_text="", display_text="", metadata=None, projections=None):
+        self.doc_id = doc_id
+        self.fields = fields
+        self.dense_text = dense_text
+        self.display_text = display_text
+        self.metadata = metadata or {}
+        self.projections = projections or {}
+
+
+class _FakeIRSource:
+    name = "conversation"
+
+    def default_field_weights(self):
+        return {"user_text": 1.5, "assistant_text": 1.0}
+
+    def discover(self):
+        return [("sess1", 100.0), ("sess2", 200.0)]
+
+    def parse(self, item_id):
+        return [_FakeIRDoc(
+            doc_id=f"{item_id}:0", fields={"user_text": "hello"},
+            dense_text="hello world span", display_text="a span",
+            metadata={"start_time": "2026-01-01T00:00:00+00:00", "session_id": item_id},
+        )]
+
+
+class TestIRSourcePartition:
+    def test_wraps_name_and_weights(self):
+        p = IRSourcePartition(_FakeIRSource())
+        assert p.name == "conversation"
+        assert p.change_key == "mtime"
+        assert p.field_weights()["user_text"] == 1.5
+
+    def test_discover_normalizes_to_itemrefs(self):
+        p = IRSourcePartition(_FakeIRSource())
+        refs = list(p.discover())
+        assert {r.item_id for r in refs} == {"sess1", "sess2"}
+        assert {r.mtime for r in refs} == {100.0, 200.0}
+
+    def test_parse_converts_ir_doc(self):
+        p = IRSourcePartition(_FakeIRSource())
+        docs = p.parse("sess1")
+        d = docs[0]
+        assert d.doc_id == "conversation:sess1:0"   # prefixed with partition
+        assert d.partition == "conversation"
+        assert d.fields["user_text"] == "hello"
+        # bare dense_text → a content PASSAGE projection
+        assert d.projections["content"].text == "hello world span"
+        # ISO start_time → epoch timestamp (for recency)
+        assert d.timestamp is not None and d.timestamp > 0
+
+    def test_projection_schema_defaults_to_content_passage(self):
+        p = IRSourcePartition(_FakeIRSource())
+        sch = p.projection_schema()
+        assert sch["content"].kind == ProjectionKind.PASSAGE
+
+
+class _FakeDiscoveredFile:
+    def __init__(self, item_id, abs_path, vault_id="v1", mtime=10.0):
+        self.item_id = item_id
+        self.source_path = item_id
+        self.vault_id = vault_id
+        self.mtime = mtime
+        self.size = 0
+        self.abs_path = str(abs_path)
+
+
+class _FakeVaultSource:
+    def __init__(self, files):
+        self._files = files
+
+    def discover(self):
+        return (self._files, [])
+
+
+class TestVaultChunkPartition:
+    def test_discover_and_parse_chunks(self, tmp_path):
+        from work_buddy.vault_index.partition import VaultChunkPartition
+
+        md = tmp_path / "note.md"
+        md.write_text(
+            "# Title\n\nIntro text.\n\n## Section A\n\nAlpha body.\n\n## Section B\n\nBeta body.\n",
+            encoding="utf-8",
+        )
+        src = _FakeVaultSource([_FakeDiscoveredFile("v1/note.md", md)])
+        part = VaultChunkPartition(source=src)
+
+        refs = list(part.discover())
+        assert refs[0].item_id == "v1/note.md"
+        assert part.change_key == "mtime"
+
+        docs = part.parse("v1/note.md")
+        assert len(docs) >= 2  # at least Section A + Section B chunks
+        d = docs[0]
+        assert d.partition == "vault"
+        assert d.doc_id.startswith("vault:")
+        assert "content" in d.projections
+        assert d.metadata["vault_id"] == "v1"
+
+    def test_unknown_item_returns_empty(self, tmp_path):
+        from work_buddy.vault_index.partition import VaultChunkPartition
+        part = VaultChunkPartition(source=_FakeVaultSource([]))
+        list(part.discover())
+        assert part.parse("nope") == []
+
+
+class TestBootstrap:
+    def test_ensure_registers_core_partitions(self):
+        from work_buddy.index.partition import get_partition_registry
+        from work_buddy.index.partitions.bootstrap import ensure_partitions_registered
+        ensure_partitions_registered()
+        names = get_partition_registry().names()
+        assert "knowledge" in names
+        for ir_name in ("conversation", "projects", "chrome", "summary", "task_note"):
+            assert ir_name in names
+        # the redundant IR "docs" source is intentionally NOT a partition
+        assert "docs" not in names

--- a/tests/unit/test_index_resident.py
+++ b/tests/unit/test_index_resident.py
@@ -1,0 +1,120 @@
+"""Tests for index/resident.py — generic ResidentCache + registry (injected behavior)."""
+
+from __future__ import annotations
+
+from work_buddy.index.resident import ResidentCache, ResidentCacheRegistry
+
+
+class _Clock:
+    """Manually-advanced monotonic clock for deterministic idle-TTL tests."""
+
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+class TestResidentCache:
+    def test_loads_once_and_serves_from_ram(self):
+        calls = {"n": 0}
+
+        def loader():
+            calls["n"] += 1
+            return [calls["n"]]
+
+        cache = ResidentCache(loader, version_fn=lambda: "v1")
+        assert cache.get() == [1]
+        assert cache.get() == [1]   # served from RAM, not reloaded
+        assert calls["n"] == 1
+        assert cache.is_cached()
+
+    def test_version_change_reloads(self):
+        calls = {"n": 0}
+        version = {"v": "v1"}
+
+        def loader():
+            calls["n"] += 1
+            return calls["n"]
+
+        cache = ResidentCache(loader, version_fn=lambda: version["v"])
+        assert cache.get() == 1
+        version["v"] = "v2"          # rebuild bumped the version
+        assert cache.get() == 2      # reloaded
+        assert calls["n"] == 2
+
+    def test_invalidate_forces_reload(self):
+        calls = {"n": 0}
+
+        def loader():
+            calls["n"] += 1
+            return calls["n"]
+
+        cache = ResidentCache(loader, version_fn=lambda: "v1")
+        cache.get()
+        cache.invalidate()
+        assert not cache.is_cached()
+        cache.get()
+        assert calls["n"] == 2
+
+    def test_none_loader_not_cached(self):
+        cache = ResidentCache(lambda: None, version_fn=lambda: "v1")
+        assert cache.get() is None
+        assert not cache.is_cached()
+
+    def test_release_if_idle(self):
+        clock = _Clock()
+        cache = ResidentCache(lambda: [1], version_fn=lambda: "v1", clock=clock)
+        cache.get()
+        assert cache.is_cached()
+        assert cache.release_if_idle(ttl_s=600) is False  # just loaded
+        clock.advance(601)
+        assert cache.release_if_idle(ttl_s=600) is True    # now idle
+        assert not cache.is_cached()
+
+    def test_version_fn_failure_returns_none(self):
+        def boom():
+            raise RuntimeError("db down")
+
+        cache = ResidentCache(lambda: [1], version_fn=boom)
+        assert cache.get() is None
+
+
+class TestResidentCacheRegistry:
+    def test_register_and_get(self):
+        reg = ResidentCacheRegistry()
+        c = ResidentCache(lambda: 1, version_fn=lambda: "v")
+        reg.register("a", c)
+        assert reg.get("a") is c
+        assert reg.get("missing") is None
+
+    def test_get_or_create_is_idempotent(self):
+        reg = ResidentCacheRegistry()
+        c1 = reg.get_or_create("k", lambda: 1, lambda: "v")
+        c2 = reg.get_or_create("k", lambda: 2, lambda: "v")
+        assert c1 is c2
+
+    def test_sweep_idle_releases_idle_caches(self):
+        clock = _Clock()
+        reg = ResidentCacheRegistry()
+        a = ResidentCache(lambda: [1], version_fn=lambda: "v", clock=clock)
+        b = ResidentCache(lambda: [2], version_fn=lambda: "v", clock=clock)
+        reg.register("a", a)
+        reg.register("b", b)
+        a.get(); b.get()
+        clock.advance(601)
+        b.get()  # b touched recently (re-stamps loaded_at)
+        released = reg.sweep_idle(ttl_s=600)
+        assert "a" in released
+        assert "b" not in released
+
+    def test_invalidate_all(self):
+        reg = ResidentCacheRegistry()
+        a = ResidentCache(lambda: [1], version_fn=lambda: "v")
+        reg.register("a", a)
+        a.get()
+        reg.invalidate_all()
+        assert not a.is_cached()

--- a/tests/unit/test_index_search.py
+++ b/tests/unit/test_index_search.py
@@ -1,0 +1,146 @@
+"""Tests for index/search.py — HybridSearcher + MultiQueryFuser.
+
+A FakeEncoder stands in for the embedding service; vectors are pre-loaded into a
+tmp_path IndexStore. Exercises lexical-only, hybrid fusion, degrade-to-lexical,
+metadata filtering, recency, and the multi-query fan-out.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from work_buddy.index.config import PartitionConfig
+from work_buddy.index.model import Document, Hit, Projection, ProjectionKind, ProjectionSpec, Query
+from work_buddy.index.resident import ResidentCacheRegistry
+from work_buddy.index.search import HybridSearcher, MultiQueryFuser
+from work_buddy.index.store import IndexStore
+
+
+class FakeEncoder:
+    def __init__(self, qvec=(1.0, 0.0), down=False):
+        self.qvec = list(qvec)
+        self.down = down
+
+    def encode_query(self, texts, kind, model_key=None):
+        if self.down:
+            return None
+        return np.array([self.qvec], dtype=np.float32)
+
+    def encode_documents(self, texts, kind, model_key=None):
+        return np.zeros((len(texts), len(self.qvec)), dtype=np.float32)
+
+
+@pytest.fixture
+def store(tmp_path):
+    return IndexStore(tmp_path / "search-index.db")
+
+
+def _seed(store, *, with_vectors=True, timestamps=None):
+    """3 knowledge docs; optional content vectors aligning 'a' with query [1,0]."""
+    ts = timestamps or {}
+    docs = [
+        Document(doc_id="knowledge:a", partition="knowledge",
+                 fields={"name": "alpha", "body": "first doc"},
+                 display_text="alpha", projections={"content": Projection(text="alpha first")},
+                 metadata={"kind": "system"}, timestamp=ts.get("a")),
+        Document(doc_id="knowledge:b", partition="knowledge",
+                 fields={"name": "beta", "body": "second doc"},
+                 display_text="beta", projections={"content": Projection(text="beta second")},
+                 metadata={"kind": "directions"}, timestamp=ts.get("b")),
+        Document(doc_id="knowledge:c", partition="knowledge",
+                 fields={"name": "gamma alpha", "body": "third doc"},
+                 display_text="gamma", projections={"content": Projection(text="gamma third")},
+                 metadata={"kind": "system"}, timestamp=ts.get("c")),
+    ]
+    store.upsert_documents(docs, item_id="seed")
+    if with_vectors:
+        store.upsert_vectors("content", [
+            ("knowledge:a", np.array([1.0, 0.0], dtype=np.float32)),    # aligns w/ query
+            ("knowledge:b", np.array([0.0, 1.0], dtype=np.float32)),    # orthogonal
+            ("knowledge:c", np.array([0.7, 0.7], dtype=np.float32)),    # partial
+        ])
+
+
+def _searcher(store, encoder, cfg=None):
+    return HybridSearcher(
+        store, encoder, partition="knowledge",
+        projection_schema={"content": ProjectionSpec(kind=ProjectionKind.PASSAGE)},
+        cfg=cfg or PartitionConfig(name="knowledge"),
+        residents=ResidentCacheRegistry(),  # fresh per searcher (test isolation)
+    )
+
+
+class TestHybridSearch:
+    def test_empty_query(self, store):
+        _seed(store)
+        assert _searcher(store, FakeEncoder()).search(Query(text="")) == []
+
+    def test_lexical_only_method(self, store):
+        _seed(store)
+        hits = _searcher(store, FakeEncoder()).search(Query(text="alpha", method="lexical"))
+        ids = [h.doc_id for h in hits]
+        assert "knowledge:a" in ids  # name match
+        # all hits carry a lexical signal, no dense
+        assert all("lexical" in h.signals for h in hits)
+        assert all("content" not in h.signals for h in hits)
+
+    def test_degrade_to_lexical_when_encoder_down(self, store):
+        _seed(store)
+        hits = _searcher(store, FakeEncoder(down=True)).search(Query(text="alpha"))
+        assert hits  # still works (lexical only)
+        assert all("content" not in h.signals for h in hits)
+
+    def test_hybrid_fuses_lexical_and_dense(self, store):
+        _seed(store)
+        hits = _searcher(store, FakeEncoder(qvec=(1.0, 0.0))).search(Query(text="alpha"))
+        assert hits[0].doc_id == "knowledge:a"  # top of both lexical + dense
+        top = hits[0]
+        assert "lexical" in top.signals and "content" in top.signals
+
+    def test_dense_only_method(self, store):
+        _seed(store)
+        # query text has no lexical match, but dense aligns with 'a'
+        hits = _searcher(store, FakeEncoder(qvec=(1.0, 0.0))).search(
+            Query(text="zzz", method="dense")
+        )
+        ids = [h.doc_id for h in hits]
+        assert ids[0] == "knowledge:a"
+        assert all("lexical" not in h.signals for h in hits)
+
+    def test_metadata_filter(self, store):
+        _seed(store)
+        hits = _searcher(store, FakeEncoder()).search(
+            Query(text="alpha", filters={"kind": "directions"})
+        )
+        # only beta is kind=directions, but it has no 'alpha' — lexical empty;
+        # dense restricted to allowed set {b}. So either empty or only b.
+        assert all(h.doc_id == "knowledge:b" for h in hits)
+
+    def test_recency_reorders(self, store):
+        import time
+        now = time.time()  # searcher's recency uses real time.time()
+        # 'a' is ancient, 'c' is fresh; both match 'alpha' lexically (c name has alpha)
+        _seed(store, with_vectors=False, timestamps={
+            "a": now - 365 * 86400.0, "c": now,
+        })
+        cfg = PartitionConfig(name="knowledge", recency=True, recency_half_life_days=14.0)
+        hits = HybridSearcher(
+            store, FakeEncoder(down=True), partition="knowledge",
+            projection_schema={}, cfg=cfg, residents=ResidentCacheRegistry(),
+        ).search(Query(text="alpha", method="lexical", recency=True))
+        ids = [h.doc_id for h in hits]
+        # fresh 'c' should outrank ancient 'a' after recency decay
+        assert ids.index("knowledge:c") < ids.index("knowledge:a")
+
+
+class TestMultiQueryFuser:
+    def test_shared_doc_ranks_higher(self):
+        q1 = [Hit(doc_id="a", score=0.9), Hit(doc_id="b", score=0.5)]
+        q2 = [Hit(doc_id="b", score=0.9), Hit(doc_id="c", score=0.5)]
+        fused = MultiQueryFuser.fuse([q1, q2])
+        assert fused[0].doc_id == "b"  # in both queries
+
+    def test_empty(self):
+        assert MultiQueryFuser.fuse([]) == []
+        assert MultiQueryFuser.fuse([[], []]) == []

--- a/tests/unit/test_index_store.py
+++ b/tests/unit/test_index_store.py
@@ -136,6 +136,24 @@ class TestVectors:
         # FTS row gone too
         assert store.search_lexical("a", partition="knowledge") == {}
 
+    def test_pooled_projection_multiple_subvectors(self, store):
+        # A label projection (e.g. aliases) stores MANY vectors per doc.
+        store.upsert_documents([_doc("knowledge:a", name="a")], item_id="i")
+        rng = np.random.default_rng(1)
+        vecs = rng.normal(size=(3, 6)).astype(np.float32)  # 3 aliases
+        store.upsert_vectors("aliases", [("knowledge:a", vecs)])
+        loaded = store.load_all_vectors("knowledge", "aliases")
+        assert loaded is not None
+        mat, doc_ids = loaded
+        assert mat.shape == (3, 6)
+        assert doc_ids == ["knowledge:a", "knowledge:a", "knowledge:a"]
+        # distinct-doc count is 1, not 3
+        assert store.vector_count("knowledge", "aliases") == 1
+        # re-upsert replaces (2 aliases now)
+        store.upsert_vectors("aliases", [("knowledge:a", rng.normal(size=(2, 6)).astype(np.float32))])
+        mat2, ids2 = store.load_all_vectors("knowledge", "aliases")
+        assert mat2.shape == (2, 6)
+
     def test_docs_missing_vectors_worklist(self, store):
         store.upsert_documents([
             Document(doc_id="knowledge:a", partition="knowledge", fields={"name": "a"},

--- a/tests/unit/test_index_store.py
+++ b/tests/unit/test_index_store.py
@@ -1,0 +1,176 @@
+"""Tests for index/store.py — IndexStore SQLite + FTS5 + blob vectors.
+
+Uses a tmp_path DB; no embedding service. Vectors are synthetic numpy arrays.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from work_buddy.index.model import Document, Projection
+from work_buddy.index.store import IndexStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return IndexStore(tmp_path / "t-index.db")
+
+
+def _doc(doc_id, partition="knowledge", *, name="", body="", tags="", meta=None, ts=None):
+    return Document(
+        doc_id=doc_id, partition=partition,
+        fields={"name": name, "body": body, "tags": tags},
+        display_text=f"{name}: {body}",
+        metadata=meta or {},
+        timestamp=ts,
+    )
+
+
+class TestUpsertAndLexical:
+    def test_upsert_and_fts_search(self, store):
+        store.upsert_documents([
+            _doc("knowledge:a", name="Consent System", body="approval grants ttl"),
+            _doc("knowledge:b", name="Telegram Bot", body="mobile notifications inline keyboard"),
+        ], item_id="seed")
+        hits = store.search_lexical("approval grants")
+        assert "knowledge:a" in hits
+        assert hits["knowledge:a"] > 0
+
+    def test_title_weighted_over_body(self, store):
+        # 'alpha' in a's title, in b's body. Default weights title(3) > body(1).
+        store.upsert_documents([
+            _doc("knowledge:a", name="alpha", body="filler text"),
+            _doc("knowledge:b", name="other", body="alpha appears in body only"),
+        ], item_id="seed")
+        hits = store.search_lexical("alpha")
+        assert hits["knowledge:a"] >= hits["knowledge:b"]
+
+    def test_partition_scoping(self, store):
+        store.upsert_documents([_doc("knowledge:a", name="shared term")], item_id="i1")
+        store.upsert_documents(
+            [_doc("vault:a", partition="vault", name="shared term")], item_id="i2"
+        )
+        hits = store.search_lexical("shared", partition="vault")
+        assert set(hits) == {"vault:a"}
+
+    def test_scope_prefix(self, store):
+        store.upsert_documents([
+            _doc("knowledge:tasks/x", name="triage flow"),
+            _doc("knowledge:obsidian/y", name="triage flow"),
+        ], item_id="i")
+        hits = store.search_lexical("triage", scope="knowledge:tasks/")
+        assert set(hits) == {"knowledge:tasks/x"}
+
+    def test_empty_query_returns_empty(self, store):
+        store.upsert_documents([_doc("knowledge:a", name="x")], item_id="i")
+        assert store.search_lexical("") == {}
+        assert store.search_lexical("  !! ") == {}
+
+    def test_fts_refreshed_on_reupsert(self, store):
+        store.upsert_documents([_doc("knowledge:a", name="original")], item_id="i")
+        assert "knowledge:a" in store.search_lexical("original")
+        store.upsert_documents([_doc("knowledge:a", name="replaced")], item_id="i")
+        assert store.search_lexical("original") == {}
+        assert "knowledge:a" in store.search_lexical("replaced")
+
+
+class TestMetadataFilter:
+    def test_equality_filter(self, store):
+        store.upsert_documents([
+            _doc("knowledge:a", name="alpha", meta={"kind": "system"}),
+            _doc("knowledge:b", name="alpha", meta={"kind": "directions"}),
+        ], item_id="i")
+        hits = store.search_lexical("alpha", filters={"kind": "system"})
+        assert set(hits) == {"knowledge:a"}
+
+    def test_set_membership_filter(self, store):
+        store.upsert_documents([
+            _doc("knowledge:a", name="alpha", meta={"kind": "system"}),
+            _doc("knowledge:b", name="alpha", meta={"kind": "directions"}),
+            _doc("knowledge:c", name="alpha", meta={"kind": "capability"}),
+        ], item_id="i")
+        hits = store.search_lexical("alpha", filters={"kind": ["system", "capability"]})
+        assert set(hits) == {"knowledge:a", "knowledge:c"}
+
+    def test_load_documents_with_filter(self, store):
+        store.upsert_documents([
+            _doc("knowledge:a", name="alpha", meta={"scope": "system"}),
+            _doc("knowledge:b", name="beta", meta={"scope": "personal"}),
+        ], item_id="i")
+        docs = store.load_documents(partition="knowledge", filters={"scope": "personal"})
+        assert set(docs) == {"knowledge:b"}
+        assert docs["knowledge:b"]["fields"]["name"] == "beta"
+
+
+class TestVectors:
+    def test_blob_roundtrip(self, store):
+        store.upsert_documents([
+            _doc("knowledge:a", name="a"), _doc("knowledge:b", name="b"),
+        ], item_id="i")
+        rng = np.random.default_rng(0)
+        v_a = rng.normal(size=8).astype(np.float32)
+        v_b = rng.normal(size=8).astype(np.float32)
+        n = store.upsert_vectors("content", [("knowledge:a", v_a), ("knowledge:b", v_b)])
+        assert n == 2
+        loaded = store.load_all_vectors("knowledge", "content")
+        assert loaded is not None
+        mat, doc_ids = loaded
+        assert mat.shape == (2, 8)
+        assert doc_ids == ["knowledge:a", "knowledge:b"]
+        # float16 round-trip tolerance
+        idx = doc_ids.index("knowledge:a")
+        assert np.allclose(mat[idx], v_a, atol=1e-2)
+
+    def test_load_vectors_empty(self, store):
+        assert store.load_all_vectors("knowledge", "content") is None
+
+    def test_fk_cascade_deletes_vectors(self, store):
+        store.upsert_documents([_doc("knowledge:a", name="a")], item_id="item1")
+        store.upsert_vectors("content", [("knowledge:a", np.ones(4, dtype=np.float32))])
+        assert store.vector_count("knowledge", "content") == 1
+        store.delete_item_docs("item1", partition="knowledge")
+        # vectors cascade-deleted with the document
+        assert store.vector_count("knowledge", "content") == 0
+        assert store.doc_count("knowledge") == 0
+        # FTS row gone too
+        assert store.search_lexical("a", partition="knowledge") == {}
+
+    def test_docs_missing_vectors_worklist(self, store):
+        store.upsert_documents([
+            Document(doc_id="knowledge:a", partition="knowledge", fields={"name": "a"},
+                     projections={"content": Projection(text="alpha body")}),
+            Document(doc_id="knowledge:b", partition="knowledge", fields={"name": "b"},
+                     projections={"content": Projection(text="beta body")}),
+        ], item_id="i")
+        work = store.docs_missing_vectors("knowledge", "content")
+        assert {d for d, _ in work} == {"knowledge:a", "knowledge:b"}
+        # encode one → it drops off the work-list
+        store.upsert_vectors("content", [("knowledge:a", np.ones(4, dtype=np.float32))])
+        work2 = store.docs_missing_vectors("knowledge", "content")
+        assert {d for d, _ in work2} == {"knowledge:b"}
+
+
+class TestLedgerAndVersion:
+    def test_indexed_items_ledger(self, store):
+        store.mark_item_indexed("f.md", "knowledge", mtime=123.0, content_hash="abc", doc_count=2)
+        items = store.get_indexed_items("knowledge")
+        assert items["f.md"] == (123.0, "abc")
+
+    def test_build_version_bump(self, store):
+        assert store.build_version("knowledge") == 0
+        assert store.bump_version("knowledge") == 1
+        assert store.bump_version("knowledge") == 2
+        assert store.build_version("knowledge") == 2
+        # per-partition isolation
+        assert store.build_version("vault") == 0
+
+    def test_meta_roundtrip(self, store):
+        assert store.get_meta("k") is None
+        store.set_meta("k", "v")
+        assert store.get_meta("k") == "v"
+
+    def test_partitions_listing(self, store):
+        store.upsert_documents([_doc("knowledge:a", name="a")], item_id="i")
+        store.upsert_documents([_doc("vault:a", partition="vault", name="a")], item_id="j")
+        assert store.partitions() == ["knowledge", "vault"]

--- a/tests/unit/test_index_unified.py
+++ b/tests/unit/test_index_unified.py
@@ -1,0 +1,115 @@
+"""Tests for index/partitioned.py (UnifiedIndex) + the consolidated Index seam adapter."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from work_buddy.index.config import IndexConfig
+from work_buddy.index.model import Document, ItemRef, Query
+from work_buddy.index.partition import PartitionRegistry
+from work_buddy.index.partitioned import UnifiedIndex
+from work_buddy.index.resident import ResidentCacheRegistry
+from work_buddy.index.store import IndexStore
+
+
+class FakeEncoder:
+    def encode_query(self, texts, kind, model_key=None):
+        return np.ones((len(texts), 4), dtype=np.float32)
+
+    def encode_documents(self, texts, kind, model_key=None):
+        return np.ones((len(texts), 4), dtype=np.float32)
+
+
+class FakePartition:
+    """Lexical-only partition (no projections → encoder unused)."""
+
+    def __init__(self, name, items):
+        self.name = name
+        self.change_key = "hash"
+        self._items = items  # {item_id: [(suffix, name_text)]}
+
+    def field_weights(self):
+        return {}
+
+    def projection_schema(self):
+        return {}
+
+    def discover(self):
+        return [ItemRef(item_id=i, content_hash=i) for i in self._items]
+
+    def parse(self, item_id):
+        return [
+            Document(doc_id=f"{self.name}:{s}", partition=self.name,
+                     fields={"name": n, "body": n}, display_text=n)
+            for s, n in self._items[item_id]
+        ]
+
+
+@pytest.fixture
+def unified(tmp_path):
+    reg = PartitionRegistry()
+    reg.register("p1", lambda: FakePartition("p1", {"i1": [("a", "alpha one")]}))
+    reg.register("p2", lambda: FakePartition("p2", {"i2": [("b", "alpha two")]}))
+    return UnifiedIndex(
+        store=IndexStore(tmp_path / "uni.db"),
+        encoder=FakeEncoder(),
+        config=IndexConfig(enabled=True),
+        residents=ResidentCacheRegistry(),
+        registry=reg,
+    )
+
+
+class TestUnifiedIndex:
+    def test_build_and_search_single_partition(self, unified):
+        unified.build("p1")
+        hits = unified.search(Query(text="alpha", top_k=5), partitions=["p1"])
+        assert [h.doc_id for h in hits] == ["p1:a"]
+
+    def test_federated_search_across_partitions(self, unified):
+        unified.build("p1")
+        unified.build("p2")
+        hits = unified.search(Query(text="alpha", top_k=5))  # default: all built partitions
+        assert {h.doc_id for h in hits} == {"p1:a", "p2:b"}
+
+    def test_available_lists_registered(self, unified):
+        assert set(unified.available()) == {"p1", "p2"}
+
+    def test_hydrate_default_passthrough(self, unified):
+        unified.build("p1")
+        hits = unified.search(Query(text="alpha"), partitions=["p1"])
+        # FakePartition has no hydrate() → passthrough returns the hits
+        assert unified.hydrate("p1", hits) == hits
+
+    def test_status_reports_partitions(self, unified):
+        unified.build("p1")
+        unified.build("p2")
+        st = unified.status()
+        assert st.name == "consolidated"
+        keys = {p.key for p in st.partitions}
+        assert keys == {"p1", "p2"}
+        for p in st.partitions:
+            assert p.total_items == 1
+
+    def test_search_empty_when_nothing_built(self, unified):
+        assert unified.search(Query(text="alpha")) == []
+
+
+class TestConsolidatedAdapter:
+    def test_registered_in_seam(self):
+        from work_buddy.indexing.registry import get_index, index_names
+        assert "consolidated" in index_names()
+        adapter = get_index("consolidated")
+        assert adapter.name == "consolidated"
+
+    def test_bulk_build_skips_when_disabled(self):
+        from work_buddy.indexing.adapters.index_consolidated import ConsolidatedIndexAdapter
+        # default config has index.enabled=false → build is a no-op
+        res = ConsolidatedIndexAdapter().bulk_build()
+        assert res.ok is True
+        assert "skipped" in res.stats
+
+    def test_status_is_safe(self):
+        from work_buddy.indexing.adapters.index_consolidated import ConsolidatedIndexAdapter
+        st = ConsolidatedIndexAdapter().status()
+        assert st.name == "consolidated"  # never raises, even pre-build

--- a/work_buddy/embedding/service.py
+++ b/work_buddy/embedding/service.py
@@ -905,6 +905,68 @@ def vault_index_endpoint():
         return jsonify({"error": f"{type(exc).__name__}: {exc}"}), 500
 
 
+@app.route("/index/search", methods=["POST"])
+def index_search_endpoint():
+    """Hybrid search over the consolidated index, in-process (resident matrices).
+
+    Flag-gated infrastructure: inert unless something queries it; the live
+    knowledge/vault/IR paths are unaffected. Runs here so the query encoder is
+    ``_IN_SERVICE``-aware and the per-(partition,projection) resident matrices stay warm.
+
+    Request body: {"query", "top_k"?, "method"?, "partitions"?, "filters"?, "scope"?, "recency"?, "rrf_k"?}
+    Response: {"results": [{"doc_id","score","signals","display_text","metadata"}, ...]}
+    """
+    data = request.get_json(silent=True) or {}
+    try:
+        from work_buddy.index.model import Query
+        from work_buddy.index.partitioned import UnifiedIndex
+
+        q = Query(
+            text=data.get("query", ""),
+            top_k=data.get("top_k", 10),
+            method=data.get("method", "hybrid"),
+            filters=data.get("filters") or {},
+            scope=data.get("scope"),
+            recency=data.get("recency", False),
+            rrf_k=data.get("rrf_k"),
+        )
+        hits = UnifiedIndex().search(q, partitions=data.get("partitions"))
+        results = [
+            {"doc_id": h.doc_id, "score": h.score, "signals": h.signals,
+             "display_text": h.display_text, "metadata": h.metadata}
+            for h in hits
+        ]
+        return jsonify({"results": results})
+    except Exception as exc:
+        return jsonify({"error": f"{type(exc).__name__}: {exc}"}), 500
+
+
+@app.route("/index/build", methods=["POST"])
+def index_build_endpoint():
+    """Build the consolidated index (a partition, or all) into its SEPARATE DB.
+
+    Explicit build endpoint — builds into ``db/index-consolidated`` regardless of the
+    ``index.enabled`` flag (a separate DB; building it does not change live behavior —
+    only flipping the flag + re-pointing callers would). The cron-driven seam adapter,
+    by contrast, respects the flag.
+
+    Request body: {"partition"?: str, "force"?: bool}  (omit partition → build_all)
+    Response: {"result": {...}}
+    """
+    data = request.get_json(silent=True) or {}
+    try:
+        from work_buddy.index.config import load_index_config
+        from work_buddy.index.partitioned import UnifiedIndex
+
+        ui = UnifiedIndex(config=load_index_config())
+        name = data.get("partition")
+        force = bool(data.get("force", False))
+        result = ui.build(name, force=force) if name else ui.build_all(force=force)
+        return jsonify({"result": result})
+    except Exception as exc:
+        return jsonify({"error": f"{type(exc).__name__}: {exc}"}), 500
+
+
 def _vault_matrix_evictor_loop() -> None:
     """Background thread: release the resident vault search matrix after an idle TTL.
 
@@ -1034,6 +1096,13 @@ def main():
         name="vault-matrix-evictor",
         daemon=True,
     ).start()
+    # Release idle resident matrices of the consolidated index (flag-gated; additive —
+    # does NOT replace the model/vault evictors above). One sweep for all its partitions.
+    try:
+        from work_buddy.index.resident import start_idle_evictor as _start_index_evictor
+        _start_index_evictor()
+    except Exception as exc:  # never block service startup
+        print(f"consolidated-index evictor start failed (non-fatal): {exc}", file=sys.stderr)
     # Persist completed broker calls so the dashboard Inference panel keeps
     # history across restarts (the broker's metrics ring is in-memory only).
     threading.Thread(

--- a/work_buddy/index/README.md
+++ b/work_buddy/index/README.md
@@ -1,0 +1,47 @@
+# `work_buddy/index/` — consolidated index (flag-gated, INERT by default)
+
+One SQLite + FTS5 + float16-blob-vector store across **partitions** (knowledge, vault
+chunks, conversation, projects, chrome, summary, task_note), served warm in-service and
+scheduled by the inference broker. Designed to subsume `knowledge/index.py`,
+`vault_index/`, and `ir/`.
+
+**Status: inert.** Nothing on the live hot path uses this. `index.enabled` defaults
+`false`; the live knowledge/vault/IR indexes remain the system of record. This package
+builds into a **separate** DB (`db/index-consolidated`) and is exercised only by the A/B
+harness. Activating it (flipping the flag + re-pointing `agent_docs`/`search`) and
+retiring the bespoke indexes are **deliberate, reviewed, post-A/B steps** — see
+`.data/designs/index-consolidation/{DESIGN.md, CLASS-ARCHITECTURE.md, AFK-DECISIONS.md}`.
+
+## Layers (all composition + Protocols; inheritance-free)
+
+| Module | Role |
+|---|---|
+| `model.py` | `Document`, `Projection`, `ProjectionSpec`, `Hit`, `Query`, enums, `content_hash` |
+| `config.py` | `IndexConfig`/`PartitionConfig` (the `index.enabled` flag; per-partition `rrf_k`) |
+| `fusion.py` | `rrf_fuse` (parity-lift of `ir.store.rrf_fuse`) |
+| `recency.py` | epoch-based recency bias over `Hit`s |
+| `resident.py` | generic `ResidentCache[T]` (injected loader) + registry + one evictor |
+| `store.py` | `IndexStore` — documents + standalone FTS5(title/body/tags) + `(doc_id,projection,sub)` blob vectors |
+| `encode.py` | `EmbeddingProvider` seam (`LocalProvider`/`LmStudioProvider` + `ProviderRouter`) + `BrokeredEncoder` + `score_dense` |
+| `search.py` | `HybridSearcher` (FTS5 ⊕ dense ⊕ RRF ⊕ recency ⊕ filters) + `MultiQueryFuser` |
+| `build.py` | `IndexBuilder` (incremental, content-hash diff, advisory-locked, batched BACKGROUND encode) |
+| `partition.py` | `Partition` Protocol + lazy `PartitionRegistry` |
+| `partitions/` | IR-source wrapper + bootstrap (the only domain-importing wiring) |
+| `partitioned.py` | `IndexPartition` + `UnifiedIndex` facade (federates via RRF) |
+| `ab.py` | A/B harness vs the live knowledge index |
+
+Partition adapters live with their domains: `knowledge/partition.py`,
+`vault_index/partition.py`; IR sources via `index/partitions/ir_source.py`. The engine
+core imports **no** domain — partitions register into it (`domain → index`).
+
+## How to enable (for testing, after a service restart)
+
+1. Set `index.enabled: true` in `config.local.yaml` (per-partition `rrf_k` optional).
+2. Restart the embedding service so `/index/search` + `/index/build` load.
+3. Build:  `POST /index/build {"partition": "knowledge"}`  (or in-process
+   `UnifiedIndex(config=load_index_config()).build("knowledge")`).
+4. Query:  `POST /index/search {"query": "...", "partitions": ["knowledge"]}`.
+5. A/B vs the live index:  `python -m work_buddy.index.ab`.
+
+The consolidated index is also visible in the dashboard's index panel as the
+`consolidated` index (its `bulk_build` is a no-op while the flag is off).

--- a/work_buddy/index/__init__.py
+++ b/work_buddy/index/__init__.py
@@ -1,0 +1,54 @@
+"""Consolidated index package.
+
+One substrate (SQLite + FTS5 + float16 blob vectors) holding IR-model ``Document``s
+across partitions (knowledge, vault chunks, conversations, …), served warm in-service
+and scheduled by the inference broker. Subsumes ``knowledge/index.py``, ``vault_index/``,
+and ``ir/``.
+
+**Inert until ``index.enabled`` is true** (default OFF). See
+``.data/designs/index-consolidation/{DESIGN.md, CLASS-ARCHITECTURE.md}`` for the full
+design and ``config.py`` for the feature flag.
+
+This package imports NO domain package — partitions are registered into it by their
+domains (``domain → index``), never the reverse.
+"""
+
+from __future__ import annotations
+
+from work_buddy.index.config import (
+    DEFAULT_RRF_K,
+    IndexConfig,
+    PartitionConfig,
+    load_index_config,
+)
+from work_buddy.index.model import (
+    Document,
+    Hit,
+    ItemRef,
+    PoolStrategy,
+    Projection,
+    ProjectionKind,
+    ProjectionSpec,
+    Query,
+    content_hash,
+    make_doc_id,
+)
+
+__all__ = [
+    # model
+    "Document",
+    "Hit",
+    "ItemRef",
+    "PoolStrategy",
+    "Projection",
+    "ProjectionKind",
+    "ProjectionSpec",
+    "Query",
+    "content_hash",
+    "make_doc_id",
+    # config
+    "DEFAULT_RRF_K",
+    "IndexConfig",
+    "PartitionConfig",
+    "load_index_config",
+]

--- a/work_buddy/index/ab.py
+++ b/work_buddy/index/ab.py
@@ -1,0 +1,165 @@
+"""A/B harness: consolidated knowledge index vs the live knowledge index (oracle).
+
+Builds the ``knowledge`` partition into the SEPARATE ``db/index-consolidated`` (never
+touches the live indexes' data), then runs a fixed query set through BOTH the live
+``knowledge.search`` (oracle) and the new ``UnifiedIndex``, reporting overlap@k, top-1
+agreement, and rank correlation. This is the F-EVAL evidence that gates any future
+deletion of the bespoke index — it deletes nothing.
+
+Run:  python -m work_buddy.index.ab   → writes .data/designs/index-consolidation/AB-RESULTS.md
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+# Representative knowledge queries: subsystem/capability terms, dev-doc-scan vocabulary,
+# alias-shaped phrasings, and how/why questions.
+QUERIES = [
+    "task triage",
+    "consent system grants",
+    "embedding service dense vectors",
+    "morning routine",
+    "vault writer section",
+    "how to add a workflow",
+    "reciprocal rank fusion",
+    "broker admission priority",
+    "knowledge store search index",
+    "obsidian bridge",
+    "dev document scan",
+    "artifact lifecycle cleanup",
+    "weekly task review",
+    "contracts and stop rules",
+    "chrome tab triage",
+    "calendar provider",
+    "websearch jina",
+    "entity registry resolve",
+]
+
+
+def _oracle(query: str, top_n: int) -> list[str]:
+    """Live knowledge index ranking (paths), system scope — the oracle."""
+    from work_buddy.knowledge.search import search
+    res = search(query=query, knowledge_scope="system", top_n=top_n, depth="index")
+    return [r["path"] for r in (res.get("results") or [])]
+
+
+def _new(ui, query: str, top_k: int) -> list[str]:
+    """Consolidated index ranking (paths), system scope."""
+    from work_buddy.index.model import Query
+    hits = ui.search(
+        Query(text=query, top_k=top_k, filters={"scope": "system"}),
+        partitions=["knowledge"],
+    )
+    out = []
+    for h in hits:
+        out.append(h.doc_id.split(":", 1)[1] if ":" in h.doc_id else h.doc_id)
+    return out
+
+
+def _metrics(oracle: list[str], new: list[str], k: int) -> dict[str, Any]:
+    sa, sb = set(oracle[:k]), set(new[:k])
+    overlap = (len(sa & sb) / k) if k else 0.0
+    top1 = 1.0 if (oracle and new and oracle[0] == new[0]) else 0.0
+    common = list(sa & sb)
+    rank_corr: float | None = None
+    if len(common) >= 2:
+        import numpy as np
+        ra = [oracle.index(d) for d in common]
+        rb = [new.index(d) for d in common]
+        if np.std(ra) > 0 and np.std(rb) > 0:
+            rank_corr = round(float(np.corrcoef(ra, rb)[0, 1]), 3)  # Spearman (rank Pearson)
+        else:
+            rank_corr = 1.0
+    return {"overlap": round(overlap, 3), "top1": top1, "common": len(common), "rank_corr": rank_corr}
+
+
+def run_ab(queries: list[str] | None = None, *, top_k: int = 10, build: bool = True) -> dict[str, Any]:
+    from work_buddy.index.config import IndexConfig, load_index_config
+    from work_buddy.index.partitioned import UnifiedIndex
+
+    base = load_index_config()
+    cfg = IndexConfig(enabled=True, db_path=base.db_path, partitions=base.partitions)
+    ui = UnifiedIndex(config=cfg)
+
+    build_stats = None
+    build_secs = None
+    if build:
+        t0 = time.time()
+        build_stats = ui.build("knowledge")
+        build_secs = round(time.time() - t0, 1)
+
+    queries = queries or QUERIES
+    rows = []
+    for q in queries:
+        oracle = _oracle(q, top_k)
+        new = _new(ui, q, top_k)
+        rows.append({"query": q, "oracle": oracle, "new": new, **_metrics(oracle, new, top_k)})
+
+    agg = _aggregate(rows)
+    return {"build_stats": build_stats, "build_secs": build_secs, "rows": rows, "aggregate": agg, "top_k": top_k}
+
+
+def _aggregate(rows: list[dict]) -> dict[str, Any]:
+    n = len(rows) or 1
+    overlaps = [r["overlap"] for r in rows]
+    corrs = [r["rank_corr"] for r in rows if r["rank_corr"] is not None]
+    return {
+        "queries": len(rows),
+        "mean_overlap": round(sum(overlaps) / n, 3),
+        "top1_agreement": round(sum(r["top1"] for r in rows) / n, 3),
+        "mean_rank_corr": round(sum(corrs) / len(corrs), 3) if corrs else None,
+        "queries_with_empty_new": sum(1 for r in rows if not r["new"]),
+    }
+
+
+def render_md(result: dict[str, Any]) -> str:
+    a = result["aggregate"]
+    lines = [
+        "# Consolidated Index — A/B vs live knowledge index (oracle)",
+        "",
+        "**Off the hot path.** Built the `knowledge` partition into the separate "
+        "`db/index-consolidated`; the live indexes were not modified. This is F-EVAL "
+        "evidence — nothing was deleted or re-pointed.",
+        "",
+        f"- build: {result.get('build_stats')}  ({result.get('build_secs')}s)",
+        f"- top_k: {result['top_k']}",
+        "",
+        "## Aggregate",
+        f"- queries: **{a['queries']}**",
+        f"- mean overlap@{result['top_k']}: **{a['mean_overlap']}**",
+        f"- top-1 agreement: **{a['top1_agreement']}**",
+        f"- mean rank-corr (on shared docs): **{a['mean_rank_corr']}**",
+        f"- queries where the new index returned nothing: **{a['queries_with_empty_new']}**",
+        "",
+        "## Per-query",
+        "",
+        "| query | overlap | top1 | shared | rank_corr | oracle[0] | new[0] |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for r in result["rows"]:
+        o0 = r["oracle"][0] if r["oracle"] else "—"
+        n0 = r["new"][0] if r["new"] else "—"
+        lines.append(
+            f"| {r['query']} | {r['overlap']} | {int(r['top1'])} | {r['common']} | "
+            f"{r['rank_corr']} | {o0} | {n0} |"
+        )
+    lines += ["", "## Divergences (oracle top-5 vs new top-5)", ""]
+    for r in result["rows"]:
+        if r["overlap"] < 0.6:
+            lines.append(f"- **{r['query']}**")
+            lines.append(f"  - oracle: {r['oracle'][:5]}")
+            lines.append(f"  - new:    {r['new'][:5]}")
+    return "\n".join(lines) + "\n"
+
+
+if __name__ == "__main__":
+    from work_buddy.paths import repo_root
+    out_dir = repo_root() / ".data" / "designs" / "index-consolidation"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    result = run_ab()
+    md = render_md(result)
+    (out_dir / "AB-RESULTS.md").write_text(md, encoding="utf-8")
+    print(md)
+    print(f"\n[written to {out_dir / 'AB-RESULTS.md'}]")

--- a/work_buddy/index/build.py
+++ b/work_buddy/index/build.py
@@ -1,0 +1,190 @@
+"""IndexBuilder — incremental, resumable, locked build of one partition.
+
+Flow (under a per-partition advisory lock):
+  discover → diff by ``change_key`` (content-hash default, or mtime) → for each
+  changed item: delete its old docs, parse, upsert, encode projections (BACKGROUND,
+  batched across docs) → prune deleted items → if anything changed, bump the partition
+  ``build_version`` and invalidate its resident matrices.
+
+Generalizes ``vault_index/indexer.py`` + ``ir/store.build_index`` and adds the advisory
+lock the IR build lacked. Resumable: re-encodes any docs still missing vectors.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Any, Callable
+
+from work_buddy.index.partition import (
+    get_change_key,
+    get_projection_schema,
+)
+from work_buddy.logging_config import get_logger
+
+if TYPE_CHECKING:
+    from work_buddy.index.encode import Encoder
+    from work_buddy.index.partition import Partition
+    from work_buddy.index.resident import ResidentCacheRegistry
+    from work_buddy.index.store import IndexStore
+
+logger = get_logger(__name__)
+
+
+class IndexBuilder:
+    def __init__(
+        self,
+        store: "IndexStore",
+        encoder: "Encoder",
+        partition: "Partition",
+        *,
+        residents: "ResidentCacheRegistry | None" = None,
+        use_lock: bool = True,
+    ) -> None:
+        self._store = store
+        self._encoder = encoder
+        self._partition = partition
+        self._use_lock = use_lock
+        if residents is None:
+            from work_buddy.index.resident import get_registry
+            residents = get_registry()
+        self._residents = residents
+
+    def _lock_ctx(self):
+        if not self._use_lock:
+            return contextlib.nullcontext()
+        try:
+            from work_buddy.utils.index_lock import index_lock
+            target = self._store.db_path.parent / f"{self._store.db_path.name}.{self._partition.name}"
+            return index_lock(target)
+        except Exception as exc:  # lock infra unavailable → proceed without (best-effort)
+            logger.debug("index_lock unavailable (%s); building without a lock", exc)
+            return contextlib.nullcontext()
+
+    def build(
+        self, *, force: bool = False,
+        on_progress: Callable[[dict], None] | None = None,
+    ) -> dict[str, Any]:
+        pname = self._partition.name
+        change_key = get_change_key(self._partition)
+        schema = get_projection_schema(self._partition)
+
+        with self._lock_ctx():
+            indexed = self._store.get_indexed_items(pname)  # {item_id: (mtime, hash)}
+            discovered = list(self._partition.discover())
+            disc_ids = {ref.item_id for ref in discovered}
+
+            # --- diff ---
+            changed = []
+            for ref in discovered:
+                prev = indexed.get(ref.item_id)
+                if force or prev is None:
+                    changed.append(ref)
+                elif change_key == "mtime":
+                    if abs(prev[0] - ref.mtime) > 1e-6:
+                        changed.append(ref)
+                else:  # hash
+                    if (ref.content_hash or "") != (prev[1] or ""):
+                        changed.append(ref)
+
+            deleted = [iid for iid in indexed if iid not in disc_ids]
+            for iid in deleted:
+                self._store.delete_item_docs(iid, partition=pname)
+
+            # --- parse + upsert + encode changed items ---
+            n_docs = 0
+            for i, ref in enumerate(changed):
+                self._store.delete_item_docs(ref.item_id, partition=pname)  # clear stale
+                docs = self._partition.parse(ref.item_id)
+                for d in docs:
+                    if not d.partition:
+                        d.partition = pname
+                    d.ensure_hash()
+                self._store.upsert_documents(docs, item_id=ref.item_id)
+                self._encode_docs(docs, schema)
+                self._store.mark_item_indexed(
+                    ref.item_id, pname, mtime=ref.mtime,
+                    content_hash=ref.content_hash or "", doc_count=len(docs),
+                )
+                n_docs += len(docs)
+                if on_progress:
+                    on_progress({"phase": "indexing", "done": i + 1, "total": len(changed)})
+
+            # --- resume: encode any docs still missing a vector ---
+            for proj_name, spec in schema.items():
+                self._encode_missing(pname, proj_name, spec)
+
+            changed_any = bool(changed or deleted)
+            if changed_any:
+                self._store.bump_version(pname)
+                for proj_name in schema:
+                    self._residents.invalidate(f"{pname}:{proj_name}")
+
+            stats = {
+                "partition": pname,
+                "changed": len(changed),
+                "deleted": len(deleted),
+                "docs_indexed": n_docs,
+                "doc_count": self._store.doc_count(pname),
+                "version": self._store.build_version(pname),
+            }
+            logger.info("index build [%s]: %s", pname, stats)
+            return stats
+
+    # -- encoding helpers -------------------------------------------------
+    def _encode_docs(self, docs: list, schema: dict) -> None:
+        """Encode each projection across the given docs in ONE batched call/projection.
+
+        Handles pooled (list) projections by flattening then regrouping per doc.
+        """
+        for proj_name, spec in schema.items():
+            flat_texts: list[str] = []
+            layout: list[tuple[str, int, int]] = []  # (doc_id, start, count)
+            for d in docs:
+                p = d.projections.get(proj_name)
+                if p is None:
+                    continue
+                text = p.text
+                if isinstance(text, list):
+                    texts = [t for t in text if t]
+                    if not texts:
+                        continue
+                    layout.append((d.doc_id, len(flat_texts), len(texts)))
+                    flat_texts.extend(texts)
+                elif text:
+                    layout.append((d.doc_id, len(flat_texts), 1))
+                    flat_texts.append(text)
+            if not flat_texts:
+                continue
+            vecs = self._encoder.encode_documents(flat_texts, spec.kind, model_key=spec.model_key)
+            if vecs is None:
+                logger.warning(
+                    "encode unavailable for %s/%s; lexical indexed, dense deferred",
+                    self._partition.name, proj_name,
+                )
+                continue
+            rows = [(doc_id, vecs[start:start + count]) for doc_id, start, count in layout]
+            self._store.upsert_vectors(proj_name, rows)
+
+    def _encode_missing(self, pname: str, projection: str, spec) -> None:
+        work = self._store.docs_missing_vectors(pname, projection)
+        if not work:
+            return
+        flat_texts: list[str] = []
+        layout: list[tuple[str, int, int]] = []
+        for doc_id, text in work:
+            if isinstance(text, list):
+                texts = [t for t in text if t]
+                if not texts:
+                    continue
+                layout.append((doc_id, len(flat_texts), len(texts)))
+                flat_texts.extend(texts)
+            elif text:
+                layout.append((doc_id, len(flat_texts), 1))
+                flat_texts.append(text)
+        if not flat_texts:
+            return
+        vecs = self._encoder.encode_documents(flat_texts, spec.kind, model_key=spec.model_key)
+        if vecs is None:
+            return
+        rows = [(doc_id, vecs[start:start + count]) for doc_id, start, count in layout]
+        self._store.upsert_vectors(projection, rows)

--- a/work_buddy/index/build.py
+++ b/work_buddy/index/build.py
@@ -116,6 +116,8 @@ class IndexBuilder:
             changed_any = bool(changed or deleted)
             if changed_any:
                 self._store.bump_version(pname)
+                from datetime import datetime, timezone
+                self._store.set_meta(f"last_build:{pname}", datetime.now(timezone.utc).isoformat())
                 for proj_name in schema:
                     self._residents.invalidate(f"{pname}:{proj_name}")
 

--- a/work_buddy/index/config.py
+++ b/work_buddy/index/config.py
@@ -1,0 +1,119 @@
+"""Config for the consolidated index — the master feature flag + per-partition tuning.
+
+The whole consolidated index is **inert until ``index.enabled`` is true** (default
+False). Per-partition config carries the single-sourced RRF ``k`` (fork F-RRFK), the
+hybrid weights, the candidate-pool sizing, and the recency knobs.
+
+Config shape (``config.yaml`` / ``config.local.yaml``):
+
+```yaml
+index:
+  enabled: false                 # master flag — OFF by default
+  db_path: null                  # null → paths.resolve("db/index-consolidated")
+  partitions:
+    knowledge:
+      rrf_k: 20                  # smaller default per the A/B finding (was hardcoded 60)
+      recency: false
+    conversation:
+      rrf_k: 60
+      recency: true
+```
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Default RRF k. The hardcoded ×7 value was 60; the A/B (session 9dda8859) showed
+# k=60 vs k=15 give identical top-8/10 ranking, so the default is a legibility knob.
+# Per-partition overrides live in config (fork F-RRFK).
+DEFAULT_RRF_K = 20
+
+
+@dataclass(frozen=True)
+class PartitionConfig:
+    """Per-partition tuning. All fields have safe defaults; config overrides any."""
+
+    name: str
+    enabled: bool = True
+    rrf_k: int = DEFAULT_RRF_K
+    meta_weight: float = 0.3
+    content_weight: float = 0.7
+    pool_multiplier: int = 5      # candidate pool = max(top_k * mult, floor)
+    pool_floor: int = 50
+    recency: bool = False
+    recency_half_life_days: float = 14.0
+    recency_floor: float = 0.15
+
+    @classmethod
+    def from_dict(cls, name: str, raw: dict[str, Any] | None) -> "PartitionConfig":
+        raw = raw or {}
+        defaults = cls(name=name)
+        return cls(
+            name=name,
+            enabled=bool(raw.get("enabled", defaults.enabled)),
+            rrf_k=int(raw.get("rrf_k", defaults.rrf_k)),
+            meta_weight=float(raw.get("meta_weight", defaults.meta_weight)),
+            content_weight=float(raw.get("content_weight", defaults.content_weight)),
+            pool_multiplier=int(raw.get("pool_multiplier", defaults.pool_multiplier)),
+            pool_floor=int(raw.get("pool_floor", defaults.pool_floor)),
+            recency=bool(raw.get("recency", defaults.recency)),
+            recency_half_life_days=float(
+                raw.get("recency_half_life_days", defaults.recency_half_life_days)
+            ),
+            recency_floor=float(raw.get("recency_floor", defaults.recency_floor)),
+        )
+
+
+@dataclass(frozen=True)
+class IndexConfig:
+    """Top-level consolidated-index config. ``enabled`` is the master kill-switch."""
+
+    enabled: bool = False
+    db_path: Path | None = None
+    partitions: dict[str, PartitionConfig] = field(default_factory=dict)
+
+    def partition(self, name: str) -> PartitionConfig:
+        """Config for ``name`` — falls back to defaults for an unlisted partition."""
+        return self.partitions.get(name) or PartitionConfig(name=name)
+
+    def resolved_db_path(self) -> Path:
+        if self.db_path is not None:
+            return self.db_path
+        from work_buddy.paths import resolve
+        return resolve("db/index-consolidated")
+
+
+def load_index_config(cfg: dict[str, Any] | None = None) -> IndexConfig:
+    """Load the ``index:`` config block, defensively. Returns defaults if absent.
+
+    Never raises — a malformed block degrades to the OFF default so the consolidated
+    index can't accidentally activate or crash a caller.
+    """
+    try:
+        if cfg is None:
+            from work_buddy.config import load_config
+            cfg = load_config()
+        raw = (cfg or {}).get("index", {}) or {}
+    except Exception:
+        raw = {}
+    if not isinstance(raw, dict):
+        raw = {}
+
+    db_path_raw = raw.get("db_path")
+    db_path = Path(db_path_raw) if isinstance(db_path_raw, str) and db_path_raw else None
+
+    parts_raw = raw.get("partitions", {}) or {}
+    partitions = {
+        name: PartitionConfig.from_dict(name, pc)
+        for name, pc in parts_raw.items()
+        if isinstance(pc, dict) or pc is None
+    }
+
+    return IndexConfig(
+        enabled=bool(raw.get("enabled", False)),
+        db_path=db_path,
+        partitions=partitions,
+    )

--- a/work_buddy/index/encode.py
+++ b/work_buddy/index/encode.py
@@ -1,0 +1,299 @@
+"""Encoding for the consolidated index — two orthogonal axes.
+
+- **Backend (who computes vectors):** ``EmbeddingProvider`` — ``LocalProvider``
+  (in-process sentence-transformers, or the HTTP client when out-of-service),
+  ``LmStudioProvider`` (remote LM-Link peer). Selected per-model by ``ProviderRouter``
+  (``embedding.models.<key>.provider`` + on_error fallback). Cross-device offload is a
+  *provider*, never a kind of encoder.
+- **Locus (where the index code runs):** handled INSIDE ``LocalProvider`` via the
+  ``_IN_SERVICE``-awareness pattern (in-service → ``service._get_model`` + the
+  ``local:embedding`` broker slot; else → the embedding HTTP client, which makes the
+  running service do the compute). So one ``Encoder`` suffices — no separate HttpEncoder.
+
+The **X1 broker admission is reused, not reinvented**: ``LocalProvider`` wraps each
+in-service encode in ``inference.local_slot.local_embed_slot(priority)`` — query encode
+at INTERACTIVE, bulk doc encode at BACKGROUND (per batch), so a rebuild yields to a
+live search on the shared GPU.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from work_buddy.index.model import PoolStrategy, ProjectionKind
+from work_buddy.inference.broker import Priority
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Cold-load tolerance for the lazy leaf-ir doc encoder over HTTP (mirrors
+# knowledge/index.py::_CONTENT_COLD_LOAD_TIMEOUT_S).
+_COLD_LOAD_TIMEOUT_S = 120
+_BATCH_SIZE = 32
+
+
+# ---------------------------------------------------------------------------
+# Dense scoring (cosine + per-doc pooling + max-normalize)
+# ---------------------------------------------------------------------------
+
+def score_dense(
+    query_vec: "Any",
+    matrix: "Any",
+    doc_ids: list[str],
+    *,
+    pool: str = PoolStrategy.MAX,
+) -> dict[str, float]:
+    """Cosine-score a query vector against a (possibly pooled) doc matrix.
+
+    ``doc_ids`` is parallel to ``matrix`` rows and may repeat (pooled projection);
+    scores are aggregated per doc by ``pool`` (max default; mean), then max-normalized
+    to [0, 1]. Returns ``{doc_id: score}``. Mirrors ``ir/dense.score_dense``.
+    """
+    import numpy as np
+
+    if matrix is None or len(doc_ids) == 0:
+        return {}
+    q = np.asarray(query_vec, dtype=np.float32).reshape(-1)
+    qn = float(np.linalg.norm(q))
+    if qn == 0:
+        return {}
+    q = q / qn
+    m = np.asarray(matrix, dtype=np.float32)
+    norms = np.linalg.norm(m, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    sims = (m / norms) @ q  # (R,)
+
+    if pool == PoolStrategy.MEAN:
+        sums: dict[str, float] = {}
+        counts: dict[str, int] = {}
+        for did, s in zip(doc_ids, sims):
+            sums[did] = sums.get(did, 0.0) + float(s)
+            counts[did] = counts.get(did, 0) + 1
+        per_doc = {d: sums[d] / counts[d] for d in sums}
+    else:  # MAX (and NONE — one vector per doc → the value itself)
+        per_doc = {}
+        for did, s in zip(doc_ids, sims):
+            sv = float(s)
+            if did not in per_doc or sv > per_doc[did]:
+                per_doc[did] = sv
+
+    if not per_doc:
+        return {}
+    hi = max(per_doc.values())
+    if hi <= 0:
+        # No positive similarity — return empty so this signal contributes nothing.
+        return {}
+    return {d: v / hi for d, v in per_doc.items() if v > 0}
+
+
+# ---------------------------------------------------------------------------
+# Model resolution (kind + role → model id + prompt)
+# ---------------------------------------------------------------------------
+
+def resolve_model(
+    kind: str, role: str, model_key: str | None = None
+) -> tuple[str, str | None]:
+    """Map (projection kind, role) → (model_id, prompt_name).
+
+    role ∈ {"query", "document"}. LABEL → symmetric ``leaf-mt`` (no prompt). PASSAGE →
+    asymmetric ``leaf-ir-query`` (query) / ``leaf-ir`` (document). ``model_key`` overrides
+    (fork F-RECENCY/MODEL — per-partition model choice).
+    """
+    if model_key:
+        if model_key in ("leaf-ir", "leaf-ir-query"):
+            return ("leaf-ir-query", "query") if role == "query" else ("leaf-ir", "document")
+        return (model_key, None)
+    if kind == ProjectionKind.LABEL:
+        return ("leaf-mt", None)
+    return ("leaf-ir-query", "query") if role == "query" else ("leaf-ir", "document")
+
+
+# ---------------------------------------------------------------------------
+# Provider seam (backend axis)
+# ---------------------------------------------------------------------------
+
+@runtime_checkable
+class EmbeddingProvider(Protocol):
+    name: str
+
+    def encode(
+        self, texts: list[str], *, model_id: str, prompt_name: str | None = None,
+        priority: Priority = Priority.BACKGROUND,
+    ) -> "Any | None":
+        """Encode → ``(N, D)`` float32 ndarray, or ``None`` if unavailable."""
+        ...
+
+
+class LocalProvider:
+    """In-process sentence-transformers (in-service) or HTTP client (out-of-service).
+
+    Reuses the shipped X1 primitive: in-service encodes are admitted through the
+    ``local:embedding`` broker profile via ``local_embed_slot(priority)``.
+    """
+
+    name = "local"
+
+    def encode(
+        self, texts: list[str], *, model_id: str, prompt_name: str | None = None,
+        priority: Priority = Priority.BACKGROUND,
+    ) -> "Any | None":
+        import numpy as np
+        if not texts:
+            return np.zeros((0, 0), dtype=np.float32)
+
+        try:
+            from work_buddy.ir import dense as _ir_dense
+            in_service = bool(getattr(_ir_dense, "_IN_SERVICE", False))
+        except Exception:
+            in_service = False
+
+        if in_service:
+            try:
+                from work_buddy.embedding.service import _get_model
+                from work_buddy.inference.local_slot import local_embed_slot
+                model = _get_model(model_id)
+                kwargs: dict[str, Any] = {"show_progress_bar": False}
+                if prompt_name:
+                    kwargs["prompt_name"] = prompt_name
+                with local_embed_slot(priority):
+                    vecs = model.encode(list(texts), **kwargs)
+                return np.asarray(vecs, dtype=np.float32)
+            except Exception as exc:  # in-service encode failed → signal unavailable
+                logger.warning("LocalProvider in-service encode failed: %s", exc)
+                return None
+
+        # Out-of-service: round-trip to the running service (it does the compute).
+        from work_buddy.embedding.client import embed
+        timeout = max(_COLD_LOAD_TIMEOUT_S, len(texts) * 2)
+        vecs = embed(list(texts), model=model_id, prompt_name=prompt_name, timeout_s=timeout)
+        if vecs is None:
+            return None
+        return np.asarray(vecs, dtype=np.float32)
+
+
+class LmStudioProvider:
+    """Remote LM-Link peer via LM Studio's /v1/embeddings.
+
+    Thin wrapper over the existing ``embedding/providers/lmstudio.encode``. Wired for
+    completeness; not exercised by tonight's A/B (which uses local). Query offload is
+    discouraged (latency) — the router only routes document encode here when configured.
+    """
+
+    name = "lmstudio"
+
+    def encode(
+        self, texts: list[str], *, model_id: str, prompt_name: str | None = None,
+        priority: Priority = Priority.BACKGROUND,
+    ) -> "Any | None":
+        import numpy as np
+        if not texts:
+            return np.zeros((0, 0), dtype=np.float32)
+        try:
+            from work_buddy.embedding.providers.lmstudio import encode as lm_encode
+            arr = lm_encode(list(texts), model_id=model_id, priority=priority)
+            return np.asarray(arr, dtype=np.float32)
+        except Exception as exc:
+            logger.warning("LmStudioProvider encode failed: %s", exc)
+            return None
+
+
+class ProviderRouter:
+    """(model_id) → provider, with on-error fallback to local."""
+
+    def __init__(
+        self,
+        providers: dict[str, EmbeddingProvider] | None = None,
+        cfg: dict[str, Any] | None = None,
+    ) -> None:
+        self._providers: dict[str, EmbeddingProvider] = providers or {
+            "local": LocalProvider(),
+            "lmstudio": LmStudioProvider(),
+        }
+        if "local" not in self._providers:
+            self._providers["local"] = LocalProvider()
+        self._cfg = cfg
+
+    def _provider_name_for(self, model_id: str) -> str:
+        try:
+            cfg = self._cfg
+            if cfg is None:
+                from work_buddy.config import load_config
+                cfg = load_config()
+            models = (cfg or {}).get("embedding", {}).get("models", {}) or {}
+            return (models.get(model_id, {}) or {}).get("provider", "local")
+        except Exception:
+            return "local"
+
+    def encode(
+        self, texts: list[str], *, model_id: str, prompt_name: str | None = None,
+        priority: Priority = Priority.BACKGROUND,
+    ) -> "Any | None":
+        name = self._provider_name_for(model_id)
+        provider = self._providers.get(name, self._providers["local"])
+        out = provider.encode(
+            texts, model_id=model_id, prompt_name=prompt_name, priority=priority,
+        )
+        if out is not None:
+            return out
+        if provider.name != "local":  # on_error fallback to local
+            logger.info("provider %r unavailable for %s; falling back to local", name, model_id)
+            return self._providers["local"].encode(
+                texts, model_id=model_id, prompt_name=prompt_name, priority=priority,
+            )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Encoder (locus-agnostic; provider handles in-service vs HTTP)
+# ---------------------------------------------------------------------------
+
+@runtime_checkable
+class Encoder(Protocol):
+    def encode_query(
+        self, texts: list[str], kind: str, model_key: str | None = None
+    ) -> "Any | None": ...
+
+    def encode_documents(
+        self, texts: list[str], kind: str, model_key: str | None = None
+    ) -> "Any | None": ...
+
+
+class BrokeredEncoder:
+    """The default encoder: resolves models, routes through the provider seam, and
+    admits via the broker (INTERACTIVE for queries, BACKGROUND for builds)."""
+
+    def __init__(self, router: ProviderRouter | None = None) -> None:
+        self._router = router or ProviderRouter()
+
+    def encode_query(
+        self, texts: list[str], kind: str, model_key: str | None = None
+    ) -> "Any | None":
+        model_id, prompt = resolve_model(kind, "query", model_key)
+        return self._router.encode(
+            list(texts), model_id=model_id, prompt_name=prompt,
+            priority=Priority.INTERACTIVE,
+        )
+
+    def encode_documents(
+        self, texts: list[str], kind: str, model_key: str | None = None,
+        *, batch_size: int = _BATCH_SIZE,
+    ) -> "Any | None":
+        import numpy as np
+        if not texts:
+            return np.zeros((0, 0), dtype=np.float32)
+        model_id, prompt = resolve_model(kind, "document", model_key)
+        out = []
+        for i in range(0, len(texts), batch_size):
+            batch = list(texts[i:i + batch_size])
+            v = self._router.encode(
+                batch, model_id=model_id, prompt_name=prompt,
+                priority=Priority.BACKGROUND,
+            )
+            if v is None:
+                return None  # service/provider unavailable → caller degrades
+            out.append(np.asarray(v, dtype=np.float32))
+        return np.vstack(out) if out else np.zeros((0, 0), dtype=np.float32)
+
+
+def default_encoder() -> BrokeredEncoder:
+    return BrokeredEncoder()

--- a/work_buddy/index/fusion.py
+++ b/work_buddy/index/fusion.py
@@ -1,0 +1,30 @@
+"""Reciprocal Rank Fusion — the single source for the consolidated index.
+
+A verbatim lift of ``ir/store.py::rrf_fuse`` (parity-tested) so the consolidated index
+and the IR engine fuse identically. ``RRF_K`` is the algorithm's neutral default (60,
+Cormack/Clarke/Buettcher 2009); per-partition ``rrf_k`` overrides live in config
+(fork F-RRFK — the smaller per-partition default that the searcher passes in).
+
+Pure Python — safe to import anywhere (no numpy, no sqlite3).
+"""
+
+from __future__ import annotations
+
+RRF_K = 60
+
+
+def rrf_fuse(rankings: list[dict[str, float]], k: int = RRF_K) -> dict[str, float]:
+    """Reciprocal Rank Fusion over multiple ``{doc_id: score}`` ranking lists.
+
+    Each ranking is ranked by score desc; a doc's fused score is the sum of
+    ``1 / (k + rank)`` (1-based) across every ranking it appears in. Empty
+    rankings contribute nothing.
+    """
+    fused: dict[str, float] = {}
+    for ranking in rankings:
+        if not ranking:
+            continue
+        sorted_ids = sorted(ranking, key=ranking.get, reverse=True)
+        for rank, doc_id in enumerate(sorted_ids, start=1):
+            fused[doc_id] = fused.get(doc_id, 0.0) + 1.0 / (k + rank)
+    return fused

--- a/work_buddy/index/model.py
+++ b/work_buddy/index/model.py
@@ -1,0 +1,154 @@
+"""Value types for the consolidated index — domain-agnostic, lifted from the IR
+engine's ``ir/sources/base.py`` data model and extended for the consolidation.
+
+This module imports NOTHING from any work-buddy domain package (knowledge, vault,
+ir, …). Partitions are registered *into* the index by their domains; the arrow is
+always ``domain → index``, never the reverse. See
+``.data/designs/index-consolidation/CLASS-ARCHITECTURE.md`` §2.
+
+Design notes
+------------
+- ``ProjectionKind`` / ``PoolStrategy`` are ``(str, Enum)`` (not ``StrEnum``) so they
+  are string-equal to the IR engine's ``Literal`` values (``"label"``, ``"passage"``,
+  ``"none"``/``"max"``/``"mean"``) — full interop with ``ir/sources/*`` and JSON, with
+  no Python-3.11 floor.
+- ``Document`` renames IR's ``source`` to ``partition`` and drops the legacy
+  ``dense_text`` scalar; dense views live only in ``projections``. IR-source partition
+  wrappers adapt a bare ``dense_text`` into a single ``"default"`` PASSAGE projection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Literal
+
+# 16 hex chars = 8 bytes of SHA-256 prefix — same scheme as
+# ``knowledge/persistence.py::content_hash`` (defined here to keep index/ domain-free).
+_HASH_LEN = 16
+
+
+def content_hash(text: str) -> str:
+    """Deterministic 16-char SHA-256 prefix of ``text`` — change-detection key."""
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()[:_HASH_LEN]
+
+
+def make_doc_id(partition: str, stable_id: str) -> str:
+    """The globally-unique doc id scheme (fork F-IDENTITY): ``"{partition}:{stable_id}"``."""
+    return f"{partition}:{stable_id}"
+
+
+class ProjectionKind(str, Enum):
+    """How a dense projection is encoded on both sides of the comparison.
+
+    - ``LABEL``: short identifying text (alias, title) — symmetric ``leaf-mt`` on doc
+      AND query side (peer-to-peer match).
+    - ``PASSAGE``: longer body text — asymmetric (``leaf-ir`` doc side, ``leaf-ir-query``
+      query side).
+    """
+
+    LABEL = "label"
+    PASSAGE = "passage"
+
+
+class PoolStrategy(str, Enum):
+    """Per-doc aggregation for a list-valued projection (e.g. many aliases → one score)."""
+
+    NONE = "none"
+    MAX = "max"
+    MEAN = "mean"
+
+
+@dataclass(frozen=True)
+class ProjectionSpec:
+    """A partition's declaration of one named dense projection (once per partition).
+
+    ``model_key`` overrides the encoder model; when ``None`` the router derives it from
+    ``kind`` (LABEL→symmetric, PASSAGE→asymmetric). Wires the per-partition model choice
+    (fork F-RECENCY/MODEL).
+    """
+
+    kind: ProjectionKind
+    pool: PoolStrategy = PoolStrategy.NONE
+    model_key: str | None = None
+
+
+@dataclass
+class Projection:
+    """A single document's value for one named projection (scalar or list-for-pooling)."""
+
+    text: str | list[str]
+
+
+@dataclass
+class Document:
+    """The universal indexable record.
+
+    ``fields`` feed BM25 (named, per-field weighted). ``projections`` are the dense
+    views, keyed to the partition's ``projection_schema()``. ``metadata`` is
+    ``json_extract``-filterable (carries kind/path/scope/vault_id/…). ``content_hash``
+    drives change detection; ``timestamp`` (epoch seconds) drives optional recency.
+    """
+
+    doc_id: str
+    partition: str
+    fields: dict[str, str]
+    display_text: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+    projections: dict[str, Projection] = field(default_factory=dict)
+    content_hash: str = ""
+    timestamp: float | None = None
+
+    def ensure_hash(self) -> str:
+        """Populate ``content_hash`` from fields+projections if unset; return it."""
+        if not self.content_hash:
+            self.content_hash = content_hash(self.hashable_text())
+        return self.content_hash
+
+    def hashable_text(self) -> str:
+        """Stable concatenation of everything that should trigger a re-embed on change."""
+        parts: list[str] = [self.partition]
+        for k in sorted(self.fields):
+            parts.append(f"{k}={self.fields[k]}")
+        for k in sorted(self.projections):
+            t = self.projections[k].text
+            parts.append(f"{k}~{t if isinstance(t, str) else '|'.join(t)}")
+        return "\n".join(parts)
+
+
+@dataclass(frozen=True)
+class ItemRef:
+    """One discoverable source item: an id + change-detection signal(s).
+
+    Partitions whose ``change_key`` is ``"mtime"`` populate ``mtime``; those using
+    ``"hash"`` populate ``content_hash`` (the precise default — fork F-HASH).
+    """
+
+    item_id: str
+    mtime: float = 0.0
+    content_hash: str | None = None
+
+
+@dataclass(frozen=True)
+class Query:
+    """A search request against one or more partitions."""
+
+    text: str
+    top_k: int = 10
+    method: Literal["hybrid", "lexical", "dense"] = "hybrid"
+    filters: dict[str, Any] = field(default_factory=dict)
+    scope: str | None = None
+    recency: bool = False
+    rrf_k: int | None = None  # per-call override; else the partition's configured rrf_k
+
+
+@dataclass
+class Hit:
+    """A ranked result: id + fused score + the per-signal breakdown (observability)."""
+
+    doc_id: str
+    score: float
+    signals: dict[str, float] = field(default_factory=dict)
+    display_text: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)

--- a/work_buddy/index/partition.py
+++ b/work_buddy/index/partition.py
@@ -1,0 +1,107 @@
+"""Partition — the consolidated index's "source" PORT (a Protocol) + a registry.
+
+A partition is a domain adapter that produces ``Document``s (knowledge units, vault
+chunks, conversation spans, …). The index defines the *shape*; domains implement and
+register it (``domain → index``, never the reverse — F-PLACEMENT). The registry holds
+lazy factories so the engine never imports a domain at module load.
+
+Optional methods (``projection_schema``, ``hydrate``) are accessed via safe module-level
+helpers — IR's ``get_projection_schema`` pattern — so a partition that omits them keeps
+working (no base class, no forced overrides).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Protocol, runtime_checkable
+
+from work_buddy.index.model import ProjectionSpec
+
+if TYPE_CHECKING:
+    from work_buddy.index.model import Document, Hit, ItemRef
+
+
+@runtime_checkable
+class Partition(Protocol):
+    """A registered source of Documents for one partition of the consolidated index."""
+
+    name: str
+    # "hash" (precise; default) | "mtime" — drives change detection (fork F-HASH).
+    change_key: str
+
+    def field_weights(self) -> dict[str, float]:
+        """BM25 field-importance hints (advisory; the store maps to FTS tiers)."""
+        ...
+
+    def discover(self) -> "Iterable[ItemRef]":
+        """All indexable source items + their change-detection signal."""
+        ...
+
+    def parse(self, item_id: str) -> "list[Document]":
+        """Parse one source item into one or more Documents."""
+        ...
+
+    # OPTIONAL (accessed via the helpers below, not part of the structural contract):
+    #   def projection_schema(self) -> dict[str, ProjectionSpec]: ...
+    #   def hydrate(self, hits: list[Hit], **opts) -> list[Any]: ...
+
+
+def get_projection_schema(partition: Any) -> dict[str, ProjectionSpec]:
+    """A partition's dense-projection schema, or ``{}`` if it declares none."""
+    getter = getattr(partition, "projection_schema", None)
+    if getter is None:
+        return {}
+    try:
+        return getter() or {}
+    except Exception:
+        return {}
+
+
+def get_change_key(partition: Any) -> str:
+    return getattr(partition, "change_key", "hash") or "hash"
+
+
+def hydrate(partition: Any, hits: "list[Hit]", **opts: Any) -> list[Any]:
+    """Domain-shape the ranked hits (e.g. tier knowledge units). Default: the hits."""
+    fn = getattr(partition, "hydrate", None)
+    if fn is None:
+        return hits
+    return fn(hits, **opts)
+
+
+class PartitionRegistry:
+    """Lazy factory registry. Domains register a ``() -> Partition`` factory; the
+    instance is built (and cached) on first ``get``."""
+
+    def __init__(self) -> None:
+        self._factories: dict[str, Callable[[], Partition]] = {}
+        self._instances: dict[str, Partition] = {}
+
+    def register(self, name: str, factory: "Callable[[], Partition]") -> None:
+        self._factories[name] = factory
+        self._instances.pop(name, None)
+
+    def names(self) -> list[str]:
+        return sorted(self._factories)
+
+    def get(self, name: str) -> "Partition":
+        if name not in self._factories:
+            raise KeyError(f"Unknown partition: {name!r}. Registered: {self.names()}")
+        if name not in self._instances:
+            self._instances[name] = self._factories[name]()
+        return self._instances[name]
+
+    def all(self) -> "list[Partition]":
+        return [self.get(n) for n in self.names()]
+
+
+_REGISTRY = PartitionRegistry()
+
+
+def get_partition_registry() -> PartitionRegistry:
+    """Module-global partition registry (one per process)."""
+    return _REGISTRY
+
+
+def register_partition(name: str, factory: "Callable[[], Partition]") -> None:
+    """Domains call this at import time to register their partition (lazily)."""
+    _REGISTRY.register(name, factory)

--- a/work_buddy/index/partitioned.py
+++ b/work_buddy/index/partitioned.py
@@ -1,0 +1,184 @@
+"""IndexPartition + UnifiedIndex — the facade callers use.
+
+``UnifiedIndex`` is the single entry point: it owns the shared store + encoder +
+resident registry, lazily wires an ``IndexPartition`` per partition (search + build),
+federates cross-partition search via RRF (fork F-CROSS), and reports status through the
+``indexing`` seam. Everything is inert until ``index.enabled`` (the caller checks it).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable
+
+from work_buddy.index.config import IndexConfig, load_index_config
+from work_buddy.index.model import Hit, Query
+from work_buddy.index.partition import (
+    get_partition_registry,
+    get_projection_schema,
+    hydrate,
+)
+from work_buddy.index.search import HybridSearcher, MultiQueryFuser
+from work_buddy.logging_config import get_logger
+
+if TYPE_CHECKING:
+    from work_buddy.index.encode import Encoder
+    from work_buddy.index.partition import Partition, PartitionRegistry
+    from work_buddy.index.resident import ResidentCacheRegistry
+    from work_buddy.index.store import IndexStore
+
+logger = get_logger(__name__)
+
+
+class IndexPartition:
+    """One partition end-to-end: search (HybridSearcher) + build (IndexBuilder)."""
+
+    def __init__(
+        self,
+        partition: "Partition",
+        store: "IndexStore",
+        encoder: "Encoder",
+        cfg,
+        residents: "ResidentCacheRegistry",
+    ) -> None:
+        from work_buddy.index.build import IndexBuilder
+
+        self._partition = partition
+        self._store = store
+        self._cfg = cfg
+        self._searcher = HybridSearcher(
+            store, encoder, partition=partition.name,
+            projection_schema=get_projection_schema(partition), cfg=cfg,
+            residents=residents,
+        )
+        self._builder = IndexBuilder(store, encoder, partition, residents=residents)
+
+    @property
+    def name(self) -> str:
+        return self._partition.name
+
+    def search(self, q: Query) -> list[Hit]:
+        return self._searcher.search(q)
+
+    def hydrate(self, hits: list[Hit], **opts) -> list[Any]:
+        return hydrate(self._partition, hits, **opts)
+
+    def build(self, *, force: bool = False, on_progress=None) -> dict[str, Any]:
+        return self._builder.build(force=force, on_progress=on_progress)
+
+    def status(self):
+        from work_buddy.indexing.protocol import PartitionStatus
+        total = self._store.doc_count(self.name)
+        vcount = self._store.vector_count(self.name)
+        return PartitionStatus(
+            key=self.name,
+            total_items=total,
+            dense_eligible=total,
+            vector_count=min(vcount, total),
+            pending=max(0, total - vcount),
+            last_build=self._store.get_meta(f"last_build:{self.name}"),
+            health="ok",
+        )
+
+
+class UnifiedIndex:
+    """The consolidated index facade."""
+
+    NAME = "consolidated"
+
+    def __init__(
+        self,
+        store: "IndexStore | None" = None,
+        encoder: "Encoder | None" = None,
+        config: IndexConfig | None = None,
+        residents: "ResidentCacheRegistry | None" = None,
+        registry: "PartitionRegistry | None" = None,
+    ) -> None:
+        self._config = config or load_index_config()
+        if store is None:
+            from work_buddy.index.store import IndexStore
+            store = IndexStore(self._config.resolved_db_path())
+        self._store = store
+        if encoder is None:
+            from work_buddy.index.encode import default_encoder
+            encoder = default_encoder()
+        self._encoder = encoder
+        if residents is None:
+            from work_buddy.index.resident import get_registry
+            residents = get_registry()
+        self._residents = residents
+        if registry is None:
+            from work_buddy.index.partitions.bootstrap import ensure_partitions_registered
+            ensure_partitions_registered()
+            registry = get_partition_registry()
+        self._registry = registry
+        self._partitions: dict[str, IndexPartition] = {}
+
+    @property
+    def store(self) -> "IndexStore":
+        return self._store
+
+    def available(self) -> list[str]:
+        return self._registry.names()
+
+    def partition(self, name: str) -> IndexPartition:
+        if name not in self._partitions:
+            part = self._registry.get(name)
+            self._partitions[name] = IndexPartition(
+                part, self._store, self._encoder, self._config.partition(name),
+                self._residents,
+            )
+        return self._partitions[name]
+
+    def search(self, q: Query, partitions: list[str] | None = None) -> list[Hit]:
+        # Default: search the partitions that actually have docs in the store.
+        names = partitions if partitions is not None else (
+            self._store.partitions() or self.available()
+        )
+        results: list[list[Hit]] = []
+        for name in names:
+            try:
+                hits = self.partition(name).search(q)
+            except Exception as exc:  # one partition failing must not kill the query
+                logger.warning("partition %r search failed: %s", name, exc)
+                continue
+            if hits:
+                results.append(hits)
+        if not results:
+            return []
+        if len(results) == 1:
+            return results[0][: q.top_k]
+        # Cross-partition federation via RRF (fork F-CROSS).
+        return MultiQueryFuser.fuse(results, k=(q.rrf_k or 60), top_k=q.top_k)
+
+    def hydrate(self, partition: str, hits: list[Hit], **opts) -> list[Any]:
+        return self.partition(partition).hydrate(hits, **opts)
+
+    def build(self, name: str, *, force: bool = False, on_progress=None) -> dict[str, Any]:
+        return self.partition(name).build(force=force, on_progress=on_progress)
+
+    def build_all(self, *, force: bool = False) -> list[dict[str, Any]]:
+        out = []
+        for name in self.available():
+            try:
+                out.append(self.build(name, force=force))
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.warning("build_all: %r failed: %s", name, exc)
+                out.append({"partition": name, "error": str(exc)})
+        return out
+
+    def status(self):
+        from work_buddy.indexing.protocol import IndexStatus
+        # Report partitions present in the store (built); fall back to registered names.
+        names = self._store.partitions() or self.available()
+        parts = []
+        for name in names:
+            try:
+                parts.append(self.partition(name).status())
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.debug("status for %r failed: %s", name, exc)
+        size_mb = None
+        try:
+            size_mb = round(self._store.db_path.stat().st_size / 1024 / 1024, 2)
+        except OSError:
+            pass
+        return IndexStatus(name=self.NAME, partitions=parts, size_on_disk_mb=size_mb)

--- a/work_buddy/index/partitions/__init__.py
+++ b/work_buddy/index/partitions/__init__.py
@@ -1,0 +1,7 @@
+"""Fallback home for partition adapters with no natural domain package.
+
+Partitions WITH a domain home live there (``knowledge/partition.py``,
+``vault_index/partition.py``). The IR sources (conversation, projects, chrome, summary,
+task_note) are adapted here via the generic ``IRSourcePartition`` wrapper, since they
+have no single domain package. See ``bootstrap.py`` for registration.
+"""

--- a/work_buddy/index/partitions/bootstrap.py
+++ b/work_buddy/index/partitions/bootstrap.py
@@ -1,0 +1,43 @@
+"""Partition registry bootstrap — the ONE place that imports partition providers.
+
+Keeps the engine core domain-free: only this thin wiring module imports the domain
+partition adapters to trigger their self-registration (mirrors how ``ir/store._get_source``
+imports the IR sources). Each import is defensive — a partition whose domain fails to
+import is logged and skipped, never crashing the others.
+"""
+
+from __future__ import annotations
+
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_DONE = False
+
+
+def ensure_partitions_registered() -> None:
+    """Idempotently register all available partitions into the global registry."""
+    global _DONE
+    if _DONE:
+        return
+
+    # knowledge — self-registers on import (the critical path + A/B target).
+    try:
+        import work_buddy.knowledge.partition  # noqa: F401
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("knowledge partition registration failed: %s", exc)
+
+    # IR sources (conversation, projects, chrome, summary, task_note) via the wrapper.
+    try:
+        from work_buddy.index.partitions.ir_source import register_ir_partitions
+        register_ir_partitions()
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("IR partition registration failed: %s", exc)
+
+    # vault chunks — self-registers on import IF present (may be deferred; tolerated).
+    try:
+        import work_buddy.vault_index.partition  # noqa: F401
+    except Exception as exc:
+        logger.debug("vault partition not registered (deferred or unavailable): %s", exc)
+
+    _DONE = True

--- a/work_buddy/index/partitions/ir_source.py
+++ b/work_buddy/index/partitions/ir_source.py
@@ -1,0 +1,133 @@
+"""IRSourcePartition — adapt an existing IR ``Source`` into an index ``Partition``.
+
+ONE generic wrapper covers every IR source (conversation, projects, chrome, summary,
+task_note) by delegating to its ``discover``/``parse``/``default_field_weights``/
+``projection_schema`` and converting IR ``Document``s into index ``Document``s:
+``source`` → ``partition``, a bare ``dense_text`` → a single ``content`` PASSAGE
+projection, and ISO ``start_time``/``end_time`` metadata → an epoch ``timestamp`` (so
+recency works). Reuses the live ``ir/sources/*`` — does not rewrite them.
+
+NOTE: the IR ``docs`` source is intentionally NOT wrapped — it's the redundant second
+index of the knowledge store, replaced by ``KnowledgePartition``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from work_buddy.index.model import (
+    Document,
+    ItemRef,
+    PoolStrategy,
+    Projection,
+    ProjectionKind,
+    ProjectionSpec,
+    make_doc_id,
+)
+from work_buddy.index.partition import register_partition
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# IR sources to expose as partitions (everything except the redundant "docs").
+_IR_PARTITIONS = ("conversation", "projects", "chrome", "summary", "task_note")
+
+
+def _to_epoch(meta: dict | None) -> float | None:
+    ts = (meta or {}).get("start_time") or (meta or {}).get("end_time")
+    if not ts:
+        return None
+    try:
+        from datetime import datetime, timezone
+        dt = datetime.fromisoformat(str(ts))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except Exception:
+        return None
+
+
+class IRSourcePartition:
+    """Adapter wrapping one ``ir.sources`` Source as an index Partition."""
+
+    change_key = "mtime"
+
+    def __init__(self, ir_source: Any) -> None:
+        self._src = ir_source
+        self.name = ir_source.name
+
+    def field_weights(self) -> dict[str, float]:
+        try:
+            return self._src.default_field_weights() or {}
+        except Exception:
+            return {}
+
+    def projection_schema(self) -> dict[str, ProjectionSpec]:
+        try:
+            from work_buddy.ir.sources.base import get_projection_schema
+            sch = get_projection_schema(self._src)
+        except Exception:
+            sch = {}
+        if sch:
+            out: dict[str, ProjectionSpec] = {}
+            for k, spec in sch.items():
+                try:
+                    out[k] = ProjectionSpec(
+                        kind=ProjectionKind(spec.kind), pool=PoolStrategy(spec.pool),
+                    )
+                except Exception:
+                    out[k] = ProjectionSpec(kind=ProjectionKind.PASSAGE)
+            return out
+        # legacy single-projection sources: dense_text → one PASSAGE projection
+        return {"content": ProjectionSpec(kind=ProjectionKind.PASSAGE)}
+
+    def discover(self):
+        try:
+            raw = self._src.discover()
+        except TypeError:
+            raw = self._src.discover(days=3650)  # some sources require a lookback arg
+        refs: list[ItemRef] = []
+        for entry in raw or []:
+            if isinstance(entry, (tuple, list)) and len(entry) >= 2:
+                item_id, mtime = entry[0], float(entry[1])
+            else:
+                item_id, mtime = entry, 0.0
+            refs.append(ItemRef(item_id=str(item_id), mtime=mtime))
+        return refs
+
+    def parse(self, item_id: str) -> list[Document]:
+        out: list[Document] = []
+        for d in (self._src.parse(item_id) or []):
+            stable = getattr(d, "doc_id", "")
+            doc_id = stable if stable.startswith(self.name + ":") else make_doc_id(self.name, stable)
+            projections: dict[str, Projection] = {}
+            ir_projs = getattr(d, "projections", None) or {}
+            if ir_projs:
+                for k, p in ir_projs.items():
+                    projections[k] = Projection(text=p.text)
+            elif getattr(d, "dense_text", ""):
+                projections["content"] = Projection(text=d.dense_text)
+            meta = dict(getattr(d, "metadata", None) or {})
+            out.append(Document(
+                doc_id=doc_id,
+                partition=self.name,
+                fields=dict(getattr(d, "fields", None) or {}),
+                display_text=getattr(d, "display_text", "") or "",
+                metadata=meta,
+                projections=projections,
+                timestamp=_to_epoch(meta),
+            ))
+        return out
+
+
+def _factory(name: str):
+    def make():
+        from work_buddy.ir.store import _get_source
+        return IRSourcePartition(_get_source(name))
+    return make
+
+
+def register_ir_partitions() -> None:
+    """Register every IR source (except ``docs``) as a lazy partition."""
+    for name in _IR_PARTITIONS:
+        register_partition(name, _factory(name))

--- a/work_buddy/index/recency.py
+++ b/work_buddy/index/recency.py
@@ -1,0 +1,70 @@
+"""Recency bias for the consolidated index — epoch-based, operates on ``Hit`` objects.
+
+Adapted from ``ir/recency.py``. The IR version read ISO strings from
+``metadata.start_time``; the consolidated ``Document`` carries an epoch ``timestamp``
+field, so this version takes epoch seconds directly via a ``{doc_id: ts_epoch}`` map.
+This is also what *fixes vault's dead recency* (the vault hydrator never emitted a
+timestamp, so its recency was a silent no-op) — once a partition populates
+``Document.timestamp``, recency works for it. Pure Python + math.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from work_buddy.index.model import Hit
+
+_LN2 = math.log(2)
+
+
+def recency_weight(
+    ts_epoch: float | None,
+    *,
+    half_life_days: float = 14.0,
+    floor: float = 0.15,
+    now_epoch: float | None = None,
+) -> float:
+    """A ``[floor, 1.0]`` exponential-decay multiplier for an epoch timestamp.
+
+    ``weight = floor + (1 - floor) * exp(-ln2 * days_old / half_life)``.
+    Returns ``1.0`` (no penalty) when ``ts_epoch is None`` or ``half_life_days <= 0``.
+    """
+    if ts_epoch is None or half_life_days <= 0:
+        return 1.0
+    if now_epoch is None:
+        now_epoch = time.time()
+    days_old = max((now_epoch - float(ts_epoch)) / 86400.0, 0.0)
+    decay = math.exp(-_LN2 * days_old / half_life_days)
+    return floor + (1.0 - floor) * decay
+
+
+def apply_recency_bias(
+    hits: "list[Hit]",
+    timestamps: dict[str, float | None],
+    *,
+    half_life_days: float = 14.0,
+    floor: float = 0.15,
+    now_epoch: float | None = None,
+) -> "list[Hit]":
+    """Multiply each hit's score by its recency weight and re-sort, in place.
+
+    ``timestamps`` maps ``doc_id → epoch seconds`` (or None). Records the multiplier
+    and the pre-bias score on ``hit.signals`` (``recency_weight`` / ``raw_score``).
+    """
+    if not hits or half_life_days <= 0:
+        return hits
+    if now_epoch is None:
+        now_epoch = time.time()
+    for h in hits:
+        w = recency_weight(
+            timestamps.get(h.doc_id),
+            half_life_days=half_life_days, floor=floor, now_epoch=now_epoch,
+        )
+        h.signals.setdefault("raw_score", h.score)
+        h.signals["recency_weight"] = round(w, 4)
+        h.score = round(h.score * w, 4)
+    hits.sort(key=lambda h: h.score, reverse=True)
+    return hits

--- a/work_buddy/index/resident.py
+++ b/work_buddy/index/resident.py
@@ -1,0 +1,200 @@
+"""Generic resident cache — version-keyed, idle-evicted, RLock-guarded.
+
+Generalizes ``vault_index/dense_cache.py`` into a reusable ``ResidentCache[T]`` whose
+behavior is **injected** (a ``loader`` + a ``version_fn``), NOT subclassed — per the
+inheritance-free design (CLASS-ARCHITECTURE §6). Lives in the long-lived
+embedding-service process: load-once, serve-from-RAM, reload when the on-disk version
+changes (a stale value must never outlive a rebuild), free after an idle TTL.
+
+A single ``ResidentCacheRegistry`` + one evictor daemon sweeps every registered cache —
+collapsing what are today three bespoke evictors (model registry, vault matrix, /search
+candidate cache). The consolidated index registers one ``ResidentCache`` per
+(partition, projection) for its vector matrices.
+
+Additive: this does NOT touch the existing live evictors; consolidating them onto this
+is a later (flag-flip-time) step.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Generic, TypeVar
+
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+DEFAULT_IDLE_TTL_S = 600.0
+DEFAULT_EVICT_INTERVAL_S = 60.0
+
+
+@dataclass
+class _Cached(Generic[T]):
+    value: T
+    version: str
+    loaded_at: float
+
+
+class ResidentCache(Generic[T]):
+    """A resident object reloaded on version change, freed after idle TTL.
+
+    Args:
+        loader: ``() -> T | None`` — produces the resident value (e.g. load the
+            vector matrix from SQLite blobs). ``None`` means "nothing to cache".
+        version_fn: ``() -> str`` — the current on-disk version; when it differs
+            from the cached copy, ``get()`` reloads.
+        name: label for logs.
+        clock: monotonic clock (injectable for tests).
+    """
+
+    def __init__(
+        self,
+        loader: Callable[[], T | None],
+        version_fn: Callable[[], str],
+        *,
+        name: str = "resident-cache",
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._loader = loader
+        self._version_fn = version_fn
+        self._name = name
+        self._clock = clock
+        self._cached: _Cached[T] | None = None
+        self._lock = threading.RLock()
+
+    def get(self) -> T | None:
+        """Return the resident value, (re)loading on a version change. ``None`` if empty."""
+        try:
+            version = self._version_fn()
+        except Exception as exc:  # version source unavailable → no cache
+            logger.debug("%s: version_fn failed (%s); not caching", self._name, exc)
+            return None
+
+        with self._lock:
+            if self._cached is not None and self._cached.version == version:
+                self._cached.loaded_at = self._clock()
+                return self._cached.value
+
+        # Load OUTSIDE the lock so a slow load doesn't block readers of other caches.
+        value = self._loader()
+        with self._lock:
+            if value is None:
+                self._cached = None
+                return None
+            self._cached = _Cached(value=value, version=version, loaded_at=self._clock())
+            logger.info("%s: loaded resident value (version=%s)", self._name, version)
+            return self._cached.value
+
+    def invalidate(self) -> None:
+        """Drop the cached value (call after a rebuild bumps the version)."""
+        with self._lock:
+            self._cached = None
+
+    def release_if_idle(self, ttl_s: float = DEFAULT_IDLE_TTL_S) -> bool:
+        """Free the value if untouched for ``ttl_s``. Returns True if released."""
+        with self._lock:
+            if self._cached is not None and (self._clock() - self._cached.loaded_at) > ttl_s:
+                self._cached = None
+                return True
+        return False
+
+    def is_cached(self) -> bool:
+        with self._lock:
+            return self._cached is not None
+
+
+class ResidentCacheRegistry:
+    """Holds named resident caches so one evictor can sweep them all."""
+
+    def __init__(self) -> None:
+        self._caches: dict[str, ResidentCache] = {}
+        self._lock = threading.RLock()
+
+    def register(self, key: str, cache: ResidentCache) -> ResidentCache:
+        with self._lock:
+            self._caches[key] = cache
+        return cache
+
+    def get_or_create(
+        self,
+        key: str,
+        loader: Callable[[], object | None],
+        version_fn: Callable[[], str],
+    ) -> ResidentCache:
+        with self._lock:
+            existing = self._caches.get(key)
+            if existing is not None:
+                return existing
+            cache = ResidentCache(loader, version_fn, name=key)
+            self._caches[key] = cache
+            return cache
+
+    def get(self, key: str) -> ResidentCache | None:
+        with self._lock:
+            return self._caches.get(key)
+
+    def invalidate(self, key: str) -> None:
+        with self._lock:
+            c = self._caches.get(key)
+        if c is not None:
+            c.invalidate()
+
+    def invalidate_all(self) -> None:
+        with self._lock:
+            caches = list(self._caches.values())
+        for c in caches:
+            c.invalidate()
+
+    def sweep_idle(self, ttl_s: float = DEFAULT_IDLE_TTL_S) -> list[str]:
+        """Release every cache idle past ``ttl_s``; return the released keys."""
+        with self._lock:
+            items = list(self._caches.items())
+        released: list[str] = []
+        for key, cache in items:
+            try:
+                if cache.release_if_idle(ttl_s):
+                    released.append(key)
+            except Exception as exc:  # one bad cache must not stall the sweep
+                logger.debug("resident sweep: %s release failed: %s", key, exc)
+        return released
+
+
+_REGISTRY = ResidentCacheRegistry()
+
+
+def get_registry() -> ResidentCacheRegistry:
+    """Module-global resident-cache registry (one per process)."""
+    return _REGISTRY
+
+
+def start_idle_evictor(
+    registry: ResidentCacheRegistry | None = None,
+    *,
+    ttl_s: float = DEFAULT_IDLE_TTL_S,
+    interval_s: float = DEFAULT_EVICT_INTERVAL_S,
+    name: str = "index-resident-evictor",
+) -> threading.Thread:
+    """Start a daemon thread that periodically sweeps idle resident caches.
+
+    Started by the embedding-service ``main()`` (step 10); additive — does not replace
+    the existing model/vault evictors yet.
+    """
+    reg = registry or _REGISTRY
+
+    def _loop() -> None:
+        while True:
+            time.sleep(interval_s)
+            try:
+                released = reg.sweep_idle(ttl_s)
+                if released:
+                    logger.info("index resident evictor released: %s", released)
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.debug("index resident evictor error: %s", exc)
+
+    t = threading.Thread(target=_loop, name=name, daemon=True)
+    t.start()
+    return t

--- a/work_buddy/index/search.py
+++ b/work_buddy/index/search.py
@@ -1,0 +1,188 @@
+"""HybridSearcher — the single retrieval path for the consolidated index.
+
+FTS5 lexical (bm25) ⊕ per-projection dense (cosine over the resident matrix) fused by
+RRF (per-partition ``rrf_k``), with metadata filtering + scope (pushed into the store),
+optional recency, candidate-pool widening, single-signal passthrough, and
+degrade-to-lexical when the embedding service is unavailable. Generalizes
+``vault_index/search.py`` + ``ir/engine.py``.
+
+Metadata filtering lives in ``IndexStore._metadata_where`` (json_extract); the searcher
+just forwards ``query.filters``. Dense rankings are intersected with the allowed-id set
+when filters/scope are present (filter-then-rank, like IR).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from work_buddy.index.encode import score_dense
+from work_buddy.index.fusion import rrf_fuse
+from work_buddy.index.model import Hit, PoolStrategy, ProjectionSpec, Query
+from work_buddy.index.recency import apply_recency_bias
+from work_buddy.index.resident import ResidentCacheRegistry, get_registry
+from work_buddy.logging_config import get_logger
+
+if TYPE_CHECKING:
+    from work_buddy.index.config import PartitionConfig
+    from work_buddy.index.encode import Encoder
+    from work_buddy.index.store import IndexStore
+
+logger = get_logger(__name__)
+
+
+class HybridSearcher:
+    """Per-partition hybrid searcher.
+
+    Args:
+        store: the shared IndexStore.
+        encoder: query encoder (degrades to None when the service is down).
+        partition: the partition this searcher serves.
+        projection_schema: ``{projection_name: ProjectionSpec}`` — the dense signals.
+        cfg: the partition's config (rrf_k, pool sizing, recency).
+        residents: resident-cache registry (defaults to the process-global one).
+    """
+
+    def __init__(
+        self,
+        store: "IndexStore",
+        encoder: "Encoder",
+        *,
+        partition: str,
+        projection_schema: dict[str, ProjectionSpec],
+        cfg: "PartitionConfig",
+        residents: ResidentCacheRegistry | None = None,
+    ) -> None:
+        self._store = store
+        self._encoder = encoder
+        self._partition = partition
+        self._schema = projection_schema or {}
+        self._cfg = cfg
+        self._residents = residents or get_registry()
+
+    def _resident(self, projection: str):
+        key = f"{self._partition}:{projection}"
+        return self._residents.get_or_create(
+            key,
+            loader=lambda: self._store.load_all_vectors(self._partition, projection),
+            version_fn=lambda: str(self._store.build_version(self._partition)),
+        )
+
+    def search(self, q: Query) -> list[Hit]:
+        if not (q.text or "").strip():
+            return []
+
+        pool = max(q.top_k * self._cfg.pool_multiplier, self._cfg.pool_floor)
+        rrf_k = q.rrf_k if q.rrf_k is not None else self._cfg.rrf_k
+
+        # Allowed-id set for filter-then-rank on the dense side (lexical filters in SQL).
+        allowed: set[str] | None = None
+        if q.filters or q.scope:
+            allowed = set(self._store.load_documents(
+                partition=self._partition, filters=q.filters, scope=q.scope,
+            ).keys())
+
+        rankings: list[dict[str, float]] = []
+        signal_scores: dict[str, dict[str, float]] = {}
+
+        # --- Lexical (FTS5 bm25) ---
+        if q.method in ("hybrid", "lexical"):
+            lex = self._store.search_lexical(
+                q.text, partition=self._partition, filters=q.filters,
+                scope=q.scope, top_k=pool,
+            )
+            if lex:
+                rankings.append(lex)
+                signal_scores["lexical"] = lex
+
+        # --- Dense (per projection) ---
+        if q.method in ("hybrid", "dense"):
+            for proj_name, spec in self._schema.items():
+                qvecs = self._encoder.encode_query(
+                    [q.text], spec.kind, model_key=spec.model_key,
+                )
+                if qvecs is None or len(qvecs) == 0:
+                    continue  # service down for this signal → degrade
+                loaded = self._resident(proj_name).get()
+                if loaded is None:
+                    continue  # no vectors for this projection yet
+                matrix, doc_ids = loaded
+                scores = score_dense(qvecs[0], matrix, doc_ids, pool=spec.pool)
+                if allowed is not None:
+                    scores = {d: s for d, s in scores.items() if d in allowed}
+                if scores:
+                    rankings.append(scores)
+                    signal_scores[proj_name] = scores
+
+        if not rankings:
+            return []
+
+        # --- Fuse (single-signal passthrough when only one) ---
+        if len(rankings) == 1:
+            fused = rankings[0]
+        else:
+            fused = rrf_fuse(rankings, k=rrf_k)
+
+        top_ids = sorted(fused, key=fused.get, reverse=True)[: max(q.top_k, 1)]
+        if not top_ids:
+            return []
+
+        # --- Hydrate (display + metadata + timestamp) ---
+        docs = self._store.load_documents(partition=self._partition, doc_ids=top_ids)
+        hits: list[Hit] = []
+        timestamps: dict[str, float | None] = {}
+        for did in top_ids:
+            d = docs.get(did, {})
+            sig = {"fused": round(float(fused[did]), 6)}
+            for name, sc in signal_scores.items():
+                if did in sc:
+                    sig[name] = round(float(sc[did]), 6)
+            hits.append(Hit(
+                doc_id=did,
+                score=round(float(fused[did]), 6),
+                signals=sig,
+                display_text=d.get("display_text", ""),
+                metadata=d.get("metadata", {}),
+            ))
+            timestamps[did] = d.get("timestamp")
+
+        # --- Recency (optional) ---
+        if q.recency and self._cfg.recency:
+            apply_recency_bias(
+                hits, timestamps,
+                half_life_days=self._cfg.recency_half_life_days,
+                floor=self._cfg.recency_floor,
+            )
+
+        return hits
+
+
+class MultiQueryFuser:
+    """Outer RRF across several queries' result lists (the knowledge scan fan-out).
+
+    Preserves ``knowledge/search.rrf_combine`` semantics: a doc appearing in multiple
+    queries' top lists ranks higher. Returns a single fused, hydrated Hit list.
+    """
+
+    @staticmethod
+    def fuse(per_query_hits: list[list[Hit]], *, k: int = 60, top_k: int = 20) -> list[Hit]:
+        rankings: list[dict[str, float]] = []
+        by_id: dict[str, Hit] = {}
+        for hits in per_query_hits:
+            ranking: dict[str, float] = {}
+            for h in hits:
+                ranking[h.doc_id] = h.score
+                by_id.setdefault(h.doc_id, h)
+            if ranking:
+                rankings.append(ranking)
+        if not rankings:
+            return []
+        fused = rrf_fuse(rankings, k=k)
+        out: list[Hit] = []
+        for did in sorted(fused, key=fused.get, reverse=True)[:top_k]:
+            base = by_id[did]
+            out.append(Hit(
+                doc_id=did, score=round(float(fused[did]), 6),
+                signals={**base.signals, "multiquery_rrf": round(float(fused[did]), 6)},
+                display_text=base.display_text, metadata=base.metadata,
+            ))
+        return out

--- a/work_buddy/index/store.py
+++ b/work_buddy/index/store.py
@@ -1,0 +1,518 @@
+"""IndexStore — the consolidated index's shared SQLite substrate.
+
+One DB (``index.db_path``, default ``db/index-consolidated``) holding ALL partitions
+(fork F-STORE: one shared DB, ``partition`` column). Generalizes
+``vault_index/store.py`` to whole ``Document``s with named ``fields`` (BM25) +
+``projections`` (dense), and lifts the IR engine's JSON ``metadata`` filtering.
+
+Tables:
+- ``documents`` — one row per doc (fields/projections/metadata as JSON; ``content_hash``
+  for change detection; ``timestamp`` for recency).
+- ``doc_fts`` — a STANDALONE FTS5 index over canonical ``(title, body, tags)`` text
+  (not external-content: avoids rowid/trigger coupling and lets us delete by ``doc_id``).
+  Per-field importance is preserved via FTS5's native ``bm25(doc_fts, wt, wb, wg)``
+  column weights. Partition/metadata scoping is a JOIN to ``documents``.
+- ``doc_vectors`` — one float16 blob per ``(doc_id, projection)``, FK-cascaded to
+  ``documents`` (incremental O(1) writes; vectors auto-deleted with their doc).
+- ``indexed_items`` — the change-detection ledger (mtime + content_hash per item).
+- ``index_meta`` — KV (per-partition ``build_version`` etc.).
+
+Thread-safety: a fresh connection per public method (sqlite3 connections aren't
+shareable across threads; the embedding service is multi-threaded). ``CREATE … IF NOT
+EXISTS`` runs each open — cheap and idempotent, matching ``vault_index/store.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from work_buddy.index.model import Document, Projection
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_SCHEMA = """\
+CREATE TABLE IF NOT EXISTS documents (
+    doc_id        TEXT PRIMARY KEY,
+    partition     TEXT NOT NULL,
+    item_id       TEXT NOT NULL DEFAULT '',
+    fields        TEXT NOT NULL DEFAULT '{}',   -- JSON {name: text}
+    projections   TEXT NOT NULL DEFAULT '{}',   -- JSON {key: {"text": str | list[str]}}
+    display_text  TEXT NOT NULL DEFAULT '',
+    metadata      TEXT NOT NULL DEFAULT '{}',   -- JSON, json_extract-filterable
+    content_hash  TEXT NOT NULL DEFAULT '',
+    timestamp     REAL,                          -- epoch seconds, nullable (recency)
+    indexed_at    TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_documents_partition ON documents(partition);
+CREATE INDEX IF NOT EXISTS idx_documents_item ON documents(item_id);
+
+CREATE TABLE IF NOT EXISTS doc_vectors (
+    doc_id      TEXT NOT NULL REFERENCES documents(doc_id) ON DELETE CASCADE,
+    projection  TEXT NOT NULL,
+    dim         INTEGER NOT NULL,
+    vector      BLOB NOT NULL,
+    PRIMARY KEY (doc_id, projection)
+);
+CREATE INDEX IF NOT EXISTS idx_doc_vectors_proj ON doc_vectors(projection);
+
+CREATE TABLE IF NOT EXISTS indexed_items (
+    item_id       TEXT NOT NULL,
+    partition     TEXT NOT NULL DEFAULT '',
+    mtime         REAL NOT NULL DEFAULT 0,
+    content_hash  TEXT NOT NULL DEFAULT '',
+    doc_count     INTEGER NOT NULL DEFAULT 0,
+    indexed_at    TEXT NOT NULL,
+    PRIMARY KEY (item_id, partition)
+);
+
+CREATE TABLE IF NOT EXISTS index_meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+-- Standalone FTS5 (NOT external-content): canonical title/body/tags columns +
+-- an UNINDEXED doc_id so we can delete by id and JOIN back to documents.
+CREATE VIRTUAL TABLE IF NOT EXISTS doc_fts USING fts5(
+    doc_id UNINDEXED, title, body, tags
+);
+"""
+
+# Default FTS5 bm25() column weights (title > tags > body), overridable per partition.
+_DEFAULT_FTS_WEIGHTS = (3.0, 1.0, 2.0)  # (title, body, tags)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _fts_columns(fields: dict[str, str]) -> tuple[str, str, str]:
+    """Map a Document's generic ``fields`` into canonical (title, body, tags) text.
+
+    Convention: ``title``/``name`` → title; ``tags`` → tags; every other field value
+    → body. Partition-agnostic — partitions just use conventional field keys.
+    """
+    title = (fields.get("title") or fields.get("name") or "").strip()
+    tags = (fields.get("tags") or "").strip()
+    body = " ".join(
+        str(v) for k, v in fields.items()
+        if k not in ("title", "name", "tags") and v
+    ).strip()
+    return title, body, tags
+
+
+def _fts_match_expr(query: str) -> str | None:
+    """Reduce arbitrary user text to a safe FTS5 MATCH expr (OR of quoted tokens)."""
+    terms = [t for t in re.split(r"\W+", (query or "").lower()) if len(t) > 1]
+    if not terms:
+        return None
+    return " OR ".join(f'"{t}"' for t in terms)
+
+
+def _metadata_where(filters: dict[str, Any] | None) -> tuple[str, list[Any]]:
+    """Build a SQL fragment + params for json_extract metadata filtering.
+
+    Scalar value → equality; list value → set-membership (IN). Keys are the
+    metadata dict keys. Returns ``("", [])`` for no filters.
+    """
+    if not filters:
+        return "", []
+    clauses: list[str] = []
+    params: list[Any] = []
+    for key, val in filters.items():
+        path = f"$.{key}"
+        if isinstance(val, (list, tuple, set)):
+            vals = list(val)
+            if not vals:
+                clauses.append("0")  # empty set matches nothing
+                continue
+            placeholders = ",".join("?" * len(vals))
+            clauses.append(f"json_extract(d.metadata, ?) IN ({placeholders})")
+            params.append(path)
+            params.extend(str(v) for v in vals)
+        else:
+            clauses.append("json_extract(d.metadata, ?) = ?")
+            params.append(path)
+            params.append(str(val))
+    return (" AND " + " AND ".join(clauses)) if clauses else "", params
+
+
+class IndexStore:
+    """Connection-per-operation SQLite store for the consolidated index."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = Path(db_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # -- connection -------------------------------------------------------
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self._db_path), timeout=10)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.executescript(_SCHEMA)
+        return conn
+
+    # -- writes -----------------------------------------------------------
+    def upsert_documents(self, docs: list[Document], item_id: str = "") -> int:
+        """Insert/replace documents (tagged with ``item_id``) and refresh FTS rows.
+
+        ``item_id`` is the source item the docs came from (``parse(item_id)``), used
+        for per-item deletes. Returns the number of docs written.
+        """
+        if not docs:
+            return 0
+        conn = self._connect()
+        try:
+            now = _now_iso()
+            for d in docs:
+                d.ensure_hash()
+                conn.execute(
+                    "INSERT OR REPLACE INTO documents "
+                    "(doc_id, partition, item_id, fields, projections, display_text, "
+                    " metadata, content_hash, timestamp, indexed_at) "
+                    "VALUES (?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        d.doc_id, d.partition, item_id,
+                        json.dumps(d.fields),
+                        json.dumps({k: {"text": p.text} for k, p in d.projections.items()}),
+                        d.display_text, json.dumps(d.metadata), d.content_hash,
+                        d.timestamp, now,
+                    ),
+                )
+                # refresh FTS (standalone → manage explicitly)
+                conn.execute("DELETE FROM doc_fts WHERE doc_id = ?", (d.doc_id,))
+                title, body, tags = _fts_columns(d.fields)
+                conn.execute(
+                    "INSERT INTO doc_fts (doc_id, title, body, tags) VALUES (?,?,?,?)",
+                    (d.doc_id, title, body, tags),
+                )
+            conn.commit()
+            return len(docs)
+        finally:
+            conn.close()
+
+    def upsert_vectors(
+        self, projection: str, rows: list[tuple[str, "Any"]]
+    ) -> int:
+        """Insert/replace one float16 blob per (doc_id, projection). Returns count."""
+        if not rows:
+            return 0
+        import numpy as np
+        conn = self._connect()
+        try:
+            payload = [
+                (
+                    doc_id, projection, int(len(vec)),
+                    np.asarray(vec, dtype=np.float16).tobytes(),
+                )
+                for doc_id, vec in rows
+            ]
+            conn.executemany(
+                "INSERT OR REPLACE INTO doc_vectors (doc_id, projection, dim, vector) "
+                "VALUES (?,?,?,?)",
+                payload,
+            )
+            conn.commit()
+            return len(payload)
+        finally:
+            conn.close()
+
+    def delete_item_docs(self, item_id: str, partition: str | None = None) -> int:
+        """Delete all docs for an item (FTS rows + cascaded vectors). Returns rows."""
+        conn = self._connect()
+        try:
+            sql = "SELECT doc_id FROM documents WHERE item_id = ?"
+            args: list[Any] = [item_id]
+            if partition is not None:
+                sql += " AND partition = ?"
+                args.append(partition)
+            doc_ids = [r["doc_id"] for r in conn.execute(sql, args).fetchall()]
+            for did in doc_ids:
+                conn.execute("DELETE FROM doc_fts WHERE doc_id = ?", (did,))
+            cur = conn.execute(
+                "DELETE FROM documents WHERE item_id = ?"
+                + (" AND partition = ?" if partition is not None else ""),
+                args,
+            )
+            if partition is not None:
+                conn.execute(
+                    "DELETE FROM indexed_items WHERE item_id = ? AND partition = ?",
+                    (item_id, partition),
+                )
+            else:
+                conn.execute("DELETE FROM indexed_items WHERE item_id = ?", (item_id,))
+            conn.commit()
+            return cur.rowcount
+        finally:
+            conn.close()
+
+    def delete_partition(self, partition: str) -> int:
+        """Drop an entire partition (FTS + docs + cascaded vectors + ledger)."""
+        conn = self._connect()
+        try:
+            doc_ids = [
+                r["doc_id"] for r in conn.execute(
+                    "SELECT doc_id FROM documents WHERE partition = ?", (partition,)
+                ).fetchall()
+            ]
+            for did in doc_ids:
+                conn.execute("DELETE FROM doc_fts WHERE doc_id = ?", (did,))
+            cur = conn.execute("DELETE FROM documents WHERE partition = ?", (partition,))
+            conn.execute("DELETE FROM indexed_items WHERE partition = ?", (partition,))
+            conn.commit()
+            return cur.rowcount
+        finally:
+            conn.close()
+
+    # -- change-detection ledger -----------------------------------------
+    def get_indexed_items(self, partition: str) -> dict[str, tuple[float, str]]:
+        """``{item_id: (mtime, content_hash)}`` for a partition."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT item_id, mtime, content_hash FROM indexed_items WHERE partition = ?",
+                (partition,),
+            ).fetchall()
+            return {r["item_id"]: (r["mtime"], r["content_hash"]) for r in rows}
+        finally:
+            conn.close()
+
+    def mark_item_indexed(
+        self, item_id: str, partition: str, *, mtime: float = 0.0,
+        content_hash: str = "", doc_count: int = 0,
+    ) -> None:
+        conn = self._connect()
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO indexed_items "
+                "(item_id, partition, mtime, content_hash, doc_count, indexed_at) "
+                "VALUES (?,?,?,?,?,?)",
+                (item_id, partition, mtime, content_hash, doc_count, _now_iso()),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    # -- meta + versioning ------------------------------------------------
+    def get_meta(self, key: str) -> str | None:
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT value FROM index_meta WHERE key = ?", (key,)
+            ).fetchone()
+            return row["value"] if row else None
+        finally:
+            conn.close()
+
+    def set_meta(self, key: str, value: str) -> None:
+        conn = self._connect()
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO index_meta (key, value) VALUES (?, ?)",
+                (key, value),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def build_version(self, partition: str) -> int:
+        v = self.get_meta(f"build_version:{partition}")
+        try:
+            return int(v) if v is not None else 0
+        except (TypeError, ValueError):
+            return 0
+
+    def bump_version(self, partition: str) -> int:
+        nxt = self.build_version(partition) + 1
+        self.set_meta(f"build_version:{partition}", str(nxt))
+        return nxt
+
+    # -- reads ------------------------------------------------------------
+    def search_lexical(
+        self, query: str, *, partition: str | None = None,
+        filters: dict[str, Any] | None = None, scope: str | None = None,
+        weights: tuple[float, float, float] = _DEFAULT_FTS_WEIGHTS, top_k: int = 50,
+    ) -> dict[str, float]:
+        """FTS5 bm25 lexical search → ``{doc_id: score}`` max-normalized to [0,1].
+
+        Higher score = better (same shape as the IR engine's BM25 → ready for RRF).
+        ``weights`` are the (title, body, tags) bm25 column weights.
+        """
+        match = _fts_match_expr(query)
+        if match is None:
+            return {}
+        wt, wb, wg = weights
+        meta_sql, meta_params = _metadata_where(filters)
+        conn = self._connect()
+        try:
+            # bm25() takes one weight per FTS column IN ORDER, including the leading
+            # UNINDEXED doc_id (col 0) — so a 0.0 placeholder precedes title/body/tags.
+            sql = (
+                f"SELECT f.doc_id AS doc_id, bm25(doc_fts, 0.0, {wt}, {wb}, {wg}) AS rank "
+                "FROM doc_fts f JOIN documents d ON d.doc_id = f.doc_id "
+                "WHERE doc_fts MATCH ?"
+            )
+            params: list[Any] = [match]
+            if partition is not None:
+                sql += " AND d.partition = ?"
+                params.append(partition)
+            if scope:
+                sql += " AND d.doc_id LIKE ?"
+                params.append(scope + "%")
+            sql += meta_sql
+            params.extend(meta_params)
+            sql += " ORDER BY rank LIMIT ?"  # bm25 ascending: more-negative = better
+            params.append(top_k)
+            rows = conn.execute(sql, params).fetchall()
+        finally:
+            conn.close()
+        if not rows:
+            return {}
+        raw = {r["doc_id"]: -float(r["rank"]) for r in rows}  # negate → higher=better
+        hi = max(raw.values())
+        if hi <= 0:
+            return {d: 0.0 for d in raw}
+        return {d: v / hi for d, v in raw.items()}
+
+    def load_documents(
+        self, *, partition: str | None = None, doc_ids: list[str] | None = None,
+        filters: dict[str, Any] | None = None, scope: str | None = None,
+    ) -> dict[str, dict[str, Any]]:
+        """Load documents (parsed JSON) keyed by doc_id, with optional filters."""
+        meta_sql, meta_params = _metadata_where(filters)
+        conn = self._connect()
+        try:
+            sql = (
+                "SELECT d.doc_id, d.partition, d.item_id, d.fields, d.projections, "
+                "d.display_text, d.metadata, d.content_hash, d.timestamp "
+                "FROM documents d WHERE 1=1"
+            )
+            params: list[Any] = []
+            if partition is not None:
+                sql += " AND d.partition = ?"
+                params.append(partition)
+            if doc_ids is not None:
+                if not doc_ids:
+                    return {}
+                sql += f" AND d.doc_id IN ({','.join('?' * len(doc_ids))})"
+                params.extend(doc_ids)
+            if scope:
+                sql += " AND d.doc_id LIKE ?"
+                params.append(scope + "%")
+            sql += meta_sql
+            params.extend(meta_params)
+            rows = conn.execute(sql, params).fetchall()
+        finally:
+            conn.close()
+        out: dict[str, dict[str, Any]] = {}
+        for r in rows:
+            out[r["doc_id"]] = {
+                "doc_id": r["doc_id"],
+                "partition": r["partition"],
+                "item_id": r["item_id"],
+                "fields": json.loads(r["fields"] or "{}"),
+                "projections": json.loads(r["projections"] or "{}"),
+                "display_text": r["display_text"] or "",
+                "metadata": json.loads(r["metadata"] or "{}"),
+                "content_hash": r["content_hash"] or "",
+                "timestamp": r["timestamp"],
+            }
+        return out
+
+    def load_all_vectors(
+        self, partition: str, projection: str
+    ) -> "tuple[Any, list[str]] | None":
+        """Load every vector for (partition, projection) → (matrix, doc_ids) | None."""
+        import numpy as np
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT v.doc_id AS doc_id, v.vector AS vector "
+                "FROM doc_vectors v JOIN documents d ON d.doc_id = v.doc_id "
+                "WHERE v.projection = ? AND d.partition = ? ORDER BY v.doc_id",
+                (projection, partition),
+            ).fetchall()
+        finally:
+            conn.close()
+        if not rows:
+            return None
+        doc_ids = [r["doc_id"] for r in rows]
+        flat = np.frombuffer(b"".join(r["vector"] for r in rows), dtype=np.float16)
+        matrix = flat.reshape(len(doc_ids), -1).astype(np.float32)
+        return matrix, doc_ids
+
+    def docs_missing_vectors(
+        self, partition: str, projection: str
+    ) -> list[tuple[str, Any]]:
+        """``(doc_id, projection_text)`` for docs in the partition lacking a vector.
+
+        The incremental/resumable encode work-list. ``projection_text`` is read from
+        the document's stored ``projections`` JSON (scalar or list).
+        """
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT d.doc_id AS doc_id, d.projections AS projections "
+                "FROM documents d "
+                "LEFT JOIN doc_vectors v ON v.doc_id = d.doc_id AND v.projection = ? "
+                "WHERE d.partition = ? AND v.doc_id IS NULL ORDER BY d.doc_id",
+                (projection, partition),
+            ).fetchall()
+        finally:
+            conn.close()
+        out: list[tuple[str, Any]] = []
+        for r in rows:
+            projs = json.loads(r["projections"] or "{}")
+            entry = projs.get(projection)
+            if entry is None:
+                continue
+            text = entry.get("text") if isinstance(entry, dict) else entry
+            if text:
+                out.append((r["doc_id"], text))
+        return out
+
+    # -- counts -----------------------------------------------------------
+    def doc_count(self, partition: str | None = None) -> int:
+        conn = self._connect()
+        try:
+            if partition is None:
+                return conn.execute("SELECT COUNT(*) AS n FROM documents").fetchone()["n"]
+            return conn.execute(
+                "SELECT COUNT(*) AS n FROM documents WHERE partition = ?", (partition,)
+            ).fetchone()["n"]
+        finally:
+            conn.close()
+
+    def vector_count(self, partition: str, projection: str | None = None) -> int:
+        conn = self._connect()
+        try:
+            if projection is None:
+                return conn.execute(
+                    "SELECT COUNT(*) AS n FROM doc_vectors v "
+                    "JOIN documents d ON d.doc_id = v.doc_id WHERE d.partition = ?",
+                    (partition,),
+                ).fetchone()["n"]
+            return conn.execute(
+                "SELECT COUNT(*) AS n FROM doc_vectors v "
+                "JOIN documents d ON d.doc_id = v.doc_id "
+                "WHERE d.partition = ? AND v.projection = ?",
+                (partition, projection),
+            ).fetchone()["n"]
+        finally:
+            conn.close()
+
+    def partitions(self) -> list[str]:
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT DISTINCT partition FROM documents ORDER BY partition"
+            ).fetchall()
+            return [r["partition"] for r in rows]
+        finally:
+            conn.close()

--- a/work_buddy/index/store.py
+++ b/work_buddy/index/store.py
@@ -153,6 +153,10 @@ class IndexStore:
         self._db_path = Path(db_path)
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
 
+    @property
+    def db_path(self) -> Path:
+        return self._db_path
+
     # -- connection -------------------------------------------------------
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(str(self._db_path), timeout=10)

--- a/work_buddy/index/store.py
+++ b/work_buddy/index/store.py
@@ -52,12 +52,16 @@ CREATE TABLE IF NOT EXISTS documents (
 CREATE INDEX IF NOT EXISTS idx_documents_partition ON documents(partition);
 CREATE INDEX IF NOT EXISTS idx_documents_item ON documents(item_id);
 
+-- One row per (doc_id, projection, sub). ``sub`` lets a single projection carry
+-- MULTIPLE vectors per doc (e.g. one per alias) which are pooled (max/mean) at query
+-- time — preserving the knowledge alias signal. Scalar projections use sub=0 only.
 CREATE TABLE IF NOT EXISTS doc_vectors (
     doc_id      TEXT NOT NULL REFERENCES documents(doc_id) ON DELETE CASCADE,
     projection  TEXT NOT NULL,
+    sub         INTEGER NOT NULL DEFAULT 0,
     dim         INTEGER NOT NULL,
     vector      BLOB NOT NULL,
-    PRIMARY KEY (doc_id, projection)
+    PRIMARY KEY (doc_id, projection, sub)
 );
 CREATE INDEX IF NOT EXISTS idx_doc_vectors_proj ON doc_vectors(projection);
 
@@ -200,26 +204,38 @@ class IndexStore:
     def upsert_vectors(
         self, projection: str, rows: list[tuple[str, "Any"]]
     ) -> int:
-        """Insert/replace one float16 blob per (doc_id, projection). Returns count."""
+        """Insert/replace vectors for a projection. Returns rows written.
+
+        Each item is ``(doc_id, vecs)`` where ``vecs`` is a 1-D vector (scalar
+        projection → one sub) or a 2-D array / list-of-vectors (pooled projection →
+        one sub per row). Existing rows for each ``(doc_id, projection)`` are replaced.
+        """
         if not rows:
             return 0
         import numpy as np
         conn = self._connect()
         try:
-            payload = [
-                (
-                    doc_id, projection, int(len(vec)),
-                    np.asarray(vec, dtype=np.float16).tobytes(),
+            written = 0
+            for doc_id, vecs in rows:
+                arr = np.asarray(vecs, dtype=np.float16)
+                if arr.ndim == 1:
+                    arr = arr.reshape(1, -1)
+                conn.execute(
+                    "DELETE FROM doc_vectors WHERE doc_id = ? AND projection = ?",
+                    (doc_id, projection),
                 )
-                for doc_id, vec in rows
-            ]
-            conn.executemany(
-                "INSERT OR REPLACE INTO doc_vectors (doc_id, projection, dim, vector) "
-                "VALUES (?,?,?,?)",
-                payload,
-            )
+                payload = [
+                    (doc_id, projection, i, int(arr.shape[1]), arr[i].tobytes())
+                    for i in range(arr.shape[0])
+                ]
+                conn.executemany(
+                    "INSERT INTO doc_vectors (doc_id, projection, sub, dim, vector) "
+                    "VALUES (?,?,?,?,?)",
+                    payload,
+                )
+                written += len(payload)
             conn.commit()
-            return len(payload)
+            return written
         finally:
             conn.close()
 
@@ -428,14 +444,18 @@ class IndexStore:
     def load_all_vectors(
         self, partition: str, projection: str
     ) -> "tuple[Any, list[str]] | None":
-        """Load every vector for (partition, projection) → (matrix, doc_ids) | None."""
+        """Load every vector for (partition, projection) → (matrix, doc_ids) | None.
+
+        For pooled projections ``doc_ids`` repeats (one entry per sub-vector, parallel
+        to the matrix rows); the caller max/mean-pools per doc_id at query time.
+        """
         import numpy as np
         conn = self._connect()
         try:
             rows = conn.execute(
                 "SELECT v.doc_id AS doc_id, v.vector AS vector "
                 "FROM doc_vectors v JOIN documents d ON d.doc_id = v.doc_id "
-                "WHERE v.projection = ? AND d.partition = ? ORDER BY v.doc_id",
+                "WHERE v.projection = ? AND d.partition = ? ORDER BY v.doc_id, v.sub",
                 (projection, partition),
             ).fetchall()
         finally:
@@ -490,16 +510,17 @@ class IndexStore:
             conn.close()
 
     def vector_count(self, partition: str, projection: str | None = None) -> int:
+        """Count DISTINCT docs with ≥1 vector (pooled projections have many rows/doc)."""
         conn = self._connect()
         try:
             if projection is None:
                 return conn.execute(
-                    "SELECT COUNT(*) AS n FROM doc_vectors v "
+                    "SELECT COUNT(DISTINCT v.doc_id) AS n FROM doc_vectors v "
                     "JOIN documents d ON d.doc_id = v.doc_id WHERE d.partition = ?",
                     (partition,),
                 ).fetchone()["n"]
             return conn.execute(
-                "SELECT COUNT(*) AS n FROM doc_vectors v "
+                "SELECT COUNT(DISTINCT v.doc_id) AS n FROM doc_vectors v "
                 "JOIN documents d ON d.doc_id = v.doc_id "
                 "WHERE d.partition = ? AND v.projection = ?",
                 (partition, projection),

--- a/work_buddy/indexing/adapters/index_consolidated.py
+++ b/work_buddy/indexing/adapters/index_consolidated.py
@@ -1,0 +1,57 @@
+"""``Index`` adapter for the consolidated index (flag-gated).
+
+Surfaces the consolidated index in the same dashboard/status/build seam as the IR,
+vault, and knowledge indexes. ``bulk_build`` is a no-op unless ``index.enabled`` — the
+consolidated index never builds (or touches its DB) on the live path until the flag is
+flipped. ``status`` is always safe (pure store reads; empty before first build).
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from work_buddy.indexing.protocol import (
+    BuildProgress,
+    BuildResult,
+    IndexStatus,
+)
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class ConsolidatedIndexAdapter:
+    name = "consolidated"
+
+    def status(self) -> IndexStatus:
+        try:
+            from work_buddy.index.partitioned import UnifiedIndex
+            return UnifiedIndex().status()
+        except Exception as exc:  # never blank the panel on one bad index
+            logger.debug("consolidated status failed: %s", exc)
+            return IndexStatus(name=self.name, partitions=[])
+
+    def lock_key(self) -> str:
+        from work_buddy.index.config import load_index_config
+        return str(load_index_config().resolved_db_path())
+
+    def bulk_build(
+        self, *, full_history: bool = False,
+        on_progress: Callable[[BuildProgress], None] | None = None,
+    ) -> BuildResult:
+        from work_buddy.index.config import load_index_config
+        cfg = load_index_config()
+        if not cfg.enabled:
+            return BuildResult(
+                name=self.name, ok=True,
+                stats={"skipped": "index.enabled is false (flag-gated; off by default)"},
+            )
+        try:
+            from work_buddy.index.partitioned import UnifiedIndex
+            stats = UnifiedIndex(config=cfg).build_all(force=full_history)
+            return BuildResult(name=self.name, ok=True, stats={"partitions": stats})
+        except Exception as exc:
+            return BuildResult(
+                name=self.name, ok=False, stats={},
+                error=f"{type(exc).__name__}: {exc}",
+            )

--- a/work_buddy/indexing/registry.py
+++ b/work_buddy/indexing/registry.py
@@ -23,10 +23,16 @@ def _knowledge() -> Index:
     return KnowledgeIndexAdapter()
 
 
+def _consolidated() -> Index:
+    from work_buddy.indexing.adapters.index_consolidated import ConsolidatedIndexAdapter
+    return ConsolidatedIndexAdapter()
+
+
 _FACTORIES = {
     "ir": _ir,
     "vault_index": _vault,
     "knowledge": _knowledge,
+    "consolidated": _consolidated,  # flag-gated; status safe, build no-op unless index.enabled
 }
 
 

--- a/work_buddy/knowledge/partition.py
+++ b/work_buddy/knowledge/partition.py
@@ -1,0 +1,161 @@
+"""KnowledgePartition — the knowledge store as a consolidated-index partition.
+
+Domain-owned (F-PLACEMENT): lives in ``knowledge/`` and registers itself into the
+index's partition registry at import time. ``index/`` never imports this; the registry
+bootstrap (``index/partitions/bootstrap.py``) imports it to trigger registration.
+
+Preserves the knowledge index's domain fit:
+- one Document per unit (whole-unit), ``<<wb:>>``-resolved content;
+- a ``content`` PASSAGE projection (asymmetric) + an ``aliases`` LABEL/MAX projection
+  (the max-pooled alias signal);
+- content-hash change detection;
+- ``scope`` metadata (system/personal/all → one partition + a filter, fork F-SCOPE);
+- ``hydrate`` → ``KnowledgeUnit.tier(depth)`` so agent_docs-style results are unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from work_buddy.index.model import (
+    Document,
+    ItemRef,
+    PoolStrategy,
+    Projection,
+    ProjectionKind,
+    ProjectionSpec,
+    content_hash,
+    make_doc_id,
+)
+from work_buddy.index.partition import register_partition
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_PARTITION = "knowledge"
+
+
+def _spaced(name: str) -> str:
+    return (name or "").replace("-", " ").replace("_", " ")
+
+
+def _aliases(unit: Any) -> list[str]:
+    return [a for a in (getattr(unit, "aliases", None) or []) if a and a.strip()]
+
+
+def _content_text(unit: Any, store: dict | None) -> str:
+    """Dense passage text: name + description + tags + summary + (resolved) full body.
+
+    Excludes aliases (they get their own LABEL projection) — matches the old knowledge
+    index's ``content_text``.
+    """
+    from work_buddy.knowledge.model import _resolve_placeholders
+
+    content = getattr(unit, "content", None) or {}
+    summary = content.get("summary", "") or ""
+    full = content.get("full", "") or summary
+    if store is not None and full and "<<wb:" in full:
+        try:
+            full = _resolve_placeholders(full, store)
+        except Exception:  # resolution must never break indexing
+            pass
+    parts = [_spaced(getattr(unit, "name", "")), getattr(unit, "description", "") or ""]
+    tags = list(getattr(unit, "tags", None) or [])
+    if tags:
+        parts.append(" ".join(tags))
+    if summary:
+        parts.append(summary)
+    if full and full != summary:
+        parts.append(full)
+    return "\n".join(p for p in parts if p)
+
+
+class KnowledgePartition:
+    name = _PARTITION
+    change_key = "hash"
+
+    def __init__(self, store_loader=None) -> None:
+        # store_loader: () -> dict[path, KnowledgeUnit]; default load_store(scope="all").
+        self._store_loader = store_loader
+
+    def _store(self) -> dict:
+        if self._store_loader is not None:
+            return self._store_loader()
+        from work_buddy.knowledge.store import load_store
+        return load_store(scope="all")
+
+    def field_weights(self) -> dict[str, float]:
+        return {"name": 3.0, "tags": 2.0, "body": 1.0}
+
+    def projection_schema(self) -> dict[str, ProjectionSpec]:
+        return {
+            "content": ProjectionSpec(kind=ProjectionKind.PASSAGE),
+            "aliases": ProjectionSpec(kind=ProjectionKind.LABEL, pool=PoolStrategy.MAX),
+        }
+
+    def discover(self) -> Iterable[ItemRef]:
+        store = self._store()
+        refs: list[ItemRef] = []
+        for path, unit in store.items():
+            ct = _content_text(unit, store)
+            aliases = _aliases(unit)
+            h = content_hash(ct + "\x01" + "\x01".join(aliases))
+            refs.append(ItemRef(item_id=path, content_hash=h))
+        return refs
+
+    def parse(self, item_id: str) -> list[Document]:
+        store = self._store()
+        unit = store.get(item_id)
+        if unit is None:
+            return []
+        return [self._to_document(item_id, unit, store)]
+
+    def _to_document(self, path: str, unit: Any, store: dict) -> Document:
+        from work_buddy.knowledge.model import VaultUnit
+
+        ct = _content_text(unit, store)
+        aliases = _aliases(unit)
+        tags = list(getattr(unit, "tags", None) or [])
+        kind = getattr(unit, "kind", "") or ""
+        scope = "personal" if isinstance(unit, VaultUnit) else "system"
+        description = getattr(unit, "description", "") or ""
+
+        # Body for lexical recall = full content text + aliases (title=name weighted higher).
+        body = ct + (("\n" + " ".join(aliases)) if aliases else "")
+        fields = {
+            "name": _spaced(getattr(unit, "name", "")),
+            "tags": " ".join(tags),
+            "body": body,
+        }
+        projections: dict[str, Projection] = {"content": Projection(text=ct)}
+        if aliases:
+            projections["aliases"] = Projection(text=aliases)
+
+        return Document(
+            doc_id=make_doc_id(_PARTITION, path),
+            partition=_PARTITION,
+            fields=fields,
+            display_text=f"[{kind}] {path}: {description}",
+            metadata={"kind": kind, "path": path, "scope": scope, "tags": tags},
+            projections=projections,
+        )
+
+    def hydrate(self, hits: list, *, depth: str = "index", dev: bool = False, **opts) -> list[Any]:
+        """Map ranked hits → depth-tiered units (agent_docs-shaped results)."""
+        store = self._store()
+        out: list[Any] = []
+        for h in hits:
+            path = h.doc_id.split(":", 1)[1] if ":" in h.doc_id else h.doc_id
+            unit = store.get(path)
+            if unit is None:
+                continue
+            try:
+                tiered = unit.tier(depth, store=store, dev=dev)
+            except Exception as exc:  # tiering must not break a result
+                logger.debug("knowledge hydrate tier(%s) failed: %s", path, exc)
+                tiered = {"name": getattr(unit, "name", path)}
+            out.append({"path": path, "score": h.score, **tiered})
+        return out
+
+
+register_partition(_PARTITION, lambda: KnowledgePartition())

--- a/work_buddy/paths.py
+++ b/work_buddy/paths.py
@@ -72,6 +72,7 @@ RESOURCES: dict[str, str] = {
     "db/llm_queue":              "db/llm_call_queue.db",  # LLM-call priority queue
     "db/work_item_events":       "db/work_item_events.db",  # WorkItem audit/provenance log
     "db/vault-index":            "db/vault-index.db",  # Vault semantic-index chunk store
+    "db/index-consolidated":     "db/index-consolidated.db",  # Consolidated index (flag-gated; index.enabled)
     "db/broker-metrics":         "db/broker_metrics.db",  # Persisted LocalInferenceBroker call metrics
 
     # Logs

--- a/work_buddy/vault_index/partition.py
+++ b/work_buddy/vault_index/partition.py
@@ -1,0 +1,91 @@
+"""VaultChunkPartition — vault markdown chunks as a consolidated-index partition.
+
+Domain-owned (F-PLACEMENT): reuses ``vault_index``'s ``FilesystemSource`` (multi-vault
+discovery) + ``chunk_markdown`` (heading-aware chunker) as collaborators — it does NOT
+re-implement them. One Document per chunk; a ``content`` PASSAGE projection from the
+chunk's breadcrumb-prefixed ``embed_input``.
+
+Best-effort for the overnight build: registered + smoke-tested against a tmp file, but
+NOT part of tonight's A/B (the vault's own index is the live path and is unaffected).
+See AFK-DECISIONS D12.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from work_buddy.index.model import (
+    Document,
+    ItemRef,
+    Projection,
+    ProjectionKind,
+    ProjectionSpec,
+    make_doc_id,
+)
+from work_buddy.index.partition import register_partition
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_PARTITION = "vault"
+
+
+class VaultChunkPartition:
+    name = _PARTITION
+    change_key = "mtime"
+
+    def __init__(self, source: Any = None) -> None:
+        self._source = source  # inject for tests; else FilesystemSource() lazily
+        self._files: dict[str, Any] = {}  # item_id -> DiscoveredFile (populated by discover)
+
+    def _get_source(self):
+        if self._source is not None:
+            return self._source
+        from work_buddy.vault_index.source import FilesystemSource
+        return FilesystemSource()
+
+    def field_weights(self) -> dict[str, float]:
+        return {"name": 2.0, "body": 1.0}
+
+    def projection_schema(self) -> dict[str, ProjectionSpec]:
+        return {"content": ProjectionSpec(kind=ProjectionKind.PASSAGE)}
+
+    def discover(self) -> Iterable[ItemRef]:
+        result = self._get_source().discover()
+        files = result[0] if isinstance(result, tuple) else result
+        self._files = {f.item_id: f for f in files}
+        return [ItemRef(item_id=f.item_id, mtime=float(getattr(f, "mtime", 0.0))) for f in files]
+
+    def parse(self, item_id: str) -> list[Document]:
+        df = self._files.get(item_id)
+        if df is None:
+            return []
+        try:
+            with open(df.abs_path, "r", encoding="utf-8") as fh:
+                text = fh.read()
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.debug("vault parse: cannot read %s: %s", df.abs_path, exc)
+            return []
+
+        from work_buddy.vault_index.chunker import chunk_markdown
+
+        docs: list[Document] = []
+        for chunk in chunk_markdown(text, source_path=df.source_path):
+            crumb = " > ".join(chunk.heading_path) if chunk.heading_path else df.item_id
+            docs.append(Document(
+                doc_id=make_doc_id(_PARTITION, chunk.key),
+                partition=_PARTITION,
+                fields={"name": crumb, "body": chunk.text},
+                display_text=chunk.text[:300],
+                metadata={
+                    "source_path": chunk.source_path,
+                    "heading_path": chunk.heading_path,
+                    "vault_id": getattr(df, "vault_id", ""),
+                    "line_start": chunk.line_start,
+                },
+                projections={"content": Projection(text=chunk.embed_input)},
+            ))
+        return docs
+
+
+register_partition(_PARTITION, lambda: VaultChunkPartition())


### PR DESCRIPTION
## What

Builds the **consolidated index** (`work_buddy/index/`) from the locked design
(`.data/designs/index-consolidation/{DESIGN.md, CLASS-ARCHITECTURE.md}`) — one SQLite +
FTS5 + float16-blob-vector store across partitions (knowledge, vault chunks, conversation,
projects, chrome, summary, task_note), served warm in-service and broker-scheduled.

**It is INERT.** `index.enabled` defaults `false`; the live knowledge/vault/IR indexes are
untouched on the hot path. The consolidated index builds into a **separate** DB
(`db/index-consolidated`) and is exercised only by the A/B harness. **Nothing is deleted,
no default is flipped, no caller is re-pointed, no service restarted.** This is an
overnight `/afk` build — see `AFK-DECISIONS.md` for every judgement call.

## Layers (13 commits, all green; composition + Protocols, inheritance-free)

model · config(flag) · fusion(RRF) · recency · ResidentCache(+registry/evictor) ·
IndexStore(SQLite/FTS5/blob vectors) · encode(provider seam, reuses the shipped
`local_embed_slot`) · HybridSearcher · IndexBuilder(incremental, locked, content-hash) ·
Partition protocol+registry · partition adapters (knowledge full, 5 IR sources via one
generic wrapper, vault best-effort) · UnifiedIndex facade + `consolidated` Index-seam
adapter · `/index/*` service endpoints + `index:` config block · A/B harness.

## Validation — A/B vs the live knowledge index (oracle)

Built 425 knowledge units into the separate DB; 18 representative queries, top_k=10:

- **mean overlap@10 = 0.806**, **top-1 agreement = 0.722 (13/18)**, **mean rank-corr = 0.856**, **0 empty results**.

Oracle-comparable rankings from a from-scratch reimplementation. Divergences are mostly
"both relevant, different framing." One genuine weak spot flagged: `"reciprocal rank
fusion"` (rank-corr 0.48). Full table in `.data/designs/index-consolidation/AB-RESULTS.md`.

## Tests

115 new unit tests across the index package; full `tests/unit` sweep green (exit 0).
Verification is pytest + fresh-subprocess imports + code inspection — **no service restart**.

## NOT in this PR (the safety boundary, deliberate)

- ❌ deleting `knowledge/index.py` / `.npz` / the IR `docs` source (F-EVAL-gated)
- ❌ flipping `index.enabled` or re-pointing `agent_docs`/`search`/the dev-document scan
- ❌ collapsing the 3 live resident-cache evictors (added a new one, additive)
- ❌ live vault→ir import re-point (signatures not drop-in — AFK D4)

## Suggested next steps (post-review)

1. Read `AB-RESULTS.md`. 2. Restart the embedding service to load `/index/*`. 3. Live A/B
+ investigate the RRF divergence. 4. If satisfied, enable the flag for the dev-document
scan first (most-to-gain, degrade-tolerant), A/B live. 5. Then the F-EVAL-gated deletions
+ evictor collapse as a SEPARATE PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)