### PR TITLE
fix(chat): render real session time in chat summary, not file mtime

### DIFF
--- a/tests/unit/test_chat_collector_session_time.py
+++ b/tests/unit/test_chat_collector_session_time.py
@@ -1,0 +1,112 @@
+"""Regression: chat_collector must render a conversation's real time, not file mtime.
+
+A Claude Code session JSONL is rewritten (mtime bumped to the present) whenever
+the session is resumed. The chat summary used to display that mtime as the
+session's timestamp, which silently misdated resumed sessions by days — a
+collected June-5 conversation showed up under a June-14 header and nearly drove a
+fabricated journal entry. The session's own message timestamps are the
+authoritative "when did this happen" signal; these tests pin that contract.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+from work_buddy.collectors import chat_collector as cc
+
+
+# ---------------------------------------------------------------------------
+# _format_session_when — prefers real start/end, falls back only when absent
+# ---------------------------------------------------------------------------
+
+
+def test_format_session_when_same_day_range():
+    out = cc._format_session_when("2026-06-05T17:30:00Z", "2026-06-05T18:11:00Z")
+    assert out == "2026-06-05 17:30–18:11"
+
+
+def test_format_session_when_cross_day_range():
+    out = cc._format_session_when("2026-06-05T23:30:00Z", "2026-06-06T01:11:00Z")
+    assert out == "2026-06-05 23:30–2026-06-06 01:11"
+
+
+def test_format_session_when_falls_back_only_without_timestamps():
+    # No real timestamps → use the supplied fallback (e.g. mtime), as a last resort.
+    assert cc._format_session_when(None, None, fallback="2026-06-14 19:58") == "2026-06-14 19:58"
+    # But a real start_time always wins over the fallback.
+    assert cc._format_session_when(
+        "2026-06-05T17:30:00Z", None, fallback="2026-06-14 19:58"
+    ) == "2026-06-05 17:30"
+
+
+# ---------------------------------------------------------------------------
+# collect() — a resumed session renders its real date, never its mtime
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def claude_home(tmp_path, monkeypatch):
+    """Isolated ~/.claude with one project dir; cache redirected to tmp."""
+    home = tmp_path / "home"
+    projects = home / ".claude" / "projects"
+    projects.mkdir(parents=True)
+
+    monkeypatch.setattr(cc.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(cc, "_CACHE_PATH", home / ".claude" / "chat_cache.json")
+    # Defeat the in-process memo so the redirected cache path is honored.
+    monkeypatch.setattr(cc, "_parsed_cache", None)
+    monkeypatch.setattr(cc, "_parsed_cache_state", None)
+    return projects
+
+
+def _write_session(project_dir, session_id, turns, mtime_iso):
+    """Write a JSONL session with the given turns, then stamp its file mtime."""
+    project_dir.mkdir(parents=True, exist_ok=True)
+    path = project_dir / f"{session_id}.jsonl"
+    with open(path, "w", encoding="utf-8") as f:
+        for t in turns:
+            f.write(json.dumps(t) + "\n")
+    mtime = datetime.fromisoformat(mtime_iso.replace("Z", "+00:00")).timestamp()
+    os.utime(path, (mtime, mtime))
+    return path
+
+
+def test_collect_uses_session_time_not_mtime(claude_home, tmp_path):
+    project_dir = claude_home / "C--code-repos-myproject"
+    # Conversation actually happened on 2026-06-05 ...
+    turns = [
+        {
+            "type": "user",
+            "timestamp": "2026-06-05T17:30:00.000Z",
+            "message": {"role": "user", "content": "let's reconcile the merge"},
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-06-05T18:11:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Looking at both files now."}],
+            },
+        },
+    ]
+    # ... but the JSONL was rewritten on 2026-06-14 (resume), bumping its mtime.
+    _write_session(project_dir, "7fb19cb6-aaaa-bbbb-cccc-000000000000", turns, "2026-06-14T19:58:00Z")
+
+    cfg = {
+        "repos_root": str(tmp_path / "empty_repos"),  # no specstory
+        "chats": {},
+        # Window covers the June-14 mtime but NOT the June-5 conversation.
+        "since": "2026-06-14T00:00:00",
+        "until": "2026-06-15T00:00:00",
+    }
+    out = cc.collect(cfg)
+
+    # The session is pulled in by mtime, but must be labeled with its real date.
+    assert "7fb19cb6" in out
+    assert "2026-06-05 17:30–18:11" in out
+    # The misleading mtime date must NOT appear as the session's time.
+    assert "2026-06-14 19:58" not in out

--- a/work_buddy/collectors/chat_collector.py
+++ b/work_buddy/collectors/chat_collector.py
@@ -462,6 +462,42 @@ def _format_duration(start: str | None, end: str | None) -> str:
         return ""
 
 
+def _parse_iso(value: str | None) -> datetime | None:
+    """Parse an ISO timestamp (tolerating a trailing ``Z``) to a datetime."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _format_session_when(
+    start: str | None, end: str | None, fallback: str = ""
+) -> str:
+    """Render when a conversation actually happened, from its message timestamps.
+
+    Prefers the conversation's own ``start_time``/``end_time`` (the
+    authoritative "when did this happen" signal, parsed from the message
+    timestamps) over the JSONL file mtime. The file mtime drifts to the
+    present whenever a session is resumed or rewritten, so it does NOT
+    reflect when the conversation took place — rendering it as the session
+    time silently misdates resumed sessions by days. Falls back to
+    *fallback* only when neither timestamp is available.
+    """
+    s = _parse_iso(start)
+    e = _parse_iso(end)
+    if s and e:
+        if s.date() == e.date():
+            return f"{s.strftime('%Y-%m-%d %H:%M')}–{e.strftime('%H:%M')}"
+        return f"{s.strftime('%Y-%m-%d %H:%M')}–{e.strftime('%Y-%m-%d %H:%M')}"
+    if s:
+        return s.strftime("%Y-%m-%d %H:%M")
+    if e:
+        return e.strftime("%Y-%m-%d %H:%M")
+    return fallback
+
+
 def _get_claude_code_conversations(
     days: int,
     project_filter: list[str] | None = None,
@@ -617,8 +653,13 @@ def collect(cfg: dict[str, Any]) -> str:
             lines.append(
                 f"### [{conv['project_name']}] {conv.get('full_session_id', conv['session_id'])}"
             )
+            session_when = _format_session_when(
+                conv.get("start_time"),
+                conv.get("end_time"),
+                fallback=conv.get("modified", ""),
+            )
             stats_parts = [
-                conv['modified'],
+                session_when,
                 f"{conv['user_msg_count']} user msgs",
                 f"{conv.get('assistant_text_count', conv.get('assistant_msg_count', 0))} responses",
                 f"{conv['tool_use_count']} tool calls",
@@ -793,7 +834,11 @@ def search_conversations(
         lines.append(f"### [{conv.get('project_name', '?')}] {conv.get('full_session_id', conv['session_id'])}")
 
         stats = [
-            conv.get("modified", ""),
+            _format_session_when(
+                conv.get("start_time"),
+                conv.get("end_time"),
+                fallback=conv.get("modified", ""),
+            ),
             f"{conv['user_msg_count']} user msgs",
             f"{conv['tool_use_count']} tool calls",
         ]


### PR DESCRIPTION
## Summary
- The chat summary and conversation-search surfaces rendered each session's header from the **JSONL file mtime**. A session file is rewritten when the session is **resumed**, bumping mtime to the present — so a conversation from days ago could surface under a recent header. In a journal update this nearly drove a wrong-dated Log entry (a June-5 session showed under a June-14 header).
- Now renders the conversation's **real start/end**, parsed from the message timestamps — the same authoritative signal `claude_session_summary` already uses — via shared `_parse_iso` + `_format_session_when` helpers used by both `collect()` and `search_conversations()`. File mtime is kept only as a fallback for sessions with no parseable timestamps.
- Scoped to the **display**. Two related follow-ups are intentionally out of scope (tracked separately): the collection window is still selected by mtime, and the session collectors render UTC while git/journal render local time.

## Test plan
- [x] New regression test `tests/unit/test_chat_collector_session_time.py` (4 cases incl. the exact resumed-session repro: old message timestamps + recent file mtime → must render the real date).
- [x] Sibling/dashboard suites still green (`test_claude_session_summary_collector`, `test_dashboard_chats_observability`, `test_dashboard_chats_merge_invariants`, `test_dashboard_chat_topics_endpoint`).
- [x] Live-verified through the MCP gateway: `wb_run("context_chat")` renders the previously-misdated session as `2026-06-05 17:30–18:11` (was `2026-06-14 19:58`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)