### PR TITLE
fix(messaging): stop consent-callback messages from blocking the Stop hook

### DIFF
--- a/knowledge/store/messaging/block-semantics.md
+++ b/knowledge/store/messaging/block-semantics.md
@@ -41,6 +41,20 @@ A read, normal/low-priority message does **not** block — it surfaced once and 
 done. A message in any non-`pending` status never blocks: it is excluded at the
 query level and pruned on the normal TTL.
 
+## Automated callbacks never block
+
+Some pending messages are automated acknowledgements of an action the recipient
+itself initiated — e.g. a consent grant a UI surface echoes back into the inbox
+for the sidecar to record. They are plumbing, not action items for the agent, so
+the Stop hook excludes them outright: any message carrying a tag in
+`NON_BLOCKING_TAGS` (`work_buddy/messaging/models.py`; currently
+`{"consent-callback"}`) is skipped on the Stop path even at high priority and even
+before it has been read, so it costs no read or resolve. Such messages still
+appear in the non-blocking SessionStart / UserPromptSubmit summaries as context,
+and the sidecar resolves them out of the pending set on its own. This differs from
+the born-resolved notifications below: a callback stays `pending` (the sidecar
+still needs to process it) but is filtered from the block by tag, not by status.
+
 ## Notifications are born resolved
 
 Fire-and-forget notifications are created with a terminal status so they never

--- a/tests/component/test_messaging_models.py
+++ b/tests/component/test_messaging_models.py
@@ -271,3 +271,45 @@ class TestSummarizePending:
         create_message(conn, sender="a", recipient="b", type="task", subject="Hi")
         result = summarize_pending(conn, "b", session="s1", include_instructions=True)
         assert "/tmp/wb/resolve" in result
+
+    @freeze_time("2026-04-12T12:00:00+00:00")
+    def test_nonblocking_callback_never_blocks_stop_hook(self, tmp_messaging_db):
+        """A consent-callback message must never block the Stop hook — not even once."""
+        conn, _ = tmp_messaging_db
+        create_message(
+            conn, sender="obsidian-consent-modal", recipient="b",
+            type="result", subject="consent_grant", priority="high",
+            tags=["consent-callback", "from-obsidian"],
+        )
+        # Excluded on the very first render (no unread tax) and on every render after.
+        first = summarize_pending(conn, "b", session="s1", include_instructions=False, unread_only=True)
+        assert first == ""
+        second = summarize_pending(conn, "b", session="s1", include_instructions=False, unread_only=True)
+        assert second == ""
+
+    @freeze_time("2026-04-12T12:00:00+00:00")
+    def test_untagged_high_priority_still_blocks(self, tmp_messaging_db):
+        """The discriminator is the tag, not the priority/subject: untagged high still blocks."""
+        conn, _ = tmp_messaging_db
+        create_message(
+            conn, sender="obsidian-consent-modal", recipient="b",
+            type="result", subject="consent_grant", priority="high",
+        )
+        first = summarize_pending(conn, "b", session="s1", include_instructions=False, unread_only=True)
+        assert "consent_grant" in first  # surfaces, auto-marks read
+        # High priority keeps blocking after read (would only release via resolve).
+        second = summarize_pending(conn, "b", session="s1", include_instructions=False, unread_only=True)
+        assert "consent_grant" in second
+
+    @freeze_time("2026-04-12T12:00:00+00:00")
+    def test_nonblocking_callback_visible_in_context_summary(self, tmp_messaging_db):
+        """Excluded only from the Stop-hook path: non-blocking summaries still show it."""
+        conn, _ = tmp_messaging_db
+        create_message(
+            conn, sender="obsidian-consent-modal", recipient="b",
+            type="result", subject="consent_grant", priority="high",
+            tags=["consent-callback", "from-obsidian"],
+        )
+        # unread_only=False (SessionStart / UserPromptSubmit) keeps it as context.
+        summary = summarize_pending(conn, "b", session="s1", include_instructions=False, unread_only=False)
+        assert "consent_grant" in summary

--- a/work_buddy/messaging/models.py
+++ b/work_buddy/messaging/models.py
@@ -314,6 +314,29 @@ def create_reply(
 # priority (pure block-on-unread semantics).
 BLOCK_UNTIL_RESOLVED_PRIORITIES = {"high", "urgent"}
 
+# Tags marking messages that are automated callbacks/acknowledgements of an
+# action the recipient itself initiated (e.g. a consent grant echoed back from
+# a UI surface for the sidecar to record). They carry no action item for the
+# agent, so they must never block the Stop hook — even at high priority.
+NON_BLOCKING_TAGS = frozenset({"consent-callback"})
+
+
+def _is_nonblocking_ack(m: dict) -> bool:
+    """True if the message is an automated callback that must not block the Stop hook.
+
+    Tags are stored as a JSON string (or NULL) in the ``tags`` column, so they
+    are parsed here rather than read as a list.
+    """
+    raw = m.get("tags")
+    if not raw:
+        return False
+    try:
+        tags = json.loads(raw)
+    except (ValueError, TypeError):
+        return False
+    return bool(NON_BLOCKING_TAGS.intersection(tags))
+
+
 def summarize_pending(
     conn: sqlite3.Connection,
     recipient: str,
@@ -338,6 +361,11 @@ def summarize_pending(
     next render returns empty and the block releases. The non-blocking summaries
     (SessionStart / UserPromptSubmit) leave it False and still show read-but-recent
     messages as context.
+
+    When ``unread_only`` is True, messages tagged with a ``NON_BLOCKING_TAGS``
+    tag (automated callbacks such as consent grants, which are plumbing for the
+    sidecar rather than action items for the agent) are excluded entirely so they
+    never block the Stop hook. They still appear in the non-blocking summaries.
     """
     if ttl_days is None:
         from work_buddy.config import load_config
@@ -356,6 +384,12 @@ def summarize_pending(
     filtered = []
     new_count = 0
     for m in msgs:
+        # Automated callbacks (e.g. consent grants) are plumbing for the sidecar,
+        # not action items for the agent — never let them block the Stop hook.
+        # Scoped to unread_only so the non-blocking context summaries still show
+        # them; the sidecar resolves them out of the pending set on its own.
+        if unread_only and _is_nonblocking_ack(m):
+            continue
         recipient_readers = _get_recipient_readers(conn, m["id"], recipient)
         is_read = len(recipient_readers) > 0
         m["_read"] = is_read


### PR DESCRIPTION
## Summary
- Consent grants echoed back from a UI surface land in the shared inbox as pending, high-priority `result` messages for the sidecar's consent router. They're plumbing the agent itself triggered, but the Stop hook taxed them twice — once while unread, then again because high-priority messages block until resolved — forcing a manual read + resolve of a pure confirmation (and racing the sidecar's ~15s auto-resolve poll).
- `summarize_pending()` now excludes messages tagged with a `NON_BLOCKING_TAGS` tag (currently `consent-callback`) from the Stop-hook path. Scoped to `unread_only`, so non-blocking SessionStart/UserPromptSubmit summaries still show them as context.
- Keys off the tag the Obsidian plugin already emits → no plugin rebuild needed. Filtering on `type`/`subject` would be broader and brittler.
- Doc: `messaging/block-semantics` gains an "Automated callbacks never block" section.

This is the inbound-message gap left open by #174 (which only made outbound `retry_success` notifications born-resolved).

## Test plan
- [x] `pytest tests/component/test_messaging_models.py` — 29 passed (incl. 3 new: never-blocks, untagged-still-blocks guard, still-visible-in-context-summaries)
- [x] `tests/test_modal_consent_propagation.py` green
- [ ] Live test: restart MCP (`Ctrl+R`) + sidecar, trigger a consent-gated capability against throwaway data, approve in the modal, confirm the Stop hook no longer blocks on the `consent_grant`