### PR TITLE
feat(index): route find (drill=False) to the consolidated index, flag-gated, inert

### DIFF
--- a/tests/unit/test_find_consolidated.py
+++ b/tests/unit/test_find_consolidated.py
@@ -1,0 +1,94 @@
+"""find → consolidated-index re-point (drill=False), reusing the shared IR-consumer helper
+with consumer="find". Verifies the per-consumer gate, find_op routing + IR fallback, and
+that drill=True never routes to the consolidated index."""
+from __future__ import annotations
+
+import importlib
+
+from work_buddy.index.config import IndexConfig
+from work_buddy.mcp_server.ops import context_consolidated as cc
+from work_buddy.mcp_server.ops.search_ops import find_op
+
+# ``work_buddy.ir.search`` is re-exported as a function in the package namespace, so a
+# string monkeypatch path resolves to the function, not the module. Grab the real module.
+_ir_mod = importlib.import_module("work_buddy.ir.search")
+
+
+def _cfg(monkeypatch, **consumers):
+    monkeypatch.setattr(
+        "work_buddy.index.config.load_index_config",
+        lambda *a, **k: IndexConfig(enabled=True, consumers=consumers),
+    )
+
+
+_HIT = {
+    "doc_id": "conversation:s1#2", "score": 0.8,
+    "signals": {"fused": 0.8, "lexical": 0.3, "default": 0.6},
+    "display_text": "span text", "metadata": {"session_id": "s1"},
+}
+
+
+class TestHelperConsumerParam:
+    def test_find_flag_gates_independently(self, monkeypatch):
+        # context_search ON but find OFF → the consumer="find" gate is closed.
+        _cfg(monkeypatch, context_search=True)
+        assert cc.search_context_via_consolidated(
+            "q", source="conversation", consumer="find") is None
+
+    def test_find_flag_on_passes_gate(self, monkeypatch):
+        _cfg(monkeypatch, find=True)
+        monkeypatch.setattr("work_buddy.embedding.client.index_search", lambda q, **k: [_HIT])
+        out = cc.search_context_via_consolidated("q", source="conversation", consumer="find")
+        assert out and out[0]["source"] == "conversation"
+        assert out[0]["doc_id"] == "conversation:s1#2"
+
+
+class TestFindRouting:
+    def test_drill_false_routes_when_find_on(self, monkeypatch):
+        _cfg(monkeypatch, find=True)
+        monkeypatch.setattr("work_buddy.embedding.client.index_search", lambda q, **k: [_HIT])
+
+        def boom(*a, **k):
+            raise AssertionError("should not hit the IR engine when routed")
+        monkeypatch.setattr(_ir_mod, "search", boom)
+        out = find_op("q", source="conversation", drill=False)
+        assert isinstance(out, list) and out[0]["source"] == "conversation"
+
+    def test_drill_false_falls_back_when_find_off(self, monkeypatch):
+        _cfg(monkeypatch)  # find off
+        sentinel = [{"doc_id": "x", "score": 1.0, "source": "conversation",
+                     "display_text": "", "metadata": {}}]
+        called = {}
+
+        def fake_ir(q, **k):
+            called["ir"] = True
+            return sentinel
+        monkeypatch.setattr(_ir_mod, "search", fake_ir)
+        out = find_op("q", source="conversation", drill=False)
+        assert called.get("ir") and out is sentinel
+
+    def test_drill_false_unsupported_subset_falls_back(self, monkeypatch):
+        _cfg(monkeypatch, find=True)
+        called = {}
+
+        def fake_ir(q, **k):
+            called["ir"] = True
+            return []
+        monkeypatch.setattr(_ir_mod, "search", fake_ir)
+        find_op("q", source=None, drill=False)  # all-source is out of the subset → IR
+        assert called.get("ir")
+
+    def test_drill_true_never_routes_to_consolidated(self, monkeypatch):
+        _cfg(monkeypatch, find=True)
+
+        def boom(*a, **k):
+            raise AssertionError("drill=True must not route to the consolidated index")
+        monkeypatch.setattr(
+            "work_buddy.mcp_server.ops.context_consolidated.search_context_via_consolidated",
+            boom,
+        )
+        monkeypatch.setattr(_ir_mod, "search", lambda q, **k: [])
+        monkeypatch.setattr(
+            "work_buddy.summarization.drill_registry.get_drill_handler", lambda s: None)
+        out = find_op("q", source="conversation", drill=True)
+        assert isinstance(out, dict) and "stage1_hits" in out  # funnel shape, helper untouched

--- a/work_buddy/mcp_server/ops/context_consolidated.py
+++ b/work_buddy/mcp_server/ops/context_consolidated.py
@@ -1,11 +1,12 @@
-"""Route `context_search` to the consolidated index when its consumer flag is on.
+"""Route an IR-search consumer to the consolidated index when its consumer flag is on.
 
-The consumer-layer bridge from the IR-engine `context_search` op (`context_ops.py`) to
-the consolidated index. Mirrors the knowledge re-point (`knowledge/search.py::
-_search_via_consolidated`): gate on `index.consumers.context_search`, push the request
-down to the matching partition, adapt hits back into the IR result-dict shape so
-`result_format.format_results` renders identically — and on ANY miss return ``None`` so
-the caller falls back to the live IR engine.
+The consumer-layer bridge from the IR-engine search ops (`context_search` in
+`context_ops.py`, and `find`'s drill=False path in `search_ops.py`) to the consolidated
+index. Mirrors the knowledge re-point (`knowledge/search.py::_search_via_consolidated`):
+gate on `index.consumers.<consumer>` (each op passes its own consumer name, so they stage
+independently), push the request down to the matching partition, adapt hits back into the
+IR result-dict shape so the callers render/return them identically — and on ANY miss
+return ``None`` so the caller falls back to the live IR engine.
 
 Deliberately scoped to the unambiguous subset: a SINGLE, named ``source`` (so the
 partition — hence the result's ``source`` tag and its preserved metadata — is known) with
@@ -23,11 +24,11 @@ from work_buddy.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-# index.consumers.<name> gate for this consumer.
+# Default index.consumers.<name> gate (context_search); `find` passes consumer="find".
 CONSUMER = "context_search"
 
-# context_search method tokens → the consolidated index's Query.method. ``substring`` is an
-# exact, no-embedding mode the consolidated index has no equivalent for → it stays on IR.
+# IR method tokens → the consolidated index's Query.method. ``substring`` is an exact,
+# no-embedding mode the consolidated index has no equivalent for → it stays on IR.
 _METHOD_MAP = {"keyword": "lexical", "semantic": "dense"}
 
 _TIMEOUT_S = 30
@@ -69,17 +70,19 @@ def search_context_via_consolidated(
     scope: str | None = None,
     method: str = "keyword,semantic",
     recency: bool | None = None,
+    consumer: str = CONSUMER,
 ) -> list[dict[str, Any]] | None:
     """Try the consolidated index; return IR-shaped results, or ``None`` to use live IR.
 
-    ``None`` (→ caller falls back to the IR engine) on any of: gate off; no ``source`` or
-    a ``scope`` (out of the supported subset); ``substring``/unknown method; the embedding
-    service failing; or zero hits.
+    ``consumer`` selects the ``index.consumers.<consumer>`` gate (e.g. "context_search" or
+    "find"). ``None`` (→ caller falls back to the IR engine) on any of: gate off; no
+    ``source`` or a ``scope`` (out of the supported subset); ``substring``/unknown method;
+    the embedding service failing; or zero hits.
     """
     try:
         from work_buddy.index.config import load_index_config
 
-        if not load_index_config().consumer_enabled(CONSUMER):
+        if not load_index_config().consumer_enabled(consumer):
             return None
     except Exception:  # noqa: BLE001 — never let config errors break search
         return None
@@ -105,7 +108,7 @@ def search_context_via_consolidated(
             timeout_s=_TIMEOUT_S,
         )
     except Exception as exc:  # noqa: BLE001 — IR fallback is the recovery
-        logger.debug("consolidated context_search failed (%s); using IR engine.", exc)
+        logger.debug("consolidated search [%s] failed (%s); using IR engine.", consumer, exc)
         return None
 
     if not hits:

--- a/work_buddy/mcp_server/ops/search_ops.py
+++ b/work_buddy/mcp_server/ops/search_ops.py
@@ -76,6 +76,20 @@ def find_op(
     from work_buddy.ir.search import search as ir_search
 
     if not drill:
+        # Route the plain (non-drill) path to the consolidated index when the `find`
+        # consumer flag is on and the request is in the supported subset (single source,
+        # no scope, hybrid-mappable method); fall back to the IR engine on any miss. The
+        # helper returns the same list[dict] shape ir.search.search does. (drill=True keeps
+        # using the IR engine + its source-specific drill handlers.)
+        from work_buddy.mcp_server.ops.context_consolidated import (
+            search_context_via_consolidated,
+        )
+        routed = search_context_via_consolidated(
+            query, top_k=top_k, source=source, scope=scope,
+            method=method, recency=recency, consumer="find",
+        )
+        if routed is not None:
+            return routed
         return ir_search(
             query,
             top_k=top_k,


### PR DESCRIPTION
## Summary
> ⚠️ **Stacked on [#187](https://github.com/KadenMc/work-buddy/pull/187)** — it reuses that PR's `ops/context_consolidated.py` helper. **Merge #187 first**; this targets the #187 branch and will retarget to `main` after.

Extends the IR-consumer re-point to the **`find` op's `drill=False` path** — the structured-return twin of `context_search` (both pass through to `ir.search.search`). Behind its own per-consumer flag **`index.consumers.find`** (default off → inert; independent of context_search's flag, so each stages separately). `drill=True` keeps using the IR engine + its source-specific drill handlers.

- Generalizes the shared bridge: `search_context_via_consolidated` gains a `consumer` param (default `"context_search"`); `find` passes `consumer="find"`.
- Same supported subset + graceful fallback as #187 — single named source, no scope, hybrid-mappable method; anything else (all-source, scope, substring, service failure, empty) → `None` → `find` falls back to `ir.search.search`. The helper returns the same `list[dict]` shape `find`'s `drill=False` contract already promises, so callers are unaffected until activation.

## Test plan
- [x] 6 new tests (`test_find_consolidated.py`): per-consumer gate (find isolated from context_search), `drill=False` routing + IR fallback + out-of-subset fallback, and that `drill=True` never routes to the consolidated index. (context_search's 15 tests still green — shared-helper regression.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)