### PR TITLE
fix(collectors): window chat by real session time; render bundle timestamps local

### DIFF
--- a/knowledge/store/journal/update-directions.md
+++ b/knowledge/store/journal/update-directions.md
@@ -64,6 +64,11 @@ The `collect` step writes a bundle directory. Read EVERY relevant file before dr
 
 If you produce a draft Log that mentions only one project across an active multi-hour day, treat that as a smell and re-check sources 1, 2, and 3 before presenting it to the user.
 
+### Timestamp semantics across the bundle
+
+- **All bundle timestamps are local wall-clock time** (the configured `timezone` / `USER_TZ`), with no "UTC" label. Times in `git_summary.md`, `chat_summary.md`, `claude_session_summary.md`, and `obsidian_summary.md` sit on one local timeline, so they can be compared and ordered directly — and they line up with the journal's own local Sign-In, office-arrival, and Log times. Place events at the local time shown.
+- **Chat and SpecStory sessions are windowed by real conversation time**, not file mtime. A Claude Code session's window membership comes from its message-derived start/end; a SpecStory session's from its filename stamp. A session resumed today but whose conversation happened days ago will NOT appear in today's window — and `chat_summary.md` labels every session with its real start/end, so a session header's date is the date the conversation actually happened.
+
 ## Before writing
 
 Present entries to user and wait for explicit approval. User may edit, reword, add, or remove. Do NOT call journal_write until approved.

--- a/tests/unit/test_chat_collector_session_time.py
+++ b/tests/unit/test_chat_collector_session_time.py
@@ -1,11 +1,15 @@
-"""Regression: chat_collector must render a conversation's real time, not file mtime.
+"""Regression: chat_collector windows on real session time and renders local.
 
 A Claude Code session JSONL is rewritten (mtime bumped to the present) whenever
-the session is resumed. The chat summary used to display that mtime as the
-session's timestamp, which silently misdated resumed sessions by days — a
-collected June-5 conversation showed up under a June-14 header and nearly drove a
-fabricated journal entry. The session's own message timestamps are the
-authoritative "when did this happen" signal; these tests pin that contract.
+the session is resumed. Two correctness contracts are pinned here:
+
+1. **Windowing** — a session is selected by its real message-derived time (or, for
+   SpecStory, its filename stamp), not the file mtime. A June-5 conversation
+   resumed on June-14 must NOT be pulled into a June-14 window. Sessions with no
+   parseable timestamp fall back to the mtime decision so they aren't dropped.
+2. **Timezone** — session times render in the user's local zone (USER_TZ), matching
+   git's local commit times and the journal's local Log entries, with no "UTC"
+   label. Tests pin America/Toronto (UTC-4 in June) so a missed conversion fails.
 """
 
 from __future__ import annotations
@@ -13,38 +17,48 @@ from __future__ import annotations
 import json
 import os
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
 
+import work_buddy.config as config
 from work_buddy.collectors import chat_collector as cc
 
 
+@pytest.fixture
+def pin_tz(monkeypatch):
+    """Pin USER_TZ to America/Toronto via the lazy cache (no config load)."""
+    monkeypatch.setattr(config, "_USER_TZ_CACHE", ZoneInfo("America/Toronto"))
+    return ZoneInfo("America/Toronto")
+
+
 # ---------------------------------------------------------------------------
-# _format_session_when — prefers real start/end, falls back only when absent
+# _format_session_when — real start/end, converted to local; fallback only absent
 # ---------------------------------------------------------------------------
 
 
-def test_format_session_when_same_day_range():
+def test_format_session_when_same_day_range(pin_tz):
     out = cc._format_session_when("2026-06-05T17:30:00Z", "2026-06-05T18:11:00Z")
-    assert out == "2026-06-05 17:30–18:11"
+    assert out == "2026-06-05 13:30–14:11"  # UTC-4
 
 
-def test_format_session_when_cross_day_range():
+def test_format_session_when_cross_day_range(pin_tz):
+    # 23:30Z → 19:30 local, 01:11Z(next) → 21:11 local: collapses to one local day.
     out = cc._format_session_when("2026-06-05T23:30:00Z", "2026-06-06T01:11:00Z")
-    assert out == "2026-06-05 23:30–2026-06-06 01:11"
+    assert out == "2026-06-05 19:30–21:11"
 
 
-def test_format_session_when_falls_back_only_without_timestamps():
+def test_format_session_when_falls_back_only_without_timestamps(pin_tz):
     # No real timestamps → use the supplied fallback (e.g. mtime), as a last resort.
     assert cc._format_session_when(None, None, fallback="2026-06-14 19:58") == "2026-06-14 19:58"
-    # But a real start_time always wins over the fallback.
+    # But a real start_time always wins over the fallback (and renders local).
     assert cc._format_session_when(
         "2026-06-05T17:30:00Z", None, fallback="2026-06-14 19:58"
-    ) == "2026-06-05 17:30"
+    ) == "2026-06-05 13:30"
 
 
 # ---------------------------------------------------------------------------
-# collect() — a resumed session renders its real date, never its mtime
+# collect() — windowing by real conversation time
 # ---------------------------------------------------------------------------
 
 
@@ -75,38 +89,116 @@ def _write_session(project_dir, session_id, turns, mtime_iso):
     return path
 
 
-def test_collect_uses_session_time_not_mtime(claude_home, tmp_path):
+def _turn(role, ts, text):
+    msg = (
+        {"role": "user", "content": text}
+        if role == "user"
+        else {"role": "assistant", "content": [{"type": "text", "text": text}]}
+    )
+    entry = {"type": role, "message": msg}
+    if ts is not None:
+        entry["timestamp"] = ts
+    return entry
+
+
+def _june14_window():
+    # Covers the June-14 mtime but not the June-5 conversation.
+    return {"since": "2026-06-14T00:00:00", "until": "2026-06-15T00:00:00"}
+
+
+def test_collect_excludes_session_outside_real_time_window(claude_home, tmp_path, pin_tz):
+    """A June-5 conversation resumed on June-14 is NOT pulled into a June-14 window."""
     project_dir = claude_home / "C--code-repos-myproject"
-    # Conversation actually happened on 2026-06-05 ...
     turns = [
-        {
-            "type": "user",
-            "timestamp": "2026-06-05T17:30:00.000Z",
-            "message": {"role": "user", "content": "let's reconcile the merge"},
-        },
-        {
-            "type": "assistant",
-            "timestamp": "2026-06-05T18:11:00.000Z",
-            "message": {
-                "role": "assistant",
-                "content": [{"type": "text", "text": "Looking at both files now."}],
-            },
-        },
+        _turn("user", "2026-06-05T17:30:00.000Z", "let's reconcile the merge"),
+        _turn("assistant", "2026-06-05T18:11:00.000Z", "Looking at both files now."),
     ]
-    # ... but the JSONL was rewritten on 2026-06-14 (resume), bumping its mtime.
+    # JSONL rewritten on 2026-06-14 (resume) → mtime is June-14.
     _write_session(project_dir, "7fb19cb6-aaaa-bbbb-cccc-000000000000", turns, "2026-06-14T19:58:00Z")
 
-    cfg = {
-        "repos_root": str(tmp_path / "empty_repos"),  # no specstory
-        "chats": {},
-        # Window covers the June-14 mtime but NOT the June-5 conversation.
-        "since": "2026-06-14T00:00:00",
-        "until": "2026-06-15T00:00:00",
-    }
+    cfg = {"repos_root": str(tmp_path / "empty_repos"), "chats": {}, **_june14_window()}
     out = cc.collect(cfg)
 
-    # The session is pulled in by mtime, but must be labeled with its real date.
-    assert "7fb19cb6" in out
-    assert "2026-06-05 17:30–18:11" in out
-    # The misleading mtime date must NOT appear as the session's time.
+    # The real conversation time falls outside the window → excluded entirely.
+    assert "7fb19cb6" not in out
+    # And the misleading mtime date never appears as the session's time.
     assert "2026-06-14 19:58" not in out
+
+
+def test_collect_includes_in_window_session_with_local_render(claude_home, tmp_path, pin_tz):
+    """A session whose real time is in-window is included, rendered in local time."""
+    project_dir = claude_home / "C--code-repos-myproject"
+    turns = [
+        _turn("user", "2026-06-14T15:00:00.000Z", "kick off the run"),
+        _turn("assistant", "2026-06-14T15:30:00.000Z", "Run started."),
+    ]
+    _write_session(project_dir, "abc12345-aaaa-bbbb-cccc-000000000000", turns, "2026-06-14T15:30:00Z")
+
+    cfg = {"repos_root": str(tmp_path / "empty_repos"), "chats": {}, **_june14_window()}
+    out = cc.collect(cfg)
+
+    assert "abc12345" in out
+    # 15:00–15:30 UTC → 11:00–11:30 local (UTC-4).
+    assert "2026-06-14 11:00–11:30" in out
+    # The Collected header is local — no "UTC" label anywhere in the summary.
+    assert "UTC" not in out
+
+
+def test_collect_keeps_timestampless_session_via_mtime_fallback(claude_home, tmp_path, pin_tz):
+    """A session with no parseable timestamps falls back to the mtime decision."""
+    project_dir = claude_home / "C--code-repos-myproject"
+    turns = [
+        _turn("user", None, "no timestamps here"),
+        _turn("assistant", None, "still answering"),
+    ]
+    # mtime is in-window; real timestamps are absent.
+    _write_session(project_dir, "deadbeef-aaaa-bbbb-cccc-000000000000", turns, "2026-06-14T12:00:00Z")
+
+    cfg = {"repos_root": str(tmp_path / "empty_repos"), "chats": {}, **_june14_window()}
+    out = cc.collect(cfg)
+
+    # HARD CONSTRAINT: timestamp-less sessions are not silently dropped.
+    assert "deadbeef" in out
+
+
+# ---------------------------------------------------------------------------
+# SpecStory — windowed by filename stamp, mtime fallback when unparseable
+# ---------------------------------------------------------------------------
+
+
+def _write_specstory(repos_root, repo, filename, content="_User_\nhello\n", mtime_iso=None):
+    history = repos_root / repo / ".specstory" / "history"
+    history.mkdir(parents=True, exist_ok=True)
+    path = history / filename
+    path.write_text(content, encoding="utf-8")
+    if mtime_iso:
+        m = datetime.fromisoformat(mtime_iso.replace("Z", "+00:00")).timestamp()
+        os.utime(path, (m, m))
+    return path
+
+
+def test_collect_excludes_specstory_outside_real_time_window(claude_home, tmp_path, pin_tz):
+    """A SpecStory file whose filename stamp is old is excluded despite a recent mtime."""
+    repos_root = tmp_path / "repos"
+    _write_specstory(
+        repos_root, "myrepo", "2026-06-05_17-30-00Z-old-conversation.md",
+        mtime_iso="2026-06-14T19:58:00Z",
+    )
+    cfg = {"repos_root": str(repos_root), "chats": {}, **_june14_window()}
+    out = cc.collect(cfg)
+
+    assert "Old Conversation" not in out
+
+
+def test_collect_keeps_specstory_without_parseable_name_via_mtime(claude_home, tmp_path, pin_tz):
+    """A SpecStory file with no parseable filename stamp falls back to mtime."""
+    repos_root = tmp_path / "repos"
+    _write_specstory(
+        repos_root, "myrepo", "freeform-notes.md",
+        mtime_iso="2026-06-14T12:00:00Z",
+    )
+    cfg = {"repos_root": str(repos_root), "chats": {}, **_june14_window()}
+    out = cc.collect(cfg)
+
+    # Title slug falls back to the filename stem; mtime is in-window → included.
+    assert "freeform-notes" in out

--- a/tests/unit/test_chrome_ledger_parse_ts.py
+++ b/tests/unit/test_chrome_ledger_parse_ts.py
@@ -1,0 +1,38 @@
+"""Pin chrome_ledger._parse_ts local-time behavior after the timefmt migration.
+
+``_parse_ts`` renders ledger timestamps in the user's local zone via the shared
+helper. The conversion only fires for tz-aware inputs — a naive string is left
+naive (unconverted), the behavior callers have always relied on. America/Toronto
+(UTC-4 in June) is pinned so a regression to UTC fails loudly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+import work_buddy.config as config
+from work_buddy.collectors import chrome_ledger
+
+
+@pytest.fixture
+def pin_tz(monkeypatch):
+    monkeypatch.setattr(config, "_USER_TZ_CACHE", ZoneInfo("America/Toronto"))
+
+
+def test_parse_ts_converts_aware_to_local(pin_tz):
+    assert chrome_ledger._parse_ts("2026-06-05T17:30:00Z") == datetime(2026, 6, 5, 13, 30)
+
+
+def test_parse_ts_converts_explicit_offset(pin_tz):
+    # 17:30-00:00 → 13:30 local; result is naive local.
+    out = chrome_ledger._parse_ts("2026-06-05T17:30:00+00:00")
+    assert out == datetime(2026, 6, 5, 13, 30)
+    assert out.tzinfo is None
+
+
+def test_parse_ts_leaves_naive_unconverted(pin_tz):
+    # No offset in the string → naive → guard skips conversion (unchanged behavior).
+    assert chrome_ledger._parse_ts("2026-06-05T17:30:00") == datetime(2026, 6, 5, 17, 30)

--- a/tests/unit/test_claude_session_summary_collector.py
+++ b/tests/unit/test_claude_session_summary_collector.py
@@ -163,6 +163,31 @@ def test_collector_groups_by_project(co_env) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Timezone — session times render in the user's local zone
+# ---------------------------------------------------------------------------
+
+
+def test_format_time_range_renders_local(monkeypatch) -> None:
+    """_format_time_range converts UTC message timestamps to local wall-clock."""
+    from zoneinfo import ZoneInfo
+
+    import work_buddy.config as config
+    from work_buddy.collectors.claude_session_summary_collector import (
+        _format_time_range,
+    )
+
+    monkeypatch.setattr(config, "_USER_TZ_CACHE", ZoneInfo("America/Toronto"))
+
+    # 10:42–11:31 UTC → 06:42–07:31 local (UTC-4).
+    assert (
+        _format_time_range("2026-05-27T10:42:00Z", "2026-05-27T11:31:00Z")
+        == "2026-05-27 06:42–07:31"
+    )
+    # Both endpoints absent → the "—" sentinel.
+    assert _format_time_range(None, None) == "—"
+
+
+# ---------------------------------------------------------------------------
 # Context source registration
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_timefmt.py
+++ b/tests/unit/test_timefmt.py
@@ -1,0 +1,136 @@
+"""Unit tests for the shared local-time formatting helpers.
+
+The bundle collectors all render timestamps through ``work_buddy.timefmt`` so the
+journal agent reads one local-time timeline. These tests pin a non-UTC zone
+(America/Toronto = UTC-4 in June) so a missing UTC→local conversion fails loudly
+rather than passing by coincidence under a UTC test host.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+import work_buddy.config as config
+from work_buddy import timefmt
+
+
+@pytest.fixture
+def pin_tz(monkeypatch):
+    """Pin USER_TZ to America/Toronto by defeating the lazy cache.
+
+    Monkeypatching the cached value short-circuits ``_compute_user_tz`` (no
+    config load) and pins every call-time ``config.USER_TZ`` reader. The
+    fixture auto-restores the original cache.
+    """
+    monkeypatch.setattr(config, "_USER_TZ_CACHE", ZoneInfo("America/Toronto"))
+    return ZoneInfo("America/Toronto")
+
+
+# ---------------------------------------------------------------------------
+# parse_iso
+# ---------------------------------------------------------------------------
+
+
+def test_parse_iso_handles_z_suffix():
+    assert timefmt.parse_iso("2026-06-05T17:30:00Z") == datetime(
+        2026, 6, 5, 17, 30, tzinfo=timezone.utc
+    )
+
+
+def test_parse_iso_handles_explicit_offset():
+    dt = timefmt.parse_iso("2026-06-05T17:30:00-04:00")
+    assert dt.utcoffset().total_seconds() == -4 * 3600
+
+
+def test_parse_iso_passes_datetime_through():
+    dt = datetime(2026, 6, 5, 17, 30, tzinfo=timezone.utc)
+    assert timefmt.parse_iso(dt) is dt
+
+
+def test_parse_iso_none_and_garbage():
+    assert timefmt.parse_iso(None) is None
+    assert timefmt.parse_iso("") is None
+    assert timefmt.parse_iso("not-a-date") is None
+
+
+# ---------------------------------------------------------------------------
+# to_local_naive
+# ---------------------------------------------------------------------------
+
+
+def test_to_local_naive_converts_aware(pin_tz):
+    out = timefmt.to_local_naive(datetime(2026, 6, 5, 17, 30, tzinfo=timezone.utc))
+    assert out == datetime(2026, 6, 5, 13, 30)  # UTC-4
+    assert out.tzinfo is None
+
+
+def test_to_local_naive_assumes_utc_for_naive(pin_tz):
+    # A naive input is treated as UTC, making the helper total.
+    out = timefmt.to_local_naive(datetime(2026, 6, 5, 17, 30))
+    assert out == datetime(2026, 6, 5, 13, 30)
+
+
+def test_to_local_naive_none_passes_through():
+    assert timefmt.to_local_naive(None) is None
+
+
+# ---------------------------------------------------------------------------
+# format_local
+# ---------------------------------------------------------------------------
+
+
+def test_format_local_from_string(pin_tz):
+    assert timefmt.format_local("2026-06-05T17:30:00Z", "%H:%M") == "13:30"
+
+
+def test_format_local_from_datetime(pin_tz):
+    dt = datetime(2026, 6, 5, 17, 30, tzinfo=timezone.utc)
+    assert timefmt.format_local(dt, "%Y-%m-%d %H:%M") == "2026-06-05 13:30"
+
+
+def test_format_local_fallback_on_unparseable(pin_tz):
+    assert timefmt.format_local(None, "%H:%M", fallback="??:??") == "??:??"
+    assert timefmt.format_local("garbage", "%H:%M", fallback="??:??") == "??:??"
+
+
+# ---------------------------------------------------------------------------
+# format_session_span
+# ---------------------------------------------------------------------------
+
+
+def test_format_session_span_same_day(pin_tz):
+    out = timefmt.format_session_span("2026-06-05T17:30:00Z", "2026-06-05T18:11:00Z")
+    assert out == "2026-06-05 13:30–14:11"
+
+
+def test_format_session_span_cross_day_local_boundary(pin_tz):
+    # 23:30Z → 19:30 local, 01:11Z(next) → 21:11 local — same local day.
+    out = timefmt.format_session_span("2026-06-05T23:30:00Z", "2026-06-06T01:11:00Z")
+    assert out == "2026-06-05 19:30–21:11"
+
+
+def test_format_session_span_cross_day_after_conversion(pin_tz):
+    # 02:00Z → previous local day; spans two local dates.
+    out = timefmt.format_session_span("2026-06-06T02:00:00Z", "2026-06-06T05:00:00Z")
+    assert out == "2026-06-05 22:00–2026-06-06 01:00"
+
+
+def test_format_session_span_one_sided(pin_tz):
+    assert (
+        timefmt.format_session_span("2026-06-05T17:30:00Z", None)
+        == "2026-06-05 13:30"
+    )
+    assert (
+        timefmt.format_session_span(None, "2026-06-05T18:11:00Z")
+        == "2026-06-05 14:11"
+    )
+
+
+def test_format_session_span_neither_uses_fallback_then_empty():
+    assert timefmt.format_session_span(None, None, fallback="x") == "x"
+    assert timefmt.format_session_span(None, None, empty="—") == "—"
+    # fallback wins over empty when both supplied.
+    assert timefmt.format_session_span(None, None, fallback="x", empty="—") == "x"

--- a/work_buddy/activity.py
+++ b/work_buddy/activity.py
@@ -23,6 +23,7 @@ from work_buddy.journal import (
     journal_path_for_date,
     user_now,
 )
+from work_buddy.timefmt import to_local_naive
 
 
 # ---------------------------------------------------------------------------
@@ -316,8 +317,7 @@ def _collect_git_events(
                 # Convert to user's local timezone, then strip tzinfo for
                 # consistency with journal entries (which are naive local times)
                 if ts.tzinfo is not None:
-                    from work_buddy.config import USER_TZ
-                    ts = ts.astimezone(USER_TZ).replace(tzinfo=None)
+                    ts = to_local_naive(ts)
             except ValueError:
                 continue
 
@@ -355,8 +355,7 @@ def _collect_chat_events(
         try:
             ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
             if ts.tzinfo is not None:
-                from work_buddy.config import USER_TZ
-                ts = ts.astimezone(USER_TZ).replace(tzinfo=None)
+                ts = to_local_naive(ts)
         except ValueError:
             continue
 
@@ -437,8 +436,7 @@ def _collect_vault_events(
                 ts_utc = datetime.strptime(f["modified"], "%Y-%m-%d %H:%M").replace(
                     tzinfo=_tz.utc
                 )
-                from work_buddy.config import USER_TZ
-                ts = ts_utc.astimezone(USER_TZ).replace(tzinfo=None)
+                ts = to_local_naive(ts_utc)
             except (ValueError, KeyError):
                 continue
             files.append({"path": f["path"].replace("\\", "/"), "ts": ts})
@@ -495,8 +493,7 @@ def _get_ledger_recent(
                     f["last_modified"].replace("Z", "+00:00")
                 )
                 if ts.tzinfo is not None:
-                    from work_buddy.config import USER_TZ
-                    ts = ts.astimezone(USER_TZ).replace(tzinfo=None)
+                    ts = to_local_naive(ts)
             except (ValueError, KeyError):
                 continue
             files.append({"path": f["path"], "ts": ts})
@@ -534,8 +531,7 @@ def _collect_chrome_events(
         try:
             ts = datetime.fromisoformat(time_str.replace("Z", "+00:00"))
             if ts.tzinfo is not None:
-                from work_buddy.config import USER_TZ
-                ts = ts.astimezone(USER_TZ).replace(tzinfo=None)
+                ts = to_local_naive(ts)
         except ValueError:
             continue
 
@@ -567,8 +563,7 @@ def _collect_chrome_events(
         try:
             ts = datetime.fromisoformat(first_seen.replace("Z", "+00:00"))
             if ts.tzinfo is not None:
-                from work_buddy.config import USER_TZ
-                ts = ts.astimezone(USER_TZ).replace(tzinfo=None)
+                ts = to_local_naive(ts)
         except ValueError:
             continue
 

--- a/work_buddy/collectors/chat_collector.py
+++ b/work_buddy/collectors/chat_collector.py
@@ -6,6 +6,12 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from work_buddy.timefmt import (
+    format_session_span,
+    parse_iso,
+    to_local_naive,
+)
+
 # Cache for parsed JSONL summaries — avoids re-parsing unchanged files.
 # Bump _CACHE_VERSION when the parsed schema changes (new fields, renamed keys, etc.)
 # to auto-invalidate stale entries.
@@ -72,6 +78,22 @@ def _cache_key(path: Path) -> str:
         return ""
 
 
+def _parse_specstory_filename_ts(ts_str: str) -> datetime | None:
+    """Parse a SpecStory filename timestamp (e.g. ``2026-04-01_15-44-10Z``).
+
+    Returns a UTC-aware datetime, or ``None`` if the stamp doesn't parse. The
+    trailing ``Z`` is optional; a stamp without an offset is assumed UTC.
+    """
+    norm = ts_str.replace("Z", "+0000")
+    for fmt in ("%Y-%m-%d_%H-%M-%S%z", "%Y-%m-%d_%H-%M-%S"):
+        try:
+            dt = datetime.strptime(norm, fmt)
+            return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+    return None
+
+
 def _find_specstory_files(
     repos_root: Path, days: int, since: str | None = None, until: str | None = None,
 ) -> list[dict]:
@@ -103,12 +125,22 @@ def _find_specstory_files(
             # Format: 2026-04-01_15-44-10Z-agent-instructions-modification.md
             name = md_file.stem
             ts_match = re.match(r"(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}Z?)-(.*)", name)
+            real_dt = None
             if ts_match:
-                ts_str = ts_match.group(1)
+                real_dt = _parse_specstory_filename_ts(ts_match.group(1))
                 title_slug = ts_match.group(2).replace("-", " ").title()
             else:
-                ts_str = mtime.strftime("%Y-%m-%d %H:%M")
                 title_slug = name
+
+            # Window on the session's real time (the filename stamp) when we
+            # have it; the mtime check above is only a cheap pre-filter. Fall
+            # back to the mtime decision (already passed) when the filename has
+            # no parseable timestamp, so undated sessions aren't dropped.
+            if real_dt is not None and (real_dt < cutoff or real_dt > upper):
+                continue
+
+            # Display the session's real local time, falling back to mtime.
+            ts_str = to_local_naive(real_dt or mtime).strftime("%Y-%m-%d %H:%M")
 
             # Read first user message as preview
             preview = _extract_preview(md_file)
@@ -229,8 +261,8 @@ def _parse_claude_history(
     # Convert to list and sort by start time
     result = sorted(sessions.values(), key=lambda x: x["start"], reverse=True)
     for s in result:
-        s["start_str"] = datetime.fromtimestamp(
-            s["start"] / 1000, tz=timezone.utc
+        s["start_str"] = to_local_naive(
+            datetime.fromtimestamp(s["start"] / 1000, tz=timezone.utc)
         ).strftime("%Y-%m-%d %H:%M")
         # Extract project name from path
         if s["project"]:
@@ -462,20 +494,10 @@ def _format_duration(start: str | None, end: str | None) -> str:
         return ""
 
 
-def _parse_iso(value: str | None) -> datetime | None:
-    """Parse an ISO timestamp (tolerating a trailing ``Z``) to a datetime."""
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except (ValueError, AttributeError):
-        return None
-
-
 def _format_session_when(
     start: str | None, end: str | None, fallback: str = ""
 ) -> str:
-    """Render when a conversation actually happened, from its message timestamps.
+    """Render when a conversation actually happened, in the user's local time.
 
     Prefers the conversation's own ``start_time``/``end_time`` (the
     authoritative "when did this happen" signal, parsed from the message
@@ -485,17 +507,7 @@ def _format_session_when(
     time silently misdates resumed sessions by days. Falls back to
     *fallback* only when neither timestamp is available.
     """
-    s = _parse_iso(start)
-    e = _parse_iso(end)
-    if s and e:
-        if s.date() == e.date():
-            return f"{s.strftime('%Y-%m-%d %H:%M')}–{e.strftime('%H:%M')}"
-        return f"{s.strftime('%Y-%m-%d %H:%M')}–{e.strftime('%Y-%m-%d %H:%M')}"
-    if s:
-        return s.strftime("%Y-%m-%d %H:%M")
-    if e:
-        return e.strftime("%Y-%m-%d %H:%M")
-    return fallback
+    return format_session_span(start, end, fallback=fallback)
 
 
 def _get_claude_code_conversations(
@@ -573,6 +585,21 @@ def _get_claude_code_conversations(
             if not summary:
                 continue
 
+            # Window on the conversation's real time, not the file mtime. A
+            # resumed session has a present-day mtime but old message
+            # timestamps; the mtime check above is only a cheap pre-filter to
+            # avoid parsing every JSONL. Include the session iff its real
+            # [start, end] overlaps the requested window. Fall back to the
+            # mtime decision (already passed above) when neither timestamp
+            # parses, so timestamp-less sessions aren't silently dropped.
+            s_real = parse_iso(summary.get("start_time"))
+            e_real = parse_iso(summary.get("end_time"))
+            if s_real or e_real:
+                s_eff = s_real or e_real
+                e_eff = e_real or s_real
+                if e_eff < cutoff or s_eff > upper:
+                    continue
+
             # Derive readable project name from slug
             # Slugs look like "C--path-to-repos-work-buddy"
             # The slug is the path with separators replaced by dashes
@@ -582,7 +609,7 @@ def _get_claude_code_conversations(
             summary_copy = dict(summary)
             summary_copy["project_slug"] = project_slug
             summary_copy["project_name"] = project_name
-            summary_copy["modified"] = mtime.strftime("%Y-%m-%d %H:%M")
+            summary_copy["modified"] = to_local_naive(mtime).strftime("%Y-%m-%d %H:%M")
             results.append(summary_copy)
 
     if cache_dirty:
@@ -624,7 +651,7 @@ def collect(cfg: dict[str, Any]) -> str:
     lines = [
         "# Chat Summary",
         "",
-        f"*Collected: {now.strftime('%Y-%m-%d %H:%M UTC')}*",
+        f"*Collected: {to_local_naive(now).strftime('%Y-%m-%d %H:%M')}*",
         "",
     ]
 

--- a/work_buddy/collectors/chrome_ledger.py
+++ b/work_buddy/collectors/chrome_ledger.py
@@ -29,6 +29,7 @@ from urllib.parse import urlparse
 
 from work_buddy.config import load_config
 from work_buddy.paths import resolve
+from work_buddy.timefmt import to_local_naive
 
 logger = logging.getLogger(__name__)
 
@@ -133,8 +134,7 @@ def _parse_ts(iso_str: str) -> datetime:
     """Parse an ISO timestamp string to a naive datetime."""
     dt = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
     if dt.tzinfo is not None:
-        from work_buddy.config import USER_TZ
-        dt = dt.astimezone(USER_TZ).replace(tzinfo=None)
+        dt = to_local_naive(dt)
     return dt
 
 

--- a/work_buddy/collectors/claude_session_summary_collector.py
+++ b/work_buddy/collectors/claude_session_summary_collector.py
@@ -39,9 +39,10 @@ context bundle stays robust during cold-start.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+
+from work_buddy.timefmt import format_session_span
 
 
 def collect(cfg: dict[str, Any]) -> str:
@@ -231,25 +232,5 @@ def _empty(reason: str) -> str:
 
 
 def _format_time_range(start: str | None, end: str | None) -> str:
-    """Render a compact ``HH:MM–HH:MM`` (same-day) or date range."""
-    if not start and not end:
-        return "—"
-    s = _parse_iso(start) if start else None
-    e = _parse_iso(end) if end else None
-
-    if s and e:
-        if s.date() == e.date():
-            return f"{s.strftime('%Y-%m-%d %H:%M')}–{e.strftime('%H:%M')}"
-        return f"{s.strftime('%Y-%m-%d %H:%M')}–{e.strftime('%Y-%m-%d %H:%M')}"
-    if s:
-        return s.strftime("%Y-%m-%d %H:%M")
-    if e:
-        return e.strftime("%Y-%m-%d %H:%M")
-    return "—"
-
-
-def _parse_iso(value: str) -> datetime | None:
-    try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except (ValueError, AttributeError):
-        return None
+    """Render a compact ``HH:MM–HH:MM`` (same-day) or date range, in local time."""
+    return format_session_span(start, end, empty="—")

--- a/work_buddy/collectors/git_collector.py
+++ b/work_buddy/collectors/git_collector.py
@@ -5,6 +5,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from work_buddy.timefmt import to_local_naive
+
 
 def _run_git(repo_path: Path, *args: str, timeout: int = 15) -> str:
     """Run a git command in a repo and return stdout, or empty string on failure."""
@@ -195,7 +197,7 @@ def collect(
     lines = [
         "# Git Summary",
         "",
-        f"*Collected: {now.strftime('%Y-%m-%d %H:%M UTC')}{mode_note}",
+        f"*Collected: {to_local_naive(now).strftime('%Y-%m-%d %H:%M')}{mode_note}",
         f"*Scanned {len(repos)} repositories under `{repos_root}`*",
         "",
     ]

--- a/work_buddy/collectors/obsidian_collector.py
+++ b/work_buddy/collectors/obsidian_collector.py
@@ -5,6 +5,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from work_buddy.timefmt import format_local, to_local_naive
+
 
 # Sections we want to extract from daily journal files
 JOURNAL_SECTIONS = [
@@ -190,7 +192,7 @@ def _get_recent_files(
             rel = md_file.relative_to(vault_root)
             results.append({
                 "path": str(rel),
-                "modified": mtime.strftime("%Y-%m-%d %H:%M"),
+                "modified": to_local_naive(mtime).strftime("%Y-%m-%d %H:%M"),
             })
 
     results.sort(key=lambda x: x["modified"], reverse=True)
@@ -478,7 +480,7 @@ def collect(cfg: dict[str, Any]) -> tuple[str, str]:
     lines = [
         "# Obsidian Summary",
         "",
-        f"*Collected: {now.strftime('%Y-%m-%d %H:%M UTC')}*",
+        f"*Collected: {to_local_naive(now).strftime('%Y-%m-%d %H:%M')}*",
         f"*Vault: `{vault_root}`*",
         "",
     ]
@@ -538,7 +540,7 @@ def collect(cfg: dict[str, Any]) -> tuple[str, str]:
     task_lines = [
         "# Tasks Summary",
         "",
-        f"*Collected: {now.strftime('%Y-%m-%d %H:%M UTC')}*",
+        f"*Collected: {to_local_naive(now).strftime('%Y-%m-%d %H:%M')}*",
         f"*Source: `tasks/master-task-list.md`*",
         "",
     ]
@@ -559,11 +561,8 @@ def collect(cfg: dict[str, Any]) -> tuple[str, str]:
         task_lines.append("")
         for evt in task_events:
             ts = evt["changed_at"]
-            # Format: HH:MM — task description (old_state → new_state)
-            try:
-                t = datetime.fromisoformat(ts).strftime("%H:%M")
-            except (ValueError, TypeError):
-                t = ts[:16] if ts else "??:??"
+            # Format: HH:MM (local) — task description (old_state → new_state)
+            t = format_local(ts, "%H:%M", fallback=ts[:16] if ts else "??:??")
             desc = evt["task_id"]
             old = evt.get("old_state") or "new"
             new = evt["new_state"]

--- a/work_buddy/timefmt.py
+++ b/work_buddy/timefmt.py
@@ -1,0 +1,95 @@
+"""Shared timestamp formatting for context collectors and activity rendering.
+
+The single home for "render a UTC instant as the user's local wall-clock time".
+Context bundles are read by the journal agent on one local-time timeline, so
+every collector must agree on the timezone it prints. The convention is
+**local-naive**: convert to ``config.USER_TZ`` then drop the tzinfo, matching the
+journal's own naive-local Log entries.
+
+``config.USER_TZ`` is read **inside** each function (call time), never at import,
+so importing this module stays cheap and does not pull config off disk — the same
+discipline ``config.py``'s lazy ``USER_TZ`` getter exists to preserve.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+
+def parse_iso(value: str | datetime | None) -> datetime | None:
+    """Parse an ISO timestamp (tolerating a trailing ``Z``) to a datetime.
+
+    Passes a ``datetime`` through unchanged and maps falsy / unparseable input
+    to ``None``, so callers can feed it raw cache values without pre-checking.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def to_local_naive(dt: datetime | None) -> datetime | None:
+    """Convert a datetime to the user's local timezone, tzinfo stripped.
+
+    ``None`` passes through. A naive datetime is assumed to already be UTC
+    (every collector source is UTC-aware or UTC-derived), making this a total
+    function. The result is naive local wall-clock time — consistent with the
+    journal's Log entries and git's local commit timestamps.
+    """
+    if dt is None:
+        return None
+    from datetime import timezone
+
+    from work_buddy.config import USER_TZ
+
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(USER_TZ).replace(tzinfo=None)
+
+
+def format_local(
+    value: str | datetime | None,
+    fmt: str = "%Y-%m-%d %H:%M",
+    *,
+    fallback: str = "",
+) -> str:
+    """Render *value* (ISO string or datetime) as local-naive wall-clock time.
+
+    Returns *fallback* when *value* is absent or unparseable.
+    """
+    local = to_local_naive(parse_iso(value))
+    if local is None:
+        return fallback
+    return local.strftime(fmt)
+
+
+def format_session_span(
+    start: str | datetime | None,
+    end: str | datetime | None,
+    *,
+    fallback: str = "",
+    empty: str = "",
+) -> str:
+    """Render when a session happened, from its start/end instants, in local time.
+
+    Same-day spans collapse to ``YYYY-MM-DD HH:MM–HH:MM``; cross-day spans show
+    both dates. With only one endpoint, renders that instant. With neither,
+    returns *fallback* if given, else *empty* — the only difference between the
+    two historical renderers this replaces (chat used ``""``, the session
+    summary used ``"—"``).
+    """
+    s = to_local_naive(parse_iso(start))
+    e = to_local_naive(parse_iso(end))
+    if s and e:
+        if s.date() == e.date():
+            return f"{s.strftime('%Y-%m-%d %H:%M')}–{e.strftime('%H:%M')}"
+        return f"{s.strftime('%Y-%m-%d %H:%M')}–{e.strftime('%Y-%m-%d %H:%M')}"
+    if s:
+        return s.strftime("%Y-%m-%d %H:%M")
+    if e:
+        return e.strftime("%Y-%m-%d %H:%M")
+    return fallback or empty


### PR DESCRIPTION
## Summary
- **Windowing (Problem A):** `chat_collector` selected Claude Code / SpecStory sessions for a `[since, until]` window by **file mtime**. Resuming a session rewrites its JSONL → mtime jumps to the present while the conversation's real time stays in the past, pulling old conversations into recent windows. mtime is now a cheap **pre-filter**; a **post-filter** on the real message-derived `start`/`end` (Claude Code) or filename stamp (SpecStory) decides membership. Sessions with no parseable timestamp fall back to the mtime decision — never silently dropped.
- **Timezone (Problem B):** the two session collectors rendered UTC-aware datetimes without converting (printing UTC) while git/journal render local. **All bundle collectors** now render local wall-clock time via a shared `work_buddy/timefmt` helper, and the `Collected: … UTC` headers drop the label.
- **Single-source:** the inline `astimezone(USER_TZ).replace(tzinfo=None)` copies in `activity.py` (×6) and `chrome_ledger` are migrated onto the same helper — one local-render path, no duplicates.

Completes the follow-ups triaged out of #197 (which fixed the display half — labeling a session with its real start/end instead of mtime).

## Real-data impact
On a "today" window over real `~/.claude` sessions, mtime-windowing selected 40 sessions; **24 of them were resumed-today files whose actual conversation was weeks old** — all now correctly excluded.

## Test plan
- [x] `test_timefmt.py` (new) — helper behavior under pinned `America/Toronto`
- [x] `test_chat_collector_session_time.py` — windowing assertion **inverted**; timestamp-less + SpecStory fallback/exclusion cases added
- [x] local-render cases for `claude_session_summary` and `chrome_ledger`
- [x] broad collector/activity/journal/context slice: **910 passed, 0 failed**

Task: t-6bd2d22d