### PR TITLE
fix(index): serialize builds on a DB-wide writer gate + ride out write contention

### DIFF
--- a/knowledge/store/context/index-rebuild.md
+++ b/knowledge/store/context/index-rebuild.md
@@ -1,7 +1,7 @@
 ---
 name: Index Rebuild
 kind: capability
-description: Incrementally (re)build the consolidated index (work_buddy/index/) into its separate db. Flag-gated — a no-op while index.enabled is false; when enabled it refreshes the named partition (e.g. 'knowledge'), or all partitions when none is given (one-shot full rebuilds only — recurring freshness uses one per-partition job each, e.g. index-knowledge-refresh). Pass a partition for the per-partition sidecar jobs (it self-skips when a build for that partition is already running); omit it only for a deliberate dashboard/manual full rebuild.
+description: Incrementally (re)build the consolidated index (work_buddy/index/) into its separate db. Flag-gated — a no-op while index.enabled is false; when enabled it refreshes the named partition (e.g. 'knowledge'), or all partitions when none is given (one-shot full rebuilds only — recurring freshness uses one per-partition job each, e.g. index-knowledge-refresh). Pass a partition for the per-partition sidecar jobs (it self-skips while any index build is running — the partitions share one single-writer db, so builds serialize on a db-wide writer gate); omit it only for a deliberate dashboard/manual full rebuild.
 capability_name: index_rebuild
 category: context
 op: op.wb.index_rebuild

--- a/sidecar_jobs/index-chrome-refresh.md
+++ b/sidecar_jobs/index-chrome-refresh.md
@@ -11,8 +11,9 @@ params:
 Keep the index's **`chrome` partition** current so browsing-history search serves recent pages.
 A no-op while `index.enabled` is false; once on, an incremental content-hash/mtime-diffed pass —
 embeds only new/changed items (sub-second when nothing changed), full on the first run. The corpus
-is small, so `*/15` is cheap. The `index_rebuild` op self-skips (read-only advisory-lock probe) when
-a build for this partition is already running.
+is small, so `*/15` is cheap. The `index_rebuild` op self-skips (read-only advisory-lock probe)
+while any index build is running — all partitions share one single-writer DB, so builds serialize
+on a DB-wide writer gate and a refresh never piles onto an in-flight build.
 
 **One job per partition — by design.** Sibling to the other `index-<partition>-refresh` jobs; never
 folded into a single `build_all` cron.

--- a/sidecar_jobs/index-conversation-refresh.md
+++ b/sidecar_jobs/index-conversation-refresh.md
@@ -12,7 +12,9 @@ Keep the index's **`conversation` partition** current so past sessions stay sear
 while `index.enabled` is false; once on, an incremental content-hash-diffed pass — embeds only
 new/changed spans (cheap when nothing changed), full on the first run. This is a heavy partition, so
 it runs hourly — far less frequently than the small partitions. The `index_rebuild` op self-skips
-(read-only advisory-lock probe) when a build for this partition is already running.
+(read-only advisory-lock probe) while any index build is running — all partitions share one
+single-writer DB, so builds serialize on a DB-wide writer gate and a refresh never piles onto an
+in-flight build.
 
 **One job per partition — by design.** Sibling to the other `index-<partition>-refresh` jobs; never
 folded into a single `build_all` cron.

--- a/sidecar_jobs/index-knowledge-refresh.md
+++ b/sidecar_jobs/index-knowledge-refresh.md
@@ -12,7 +12,9 @@ Keep the index's **`knowledge` partition** current so the `/wb-dev-document` sca
 up-to-date docs. A no-op while `index.enabled` is false; once on, an incremental content-hash-diffed
 pass — embeds only new/changed units (sub-second when nothing changed), full on the first run.
 `*/15` matches the `knowledge/store/` corpus's refresh cadence. The `index_rebuild` op self-skips
-(read-only advisory-lock probe) when a build for this partition is already running.
+(read-only advisory-lock probe) while any index build is running — all partitions share one
+single-writer DB, so builds serialize on a DB-wide writer gate and a refresh never piles onto an
+in-flight build.
 
 **One job per partition — by design.** Sibling to the other `index-<partition>-refresh` jobs; each
 runs at a cadence matched to its corpus (conversation/vault are far less frequent + heavier). Never

--- a/sidecar_jobs/index-summary-refresh.md
+++ b/sidecar_jobs/index-summary-refresh.md
@@ -12,8 +12,9 @@ Keep the index's **`summary` partition** current so summarization-framework summ
 searchable. A no-op while `index.enabled` is false; once on, an incremental content-hash-diffed
 pass — embeds only new/changed items (cheap when nothing changed), full on the first run. Summaries
 are produced on a 2-hour cadence, so a 30-minute picker is ample without needless churn. The
-`index_rebuild` op self-skips (read-only advisory-lock probe) when a build for this partition is
-already running.
+`index_rebuild` op self-skips (read-only advisory-lock probe) while any index build is running —
+all partitions share one single-writer DB, so builds serialize on a DB-wide writer gate and a
+refresh never piles onto an in-flight build.
 
 **One job per partition — by design.** Sibling to the other `index-<partition>-refresh` jobs; never
 folded into a single `build_all` cron.

--- a/sidecar_jobs/index-vault-refresh.md
+++ b/sidecar_jobs/index-vault-refresh.md
@@ -12,8 +12,9 @@ Keep the index's **`vault` partition** current so vault chunks stay searchable. 
 `index.enabled` is false; once on, an incremental mtime-diffed pass — embeds only new/changed chunks
 (cheap when nothing changed), full on the first run. The corpus is very large and the first full
 build is multi-hour, so this runs only every 6 hours. The `index_rebuild` op self-skips (read-only
-advisory-lock probe) when a build for this partition is already running, so an over-running build is
-never re-entered.
+advisory-lock probe) while any index build is running — all partitions share one single-writer DB,
+so builds serialize on a DB-wide writer gate, an over-running build is never re-entered, and a
+refresh never piles onto another partition's build.
 
 **One job per partition — by design.** Sibling to the other `index-<partition>-refresh` jobs; never
 folded into a single `build_all` cron.

--- a/tests/unit/test_index_build.py
+++ b/tests/unit/test_index_build.py
@@ -160,6 +160,53 @@ class TestBuild:
         assert b.build()["doc_count"] == 1
 
 
+class TestConcurrencySafety:
+    def test_build_holds_db_gate_and_partition_lock(self, store):
+        # The builder must hold BOTH the DB-wide writer gate and its partition lock
+        # while building (SQLite = one writer per DB; partitions share the DB), and
+        # release both afterwards. Observe mid-build via the partition's discover().
+        db = store.db_path
+        gate = db.parent / f"{db.name}.build.lock"
+        mine = db.parent / f"{db.name}.fake.lock"
+        seen = {}
+
+        class Spy(FakePartition):
+            def discover(self):
+                seen["gate"] = gate.exists()
+                seen["mine"] = mine.exists()
+                return super().discover()
+
+        part = Spy({"i1": {"hash": "h1", "docs": [("a", "alpha", "p")]}})
+        IndexBuilder(
+            store, FakeEncoder(), part,
+            residents=ResidentCacheRegistry(), use_lock=True,
+        ).build()
+        assert seen == {"gate": True, "mine": True}
+        assert not gate.exists() and not mine.exists()  # both released
+
+    def test_encode_missing_writes_in_batches(self, store, monkeypatch):
+        # Backfill must be analyze-a-little-write-a-little: vectors land in bounded
+        # batches (durable progress + short writer holds), never one giant commit.
+        items = {
+            f"i{n}": {"hash": f"h{n}", "docs": [(f"d{n}", f"name{n}", f"text {n}")]}
+            for n in range(5)
+        }
+        part = FakePartition(items)
+        _builder(store, part, encoder=FakeEncoder(down=True)).build()  # docs, no vectors
+        assert store.vector_count("fake", "content") == 0
+
+        monkeypatch.setattr(IndexBuilder, "_ENCODE_MISSING_BATCH", 2)
+        calls: list[int] = []
+        orig = store.upsert_vectors
+        monkeypatch.setattr(
+            store, "upsert_vectors",
+            lambda projection, rows: (calls.append(len(rows)), orig(projection, rows))[1],
+        )
+        _builder(store, part).build()  # unchanged items → pure backfill resume
+        assert store.vector_count("fake", "content") == 5
+        assert calls == [2, 2, 1]  # batched, not one giant write
+
+
 class TestPartitionRegistry:
     def test_lazy_register_and_get(self):
         reg = PartitionRegistry()

--- a/tests/unit/test_index_refresh_jobs.py
+++ b/tests/unit/test_index_refresh_jobs.py
@@ -85,3 +85,30 @@ def test_op_self_skips_against_a_real_held_lock(tmp_path, monkeypatch):
         dt = time.time() - t0
     assert out == {"skipped": "build_in_progress", "partition": "summary"}
     assert dt < 5.0  # instant skip, not the 30s blocking acquire
+
+
+def test_op_self_skips_when_any_build_holds_the_db_gate(tmp_path, monkeypatch):
+    """Cross-partition: ANY running build holds the DB-wide writer gate (all partitions
+    share one single-writer SQLite DB), so a refresh of a DIFFERENT partition must skip
+    too — not run into the shared DB and collide."""
+    import time
+    from work_buddy.mcp_server.ops import index_ops
+    from work_buddy.index.config import IndexConfig
+    from work_buddy.utils import index_lock
+
+    cfg = IndexConfig(enabled=True, db_path=tmp_path / "idx.db")
+    monkeypatch.setattr("work_buddy.index.config.load_index_config", lambda *a, **k: cfg)
+
+    def _boom(*a, **k):
+        raise AssertionError("gate failed to skip — op fell through to a real build")
+
+    monkeypatch.setattr("work_buddy.index.partitioned.UnifiedIndex.build", _boom)
+
+    db = cfg.resolved_db_path()
+    gate = db.parent / f"{db.name}.build"  # the DB-wide writer gate (e.g. a vault build)
+    with index_lock.index_lock(gate):
+        t0 = time.time()
+        out = json.loads(index_ops._index_rebuild_dispatch(partition="chrome"))
+        dt = time.time() - t0
+    assert out == {"skipped": "build_in_progress", "partition": "chrome"}
+    assert dt < 5.0

--- a/tests/unit/test_index_store.py
+++ b/tests/unit/test_index_store.py
@@ -192,3 +192,59 @@ class TestLedgerAndVersion:
         store.upsert_documents([_doc("knowledge:a", name="a")], item_id="i")
         store.upsert_documents([_doc("vault:a", partition="vault", name="a")], item_id="j")
         assert store.partitions() == ["knowledge", "vault"]
+
+
+class TestWriteContention:
+    def test_write_rides_through_transient_lock(self, tmp_path, monkeypatch):
+        # Another connection holds the write lock briefly; the store write must retry
+        # through it and land — not die on the first ``database is locked``.
+        # (sqlite3 connections are thread-bound, so the blocker lives entirely in
+        # its own thread: connect → BEGIN IMMEDIATE → hold → commit.)
+        import sqlite3
+        import threading
+        import time
+
+        from work_buddy.index import store as store_mod
+
+        st = IndexStore(tmp_path / "contend.db", busy_timeout_s=0.1)
+        st.set_meta("warm", "1")  # create the schema before contending
+        monkeypatch.setattr(store_mod, "_WRITE_RETRY_DELAYS_S", (0.1, 0.2, 0.4, 0.8))
+
+        acquired = threading.Event()
+
+        def _hold_write_lock_briefly():
+            conn = sqlite3.connect(str(st.db_path), timeout=5)
+            try:
+                conn.execute("PRAGMA journal_mode=WAL")
+                conn.execute("BEGIN IMMEDIATE")  # take the DB write lock
+                acquired.set()
+                time.sleep(0.4)
+                conn.commit()
+            finally:
+                conn.close()
+
+        blocker = threading.Thread(target=_hold_write_lock_briefly)
+        blocker.start()
+        try:
+            assert acquired.wait(5)
+            st.set_meta("k", "v")  # would raise instantly without the retry
+        finally:
+            blocker.join()
+        assert st.get_meta("k") == "v"
+
+    def test_non_lock_errors_not_retried(self, tmp_path, monkeypatch):
+        # Only contention retries; a real OperationalError surfaces immediately.
+        import sqlite3
+        from work_buddy.index import store as store_mod
+
+        st = IndexStore(tmp_path / "fail.db")
+        slept: list[float] = []
+        monkeypatch.setattr(store_mod.time, "sleep", slept.append)
+
+        def boom(self):
+            raise sqlite3.OperationalError("no such table: nope")
+
+        monkeypatch.setattr(IndexStore, "_connect", boom)
+        with pytest.raises(sqlite3.OperationalError, match="no such table"):
+            st.set_meta("k", "v")
+        assert slept == []  # zero backoff sleeps → no retry happened

--- a/tests/unit/test_index_unified.py
+++ b/tests/unit/test_index_unified.py
@@ -116,9 +116,16 @@ class TestConsolidatedAdapter:
         adapter = get_index("consolidated")
         assert adapter.name == "consolidated"
 
-    def test_bulk_build_skips_when_disabled(self):
+    def test_bulk_build_skips_when_disabled(self, monkeypatch):
+        from work_buddy.index.config import IndexConfig
         from work_buddy.indexing.adapters.index_consolidated import ConsolidatedIndexAdapter
-        # default config has index.enabled=false → build is a no-op
+        # Pin the flag OFF. bulk_build reads the MACHINE config — unpinned, a machine
+        # with index.enabled=true would really build every partition of the real DB
+        # from inside this unit test (multi-hour at vault scale).
+        monkeypatch.setattr(
+            "work_buddy.index.config.load_index_config",
+            lambda *a, **k: IndexConfig(enabled=False),
+        )
         res = ConsolidatedIndexAdapter().bulk_build()
         assert res.ok is True
         assert "skipped" in res.stats

--- a/work_buddy/index/build.py
+++ b/work_buddy/index/build.py
@@ -1,13 +1,22 @@
 """IndexBuilder — incremental, resumable, locked build of one partition.
 
-Flow (under a per-partition advisory lock):
+Flow (under the DB-wide writer gate + the per-partition advisory lock):
   discover → diff by ``change_key`` (content-hash default, or mtime) → for each
   changed item: delete its old docs, parse, upsert, encode projections (BACKGROUND,
   batched across docs) → prune deleted items → if anything changed, bump the partition
   ``build_version`` and invalidate its resident matrices.
 
+Two advisory locks, both heartbeated for the whole hold:
+- ``<db>.build`` — the DB-wide WRITER GATE. SQLite allows one writer per DB and all
+  partitions share one DB, so builds serialize across partitions AND processes
+  (sidecar refresh jobs, the embedding service's build endpoint, the CLI). The
+  refresh jobs probe this gate read-only and self-skip while any build runs.
+- ``<db>.<partition>`` — the per-partition identity lock (status probes, and the
+  same-partition self-skip message).
+
 Generalizes ``vault_index/indexer.py`` + ``ir/store.build_index`` and adds the advisory
-lock the IR build lacked. Resumable: re-encodes any docs still missing vectors.
+lock the IR build lacked. Resumable: re-encodes any docs still missing vectors, in
+bounded batches so each pass commits durable progress.
 """
 
 from __future__ import annotations
@@ -54,11 +63,23 @@ class IndexBuilder:
             return contextlib.nullcontext()
         try:
             from work_buddy.utils.index_lock import index_lock
-            target = self._store.db_path.parent / f"{self._store.db_path.name}.{self._partition.name}"
-            return index_lock(target)
         except Exception as exc:  # lock infra unavailable → proceed without (best-effort)
             logger.debug("index_lock unavailable (%s); building without a lock", exc)
             return contextlib.nullcontext()
+
+        db = self._store.db_path
+        gate = db.parent / f"{db.name}.build"          # DB-wide writer gate
+        mine = db.parent / f"{db.name}.{self._partition.name}"  # partition identity
+
+        @contextlib.contextmanager
+        def _locks():
+            # Gate first, partition second — a single fixed order, so two builders
+            # can never deadlock holding one each.
+            with index_lock(gate):
+                with index_lock(mine):
+                    yield
+
+        return _locks()
 
     def build(
         self, *, force: bool = False,
@@ -167,26 +188,32 @@ class IndexBuilder:
             rows = [(doc_id, vecs[start:start + count]) for doc_id, start, count in layout]
             self._store.upsert_vectors(proj_name, rows)
 
+    # Docs per encode→write cycle in the vector backfill. Bounds both the write
+    # transaction (a short writer hold, not one giant multi-thousand-row commit)
+    # and the unit of loss: each batch is durable the moment it lands, so an
+    # interrupted backfill resumes from the last batch, not from zero.
+    _ENCODE_MISSING_BATCH = 256
+
     def _encode_missing(self, pname: str, projection: str, spec) -> None:
         work = self._store.docs_missing_vectors(pname, projection)
-        if not work:
-            return
-        flat_texts: list[str] = []
-        layout: list[tuple[str, int, int]] = []
-        for doc_id, text in work:
-            if isinstance(text, list):
-                texts = [t for t in text if t]
-                if not texts:
-                    continue
-                layout.append((doc_id, len(flat_texts), len(texts)))
-                flat_texts.extend(texts)
-            elif text:
-                layout.append((doc_id, len(flat_texts), 1))
-                flat_texts.append(text)
-        if not flat_texts:
-            return
-        vecs = self._encoder.encode_documents(flat_texts, spec.kind, model_key=spec.model_key)
-        if vecs is None:
-            return
-        rows = [(doc_id, vecs[start:start + count]) for doc_id, start, count in layout]
-        self._store.upsert_vectors(projection, rows)
+        for batch_start in range(0, len(work), self._ENCODE_MISSING_BATCH):
+            batch = work[batch_start:batch_start + self._ENCODE_MISSING_BATCH]
+            flat_texts: list[str] = []
+            layout: list[tuple[str, int, int]] = []
+            for doc_id, text in batch:
+                if isinstance(text, list):
+                    texts = [t for t in text if t]
+                    if not texts:
+                        continue
+                    layout.append((doc_id, len(flat_texts), len(texts)))
+                    flat_texts.extend(texts)
+                elif text:
+                    layout.append((doc_id, len(flat_texts), 1))
+                    flat_texts.append(text)
+            if not flat_texts:
+                continue
+            vecs = self._encoder.encode_documents(flat_texts, spec.kind, model_key=spec.model_key)
+            if vecs is None:
+                return  # encoder unavailable — leave the remainder for the next resume
+            rows = [(doc_id, vecs[start:start + count]) for doc_id, start, count in layout]
+            self._store.upsert_vectors(projection, rows)

--- a/work_buddy/index/store.py
+++ b/work_buddy/index/store.py
@@ -20,13 +20,22 @@ Tables:
 Thread-safety: a fresh connection per public method (sqlite3 connections aren't
 shareable across threads; the embedding service is multi-threaded). ``CREATE … IF NOT
 EXISTS`` runs each open — cheap and idempotent, matching ``vault_index/store.py``.
+
+Write contention: SQLite allows ONE writer per DB. Builds serialize on a DB-wide
+advisory gate (``build.py``), but writers can still live in different processes
+(sidecar jobs, the embedding service, the CLI), so every write method additionally
+rides through transient ``database is locked`` with a bounded backoff-retry. Each
+write is a small self-contained connect→commit→close transaction, which is what
+makes the retry safe (idempotent INSERT OR REPLACE / DELETE).
 """
 
 from __future__ import annotations
 
+import functools
 import json
 import re
 import sqlite3
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -90,6 +99,49 @@ CREATE VIRTUAL TABLE IF NOT EXISTS doc_fts USING fts5(
 # Default FTS5 bm25() column weights (title > tags > body), overridable per partition.
 _DEFAULT_FTS_WEIGHTS = (3.0, 1.0, 2.0)  # (title, body, tags)
 
+# How long one connection waits on a held write lock before sqlite raises
+# ``database is locked`` (a large item — e.g. a many-thousand-span conversation
+# session — can legitimately hold the writer for seconds).
+_BUSY_TIMEOUT_S = 30.0
+
+# Backoff between write attempts after a locked error. Combined with the busy
+# timeout this rides out a concurrent writer's longest single transaction
+# instead of killing a multi-hour build over one collision.
+_WRITE_RETRY_DELAYS_S = (0.5, 1.0, 2.0, 4.0, 8.0)
+
+
+def _is_locked_error(exc: sqlite3.OperationalError) -> bool:
+    msg = str(exc).lower()
+    return "locked" in msg or "busy" in msg
+
+
+def _write_retry(fn):
+    """Retry a write method through transient lock contention.
+
+    Safe because every write method is one self-contained connect→commit→close
+    transaction of idempotent statements — a failed attempt leaves nothing behind
+    and a repeat converges to the same rows.
+    """
+    @functools.wraps(fn)
+    def wrapper(self, *args, **kwargs):
+        last: sqlite3.OperationalError | None = None
+        for attempt, delay in enumerate((0.0, *_WRITE_RETRY_DELAYS_S)):
+            if delay:
+                time.sleep(delay)
+            try:
+                return fn(self, *args, **kwargs)
+            except sqlite3.OperationalError as exc:
+                if not _is_locked_error(exc):
+                    raise
+                last = exc
+                logger.warning(
+                    "index store: %s contended (%s); attempt %d/%d",
+                    fn.__name__, exc, attempt + 1, 1 + len(_WRITE_RETRY_DELAYS_S),
+                )
+        assert last is not None
+        raise last
+    return wrapper
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -149,9 +201,12 @@ def _metadata_where(filters: dict[str, Any] | None) -> tuple[str, list[Any]]:
 class IndexStore:
     """Connection-per-operation SQLite store for the consolidated index."""
 
-    def __init__(self, db_path: str | Path) -> None:
+    def __init__(
+        self, db_path: str | Path, *, busy_timeout_s: float = _BUSY_TIMEOUT_S
+    ) -> None:
         self._db_path = Path(db_path)
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._busy_timeout_s = busy_timeout_s
 
     @property
     def db_path(self) -> Path:
@@ -159,7 +214,7 @@ class IndexStore:
 
     # -- connection -------------------------------------------------------
     def _connect(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(str(self._db_path), timeout=10)
+        conn = sqlite3.connect(str(self._db_path), timeout=self._busy_timeout_s)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA foreign_keys=ON")
@@ -167,6 +222,7 @@ class IndexStore:
         return conn
 
     # -- writes -----------------------------------------------------------
+    @_write_retry
     def upsert_documents(self, docs: list[Document], item_id: str = "") -> int:
         """Insert/replace documents (tagged with ``item_id``) and refresh FTS rows.
 
@@ -205,6 +261,7 @@ class IndexStore:
         finally:
             conn.close()
 
+    @_write_retry
     def upsert_vectors(
         self, projection: str, rows: list[tuple[str, "Any"]]
     ) -> int:
@@ -243,6 +300,7 @@ class IndexStore:
         finally:
             conn.close()
 
+    @_write_retry
     def delete_item_docs(self, item_id: str, partition: str | None = None) -> int:
         """Delete all docs for an item (FTS rows + cascaded vectors). Returns rows."""
         conn = self._connect()
@@ -272,6 +330,7 @@ class IndexStore:
         finally:
             conn.close()
 
+    @_write_retry
     def delete_partition(self, partition: str) -> int:
         """Drop an entire partition (FTS + docs + cascaded vectors + ledger)."""
         conn = self._connect()
@@ -303,6 +362,7 @@ class IndexStore:
         finally:
             conn.close()
 
+    @_write_retry
     def mark_item_indexed(
         self, item_id: str, partition: str, *, mtime: float = 0.0,
         content_hash: str = "", doc_count: int = 0,
@@ -330,6 +390,7 @@ class IndexStore:
         finally:
             conn.close()
 
+    @_write_retry
     def set_meta(self, key: str, value: str) -> None:
         conn = self._connect()
         try:

--- a/work_buddy/mcp_server/ops/index_ops.py
+++ b/work_buddy/mcp_server/ops/index_ops.py
@@ -2,11 +2,12 @@
 
 Referenced by the ``index_rebuild`` capability declaration. The sidecar's per-partition
 ``index-<partition>-refresh`` jobs call this on a schedule; it no-ops while ``index.enabled``
-is false and runs an incremental build of the named partition when enabled. When a
-``partition`` is given it also self-skips (read-only advisory-lock
-probe) if a build for that partition is already running, so a recurring refresh never
-re-enters an in-flight build. The sidecar runs in its own process and may import heavy libs,
-so the build runs in-process here (sharing the broker).
+is false and runs an incremental build of the named partition when enabled. It also
+self-skips (read-only advisory-lock probe) while ANY index build is running — the
+partitions share one single-writer SQLite DB, so builds serialize on a DB-wide writer
+gate and a recurring refresh never piles onto an in-flight build of any partition.
+The sidecar runs in its own process and may import heavy libs, so the build runs
+in-process here (sharing the broker).
 """
 
 from __future__ import annotations
@@ -20,8 +21,9 @@ def _index_rebuild_dispatch(partition: str | None = None, force: bool = False) -
     """Incrementally (re)build the consolidated index — flag-gated.
 
     Returns ``{"skipped": ...}`` while ``index.enabled`` is false, or
-    ``{"skipped": "build_in_progress"}`` when a build for ``partition`` already holds the
-    advisory lock. When enabled + free, builds ``partition`` (e.g. ``"knowledge"``) into the
+    ``{"skipped": "build_in_progress"}`` while any index build holds the DB-wide writer
+    gate (or this partition's own lock). When enabled + free, builds ``partition``
+    (e.g. ``"knowledge"``) into the
     separate ``db/index-consolidated``, or all partitions when omitted. ``force=True`` rebuilds
     from scratch; the default is incremental (content-hash diff — cheap when nothing changed).
     """
@@ -33,16 +35,21 @@ def _index_rebuild_dispatch(partition: str | None = None, force: bool = False) -
             {"skipped": "index.enabled is false (flag-gated; off by default)"}
         )
 
-    # Self-skip a partition whose build is already running. The builder takes a BLOCKING
-    # advisory lock (``index/build.py``) that raises after ~30s if a live holder owns it, so a
-    # recurring refresh re-firing mid-build would stall-then-error every tick (a multi-hour
-    # vault build would error on every fire). Probe the SAME per-partition lock target
-    # read-only and bail cheaply — mirrors ``vault_ops``'s ``is_locked`` pre-check.
-    if partition:
-        from work_buddy.utils import index_lock
+    # Self-skip while ANY index build is running. All partitions share one SQLite DB
+    # (single writer), so builds serialize on the DB-wide ``.build`` writer gate
+    # (``index/build.py``) — and a refresh firing into a held gate would block ~30s on
+    # the advisory acquire then error, every tick, for as long as the build runs (a
+    # first vault/conversation build is multi-hour). Probe the gate (and, for the
+    # message's sake, this partition's own lock) read-only and bail cheaply — mirrors
+    # ``vault_ops``'s ``is_locked`` pre-check.
+    from work_buddy.utils import index_lock
 
-        db = cfg.resolved_db_path()
-        if index_lock.is_locked(db.parent / f"{db.name}.{partition}"):
+    db = cfg.resolved_db_path()
+    targets = [db.parent / f"{db.name}.build"]
+    if partition:
+        targets.append(db.parent / f"{db.name}.{partition}")
+    for target in targets:
+        if index_lock.is_locked(target):
             return json.dumps({"skipped": "build_in_progress", "partition": partition})
 
     from work_buddy.index.partitioned import UnifiedIndex


### PR DESCRIPTION
## Summary
The consolidated index keeps every partition in **one** SQLite DB (single writer). [#184](https://github.com/KadenMc/work-buddy/pull/184) gave each build a *per-partition* advisory lock — which stops a partition racing itself but does nothing across partitions or processes. So a manual/service build and a sidecar refresh cron could write the shared DB at once, and the loser **died on a single `database is locked`**. With multiple refresh crons now live, a multi-hour first build (vault/conversation) kept colliding and never finished — a fresh install with a large backlog and crons already on hits this on day one.

Three layers, smallest to largest:

- **DB-wide writer gate.** Each build now takes a shared `<db>.build` advisory lock (heartbeated, same machinery as #184) **before** its per-partition lock, in a fixed gate→partition order so two builders can't deadlock. Builds across all partitions and all processes (sidecar crons, the service build endpoint, the CLI, the dashboard seam) physically serialize. The refresh op probes this gate too, so a cron self-skips while **any** build runs — not just its own partition's.
- **Write resilience.** `IndexStore` busy timeout 10s→30s, plus bounded backoff-retry on `database is locked` around every write method (~15s of patience). Safe because each write is one small idempotent `connect→commit→close` transaction. Non-lock `OperationalError`s still surface immediately.
- **Resumable backfill.** The vector backfill (`_encode_missing`) encodes→writes in **256-doc batches** instead of one giant terminal commit: durable progress every batch, short writer holds, resumes from the last batch after an interruption.

Also pins `index.enabled=false` in `test_bulk_build_skips_when_disabled` — it read the machine config, so on a host where the flag is on it really built the whole DB from inside a unit test (masked in CI, where the flag defaults off).

## Test plan
- [x] 168 unit tests green across the 3 changed modules + every shared-store/lock consumer (store retry + non-lock-passthrough, gate-held-during-build + released-after, cross-partition op skip via the gate, lock heartbeat, chunked backfill, unified/search/partitions/encode, old vault build/ops, knowledge re-point, dashboard seam).
- [x] **Live-verified** after restarting the embedding service onto branch code: a real vault resume holds the `.build` gate and progresses in durable batches (+182 docs/70s) while the refresh crons are live; `index_rebuild(vault)` and `index_rebuild(chrome)` both return `build_in_progress` in <5s instead of blocking-then-erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)