### PR TITLE
feat(index): per-partition coverage + lifecycle filtering for history partitions

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -251,8 +251,14 @@ index:
   partitions:
     knowledge:
       rrf_k: 20            # smaller per-partition default (A/B: k=60≈k=15 at top-k)
-    # conversation: { rrf_k: 60, recency: true }
-    # vault:        { rrf_k: 60 }
+    # `coverage: all` admits a history source's archived/closed/superseded items into
+    # the corpus so retrospective queries can find them; whether they're SHOWN is a
+    # query-time filter on `lifecycle_state`, not a build-time exclusion. Default is
+    # "active" (the source's working set). History partitions want "all":
+    task_note:
+      coverage: all
+    # conversation: { rrf_k: 60, recency: true, coverage: all }
+    # vault:        { rrf_k: 60, coverage: all }
 
 chats:
   specstory_days: 7

--- a/tests/unit/test_index_partitions.py
+++ b/tests/unit/test_index_partitions.py
@@ -193,6 +193,173 @@ class TestVaultChunkPartition:
         assert part.parse("nope") == []
 
 
+class _FakeLifecycleSource:
+    """A history-style IR source: discover() takes coverage, exposes lifecycle()."""
+
+    name = "task_note"
+
+    def __init__(self, states):
+        # states: {item_id: state}; archived items only appear under coverage="all"
+        self._states = dict(states)
+        self.last_coverage = None
+
+    def default_field_weights(self):
+        return {"line": 2.0, "body": 1.0}
+
+    def discover(self, days: int = 30, *, coverage: str = "active"):
+        self.last_coverage = coverage
+        items = []
+        for iid, state in self._states.items():
+            if coverage != "all" and state == "archived":
+                continue
+            items.append((iid, 100.0))
+        return items
+
+    def lifecycle(self, item_ids):
+        return {iid: self._states.get(iid, "unknown") for iid in item_ids}
+
+    def parse(self, item_id):
+        return [_FakeIRDoc(
+            doc_id=f"{item_id}", fields={"line": item_id},
+            dense_text=f"note body for {item_id}", display_text=item_id,
+            metadata={"note_uuid": item_id},
+        )]
+
+
+class TestIRSourcePartitionCoverage:
+    """The generic coverage + lifecycle seam (extensible to any history source)."""
+
+    def _states(self):
+        return {"open1": "open", "done1": "done", "arch1": "archived"}
+
+    def test_no_lifecycle_source_unchanged(self):
+        # A plain source (no lifecycle, no coverage kwarg) behaves exactly as before.
+        p = IRSourcePartition(_FakeIRSource())
+        assert p.change_key == "mtime"
+        refs = list(p.discover())
+        assert all(r.content_hash is None for r in refs)  # mtime-only, no token
+        d = p.parse("sess1")[0]
+        assert "lifecycle_state" not in d.metadata
+
+    def test_lifecycle_source_uses_hash_change_key(self):
+        p = IRSourcePartition(_FakeLifecycleSource(self._states()))
+        assert p.change_key == "hash"  # state can change without an mtime change
+
+    def test_active_coverage_excludes_archived(self):
+        src = _FakeLifecycleSource(self._states())
+        p = IRSourcePartition(src, coverage="active")
+        ids = {r.item_id for r in p.discover()}
+        assert ids == {"open1", "done1"}  # archived withheld
+        assert src.last_coverage == "active"
+
+    def test_all_coverage_includes_archived(self):
+        src = _FakeLifecycleSource(self._states())
+        p = IRSourcePartition(src, coverage="all")
+        ids = {r.item_id for r in p.discover()}
+        assert ids == {"open1", "done1", "arch1"}  # archived now in the corpus
+        assert src.last_coverage == "all"
+
+    def test_change_token_folds_state_and_mtime(self):
+        # A state transition (mtime unchanged) must change the item's change token.
+        s = self._states()
+        p_open = IRSourcePartition(_FakeLifecycleSource(s), coverage="all")
+        tok_open = {r.item_id: r.content_hash for r in p_open.discover()}["open1"]
+
+        s2 = dict(s, open1="done")  # same item, same mtime, new state
+        p_done = IRSourcePartition(_FakeLifecycleSource(s2), coverage="all")
+        tok_done = {r.item_id: r.content_hash for r in p_done.discover()}["open1"]
+
+        assert tok_open and tok_done and tok_open != tok_done
+
+    def test_parse_stamps_uniform_lifecycle_state(self):
+        src = _FakeLifecycleSource(self._states())
+        p = IRSourcePartition(src, coverage="all")
+        p.discover()  # populates per-item states
+        d = p.parse("arch1")[0]
+        assert d.metadata["lifecycle_state"] == "archived"  # filterable by any query
+
+    def test_configure_applies_coverage_from_config(self):
+        from work_buddy.index.config import PartitionConfig
+        src = _FakeLifecycleSource(self._states())
+        p = IRSourcePartition(src)               # constructed with default "active"
+        p.configure(PartitionConfig(name="task_note", coverage="all"))
+        ids = {r.item_id for r in p.discover()}
+        assert "arch1" in ids                    # config drove coverage → archived included
+
+
+class TestPartitionConfigCoverage:
+    def test_default_coverage_is_active(self):
+        from work_buddy.index.config import PartitionConfig
+        assert PartitionConfig(name="x").coverage == "active"
+
+    def test_from_dict_reads_coverage(self):
+        from work_buddy.index.config import PartitionConfig
+        pc = PartitionConfig.from_dict("task_note", {"coverage": "all", "rrf_k": 30})
+        assert pc.coverage == "all" and pc.rrf_k == 30
+
+    def test_load_config_threads_coverage(self):
+        from work_buddy.index.config import load_index_config
+        cfg = load_index_config({"index": {"enabled": True, "partitions": {
+            "task_note": {"coverage": "all"}}}})
+        assert cfg.partition("task_note").coverage == "all"
+        assert cfg.partition("unlisted").coverage == "active"  # safe default
+
+
+class TestTaskNoteSourceCoverage:
+    """Real-SQLite test of the task_note SOURCE change (the recall fix at the source)."""
+
+    def _setup(self, tmp_path, monkeypatch):
+        import sqlite3
+        from work_buddy.obsidian.tasks.mutations import TASK_NOTES_DIR
+
+        vault = tmp_path / "vault"
+        notes_dir = vault / TASK_NOTES_DIR
+        notes_dir.mkdir(parents=True)
+        rows = [
+            ("t-open", "uuid-open", "open", None),
+            ("t-done", "uuid-done", "done", None),
+            ("t-arch", "uuid-arch", "open", "2026-01-01T00:00:00+00:00"),  # archived
+        ]
+        for _, uuid, _, _ in rows:
+            (notes_dir / f"{uuid}.md").write_text(f"# {uuid}\n\nbody\n", encoding="utf-8")
+
+        db = tmp_path / "tasks.db"
+        c = sqlite3.connect(db)
+        c.execute("CREATE TABLE task_metadata "
+                  "(task_id TEXT, note_uuid TEXT, state TEXT, archived_at TEXT)")
+        c.executemany("INSERT INTO task_metadata VALUES (?,?,?,?)", rows)
+        c.commit(); c.close()
+
+        def _conn():
+            cc = sqlite3.connect(db); cc.row_factory = sqlite3.Row; return cc
+
+        monkeypatch.setattr("work_buddy.config.load_config",
+                            lambda *a, **k: {"vault_root": str(vault), "ir": {}})
+        monkeypatch.setattr("work_buddy.obsidian.tasks.store.get_connection", _conn)
+        from work_buddy.ir.sources.task_notes import TaskNoteSource
+        return TaskNoteSource()
+
+    def test_default_coverage_excludes_archived(self, tmp_path, monkeypatch):
+        src = self._setup(tmp_path, monkeypatch)
+        stems = {p.split("\\")[-1].split("/")[-1] for p, _ in src.discover()}
+        assert "uuid-open.md" in stems and "uuid-done.md" in stems
+        assert "uuid-arch.md" not in stems  # live-IR behavior preserved
+
+    def test_all_coverage_includes_archived(self, tmp_path, monkeypatch):
+        src = self._setup(tmp_path, monkeypatch)
+        stems = {p.split("\\")[-1].split("/")[-1] for p, _ in src.discover(coverage="all")}
+        assert "uuid-arch.md" in stems  # archived note now discoverable
+
+    def test_lifecycle_maps_state_with_archived_priority(self, tmp_path, monkeypatch):
+        src = self._setup(tmp_path, monkeypatch)
+        paths = [p for p, _ in src.discover(coverage="all")]
+        life = src.lifecycle(paths)
+        by_uuid = {p.replace("\\", "/").split("/")[-1]: s for p, s in life.items()}
+        assert by_uuid["uuid-open.md"] == "open"
+        assert by_uuid["uuid-done.md"] == "done"
+        assert by_uuid["uuid-arch.md"] == "archived"  # archived_at wins over state
+
+
 class TestBootstrap:
     def test_ensure_registers_core_partitions(self):
         from work_buddy.index.partition import get_partition_registry

--- a/work_buddy/index/config.py
+++ b/work_buddy/index/config.py
@@ -46,6 +46,13 @@ class PartitionConfig:
     recency: bool = False
     recency_half_life_days: float = 14.0
     recency_floor: float = 0.15
+    # Corpus COVERAGE this partition indexes (generic, source-interpreted). "active" =
+    # the source's working set (the safe default — preserves each source's own default,
+    # e.g. task_note excludes archived). "all" = full history incl. archived/closed/
+    # superseded items, so retrospective queries can find them; selection is then a
+    # query-time concern (Query.filters), not a build-time policy. A source that doesn't
+    # understand `coverage` simply ignores it. See HISTORY-PARTITION-COVERAGE.md.
+    coverage: str = "active"
 
     @classmethod
     def from_dict(cls, name: str, raw: dict[str, Any] | None) -> "PartitionConfig":
@@ -64,6 +71,7 @@ class PartitionConfig:
                 raw.get("recency_half_life_days", defaults.recency_half_life_days)
             ),
             recency_floor=float(raw.get("recency_floor", defaults.recency_floor)),
+            coverage=str(raw.get("coverage", defaults.coverage)),
         )
 
 

--- a/work_buddy/index/partition.py
+++ b/work_buddy/index/partition.py
@@ -68,6 +68,21 @@ def hydrate(partition: Any, hits: "list[Hit]", **opts: Any) -> list[Any]:
     return fn(hits, **opts)
 
 
+def configure_partition(partition: Any, cfg: Any) -> None:
+    """Hand a partition its ``PartitionConfig`` if it opts into one (optional hook).
+
+    Lets a partition pick up config-driven behavior (e.g. ``coverage``) from the
+    facade's *injected* config rather than reaching for global config. A partition
+    that declares no ``configure`` is unaffected. Never raises."""
+    fn = getattr(partition, "configure", None)
+    if fn is None:
+        return
+    try:
+        fn(cfg)
+    except Exception:  # pragma: no cover — config application is best-effort
+        pass
+
+
 class PartitionRegistry:
     """Lazy factory registry. Domains register a ``() -> Partition`` factory; the
     instance is built (and cached) on first ``get``."""

--- a/work_buddy/index/partitioned.py
+++ b/work_buddy/index/partitioned.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from work_buddy.index.config import IndexConfig, load_index_config
 from work_buddy.index.model import Hit, Query
 from work_buddy.index.partition import (
+    configure_partition,
     get_partition_registry,
     get_projection_schema,
     hydrate,
@@ -43,6 +44,7 @@ class IndexPartition:
         from work_buddy.index.build import IndexBuilder
 
         self._partition = partition
+        configure_partition(partition, cfg)  # apply coverage etc. before build/search
         self._store = store
         self._cfg = cfg
         self._searcher = HybridSearcher(

--- a/work_buddy/index/partitions/ir_source.py
+++ b/work_buddy/index/partitions/ir_source.py
@@ -7,12 +7,29 @@ task_note) by delegating to its ``discover``/``parse``/``default_field_weights``
 projection, and ISO ``start_time``/``end_time`` metadata → an epoch ``timestamp`` (so
 recency works). Reuses the live ``ir/sources/*`` — does not rewrite them.
 
+Two OPTIONAL, source-interpreted capabilities make the wrapper extensible to arbitrary
+"history" sources without per-source code here (see HISTORY-PARTITION-COVERAGE.md):
+
+- **Coverage** — if the source's ``discover`` accepts a ``coverage`` kwarg, the adapter
+  forwards the partition's configured coverage (``"active"`` default / ``"all"``). A
+  source that doesn't accept it is unaffected. This is what lets a history source admit
+  archived/closed items into the corpus so retrospective queries can find them.
+- **Lifecycle** — if the source exposes ``lifecycle(item_ids) -> {id: state}``, the
+  adapter (a) folds the current state into the change-detection token so an
+  archive/complete transition re-indexes the item even when its file mtime is unchanged
+  (``change_key`` becomes ``"hash"``), and (b) stamps a uniform ``lifecycle_state``
+  metadata key so ANY source's states are filterable by ANY query with one key.
+
+Both are duck-typed (``getattr``/signature introspection), so a brand-new source opts in
+by implementing them and is otherwise byte-identical to today.
+
 NOTE: the IR ``docs`` source is intentionally NOT wrapped — it's the redundant second
 index of the knowledge store, replaced by ``KnowledgePartition``.
 """
 
 from __future__ import annotations
 
+import inspect
 from typing import Any
 
 from work_buddy.index.model import (
@@ -22,6 +39,7 @@ from work_buddy.index.model import (
     Projection,
     ProjectionKind,
     ProjectionSpec,
+    content_hash,
     make_doc_id,
 )
 from work_buddy.index.partition import register_partition
@@ -31,6 +49,14 @@ logger = get_logger(__name__)
 
 # IR sources to expose as partitions (everything except the redundant "docs").
 _IR_PARTITIONS = ("conversation", "projects", "chrome", "summary", "task_note")
+
+
+def _accepts(fn: Any, param: str) -> bool:
+    """True if callable ``fn`` accepts a keyword parameter named ``param``."""
+    try:
+        return param in inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        return False
 
 
 def _to_epoch(meta: dict | None) -> float | None:
@@ -50,11 +76,25 @@ def _to_epoch(meta: dict | None) -> float | None:
 class IRSourcePartition:
     """Adapter wrapping one ``ir.sources`` Source as an index Partition."""
 
-    change_key = "mtime"
-
-    def __init__(self, ir_source: Any) -> None:
+    def __init__(self, ir_source: Any, *, coverage: str = "active") -> None:
         self._src = ir_source
         self.name = ir_source.name
+        self._coverage = coverage or "active"
+        self._has_lifecycle = callable(getattr(ir_source, "lifecycle", None))
+        # A source with a lifecycle has out-of-file mutable state (archive/complete),
+        # so mtime alone misses transitions → use a hash token that folds state in.
+        self.change_key = "hash" if self._has_lifecycle else "mtime"
+        self._states: dict[str, str] = {}
+
+    def configure(self, cfg: Any) -> None:
+        """Apply per-partition config (called by ``IndexPartition``). Reads ``coverage``.
+
+        Optional hook — uses the config the facade was constructed with (not global),
+        so the A/B harness and tests can drive coverage explicitly.
+        """
+        cov = getattr(cfg, "coverage", None)
+        if cov:
+            self._coverage = cov
 
     def field_weights(self) -> dict[str, float]:
         try:
@@ -82,20 +122,48 @@ class IRSourcePartition:
         return {"content": ProjectionSpec(kind=ProjectionKind.PASSAGE)}
 
     def discover(self):
+        # Forward coverage only when the source understands it (else byte-identical
+        # to today). Keep the existing `days`-fallback for sources that require it.
+        disc = self._src.discover
+        kwargs: dict[str, Any] = {}
+        if self._coverage and self._coverage != "active" and _accepts(disc, "coverage"):
+            kwargs["coverage"] = self._coverage
         try:
-            raw = self._src.discover()
+            raw = disc(**kwargs)
         except TypeError:
-            raw = self._src.discover(days=3650)  # some sources require a lookback arg
-        refs: list[ItemRef] = []
+            raw = disc(days=3650, **kwargs)  # some sources require a lookback arg
+
+        pairs: list[tuple[str, float]] = []
         for entry in raw or []:
             if isinstance(entry, (tuple, list)) and len(entry) >= 2:
-                item_id, mtime = entry[0], float(entry[1])
+                pairs.append((str(entry[0]), float(entry[1])))
             else:
-                item_id, mtime = entry, 0.0
-            refs.append(ItemRef(item_id=str(item_id), mtime=mtime))
+                pairs.append((str(entry), 0.0))
+
+        # Lifecycle enrichment: capture current state for change detection (token) and
+        # for the parse-time `lifecycle_state` stamp. Best-effort — a failure degrades
+        # to mtime-only behavior, never blocks the build.
+        self._states = {}
+        if self._has_lifecycle:
+            try:
+                self._states = self._src.lifecycle([iid for iid, _ in pairs]) or {}
+            except Exception as exc:
+                logger.debug("lifecycle() failed for %s; mtime-only: %s", self.name, exc)
+                self._states = {}
+
+        refs: list[ItemRef] = []
+        for item_id, mtime in pairs:
+            if self._has_lifecycle:
+                # Token folds mtime AND state, so a file edit OR a state transition
+                # both register as "changed" under hash-mode change detection.
+                token = content_hash(f"{mtime}|{self._states.get(item_id, '')}")
+                refs.append(ItemRef(item_id=item_id, mtime=mtime, content_hash=token))
+            else:
+                refs.append(ItemRef(item_id=item_id, mtime=mtime))
         return refs
 
     def parse(self, item_id: str) -> list[Document]:
+        state = self._states.get(item_id) if self._has_lifecycle else None
         out: list[Document] = []
         for d in (self._src.parse(item_id) or []):
             stable = getattr(d, "doc_id", "")
@@ -108,6 +176,10 @@ class IRSourcePartition:
             elif getattr(d, "dense_text", ""):
                 projections["content"] = Projection(text=d.dense_text)
             meta = dict(getattr(d, "metadata", None) or {})
+            # Uniform lifecycle key for cross-source query-time filtering (a source's
+            # own native key, e.g. task_state, is preserved alongside it).
+            if state is not None and "lifecycle_state" not in meta:
+                meta["lifecycle_state"] = state
             out.append(Document(
                 doc_id=doc_id,
                 partition=self.name,

--- a/work_buddy/ir/sources/task_notes.py
+++ b/work_buddy/ir/sources/task_notes.py
@@ -60,12 +60,21 @@ class TaskNoteSource:
 
     # ------------------------------------------------------------------ discover
 
-    def discover(self, days: int = 30) -> list[tuple[str, float]]:
+    def discover(self, days: int = 30, *, coverage: str = "active") -> list[tuple[str, float]]:
         """Return `(path, mtime)` for every task-linked note that exists on disk.
 
         `days` is accepted for protocol compatibility but ignored — task
         notes are long-lived and cheap to check (mtime lookup). The engine's
         `indexed_items` mtime skip handles "unchanged" efficiently.
+
+        `coverage` controls which notes enter the corpus (keyword-only so the
+        live IR's `discover(days=...)` is unaffected):
+        - ``"active"`` (default): non-archived tasks only — the live IR's
+          historical behavior, unchanged.
+        - ``"all"``: include archived tasks' notes too, so retrospective
+          search can find them. Whether archived notes are *shown* is then a
+          query-time filter on the ``lifecycle_state`` metadata, not a
+          build-time exclusion. See HISTORY-PARTITION-COVERAGE.md.
         """
         from work_buddy.config import load_config
         from work_buddy.obsidian.tasks import store as task_store
@@ -79,13 +88,16 @@ class TaskNoteSource:
 
         notes_dir = Path(vault_root) / TASK_NOTES_DIR
 
-        # Pull all non-archived tasks with a note_uuid from the store.
-        # Archived tasks' notes are intentionally excluded from the index.
+        # Pull tasks with a note_uuid from the store. Default coverage excludes
+        # archived (the working set); coverage="all" includes them for full
+        # historical recall.
+        where = "WHERE note_uuid IS NOT NULL"
+        if coverage != "all":
+            where += " AND archived_at IS NULL"
         conn = task_store.get_connection()
         try:
             rows = conn.execute(
-                """SELECT task_id, note_uuid FROM task_metadata
-                   WHERE note_uuid IS NOT NULL AND archived_at IS NULL"""
+                f"SELECT task_id, note_uuid FROM task_metadata {where}"
             ).fetchall()
         finally:
             conn.close()
@@ -108,6 +120,35 @@ class TaskNoteSource:
                 missing,
             )
         return results
+
+    # ------------------------------------------------------------------ lifecycle
+
+    def lifecycle(self, item_ids: list[str]) -> dict[str, str]:
+        """Map note path → current lifecycle state (open/done/archived/…).
+
+        Optional, generic hook (no IR-engine dependency on it): a consolidated-
+        index partition adapter calls this to (a) fold state into change
+        detection so an archive/complete transition re-indexes the note even
+        though its file mtime is unchanged, and (b) stamp a uniform
+        ``lifecycle_state`` metadata key for query-time filtering. ``archived_at``
+        being set wins over the raw ``state``. Items with no task row map to
+        ``"unknown"``.
+        """
+        from work_buddy.obsidian.tasks import store as task_store
+
+        conn = task_store.get_connection()
+        try:
+            rows = conn.execute(
+                """SELECT note_uuid, state, archived_at FROM task_metadata
+                   WHERE note_uuid IS NOT NULL"""
+            ).fetchall()
+        finally:
+            conn.close()
+        by_uuid = {
+            r["note_uuid"]: ("archived" if r["archived_at"] else (r["state"] or "open"))
+            for r in rows
+        }
+        return {iid: by_uuid.get(Path(iid).stem, "unknown") for iid in item_ids}
 
     # ------------------------------------------------------------------ parse
 


### PR DESCRIPTION
## Why

The `task_note` blind relevance A/B (after #179 merged) showed the consolidated index **losing 8–3–1** to the live IR. Diagnosis: a **coverage** gap, not a ranking or pruning one. `TaskNoteSource.discover()` excludes archived notes *at the source*, so archived-task notes never entered the corpus and couldn't be returned for the retrospective queries users actually run ("the note about extracting the browser dashboard", "email SickKids IT"). The new index was built once, so the prune path never even ran — the loss was purely missing coverage.

The fix is a **generic, source-agnostic capability**, deliberately *not* a retain-vs-prune retention policy: one global enum can't serve both retrospective ("show me the archived note") and live-work ("only what's on my plate") queries from one corpus — only query-time selection can, and that was already arbitrary (`Query.filters` → `_metadata_where`). So the only real gaps were getting archived items *into* the corpus (coverage) and keeping their state *fresh* (a state transition leaves file mtime unchanged).

## What

- **`PartitionConfig.coverage`** (`"active"` | `"all"`) — which corpus a partition indexes. Default `"active"` preserves each source's working-set behavior.
- **`IRSourcePartition`** (the one generic wrapper for all IR-source partitions):
  - forwards `coverage` **only if** the source's `discover()` accepts it (signature-introspected, like the existing `days` fallback);
  - folds an optional **`lifecycle(item_ids) -> {id: state}`** hook into the per-item change-token (`change_key → "hash"`), so an archive/complete transition that leaves mtime unchanged still triggers a re-index — **zero `IndexBuilder` changes** (hash-mode already existed);
  - stamps a uniform **`metadata["lifecycle_state"]`** so *any* source's states are filterable by *any* query with one key.
- **`configure_partition()`** — optional hook threading the facade's *injected* config to the partition (mirrors the duck-typed `hydrate`/`projection_schema` pattern; test-friendly).
- **`TaskNoteSource`** — keyword-only `coverage` (default keeps the live IR byte-identical) + a `lifecycle()` method (`archived_at` wins over raw `state`).
- **`config.example.yaml`** documents `coverage: all` for history partitions.

**Extensibility:** a brand-new history source opts in by implementing `discover(coverage=…)` + `lifecycle()`; implementing neither is byte-identical to today. Nothing in `index/` core is `task_note`-specific.

## Validation

- **Unit:** 128 index + 43 task-store tests green. New tests cover the generic adapter seam with fakes (coverage on/off, change-token folds state, `lifecycle_state` stamp, `configure`) **and** a real-SQLite test of the `TaskNoteSource` change (archived excluded by default / included under `all`, lifecycle mapping with archived-priority).
- **End-to-end:** rebuilt `task_note` → **79 → 204 docs** (125 archived now indexed). The exact note the index previously *missed* (archived "extract browser dashboard into sidecar") now returns at rank 1 under `coverage: all`; a `lifecycle_state` filter cleanly excludes archived.
- **Re-run blind Opus A/B** (fresh seed, same 12 queries): **reversed V1's 3–8 loss → new 5 / oracle 3 / 4 ties.** The new index's distinguishing edge is *fresher task-state hygiene* (the live IR surfaces stale `deleted/orphan` notes high). The 3 remaining oracle wins are **not** regressions: one is an off-disk `deleted/orphan` tombstone the user can't open (documented, deferred, default-off residue), one a dedup-ranking nuance, one a low-confidence no-exact-match tail. Full analysis: `.data/designs/index-consolidation/{RELEVANCE-EVAL-RESULTS-task_note.md (★ V2), HISTORY-PARTITION-COVERAGE.md}`.

## Safety / scope

- **Still fully inert** — `index.enabled` stays `false`; nothing routes to the consolidated index; the live knowledge/vault/IR indexes are untouched.
- `coverage: all` lives in the (gitignored) local `config.yaml` for the A/B; the shipped template documents the convention. Default remains `"active"`.
- **Not merging** — opened for review. The other history partitions (`projects`/`chrome`/`summary`/`conversation`/`vault`) reuse this same `IRSourcePartition` path and are next to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
