### PR TITLE
docs: redact personal vault name from public repo

### DIFF
--- a/tests/unit/test_dashboard_costs.py
+++ b/tests/unit/test_dashboard_costs.py
@@ -508,7 +508,7 @@ def test_aggregator_project_filter_matches_path_or_basename(tmp_path):
     root = tmp_path / "agents"
     _write_session(
         root, "2026-04-25T10-00-00_a",
-        manifest={"short_id": "a", "project": "C:\\Vaults\\SecondBrain\\repos\\work-buddy"},
+        manifest={"short_id": "a", "project": "C:\\Code\\MyVault\\repos\\work-buddy"},
         entries=[{"timestamp": "2026-04-25T10:00:00",
                    "model": "claude-sonnet-4-6", "task_id": "t",
                    "input_tokens": 100, "output_tokens": 50,
@@ -519,7 +519,7 @@ def test_aggregator_project_filter_matches_path_or_basename(tmp_path):
     s1 = costs_mod.get_costs_summary(agents_dir=root, project="work-buddy")
     assert s1["session_count"] == 1
     # Match by middle path component
-    s2 = costs_mod.get_costs_summary(agents_dir=root, project="SecondBrain")
+    s2 = costs_mod.get_costs_summary(agents_dir=root, project="MyVault")
     assert s2["session_count"] == 1
     # Case-insensitive
     s3 = costs_mod.get_costs_summary(agents_dir=root, project="WORK-BUDDY")

--- a/work_buddy/collectors/claude_session_summary_collector.py
+++ b/work_buddy/collectors/claude_session_summary_collector.py
@@ -15,7 +15,7 @@ Output format (markdown, prompt-ready). Session-level only by default::
       Commits: deadbee Add NeverExpires trigger; cafebab Refactor foo
       Uncommitted: tests/unit/test_x.py (M)
 
-    ### secondbrain
+    ### myvault
     - 14:05–14:22 [88a01ab2] 6 turns, no commits, no dirty files
 
 With ``include_topics=True`` (v2 P6 / PRD F15 / OQ5 resolution), each

--- a/work_buddy/health/requirements.py
+++ b/work_buddy/health/requirements.py
@@ -62,7 +62,7 @@ class RequirementDef:
             dashboard form can pre-fill the field's current value.
         fix_preview: One-line description of what the fix will do, shown in the
             confirm popover before the user commits. E.g. "Will create
-            C:\\Vaults\\SecondBrain\\journal\\". Null = no preview shown.
+            <vault-root>\\journal\\". Null = no preview shown.
         fix_agent_brief: For agent_handoff, the prompt the spawned Claude Code
             session receives. Should explain what the user is trying to fix and
             what the agent is empowered to do. Null = use a generic brief built


### PR DESCRIPTION
## Summary
- Replace the user's personal Obsidian vault directory name (`SecondBrain`) / path with neutral placeholders in three illustrative-only spots so it doesn't leak into the public repo.
- `claude_session_summary_collector` docstring: example bundle header `### secondbrain` → `### myvault`.
- `health/requirements` docstring: `fix_preview` example `C:\Vaults\SecondBrain\journal\` → `<vault-root>\journal\`.
- `test_dashboard_costs` fixture + assertion: `C:\Vaults\SecondBrain\repos\work-buddy` / `"SecondBrain"` → `C:\Code\MyVault\repos\work-buddy` / `"MyVault"`.

All three are illustrative examples/fixtures, not real path resolution. The PII-detection regex in `dev/commit.py` (`\bSecondBrain\b` → `personal-vault-name`) is intentionally left untouched — it's the redaction tooling itself.

## Test plan
- [x] `test_aggregator_project_filter_matches_path_or_basename` passes (behavior-preserving rename verified).
- [x] No executable/behavior change in the two docstring edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)