### PR TITLE
feat(messaging): first-class message disposition for Stop-hook block-worthiness

### DIFF
--- a/knowledge/store/messaging/block-semantics.md
+++ b/knowledge/store/messaging/block-semantics.md
@@ -2,7 +2,7 @@
 name: Messaging Block Semantics
 kind: concept
 description: When the messaging Stop hook blocks an agent from ending its turn, and how to clear it
-summary: Only the Stop hook blocks, and only on messages that still need attention — unread ones (surface once, then release) or high/urgent ones not yet resolved. Notifications born with a terminal status never block. Clear a handled message with /tmp/wb/resolve or update_message_status.
+summary: The Stop hook blocks only on `actionable` messages (unread → once; high/urgent → until resolved); `acknowledgement` messages (consent echoes, fire-and-forget FYIs) never block. A sender-declared `disposition` gates block-worthiness; priority sets intensity. Clear a handled message with /tmp/wb/resolve or update_message_status.
 tags:
 - messaging
 - stop-hook
@@ -26,27 +26,54 @@ The messaging hooks check for pending messages addressed to a session. Only the
 agent from ending its turn; SessionStart and UserPromptSubmit only inject context,
 and PostToolUse surfaces messages mid-turn without blocking.
 
-## What blocks the Stop
+## Disposition decides whether a message can block
 
-A pending message contributes to the Stop block only if it still needs attention:
+Every message carries a sender-declared **`disposition`** (a column on the messages
+table) — the first gate on block-worthiness:
+
+- **`actionable`** — an action item the agent must see/handle. May block the Stop
+  hook (subject to the read/priority rules below). This is the default.
+- **`acknowledgement`** — an auto-ack of something already handled in-band (a
+  consent decision echoed back for the sidecar to record, a fire-and-forget FYI).
+  **Never** blocks: it is excluded from the Stop summary outright, even unread and
+  high-priority. It still appears in the non-blocking SessionStart / UserPromptSubmit
+  context summaries.
+
+Senders declare disposition when they emit — the notification system marks a consent
+echo `acknowledgement` but a genuine request/question answer `actionable`; the retry
+sweep marks `retry_success` `acknowledgement` and `retry_exhausted` `actionable`.
+When a caller omits it — including the Obsidian plugin's out-of-band `consent_grant`
+POST, which cannot set it — `create_message` infers it via `_classify_disposition`
+(consent subjects/tags, a `notification_response` whose body title starts "Consent:",
+and terminal statuses → `acknowledgement`; everything else → `actionable`). Legacy
+rows are backfilled by the same rule on migration, and a missing/NULL disposition is
+treated as `actionable` so nothing silently stops blocking.
+
+(Distinct from `agent_ingest.resolve_event`'s `disposition` argument — "ack"/"process"
+— which records what the agent *did* with an ingest event; this field is the sender's
+*intent*.)
+
+## How an actionable message blocks (the read/priority axis)
+
+Among `actionable` messages, blocking is governed by read state and priority:
 
 - **Unread** by the recipient session → blocks once. The summary auto-marks it read
   as it renders, so the next Stop releases it ("surface once, then release").
 - **High/urgent priority** and still `pending` → keeps blocking even after it has
   been read, until it is resolved. Governed by `BLOCK_UNTIL_RESOLVED_PRIORITIES` in
   `work_buddy/messaging/models.py` (`{"high", "urgent"}`; set it empty to make every
-  priority surface-once).
+  actionable priority surface-once).
 
-A read, normal/low-priority message does **not** block — it surfaced once and is
-done. A message in any non-`pending` status never blocks: it is excluded at the
-query level and pruned on the normal TTL.
+A read, normal/low-priority actionable message does **not** block — it surfaced once
+and is done. Disposition and priority are orthogonal: disposition decides *whether* a
+message can block at all; priority decides *how hard* an actionable one blocks.
 
-## Notifications are born resolved
+## Born-resolved is still a non-block path
 
-Fire-and-forget notifications are created with a terminal status so they never
-block. The sidecar retry sweep emits `retry_success` as `status="resolved"` (it is
-purely informational); `retry_exhausted` stays `pending` at high priority so a
-failed background op surfaces once and is acknowledged.
+A message in any non-`pending` status never blocks: it is excluded at the query level
+and pruned on the normal TTL. Fire-and-forget notifications use this — the retry sweep
+emits `retry_success` as `status="resolved"` (also `acknowledgement`), so it never
+enters the pending/block path at all.
 
 ## Clearing a message that is blocking
 

--- a/tests/component/test_messaging_models.py
+++ b/tests/component/test_messaging_models.py
@@ -4,6 +4,8 @@ import pytest
 from datetime import datetime, timezone, timedelta
 from freezegun import freeze_time
 
+import sqlite3
+
 from work_buddy.messaging.models import (
     create_message,
     get_message,
@@ -15,6 +17,10 @@ from work_buddy.messaging.models import (
     create_reply,
     summarize_pending,
     _format_age,
+    _classify_disposition,
+    _migrate,
+    DISPOSITION_ACTIONABLE,
+    DISPOSITION_ACKNOWLEDGEMENT,
 )
 
 
@@ -271,3 +277,155 @@ class TestSummarizePending:
         create_message(conn, sender="a", recipient="b", type="task", subject="Hi")
         result = summarize_pending(conn, "b", session="s1", include_instructions=True)
         assert "/tmp/wb/resolve" in result
+
+    @freeze_time("2026-04-12T12:00:00+00:00")
+    def test_acknowledgement_never_blocks_stop_hook(self, tmp_messaging_db):
+        """An acknowledgement message is excluded from the Stop path even unread+high."""
+        conn, _ = tmp_messaging_db
+        create_message(
+            conn, sender="notification-system", recipient="b",
+            type="result", subject="Plumbing", priority="high",
+            disposition=DISPOSITION_ACKNOWLEDGEMENT,
+        )
+        first = summarize_pending(conn, "b", session="s1", include_instructions=False, unread_only=True)
+        assert first == ""  # no unread tax
+        second = summarize_pending(conn, "b", session="s1", include_instructions=False, unread_only=True)
+        assert second == ""
+
+    @freeze_time("2026-04-12T12:00:00+00:00")
+    def test_acknowledgement_visible_in_context_summary(self, tmp_messaging_db):
+        """Excluded only from the Stop path: non-blocking summaries still show it."""
+        conn, _ = tmp_messaging_db
+        create_message(
+            conn, sender="notification-system", recipient="b",
+            type="result", subject="PlumbingCtx", priority="high",
+            disposition=DISPOSITION_ACKNOWLEDGEMENT,
+        )
+        summary = summarize_pending(conn, "b", session="s1", include_instructions=False, unread_only=False)
+        assert "PlumbingCtx" in summary
+
+    @freeze_time("2026-04-12T12:00:00+00:00")
+    def test_actionable_high_blocks_until_resolved(self, tmp_messaging_db):
+        """An actionable high-priority message still blocks until resolved."""
+        conn, _ = tmp_messaging_db
+        msg = create_message(
+            conn, sender="a", recipient="b", type="task", subject="DoThis",
+            priority="high", disposition=DISPOSITION_ACTIONABLE,
+        )
+        first = summarize_pending(conn, "b", session="s1", include_instructions=False, unread_only=True)
+        assert "DoThis" in first
+        second = summarize_pending(conn, "b", session="s1", include_instructions=False, unread_only=True)
+        assert "DoThis" in second  # high + read still blocks
+        update_status(conn, msg["id"], "resolved")
+        third = summarize_pending(conn, "b", session="s1", include_instructions=False, unread_only=True)
+        assert third == ""
+
+    @freeze_time("2026-04-12T12:00:00+00:00")
+    def test_null_disposition_treated_actionable(self, tmp_messaging_db):
+        """A legacy row with NULL disposition must still block (no silent regression)."""
+        conn, _ = tmp_messaging_db
+        # Insert a row directly with NULL disposition, bypassing create_message.
+        conn.execute(
+            """INSERT INTO messages
+               (id, thread_id, sender, recipient, type, priority, status,
+                subject, created_at, updated_at, disposition)
+               VALUES ('legacy-1', 'thr-legacy-1', 'a', 'b', 'task', 'high',
+                       'pending', 'LegacyHigh', '2026-04-12T11:59:00+00:00',
+                       '2026-04-12T11:59:00+00:00', NULL)""",
+        )
+        conn.commit()
+        result = summarize_pending(conn, "b", session="s1", include_instructions=False, unread_only=True)
+        assert "LegacyHigh" in result
+
+
+class TestMessageDisposition:
+    def test_classify_consent_grant_subject(self):
+        assert _classify_disposition("result", "consent_grant", []) == DISPOSITION_ACKNOWLEDGEMENT
+
+    def test_classify_consent_callback_tag(self):
+        assert _classify_disposition(
+            "result", "anything", ["consent-callback", "from-obsidian"]
+        ) == DISPOSITION_ACKNOWLEDGEMENT
+
+    def test_classify_consent_notification_response_body(self):
+        body = '{"source": "notification_response", "title": "Consent: bundle:task_create"}'
+        assert _classify_disposition(
+            "result", "notification_response", ["notification-callback", "agent-ingest"], body=body
+        ) == DISPOSITION_ACKNOWLEDGEMENT
+
+    def test_classify_terminal_status_is_ack(self):
+        assert _classify_disposition("retry_success", "Retry succeeded", ["retry"], status="resolved") == DISPOSITION_ACKNOWLEDGEMENT
+
+    def test_classify_plain_request_is_actionable(self):
+        body = '{"source": "notification_response", "title": "Pick a venue?"}'
+        assert _classify_disposition(
+            "result", "notification_response", ["notification-callback", "agent-ingest"], body=body
+        ) == DISPOSITION_ACTIONABLE
+
+    def test_classify_default_actionable(self):
+        assert _classify_disposition("task", "Do the thing", []) == DISPOSITION_ACTIONABLE
+
+    def test_create_message_infers_when_unset(self, tmp_messaging_db):
+        conn, _ = tmp_messaging_db
+        ack = create_message(conn, sender="obsidian-consent-modal", recipient="b",
+                             type="result", subject="consent_grant")
+        act = create_message(conn, sender="a", recipient="b", type="task", subject="Real work")
+        assert ack["disposition"] == DISPOSITION_ACKNOWLEDGEMENT
+        assert act["disposition"] == DISPOSITION_ACTIONABLE
+
+    def test_create_message_explicit_wins(self, tmp_messaging_db):
+        conn, _ = tmp_messaging_db
+        # Subject would infer actionable, but explicit acknowledgement overrides.
+        msg = create_message(conn, sender="a", recipient="b", type="task",
+                            subject="Real work", disposition=DISPOSITION_ACKNOWLEDGEMENT)
+        assert msg["disposition"] == DISPOSITION_ACKNOWLEDGEMENT
+
+    def test_reply_defaults_to_acknowledgement(self, tmp_messaging_db):
+        conn, _ = tmp_messaging_db
+        parent = create_message(conn, sender="a", recipient="b", type="task", subject="Q")
+        reply = create_reply(conn, parent["id"], sender="b", body="ok")
+        assert reply["disposition"] == DISPOSITION_ACKNOWLEDGEMENT
+
+
+class TestDispositionMigration:
+    def test_migrate_adds_and_backfills_disposition(self, tmp_path):
+        """An old-schema DB gains the column and backfills consent rows as ack."""
+        db = tmp_path / "old.db"
+        conn = sqlite3.connect(str(db))
+        conn.row_factory = sqlite3.Row
+        # Old schema: messages table WITHOUT disposition.
+        conn.executescript(
+            """CREATE TABLE messages (
+                   id TEXT PRIMARY KEY, thread_id TEXT, sender TEXT NOT NULL,
+                   sender_session TEXT, recipient TEXT NOT NULL, recipient_session TEXT,
+                   type TEXT NOT NULL, priority TEXT NOT NULL DEFAULT 'normal',
+                   status TEXT NOT NULL DEFAULT 'pending', subject TEXT NOT NULL,
+                   body TEXT, in_reply_to TEXT, created_at TEXT NOT NULL,
+                   updated_at TEXT, tags TEXT);
+               CREATE TABLE message_reads (
+                   message_id TEXT NOT NULL, session_id TEXT NOT NULL,
+                   read_at TEXT NOT NULL, PRIMARY KEY (message_id, session_id));"""
+        )
+        conn.execute(
+            "INSERT INTO messages (id, sender, recipient, type, status, subject, created_at) "
+            "VALUES ('c1', 'obsidian-consent-modal', 'work-buddy', 'result', 'pending', 'consent_grant', '2026-04-12T11:00:00+00:00')"
+        )
+        conn.execute(
+            "INSERT INTO messages (id, sender, recipient, type, status, subject, created_at) "
+            "VALUES ('r1', 'a', 'work-buddy', 'task', 'pending', 'Real work', '2026-04-12T11:00:00+00:00')"
+        )
+        conn.commit()
+
+        _migrate(conn)  # adds column + backfills
+
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)").fetchall()}
+        assert "disposition" in cols
+        c1 = conn.execute("SELECT disposition FROM messages WHERE id='c1'").fetchone()[0]
+        r1 = conn.execute("SELECT disposition FROM messages WHERE id='r1'").fetchone()[0]
+        assert c1 == DISPOSITION_ACKNOWLEDGEMENT
+        assert r1 == DISPOSITION_ACTIONABLE
+
+        # Re-running is a no-op (column already present).
+        _migrate(conn)
+        assert conn.execute("SELECT disposition FROM messages WHERE id='c1'").fetchone()[0] == DISPOSITION_ACKNOWLEDGEMENT
+        conn.close()

--- a/work_buddy/messaging/client.py
+++ b/work_buddy/messaging/client.py
@@ -112,12 +112,16 @@ def send_message(
     priority: str = "normal",
     status: str = "pending",
     tags: list[str] | None = None,
+    disposition: str | None = None,
 ) -> dict | None:
     """Send a message via the HTTP service.
 
     ``status`` defaults to ``'pending'``; pass a terminal status (e.g.
     ``'resolved'``) for fire-and-forget notifications that should not block a
     recipient's Stop hook.
+
+    ``disposition`` declares Stop-hook intent — ``"actionable"`` (may block) or
+    ``"acknowledgement"`` (never blocks). Omit to let the service infer it.
     """
     payload: dict[str, Any] = {
         "sender": sender,
@@ -139,6 +143,8 @@ def send_message(
         payload["status"] = status
     if tags:
         payload["tags"] = tags
+    if disposition is not None:
+        payload["disposition"] = disposition
 
     return _request("POST", "/messages", payload)
 

--- a/work_buddy/messaging/models.py
+++ b/work_buddy/messaging/models.py
@@ -9,6 +9,52 @@ from typing import Any
 
 from work_buddy.config import load_config
 
+# Message disposition — the sender-declared intent that drives Stop-hook
+# block-worthiness. It is orthogonal to ``priority`` (which sets blocking
+# *intensity* among actionable messages — see ``BLOCK_UNTIL_RESOLVED_PRIORITIES``).
+#   "actionable":      the agent must see/handle it; may block the Stop hook. Default.
+#   "acknowledgement": an auto-ack of something already handled in-band; never blocks.
+# Distinct from ``agent_ingest.resolve_event``'s "ack"/"process" disposition, which
+# records what the agent *did* with an event; this field is the sender's *intent*.
+DISPOSITION_ACTIONABLE = "actionable"
+DISPOSITION_ACKNOWLEDGEMENT = "acknowledgement"
+
+
+def _classify_disposition(
+    type: str,
+    subject: str,
+    tags: list[str] | None,
+    status: str = "pending",
+    body: str | None = None,
+) -> str:
+    """Infer a message's disposition from known plumbing signals.
+
+    The fallback when a caller does not declare a disposition (e.g. the Obsidian
+    plugin's out-of-band ``consent_grant`` POST), and the rule used to backfill
+    legacy rows. Conservative: anything not recognised as plumbing is
+    ``actionable`` so the Stop hook never silently stops blocking what it used to.
+    """
+    tags = tags or []
+    # A non-pending message is already handled — never an action item.
+    if status and status != "pending":
+        return DISPOSITION_ACKNOWLEDGEMENT
+    # Consent decisions echoed back for the sidecar to record are plumbing the
+    # gateway already handled in-band: the Obsidian-modal fallback posts subject
+    # ``consent_grant``/tag ``consent-callback``; the notification-system path
+    # posts a ``notification_response`` whose body title is "Consent: <op>".
+    if subject == "consent_grant" or "consent-callback" in tags:
+        return DISPOSITION_ACKNOWLEDGEMENT
+    if body:
+        try:
+            payload = json.loads(body)
+            title = payload.get("title", "") if isinstance(payload, dict) else ""
+            if isinstance(title, str) and title.startswith("Consent:"):
+                return DISPOSITION_ACKNOWLEDGEMENT
+        except (ValueError, TypeError):
+            pass
+    return DISPOSITION_ACTIONABLE
+
+
 _SCHEMA = """\
 CREATE TABLE IF NOT EXISTS messages (
     id                TEXT PRIMARY KEY,
@@ -25,7 +71,8 @@ CREATE TABLE IF NOT EXISTS messages (
     in_reply_to       TEXT,
     created_at        TEXT NOT NULL,
     updated_at        TEXT,
-    tags              TEXT
+    tags              TEXT,
+    disposition       TEXT
 );
 
 CREATE TABLE IF NOT EXISTS message_reads (
@@ -80,6 +127,24 @@ def _migrate(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE message_reads ADD COLUMN reader_project TEXT")
         conn.commit()
 
+    # v2: add disposition to messages and backfill existing rows from the
+    # classifier, so legacy plumbing (consent callbacks already in the inbox)
+    # stops blocking the Stop hook too. Guarded by the column check → idempotent.
+    mcols = {r[1] for r in conn.execute("PRAGMA table_info(messages)").fetchall()}
+    if "disposition" not in mcols:
+        conn.execute("ALTER TABLE messages ADD COLUMN disposition TEXT")
+        for r in conn.execute(
+            "SELECT id, type, subject, tags, status, body FROM messages"
+        ).fetchall():
+            row_tags = json.loads(r["tags"]) if r["tags"] else []
+            disp = _classify_disposition(
+                r["type"], r["subject"], row_tags, status=r["status"], body=r["body"]
+            )
+            conn.execute(
+                "UPDATE messages SET disposition = ? WHERE id = ?", (disp, r["id"])
+            )
+        conn.commit()
+
 
 def _generate_id(sender: str) -> str:
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
@@ -110,6 +175,7 @@ def create_message(
     status: str = "pending",
     in_reply_to: str | None = None,
     tags: list[str] | None = None,
+    disposition: str | None = None,
 ) -> dict[str, Any]:
     """Insert a new message and return it as a dict.
 
@@ -117,6 +183,12 @@ def create_message(
     notifications (e.g. the retry sweep's success FYIs) pass a terminal status
     such as ``'resolved'`` so the message never enters the pending/block path and
     is pruned on the normal TTL.
+
+    ``disposition`` declares whether this message is an action item for the agent
+    (``"actionable"`` — may block the Stop hook) or an auto-acknowledgement of
+    something already handled in-band (``"acknowledgement"`` — never blocks).
+    Senders that know their intent should pass it; when omitted it is inferred by
+    ``_classify_disposition`` (conservative default ``"actionable"``).
     """
     msg_id = _generate_id(sender)
     now = _now_iso()
@@ -124,19 +196,23 @@ def create_message(
     if thread_id is None:
         thread_id = f"thr-{msg_id}"
 
+    if disposition is None:
+        disposition = _classify_disposition(type, subject, tags, status=status, body=body)
+
     conn.execute(
         """\
         INSERT INTO messages
             (id, thread_id, sender, sender_session, recipient,
              recipient_session, type, priority, status, subject,
-             body, in_reply_to, created_at, updated_at, tags)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             body, in_reply_to, created_at, updated_at, tags, disposition)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             msg_id, thread_id, sender, sender_session, recipient,
             recipient_session, type, priority, status, subject,
             body, in_reply_to, now, now,
             json.dumps(tags) if tags else None,
+            disposition,
         ),
     )
     conn.commit()
@@ -277,11 +353,15 @@ def create_reply(
     type: str = "ack",
     priority: str = "normal",
     tags: list[str] | None = None,
+    disposition: str = DISPOSITION_ACKNOWLEDGEMENT,
 ) -> dict[str, Any] | None:
     """Reply to an existing message, inheriting thread_id and swapping sender/recipient.
 
     recipient_session defaults to None (broadcast to any session in the project).
     Pass the parent's sender_session explicitly if you want to target that specific session.
+
+    Replies default to ``acknowledgement`` disposition (a confirmation, not an
+    action item); pass ``disposition="actionable"`` for a reply the recipient must act on.
     """
     parent = get_message(conn, parent_id)
     if parent is None:
@@ -300,6 +380,7 @@ def create_reply(
         priority=priority,
         in_reply_to=parent_id,
         tags=tags,
+        disposition=disposition,
     )
 
 
@@ -338,6 +419,11 @@ def summarize_pending(
     next render returns empty and the block releases. The non-blocking summaries
     (SessionStart / UserPromptSubmit) leave it False and still show read-but-recent
     messages as context.
+
+    Block-worthiness is gated first by ``disposition``: on the Stop path
+    (``unread_only=True``) ``acknowledgement`` messages are excluded outright —
+    they are auto-acks of work already handled in-band and must never block. Only
+    ``actionable`` messages reach the unread/priority logic below.
     """
     if ttl_days is None:
         from work_buddy.config import load_config
@@ -356,17 +442,26 @@ def summarize_pending(
     filtered = []
     new_count = 0
     for m in msgs:
+        # Disposition gates block-worthiness first: acknowledgement messages are
+        # auto-acks of work already handled in-band (consent grants, FYIs) and
+        # must never block the Stop hook. They still appear in the non-blocking
+        # context summaries (unread_only=False) for visibility.
+        disposition = m.get("disposition") or DISPOSITION_ACTIONABLE
+        if unread_only and disposition == DISPOSITION_ACKNOWLEDGEMENT:
+            continue
+
         recipient_readers = _get_recipient_readers(conn, m["id"], recipient)
         is_read = len(recipient_readers) > 0
         m["_read"] = is_read
         m["_readers"] = recipient_readers
 
-        # Unread messages always surface. For the non-blocking summaries
-        # (unread_only=False) also keep read messages within the TTL window so
-        # SessionStart/UserPromptSubmit retain recent context. The Stop hook
-        # passes unread_only=True: a read message is dropped (it surfaced once,
-        # now releases) UNLESS it is high/urgent priority, which keeps blocking
-        # until resolved — /tmp/wb/resolve is the discoverable exit.
+        # Among actionable messages: unread ones always surface. For the
+        # non-blocking summaries (unread_only=False) also keep read messages
+        # within the TTL window so SessionStart/UserPromptSubmit retain recent
+        # context. The Stop hook passes unread_only=True: a read message is
+        # dropped (it surfaced once, now releases) UNLESS it is high/urgent
+        # priority, which keeps blocking until resolved — /tmp/wb/resolve is the
+        # discoverable exit.
         if not is_read:
             new_count += 1
             filtered.append(m)

--- a/work_buddy/messaging/service.py
+++ b/work_buddy/messaging/service.py
@@ -156,6 +156,7 @@ def send_message():
         status=data.get("status", "pending"),
         in_reply_to=data.get("in_reply_to"),
         tags=tags,
+        disposition=data.get("disposition"),
     )
     return jsonify(msg), 201
 

--- a/work_buddy/notifications/store.py
+++ b/work_buddy/notifications/store.py
@@ -252,6 +252,16 @@ def dispatch_callback(notification: Notification) -> dict | None:
     results = []
     session_id = notification.callback_session_id
 
+    # A consent decision echoed back is plumbing the gateway already handled
+    # in-band → acknowledgement (never blocks the recipient's Stop hook). A
+    # genuine request/question answer is actionable — the agent must ingest the
+    # user's response.
+    is_consent = (
+        notification.title.startswith("Consent:")
+        or "consent" in (notification.tags or [])
+    )
+    disposition = "acknowledgement" if is_consent else "actionable"
+
     # Always dispatch via messaging if there's a callback or session target.
     # This is the AgentIngest delivery path — hooks will pick it up.
     if notification.callback:
@@ -260,6 +270,7 @@ def dispatch_callback(notification: Notification) -> dict | None:
             notification.title,
             notification.notification_id,
             recipient_session=session_id,
+            disposition=disposition,
         ))
     elif session_id:
         # No explicit callback but we have a session — create a minimal
@@ -269,6 +280,7 @@ def dispatch_callback(notification: Notification) -> dict | None:
             notification.title,
             notification.notification_id,
             recipient_session=session_id,
+            disposition=disposition,
         ))
 
     # Legacy path: also attempt session resume if configured.
@@ -386,12 +398,17 @@ def _dispatch_via_messaging(
     title: str,
     notification_id: str,
     recipient_session: str | None = None,
+    disposition: str = "actionable",
 ) -> dict:
     """Dispatch a callback via the messaging service.
 
     If *recipient_session* is provided, the message is targeted to that
     specific session.  The AgentIngest hooks (PostToolUse / Stop) will
     pick it up during the agent's turn via session-filtered queries.
+
+    *disposition* declares Stop-hook intent: ``"acknowledgement"`` for a consent
+    echo the gateway already handled in-band (never blocks), ``"actionable"`` for
+    a genuine response the agent must ingest. Defaults to ``"actionable"``.
     """
     from work_buddy.logging_config import get_logger
 
@@ -416,6 +433,7 @@ def _dispatch_via_messaging(
             priority="high",
             tags=["notification-callback", "agent-ingest"],
             recipient_session=recipient_session,
+            disposition=disposition,
         )
         logger.info(
             "Dispatched notification callback via messaging: %s (notification=%s)",

--- a/work_buddy/sidecar/retry_sweep.py
+++ b/work_buddy/sidecar/retry_sweep.py
@@ -629,6 +629,7 @@ class RetrySweep:
                         # surface once.
                         status="resolved",
                         tags=["retry", "success"],
+                        disposition="acknowledgement",
                     )
             except Exception as exc:
                 logger.warning("Failed to notify agent session: %s", exc)
@@ -673,6 +674,7 @@ class RetrySweep:
                         }),
                         priority="high",
                         tags=["retry", "exhausted"],
+                        disposition="actionable",
                     )
             except Exception as exc:
                 logger.warning("Failed to notify agent session: %s", exc)


### PR DESCRIPTION
## Summary
- "Should this message block the agent's turn?" was re-derived by the consumer from an ad-hoc mix of priority/sender/tags, set independently at each emission site. That let a consent approval block via one path (`notification_response`/`notification-callback`) while the closed #202 tag-patch only covered the other (`consent_grant`/`consent-callback`) — both are plumbing the gateway already handled in-band.
- Introduces a **sender-declared `disposition`** on the message envelope, read by a single Stop-hook policy: `actionable` (an action item; may block — the default, so nothing regresses) vs `acknowledgement` (auto-ack of in-band-handled work; never blocks).
- **Orthogonal to priority**: disposition decides *whether* a message can block; `BLOCK_UNTIL_RESOLVED_PRIORITIES` still sets *intensity* among actionable ones.
- Senders declare intent (notification store: consent echo → ack, request answer → actionable; retry sweep: success → ack, exhausted → actionable). `create_message` infers via `_classify_disposition` when omitted — covering the Obsidian plugin's un-settable `consent_grant` POST — and a forward-only migration **backfills existing rows**, clearing already-queued consent callbacks. NULL/legacy → actionable.
- Forward-compatible down-payment on the events-system envelope (classify once on a normalized field). Adds the `disposition` column + migration, plumbs the field through client/service, rewrites `messaging/block-semantics`.
- **Replaces closed [#202](https://github.com/KadenMc/work-buddy/pull/202)** (the tag hack).

## Test plan
- [x] `pytest tests/component/test_messaging_models.py` + caller tests (service, retry, consent dispatch, modal propagation) — 198 passed, incl. new classifier / Stop-predicate / migration-backfill / both-consent-paths tests
- [ ] Live (deployed sidecar, after restart): service-level — a consent `notification_response` (body title "Consent: …") and a `consent_grant` are both absent from the Stop summary while a plain high-priority actionable message remains; end-to-end — approve a consent-gated op on throwaway data and confirm the resulting `notification_response` does **not** block the Stop hook