### PR TITLE
feat(index): pluggable embedding-model registry + direct ST provider

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -123,6 +123,27 @@ embedding:
       #                      # is ~0.0002 cosine, so "fallback" is
       #                      # safe for retrieval quality.
 
+    # ---- Pluggable embedding models for the consolidated index (work_buddy/index/) ----
+    # Point a projection at a model via ProjectionSpec.model_key. The OPTIONAL `encoding`
+    # block tells the index how that model encodes each side (query vs document); with no
+    # `encoding` block the model is treated as symmetric (same model, no prompt). `provider:
+    # st` loads the model DIRECTLY via sentence-transformers in the calling process (e.g. an
+    # offline A/B) — no service restart, live service untouched. Example candidate for the
+    # embedding A/B (Apache-2.0, 768d, asymmetric prefixes):
+    # nomic:
+    #   name: "nomic-ai/nomic-embed-text-v1.5"
+    #   dims: 768
+    #   provider: st               # direct in-process load (eval); omit for service-loaded
+    #   trust_remote_code: true    # nomic requires it; its custom modeling code needs
+    #                              # einops, which ships as a core dep (works out of the
+    #                              # box). The st provider degrades gracefully if a model's
+    #                              # deps are ever missing — it won't crash the build.
+    #   encoding:
+    #     query_model: nomic
+    #     document_model: nomic    # == query_model ⇒ symmetric model, asymmetric PROMPTS
+    #     query_prompt: "search_query"      # registered prompt_name OR literal prefix
+    #     document_prompt: "search_document"
+
 # Optional: LM Studio as an offload target (embeddings and/or LLM).
 # Base URL is the BARE server root — no /v1 suffix. The health check
 # and embedding provider both append their own paths (/v1/models,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1607,6 +1607,18 @@ files = [
 ]
 
 [[package]]
+name = "einops"
+version = "0.8.2"
+description = "A new flavour of deep learning operations"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "einops-0.8.2-py3-none-any.whl", hash = "sha256:54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193"},
+    {file = "einops-0.8.2.tar.gz", hash = "sha256:609da665570e5e265e27283aab09e7f279ade90c4f01bcfca111f3d3e13f2827"},
+]
+
+[[package]]
 name = "email-validator"
 version = "2.3.0"
 description = "A robust email address syntax and deliverability validation library."
@@ -9208,4 +9220,4 @@ telegram = ["python-telegram-bot"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "40074692fd5cd1cde931ff174db28555813fe6838f8581840c771c553740d8be"
+content-hash = "30f98b01ecd0362466e7be77e4e27be5789397136b247822fb6dd561ace68b6f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ rank-bm25 = "^0.2.2"
 # Embedding & search (core — powers wb_search, IR, chrome clustering)
 torch = "^2.11.0"
 sentence-transformers = "^5.3.0"
+# Pure-Python, zero-dep: required by trust_remote_code embedding models (nomic etc.)
+# loaded via the consolidated index's `st` provider; absent it those models can't load.
+einops = "^0.8.2"
 
 # Platform-specific PTY libraries (auto-selected by OS)
 pywinpty = {version = "^3.0.3", markers = "sys_platform == 'win32'"}

--- a/tests/unit/test_index_encode.py
+++ b/tests/unit/test_index_encode.py
@@ -140,3 +140,224 @@ class TestBrokeredEncoder:
         out = router.encode(["x"], model_id="leaf-ir", priority=Priority.BACKGROUND)
         assert out is not None and out.shape == (1, 4)  # fell back to local
         assert local.calls  # local was invoked
+
+    def test_router_routes_provider_st(self):
+        from work_buddy.index.encode import SentenceTransformerProvider
+        st = FakeProvider(name="st")
+        router = ProviderRouter(
+            providers={"local": FakeProvider(name="local"), "st": st},
+            cfg={"embedding": {"models": {"nomic": {"provider": "st"}}}},
+        )
+        out = router.encode(["x"], model_id="nomic", priority=Priority.BACKGROUND)
+        assert out is not None and st.calls  # routed to st, not local
+        # the default router instantiates an st provider
+        assert isinstance(ProviderRouter()._providers["st"], SentenceTransformerProvider)
+
+
+# ---------------------------------------------------------------------------
+# Model registry (config-driven resolve_model — "test more embeddings")
+# ---------------------------------------------------------------------------
+
+class TestModelRegistry:
+    def _cfg(self):
+        return {"embedding": {"models": {
+            "nomic": {"name": "nomic-ai/nomic-embed-text-v1.5", "encoding": {
+                "query_model": "nomic", "document_model": "nomic",
+                "query_prompt": "search_query", "document_prompt": "search_document"}},
+            "leaf-mt": {"name": "MongoDB/mdbr-leaf-mt"},  # no encoding → not registered
+            "bad": "not-a-dict",
+        }}}
+
+    def test_build_registry_only_keeps_encoding_blocks(self):
+        from work_buddy.index.encode import _build_registry
+        reg = _build_registry(self._cfg())
+        assert set(reg) == {"nomic"}  # leaf-mt (no encoding) + bad (not dict) skipped
+        assert reg["nomic"].query_prompt == "search_query"
+        assert reg["nomic"].document_model == "nomic"
+
+    def test_resolve_model_uses_registry(self, monkeypatch):
+        import work_buddy.index.encode as enc
+        monkeypatch.setattr(enc, "_REGISTRY_CACHE", enc._build_registry(self._cfg()))
+        assert enc.resolve_model(ProjectionKind.PASSAGE, "query", "nomic") == ("nomic", "search_query")
+        assert enc.resolve_model(ProjectionKind.PASSAGE, "document", "nomic") == ("nomic", "search_document")
+
+    def test_resolve_model_defaults_unchanged_when_registry_empty(self, monkeypatch):
+        import work_buddy.index.encode as enc
+        monkeypatch.setattr(enc, "_REGISTRY_CACHE", {})
+        # legacy behavior preserved
+        assert enc.resolve_model(ProjectionKind.LABEL, "query") == ("leaf-mt", None)
+        assert enc.resolve_model(ProjectionKind.PASSAGE, "document") == ("leaf-ir", "document")
+        assert enc.resolve_model(ProjectionKind.PASSAGE, "query", "leaf-ir") == ("leaf-ir-query", "query")
+        assert enc.resolve_model(ProjectionKind.PASSAGE, "query", "custom-sym") == ("custom-sym", None)
+
+
+# ---------------------------------------------------------------------------
+# SentenceTransformerProvider (direct in-process load — mocked, no download)
+# ---------------------------------------------------------------------------
+
+class _FakeST:
+    construct_count = 0
+
+    def __init__(self, name, device=None, trust_remote_code=False):
+        _FakeST.construct_count += 1
+        self.name = name
+        self.trust = trust_remote_code
+        self.prompts = {"search_query": "search_query: "}  # one registered prompt
+        self.calls = []
+        self.fail = False
+
+    def encode(self, texts, prompt_name=None, show_progress_bar=False):
+        if self.fail:
+            raise RuntimeError("CUDA OOM")
+        self.calls.append((list(texts), prompt_name))
+        return np.ones((len(texts), 4), dtype=np.float32)
+
+
+class TestSentenceTransformerProvider:
+    def _provider(self, monkeypatch, *, cfg=None, fail=False):
+        import contextlib
+        import sentence_transformers
+        from work_buddy.index.encode import SentenceTransformerProvider
+        _FakeST.construct_count = 0
+        created = []
+
+        def _factory(name, device=None, trust_remote_code=False):
+            m = _FakeST(name, device=device, trust_remote_code=trust_remote_code)
+            m.fail = fail
+            created.append(m)
+            return m
+
+        monkeypatch.setattr(sentence_transformers, "SentenceTransformer", _factory)
+        monkeypatch.setattr(
+            "work_buddy.inference.local_slot.local_embed_slot",
+            lambda *a, **k: contextlib.nullcontext(),
+        )
+        monkeypatch.setattr(
+            "work_buddy.config.load_config",
+            lambda *a, **k: cfg or {"embedding": {"models": {}}},
+        )
+        return SentenceTransformerProvider(), created
+
+    def test_registered_prompt_uses_prompt_name(self, monkeypatch):
+        p, created = self._provider(monkeypatch)
+        out = p.encode(["hello"], model_id="m", prompt_name="search_query")
+        assert out.shape == (1, 4)
+        assert created[-1].calls[-1] == (["hello"], "search_query")  # prompt_name path
+
+    def test_unregistered_prompt_is_prefixed(self, monkeypatch):
+        p, created = self._provider(monkeypatch)
+        p.encode(["hello"], model_id="m", prompt_name="query")  # not in model.prompts
+        texts, prompt_name = created[-1].calls[-1]
+        assert prompt_name is None and texts == ["query: hello"]  # literal prefix applied
+
+    def test_no_prompt(self, monkeypatch):
+        p, created = self._provider(monkeypatch)
+        p.encode(["hello"], model_id="m")
+        assert created[-1].calls[-1] == (["hello"], None)
+
+    def test_model_cached_across_calls(self, monkeypatch):
+        p, _ = self._provider(monkeypatch)
+        p.encode(["a"], model_id="m")
+        p.encode(["b"], model_id="m")
+        assert _FakeST.construct_count == 1  # loaded once, reused
+
+    def test_hf_name_and_trust_from_config(self, monkeypatch):
+        cfg = {"embedding": {"models": {"nomic": {
+            "name": "nomic-ai/nomic-embed-text-v1.5", "trust_remote_code": True}}}}
+        p, created = self._provider(monkeypatch, cfg=cfg)
+        p.encode(["a"], model_id="nomic")
+        assert created[-1].name == "nomic-ai/nomic-embed-text-v1.5"
+        assert created[-1].trust is True
+
+    def test_returns_none_on_failure(self, monkeypatch):
+        p, _ = self._provider(monkeypatch, fail=True)
+        assert p.encode(["a"], model_id="m") is None  # OOM → degrade
+
+
+# ---------------------------------------------------------------------------
+# Provider bodies that previously had no direct unit coverage (test-gap closure)
+# ---------------------------------------------------------------------------
+
+class _FakeServiceModel:
+    def __init__(self):
+        self.calls = []
+
+    def encode(self, texts, **kwargs):
+        self.calls.append((list(texts), kwargs.get("prompt_name")))
+        return np.ones((len(texts), 4), dtype=np.float32)
+
+
+class TestLocalProvider:
+    def test_in_service_path_uses_get_model_and_slot(self, monkeypatch):
+        import contextlib
+        import work_buddy.ir.dense as dense
+        import work_buddy.embedding.service as svc
+        from work_buddy.index.encode import LocalProvider
+
+        fake_model = _FakeServiceModel()
+        monkeypatch.setattr(dense, "_IN_SERVICE", True, raising=False)
+        monkeypatch.setattr(svc, "_get_model", lambda key: fake_model, raising=False)
+        monkeypatch.setattr(
+            "work_buddy.inference.local_slot.local_embed_slot",
+            lambda *a, **k: contextlib.nullcontext(),
+        )
+        out = LocalProvider().encode(["x"], model_id="leaf-ir", prompt_name="document")
+        assert out.shape == (1, 4)
+        assert fake_model.calls[-1] == (["x"], "document")  # prompt_name forwarded
+
+    def test_in_service_failure_returns_none(self, monkeypatch):
+        import work_buddy.ir.dense as dense
+        import work_buddy.embedding.service as svc
+        from work_buddy.index.encode import LocalProvider
+
+        def _boom(key):
+            raise RuntimeError("model load failed")
+
+        monkeypatch.setattr(dense, "_IN_SERVICE", True, raising=False)
+        monkeypatch.setattr(svc, "_get_model", _boom, raising=False)
+        assert LocalProvider().encode(["x"], model_id="leaf-ir") is None
+
+    def test_out_of_service_uses_http_client(self, monkeypatch):
+        import work_buddy.ir.dense as dense
+        import work_buddy.embedding.client as client
+        from work_buddy.index.encode import LocalProvider
+
+        monkeypatch.setattr(dense, "_IN_SERVICE", False, raising=False)
+        seen = {}
+
+        def _embed(texts, model=None, prompt_name=None, timeout_s=None):
+            seen.update(model=model, prompt_name=prompt_name)
+            return [[1.0, 2.0]] * len(texts)
+
+        monkeypatch.setattr(client, "embed", _embed)
+        out = LocalProvider().encode(["x", "y"], model_id="leaf-mt")
+        assert out.shape == (2, 2) and seen["model"] == "leaf-mt"
+
+    def test_out_of_service_none_when_client_unavailable(self, monkeypatch):
+        import work_buddy.ir.dense as dense
+        import work_buddy.embedding.client as client
+        from work_buddy.index.encode import LocalProvider
+
+        monkeypatch.setattr(dense, "_IN_SERVICE", False, raising=False)
+        monkeypatch.setattr(client, "embed", lambda *a, **k: None)
+        assert LocalProvider().encode(["x"], model_id="leaf-mt") is None
+
+
+class TestLmStudioProvider:
+    def test_delegates_to_lmstudio_encode(self, monkeypatch):
+        import work_buddy.embedding.providers.lmstudio as lm
+        from work_buddy.index.encode import LmStudioProvider
+
+        monkeypatch.setattr(lm, "encode", lambda texts, **k: np.ones((len(texts), 3)))
+        out = LmStudioProvider().encode(["a", "b"], model_id="arctic")
+        assert out.shape == (2, 3)
+
+    def test_returns_none_on_error(self, monkeypatch):
+        import work_buddy.embedding.providers.lmstudio as lm
+        from work_buddy.index.encode import LmStudioProvider
+
+        def _boom(texts, **k):
+            raise RuntimeError("peer down")
+
+        monkeypatch.setattr(lm, "encode", _boom)
+        assert LmStudioProvider().encode(["a"], model_id="arctic") is None

--- a/work_buddy/index/encode.py
+++ b/work_buddy/index/encode.py
@@ -18,6 +18,7 @@ live search on the shared GPU.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
 from work_buddy.index.model import PoolStrategy, ProjectionKind
@@ -87,19 +88,84 @@ def score_dense(
 
 
 # ---------------------------------------------------------------------------
+# Model registry (config-driven model resolution — "test more embeddings")
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """How a registered ``model_key`` encodes each side of a comparison.
+
+    ``query_model``/``document_model`` are encoder ids (equal ⇒ symmetric). The prompts
+    are passed to the provider, which treats a value as a registered prompt_name if the
+    model declares it, else as a literal prefix to prepend (covers nomic ``search_query:``,
+    e5 ``query:``, leaf prompt_names, …).
+    """
+
+    query_model: str
+    document_model: str
+    query_prompt: str | None = None
+    document_prompt: str | None = None
+
+
+_REGISTRY_CACHE: "dict[str, ModelSpec] | None" = None
+
+
+def _build_registry(cfg: dict[str, Any] | None = None) -> "dict[str, ModelSpec]":
+    """Build the model registry from ``embedding.models.<key>.encoding`` blocks. Defensive:
+    any malformed entry is skipped, and a model with no ``encoding`` block is simply not
+    registered (so it falls through to the legacy defaults — behavior unchanged)."""
+    try:
+        if cfg is None:
+            from work_buddy.config import load_config
+            cfg = load_config()
+        models = (cfg or {}).get("embedding", {}).get("models", {}) or {}
+    except Exception:
+        return {}
+    reg: dict[str, ModelSpec] = {}
+    for key, entry in models.items():
+        if not isinstance(entry, dict):
+            continue
+        enc = entry.get("encoding")
+        if not isinstance(enc, dict):
+            continue
+        reg[key] = ModelSpec(
+            query_model=str(enc.get("query_model", key)),
+            document_model=str(enc.get("document_model", key)),
+            query_prompt=enc.get("query_prompt"),
+            document_prompt=enc.get("document_prompt"),
+        )
+    return reg
+
+
+def get_model_registry(*, reload: bool = False) -> "dict[str, ModelSpec]":
+    """Process-cached model registry. ``reload=True`` rebuilds (e.g. tests / config change)."""
+    global _REGISTRY_CACHE
+    if _REGISTRY_CACHE is None or reload:
+        _REGISTRY_CACHE = _build_registry()
+    return _REGISTRY_CACHE
+
+
+# ---------------------------------------------------------------------------
 # Model resolution (kind + role → model id + prompt)
 # ---------------------------------------------------------------------------
 
 def resolve_model(
     kind: str, role: str, model_key: str | None = None
 ) -> tuple[str, str | None]:
-    """Map (projection kind, role) → (model_id, prompt_name).
+    """Map (projection kind, role) → (model_id, prompt_name). role ∈ {"query","document"}.
 
-    role ∈ {"query", "document"}. LABEL → symmetric ``leaf-mt`` (no prompt). PASSAGE →
-    asymmetric ``leaf-ir-query`` (query) / ``leaf-ir`` (document). ``model_key`` overrides
-    (fork F-RECENCY/MODEL — per-partition model choice).
+    Precedence: (1) a config-registered ``model_key`` → its per-role (model, prompt); (2) the
+    legacy ``leaf-ir`` family special-case; (3) any other ``model_key`` → that model, no prompt
+    (symmetric); (4) no ``model_key`` → LABEL → ``leaf-mt``, PASSAGE → asymmetric ``leaf-ir``
+    pair. With no ``encoding`` config the registry is empty and (4)/(2) preserve today's behavior.
     """
     if model_key:
+        spec = get_model_registry().get(model_key)
+        if spec is not None:
+            return (
+                (spec.query_model, spec.query_prompt) if role == "query"
+                else (spec.document_model, spec.document_prompt)
+            )
         if model_key in ("leaf-ir", "leaf-ir-query"):
             return ("leaf-ir-query", "query") if role == "query" else ("leaf-ir", "document")
         return (model_key, None)
@@ -197,6 +263,73 @@ class LmStudioProvider:
             return None
 
 
+class SentenceTransformerProvider:
+    """Loads a sentence-transformers model DIRECTLY in the current process.
+
+    Decoupled from the embedding service: lets an offline A/B or CI compare embedding
+    models with no running/restarted service. Routed only when a model declares
+    ``provider: st``; production paths (local/lmstudio) are untouched. The HF repo is
+    ``embedding.models.<id>.name`` (defaulting to the id itself), ``trust_remote_code``
+    is read from the same block. Broker-admitted; returns ``None`` on any failure (OOM,
+    missing model) so the router/build degrades gracefully.
+    """
+
+    name = "st"
+
+    def __init__(self) -> None:
+        self._cache: dict[str, Any] = {}
+
+    def _spec(self, model_id: str) -> tuple[str, bool]:
+        try:
+            from work_buddy.config import load_config
+            entry = (
+                (load_config().get("embedding", {}).get("models", {}) or {}).get(model_id, {})
+                or {}
+            )
+            return str(entry.get("name", model_id)), bool(entry.get("trust_remote_code", False))
+        except Exception:
+            return model_id, False
+
+    def _model(self, model_id: str) -> Any:
+        if model_id not in self._cache:
+            from sentence_transformers import SentenceTransformer
+            hf_name, trust = self._spec(model_id)
+            # device=None → sentence-transformers auto-selects CUDA if present, else CPU.
+            self._cache[model_id] = SentenceTransformer(
+                hf_name, device=None, trust_remote_code=trust,
+            )
+        return self._cache[model_id]
+
+    def encode(
+        self, texts: list[str], *, model_id: str, prompt_name: str | None = None,
+        priority: Priority = Priority.BACKGROUND,
+    ) -> "Any | None":
+        import numpy as np
+        if not texts:
+            return np.zeros((0, 0), dtype=np.float32)
+        try:
+            from work_buddy.inference.local_slot import local_embed_slot
+            model = self._model(model_id)
+            registered = set(getattr(model, "prompts", {}) or {})
+            with local_embed_slot(priority):
+                if prompt_name and prompt_name in registered:
+                    vecs = model.encode(
+                        list(texts), prompt_name=prompt_name, show_progress_bar=False,
+                    )
+                elif prompt_name:
+                    # literal prefix (e.g. "search_query:" / "query:"); add a space if bare.
+                    pre = prompt_name if prompt_name.endswith((" ", ":")) else f"{prompt_name}: "
+                    vecs = model.encode(
+                        [f"{pre}{t}" for t in texts], show_progress_bar=False,
+                    )
+                else:
+                    vecs = model.encode(list(texts), show_progress_bar=False)
+            return np.asarray(vecs, dtype=np.float32)
+        except Exception as exc:
+            logger.warning("SentenceTransformerProvider encode failed for %s: %s", model_id, exc)
+            return None
+
+
 class ProviderRouter:
     """(model_id) → provider, with on-error fallback to local."""
 
@@ -208,6 +341,7 @@ class ProviderRouter:
         self._providers: dict[str, EmbeddingProvider] = providers or {
             "local": LocalProvider(),
             "lmstudio": LmStudioProvider(),
+            "st": SentenceTransformerProvider(),
         }
         if "local" not in self._providers:
             self._providers["local"] = LocalProvider()


### PR DESCRIPTION
## Summary

Generalizes the consolidated index's hardcoded `leaf-*` model resolution so any embedding model is selectable per-projection and describable in config — making future embedding comparisons a config line, not a code change. **All inert behind `index.enabled=false`; the live embedding service is untouched. No model-switch decision in this PR.**

- **Config-driven model registry** — `resolve_model()` consults `embedding.models.<key>.encoding` (`query_model`/`document_model`/`query_prompt`/`document_prompt`); a projection points at a model via `ProjectionSpec.model_key`. With no `encoding` block the registry is empty and `leaf-*` behavior is byte-identical (LABEL→leaf-mt, PASSAGE→leaf-ir pair, leaf-ir legacy case preserved).
- **`SentenceTransformerProvider` (`provider: st`)** — loads any HF model directly in the calling process (broker-admitted via `local_embed_slot`), so an offline A/B or CI can compare models with **no running/restarted embedding service**. Prompt applied as a registered prompt_name or, failing that, a literal prefix (covers nomic `search_query:`, e5 `query:`). Returns `None` on failure so the build degrades gracefully.
- **einops** added as a **core dependency** (pure-Python, zero-dep) — required by `trust_remote_code` embedding models (nomic etc.) the `st` provider loads, so they work out of the box.
- **Closed prior test gaps** — `LocalProvider.encode` (in-service + out-of-service) and `LmStudioProvider.encode` now have direct unit coverage (previously only router-level).

## Test plan

- [x] 159 index unit tests green (+16: registry resolution, `st` provider prompt/cache/degrade, provider bodies)
- [x] `poetry check` clean
- [x] nomic loads + encodes **end-to-end** through registry → router → `st` provider (768-d vectors, 0.64 query/doc cosine)
- [x] `resolve_model` defaults unchanged when registry empty (regression guard)
- [ ] Confirm inert before merge: `index.enabled: false`, no caller re-pointed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
