### PR TITLE
feat(index): route agent_docs search to the consolidated index (flag-gated, inert) + filter pushdown

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -280,6 +280,13 @@ index:
       coverage: all
     # conversation: { rrf_k: 60, recency: true, coverage: all }
     # vault:        { rrf_k: 60, coverage: all }
+  # Per-CONSUMER routing gates: a consumer routes to the consolidated index only when
+  # `enabled` AND its gate are both true. Lets each consumer be staged live independently
+  # even while `enabled` is already on for another (the dev-document scan reads `enabled`
+  # directly; broader-traffic consumers get their own gate so they don't flip live on
+  # reload). Default off (ships inert). Flip in config.local.yaml after a live A/B.
+  consumers:
+    agent_docs: false        # the knowledge SEARCH path (agent_docs/knowledge/knowledge_personal)
 
 chats:
   specstory_days: 7

--- a/tests/unit/test_index_partitions.py
+++ b/tests/unit/test_index_partitions.py
@@ -305,6 +305,29 @@ class TestPartitionConfigCoverage:
         assert cfg.partition("unlisted").coverage == "active"  # safe default
 
 
+class TestConsumerGate:
+    def test_consumer_enabled_requires_master_and_gate(self):
+        from work_buddy.index.config import IndexConfig
+        assert IndexConfig(enabled=True, consumers={"agent_docs": True}).consumer_enabled("agent_docs")
+        # master off → gate irrelevant
+        assert not IndexConfig(enabled=False, consumers={"agent_docs": True}).consumer_enabled("agent_docs")
+        # gate off → off
+        assert not IndexConfig(enabled=True, consumers={"agent_docs": False}).consumer_enabled("agent_docs")
+        # unlisted consumer → off (ships inert)
+        assert not IndexConfig(enabled=True, consumers={}).consumer_enabled("agent_docs")
+
+    def test_load_config_parses_consumers(self):
+        from work_buddy.index.config import load_index_config
+        cfg = load_index_config({"index": {"enabled": True, "consumers": {"agent_docs": True}}})
+        assert cfg.consumer_enabled("agent_docs") is True
+        assert cfg.consumer_enabled("unlisted") is False
+
+    def test_malformed_consumers_degrades_safely(self):
+        from work_buddy.index.config import load_index_config
+        cfg = load_index_config({"index": {"enabled": True, "consumers": "not-a-dict"}})
+        assert cfg.consumers == {} and cfg.consumer_enabled("agent_docs") is False
+
+
 class TestTaskNoteSourceCoverage:
     """Real-SQLite test of the task_note SOURCE change (the recall fix at the source)."""
 

--- a/tests/unit/test_index_search_many_client.py
+++ b/tests/unit/test_index_search_many_client.py
@@ -42,3 +42,29 @@ def test_omits_optional_keys_when_unset(monkeypatch):
     p = captured["payload"]
     assert "partitions" not in p and "filters" not in p and "scope" not in p
     assert p["queries"] == ["q"]
+
+
+# --- index_search (single-query sibling) ---
+
+def test_index_search_returns_single_list(monkeypatch):
+    captured = {}
+
+    def _req(method, path, payload, timeout=None):
+        captured.update(method=method, path=path, payload=payload, timeout=timeout)
+        return {"results": [{"doc_id": "knowledge:x", "score": 1.0}]}
+
+    monkeypatch.setattr(client, "_request", _req)
+    out = client.index_search(
+        "q", top_k=8, partitions=["knowledge"], filters={"scope": "system"}, timeout_s=15,
+    )
+    assert out == [{"doc_id": "knowledge:x", "score": 1.0}]  # one flat list, not list-of-lists
+    assert captured["method"] == "POST" and captured["path"] == "/index/search"
+    assert captured["timeout"] == 15
+    assert captured["payload"]["query"] == "q"
+    assert captured["payload"]["partitions"] == ["knowledge"]
+    assert captured["payload"]["filters"] == {"scope": "system"}
+
+
+def test_index_search_none_when_unreachable(monkeypatch):
+    monkeypatch.setattr(client, "_request", lambda *a, **k: None)
+    assert client.index_search("q") is None

--- a/tests/unit/test_knowledge_search_consolidated.py
+++ b/tests/unit/test_knowledge_search_consolidated.py
@@ -1,0 +1,212 @@
+"""Tests for the agent_docs knowledge-search re-point to the consolidated index.
+
+`knowledge.search._search_via_consolidated` (the gated helper) is tested in isolation
+(index_search + load_index_config mocked); the `_search()` branch is tested with light
+fakes for the store + the live index, asserting the consolidated path is used when gated
+on, falls back to live otherwise, preserves the result shape, and bounds the pool to top_n.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+# NB: ``import work_buddy.knowledge.search as ks`` would bind ``ks`` to the
+# ``search`` *function* re-exported by ``work_buddy/knowledge/__init__.py``
+# (it shadows the submodule attribute), not the module. Import the module
+# object directly so monkeypatching its members works.
+ks = importlib.import_module("work_buddy.knowledge.search")
+
+
+def _cfg(consumer_on: bool):
+    from work_buddy.index.config import IndexConfig
+    return IndexConfig(enabled=True, consumers={"agent_docs": consumer_on})
+
+
+# ---------------------------------------------------------------------------
+# _search_via_consolidated — the gated helper (isolated)
+# ---------------------------------------------------------------------------
+
+class TestSearchViaConsolidated:
+    def test_gate_off_returns_none_without_calling_service(self, monkeypatch):
+        calls = {"n": 0}
+        monkeypatch.setattr("work_buddy.index.config.load_index_config", lambda *a, **k: _cfg(False))
+        monkeypatch.setattr(
+            "work_buddy.embedding.client.index_search",
+            lambda *a, **k: calls.__setitem__("n", calls["n"] + 1) or [],
+        )
+        assert ks._search_via_consolidated("q", "system", 8) is None
+        assert calls["n"] == 0  # service never touched when the consumer gate is off
+
+    def test_gate_on_returns_scored_pairs(self, monkeypatch):
+        monkeypatch.setattr("work_buddy.index.config.load_index_config", lambda *a, **k: _cfg(True))
+        hits = [
+            {"doc_id": "knowledge:architecture/x", "score": 0.9, "metadata": {"path": "architecture/x"}},
+            {"doc_id": "knowledge:context/y", "score": 0.5, "metadata": {"path": "context/y"}},
+        ]
+        monkeypatch.setattr("work_buddy.embedding.client.index_search", lambda *a, **k: hits)
+        out = ks._search_via_consolidated("q", "system", 8)
+        assert out == [{"path": "architecture/x", "score": 0.9}, {"path": "context/y", "score": 0.5}]
+
+    def test_doc_id_fallback_when_metadata_path_absent(self, monkeypatch):
+        monkeypatch.setattr("work_buddy.index.config.load_index_config", lambda *a, **k: _cfg(True))
+        monkeypatch.setattr(
+            "work_buddy.embedding.client.index_search",
+            lambda *a, **k: [{"doc_id": "knowledge:foo/bar", "score": 1.0, "metadata": {}}],
+        )
+        assert ks._search_via_consolidated("q", "system", 8) == [{"path": "foo/bar", "score": 1.0}]
+
+    def test_none_when_service_down(self, monkeypatch):
+        monkeypatch.setattr("work_buddy.index.config.load_index_config", lambda *a, **k: _cfg(True))
+        monkeypatch.setattr("work_buddy.embedding.client.index_search", lambda *a, **k: None)
+        assert ks._search_via_consolidated("q", "system", 8) is None
+
+    def test_none_when_empty(self, monkeypatch):
+        monkeypatch.setattr("work_buddy.index.config.load_index_config", lambda *a, **k: _cfg(True))
+        monkeypatch.setattr("work_buddy.embedding.client.index_search", lambda *a, **k: [])
+        assert ks._search_via_consolidated("q", "system", 8) is None
+
+    def test_none_when_service_raises(self, monkeypatch):
+        monkeypatch.setattr("work_buddy.index.config.load_index_config", lambda *a, **k: _cfg(True))
+
+        def _boom(*a, **k):
+            raise RuntimeError("service exploded")
+
+        monkeypatch.setattr("work_buddy.embedding.client.index_search", _boom)
+        assert ks._search_via_consolidated("q", "system", 8) is None
+
+    def test_knowledge_scope_maps_to_filters(self, monkeypatch):
+        seen: dict = {}
+        monkeypatch.setattr("work_buddy.index.config.load_index_config", lambda *a, **k: _cfg(True))
+
+        def _cap(query, **k):
+            seen.clear()
+            seen.update(k)
+            return [{"doc_id": "knowledge:a", "score": 1.0, "metadata": {"path": "a"}}]
+
+        monkeypatch.setattr("work_buddy.embedding.client.index_search", _cap)
+        ks._search_via_consolidated("q", "system", 8)
+        assert seen["filters"] == {"scope": "system"} and seen["partitions"] == ["knowledge"]
+        ks._search_via_consolidated("q", "personal", 8)
+        assert seen["filters"] == {"scope": "personal"}
+        ks._search_via_consolidated("q", "all", 8)
+        assert seen["filters"] is None  # "all" → no scope filter → omit (both system + personal)
+
+    def test_filters_pushed_down(self, monkeypatch):
+        """kind/category/severity → metadata filters; subtree-scope → doc_id prefix; top_k==top_n.
+
+        This is the recall fix: the index filter-then-ranks within exactly the qualifying set,
+        so a tight filter returns a full top_n (no bounded-pool post-filter truncation)."""
+        seen: dict = {}
+        monkeypatch.setattr("work_buddy.index.config.load_index_config", lambda *a, **k: _cfg(True))
+
+        def _cap(query, **k):
+            seen.clear()
+            seen.update(k)
+            return [{"doc_id": "knowledge:a", "score": 1.0, "metadata": {"path": "a"}}]
+
+        monkeypatch.setattr("work_buddy.embedding.client.index_search", _cap)
+        ks._search_via_consolidated(
+            "q", "personal", 7,
+            scope="tasks/", kind="capability", category="work_pattern", severity="HIGH",
+        )
+        assert seen["filters"] == {
+            "scope": "personal", "kind": "capability",
+            "category": "work_pattern", "severity": "HIGH",
+        }
+        assert seen["scope"] == "knowledge:tasks/"  # subtree → doc_id prefix
+        assert seen["top_k"] == 7  # no over-fetch: pre-filtering makes the pool unnecessary
+
+
+# ---------------------------------------------------------------------------
+# _search() branch — consolidated vs live fallback (light fakes)
+# ---------------------------------------------------------------------------
+
+class _FakeUnit:
+    def __init__(self, path: str, kind: str = "system"):
+        self.path = path
+        self.kind = kind
+
+    def search_phrases(self):
+        return [self.path]
+
+    def tier(self, depth, store=None, dev=False, recursive_mode="default", max_depth=None):
+        return {"name": self.path, "description": "", "kind": self.kind}
+
+
+class _FakeIdx:
+    def __init__(self, result):
+        self.result = result
+        self.called = 0
+
+    def search(self, query, candidates=None, top_n=8, **k):
+        self.called += 1
+        return self.result
+
+
+class TestSearchRouting:
+    def _wire(self, monkeypatch, store, *, consolidated, live):
+        monkeypatch.setattr(ks, "load_store", lambda scope=None: store)
+        monkeypatch.setattr(
+            ks, "_search_via_consolidated", lambda q, ks_scope, top_n, **kw: consolidated
+        )
+        import work_buddy.knowledge.index as kidx
+        idx = _FakeIdx(live)
+        monkeypatch.setattr(kidx, "ensure_index", lambda **k: idx)
+        return idx
+
+    def test_gate_on_uses_consolidated_and_skips_live(self, monkeypatch):
+        store = {"architecture/x": _FakeUnit("architecture/x"), "context/y": _FakeUnit("context/y")}
+        idx = self._wire(
+            monkeypatch, store,
+            consolidated=[{"path": "architecture/x", "score": 0.9}],
+            live=[{"path": "context/y", "score": 0.1}],
+        )
+        res = ks.search(query="needle", knowledge_scope="system", top_n=5)
+        assert res["mode"] == "search"
+        assert [r["path"] for r in res["results"]] == ["architecture/x"]
+        assert idx.called == 0  # the live in-process index was NOT built/queried
+
+    def test_falls_back_to_live_when_consolidated_none(self, monkeypatch):
+        store = {"architecture/x": _FakeUnit("architecture/x"), "context/y": _FakeUnit("context/y")}
+        idx = self._wire(
+            monkeypatch, store,
+            consolidated=None,  # gate off / service down / empty
+            live=[{"path": "context/y", "score": 0.7}],
+        )
+        res = ks.search(query="needle", knowledge_scope="system", top_n=5)
+        assert idx.called == 1  # fell back to the live index
+        assert [r["path"] for r in res["results"]] == ["context/y"]
+
+    def test_consolidated_pool_bounded_to_top_n(self, monkeypatch):
+        store = {f"u/{i}": _FakeUnit(f"u/{i}") for i in range(20)}
+        self._wire(
+            monkeypatch, store,
+            consolidated=[{"path": f"u/{i}", "score": 1.0 - i * 0.01} for i in range(20)],
+            live=[],
+        )
+        res = ks.search(query="needle", knowledge_scope="system", top_n=3)
+        assert len(res["results"]) == 3  # 20-hit pool trimmed to top_n
+
+
+# ---------------------------------------------------------------------------
+# KnowledgePartition metadata — category/severity present so filters push down
+# ---------------------------------------------------------------------------
+
+class TestPartitionMetadata:
+    def _doc(self, path, **attrs):
+        from types import SimpleNamespace
+        from work_buddy.knowledge.partition import KnowledgePartition
+
+        base = dict(name="N", description="d", tags=[], kind="reference",
+                    aliases=[], content={"summary": "s", "full": "f"})
+        base.update(attrs)
+        return KnowledgePartition()._to_document(path, SimpleNamespace(**base), {})
+
+    def test_category_severity_indexed(self):
+        doc = self._doc("personal/x", category="work_pattern", severity="HIGH")
+        assert doc.metadata["category"] == "work_pattern"
+        assert doc.metadata["severity"] == "HIGH"
+
+    def test_missing_category_severity_default_empty(self):
+        doc = self._doc("architecture/x")  # no category/severity attrs → "" via getattr
+        assert doc.metadata["category"] == "" and doc.metadata["severity"] == ""

--- a/work_buddy/embedding/client.py
+++ b/work_buddy/embedding/client.py
@@ -343,6 +343,47 @@ def index_search_many(
     return result.get("results")
 
 
+def index_search(
+    query: str,
+    *,
+    top_k: int = 10,
+    method: str = "hybrid",
+    partitions: list[str] | None = None,
+    filters: dict | None = None,
+    scope: str | None = None,
+    recency: bool = False,
+    rrf_k: int | None = None,
+    timeout_s: int | None = None,
+) -> list[dict] | None:
+    """Single-query hybrid search over the consolidated index via the embedding service.
+
+    The single-query sibling of :func:`index_search_many`. Returns the result-dict list
+    (one per hit) scored against the warm resident matrices, or ``None`` when the service
+    is unreachable — the caller then degrades to the in-process knowledge path.
+    """
+    payload: dict[str, Any] = {
+        "query": query,
+        "top_k": top_k,
+        "method": method,
+        "recency": recency,
+    }
+    if partitions is not None:
+        payload["partitions"] = partitions
+    if filters:
+        payload["filters"] = filters
+    if scope:
+        payload["scope"] = scope
+    if rrf_k is not None:
+        payload["rrf_k"] = rrf_k
+    result = _request(
+        "POST", "/index/search", payload,
+        timeout=timeout_s if timeout_s is not None else 60,
+    )
+    if result is None:
+        return None
+    return result.get("results")
+
+
 def vault_index(
     action: str = "build",
     *,

--- a/work_buddy/index/config.py
+++ b/work_buddy/index/config.py
@@ -82,10 +82,20 @@ class IndexConfig:
     enabled: bool = False
     db_path: Path | None = None
     partitions: dict[str, PartitionConfig] = field(default_factory=dict)
+    # Per-CONSUMER routing gates (``index.consumers.<name>``). A consumer (e.g. the
+    # agent_docs knowledge search) routes to the consolidated index only when BOTH
+    # ``enabled`` AND its gate are true — so each consumer can be staged live
+    # independently even while ``enabled`` is already on for another. Default off.
+    consumers: dict[str, bool] = field(default_factory=dict)
 
     def partition(self, name: str) -> PartitionConfig:
         """Config for ``name`` — falls back to defaults for an unlisted partition."""
         return self.partitions.get(name) or PartitionConfig(name=name)
+
+    def consumer_enabled(self, name: str) -> bool:
+        """True iff the consolidated index is enabled AND consumer ``name``'s gate is on.
+        Unlisted consumer → False (ships inert)."""
+        return self.enabled and bool(self.consumers.get(name, False))
 
     def resolved_db_path(self) -> Path:
         if self.db_path is not None:
@@ -120,8 +130,15 @@ def load_index_config(cfg: dict[str, Any] | None = None) -> IndexConfig:
         if isinstance(pc, dict) or pc is None
     }
 
+    consumers_raw = raw.get("consumers", {}) or {}
+    consumers = (
+        {str(k): bool(v) for k, v in consumers_raw.items()}
+        if isinstance(consumers_raw, dict) else {}
+    )
+
     return IndexConfig(
         enabled=bool(raw.get("enabled", False)),
         db_path=db_path,
         partitions=partitions,
+        consumers=consumers,
     )

--- a/work_buddy/knowledge/partition.py
+++ b/work_buddy/knowledge/partition.py
@@ -119,6 +119,11 @@ class KnowledgePartition:
         kind = getattr(unit, "kind", "") or ""
         scope = "personal" if isinstance(unit, VaultUnit) else "system"
         description = getattr(unit, "description", "") or ""
+        # VaultUnit-only filter fields ("" for system units) — indexed so agent_docs
+        # category/severity filters can be PUSHED DOWN (filter-then-rank) instead of
+        # post-filtered from a bounded pool.
+        category = getattr(unit, "category", "") or ""
+        severity = getattr(unit, "severity", "") or ""
 
         # Body for lexical recall = full content text + aliases (title=name weighted higher).
         body = ct + (("\n" + " ".join(aliases)) if aliases else "")
@@ -136,7 +141,10 @@ class KnowledgePartition:
             partition=_PARTITION,
             fields=fields,
             display_text=f"[{kind}] {path}: {description}",
-            metadata={"kind": kind, "path": path, "scope": scope, "tags": tags},
+            metadata={
+                "kind": kind, "path": path, "scope": scope, "tags": tags,
+                "category": category, "severity": severity,
+            },
             projections=projections,
         )
 

--- a/work_buddy/knowledge/search.py
+++ b/work_buddy/knowledge/search.py
@@ -25,6 +25,80 @@ from work_buddy.logging_config import get_logger
 
 logger = get_logger(__name__)
 
+# Interactive agent_docs query → fall back to the live index fast if the consolidated
+# service is cold/contended past this budget.
+_CONSOLIDATED_TIMEOUT_S = 15
+
+# knowledge_scope → consolidated metadata filter. The consolidated knowledge partition
+# indexes BOTH scopes (metadata["scope"]); "all" omits the filter (both).
+_CONSOLIDATED_SCOPE_FILTERS: dict[str, dict[str, str]] = {
+    "system": {"scope": "system"},
+    "personal": {"scope": "personal"},
+    "all": {},
+}
+
+
+def _search_via_consolidated(
+    query: str,
+    knowledge_scope: str,
+    top_n: int,
+    *,
+    scope: str | None = None,
+    kind: str | None = None,
+    category: str | None = None,
+    severity: str | None = None,
+) -> list[dict[str, Any]] | None:
+    """Route the knowledge search to the resident consolidated index when activated.
+
+    All filters are PUSHED DOWN so the index filter-then-ranks and returns a full ``top_n``
+    drawn from within the qualifying set (no over-fetch, no post-filter recall loss — a tight
+    filter whose members rank low globally still yields ``top_n`` when ``top_n`` match).
+
+    Returns ``[{path, score}]`` — the SAME shape ``KnowledgeIndex.search`` returns, so the
+    caller's tier hydration is unchanged — or ``None`` to signal "use the live in-process
+    index": gate off, service unreachable, or empty.
+    """
+    from work_buddy.index.config import load_index_config
+
+    if not load_index_config().consumer_enabled("agent_docs"):
+        return None
+
+    # Push every filter down (pre-filter == filter-then-rank, which the index already does
+    # when handed the predicates). knowledge_scope + kind/category/severity → metadata
+    # equality; agent_docs subtree-scope → doc_id prefix (store does ``doc_id LIKE scope%``).
+    filters: dict[str, Any] = dict(_CONSOLIDATED_SCOPE_FILTERS.get(knowledge_scope, {}))
+    if kind:
+        filters["kind"] = kind
+    if category:
+        filters["category"] = category
+    if severity:
+        filters["severity"] = severity
+    doc_id_prefix = f"knowledge:{scope.rstrip('/')}/" if scope else None
+
+    try:
+        from work_buddy.embedding.client import index_search
+
+        hits = index_search(
+            query,
+            top_k=top_n,
+            partitions=["knowledge"],
+            filters=filters or None,
+            scope=doc_id_prefix,
+            timeout_s=_CONSOLIDATED_TIMEOUT_S,
+        )
+    except Exception as exc:  # noqa: BLE001 — live fallback is the recovery
+        logger.debug("consolidated knowledge search failed (%s); using live index.", exc)
+        return None
+    if not hits:
+        return None
+    scored: list[dict[str, Any]] = []
+    for h in hits:
+        meta = h.get("metadata") or {}
+        path = meta.get("path") or str(h.get("doc_id", "")).split(":", 1)[-1]
+        if path:
+            scored.append({"path": path, "score": h.get("score", 0.0)})
+    return scored or None
+
 
 def search(
     query: str = "",
@@ -320,15 +394,23 @@ def _search(
     # Pass full store for chain resolution
     full_store = load_store(scope="all") if depth == "full" else None
 
-    # Use the persistent knowledge index for hybrid BM25 + dense search
-    from work_buddy.knowledge.index import ensure_index
-
-    idx = ensure_index(knowledge_scope=knowledge_scope)
-    scored = idx.search(
-        query=query,
-        candidates=candidates_units,
-        top_n=top_n,
+    # Route to the resident consolidated index when the agent_docs consumer is activated;
+    # on any failure/empty, fall through to the live in-process knowledge index. All filters
+    # are pushed down so the consolidated path filter-then-ranks (full top_n within filter);
+    # it returns the same [{path, score}] shape, so the hydration below is unchanged.
+    scored = _search_via_consolidated(
+        query, knowledge_scope, top_n,
+        scope=scope, kind=kind, category=category, severity=severity,
     )
+    if scored is None:
+        from work_buddy.knowledge.index import ensure_index
+
+        idx = ensure_index(knowledge_scope=knowledge_scope)
+        scored = idx.search(
+            query=query,
+            candidates=candidates_units,
+            top_n=top_n,
+        )
 
     if scored:
         results = []
@@ -344,6 +426,8 @@ def _search(
                     recursive_mode=recursive, max_depth=max_depth,
                 ),
             })
+            if len(results) >= top_n:
+                break  # defense-in-depth cap (both backends already return ≤ top_n)
 
         return {
             "mode": "search",


### PR DESCRIPTION
## Summary
- Re-point the knowledge SEARCH path (`agent_docs` / `knowledge` / `knowledge_personal`, via `knowledge/search.py::_search`) to the resident consolidated index, behind a new per-consumer flag `index.consumers.agent_docs` (default off → ships inert; falls back to the live in-process index on any failure / empty / gate-off).
- Push all filters down so the consolidated index **filter-then-ranks** and returns a full `top_n` from within the qualifying set (`kind`/`category`/`severity` → metadata equality, `knowledge_scope` → scope metadata, subtree-scope → `knowledge:` doc-id prefix). Fixes a recall bug where the first cut post-filtered from a bounded over-fetch pool and could return fewer than `top_n` for tight filters.
- Index `category`/`severity` in the knowledge partition document metadata so the pushdown can pre-filter them (needs a one-time `knowledge` rebuild at activation, since the content hash is unchanged).

## Test plan
- [x] Unit: 47 passing (index_search client, consumer-gate, `_search` routing + fallback, filter pushdown, partition metadata)
- [x] Live: filtered queries return `min(top_n, available)` within the filter, served by consolidated with no in-process fallback; blind relevance A/B on unfiltered queries ~parity with live (live 5 · consolidated 3 · 4 ties — ranking nuances, both use RRF)
- [ ] Activation (post-merge, operational): flip `index.consumers.agent_docs: true` + a one-time `knowledge` rebuild so `category`/`severity` metadata lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)