### PR TITLE
feat(events): add the durable Events backbone spine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ Every scope below is browsable with `mcp__work-buddy__wb_run("agent_docs", {"sco
 | `websearch/` | General web search via provider seam (Jina default + keyless ddgs fallback), trafilatura/Jina-reader extraction, evidence-cards, broker-admitted LOCAL_FAST classify |
 | `threads/` | Multi-turn agent-user threads |
 | `notifications/` | Notify, request, consent, surfaces |
+| `events/` | Durable in-process delivery spine for event-shaped facts — CloudEvents-superset envelope, SQLite log (dedup + offsets + DLQ), one drain thread, consent gate; `event_publish` to emit |
 | `services/` | Messaging, memory (Hindsight), dashboard, sidecar |
 | `features/` | Preferences and feature opt-in |
 | `operations/` | Gateway, agent sessions |

--- a/knowledge/store/architecture/event-bus.md
+++ b/knowledge/store/architecture/event-bus.md
@@ -97,6 +97,10 @@ dev_notes: |-
 
 The dashboard updates in real time from server-pushed events delivered over Server-Sent Events. Each event mutates only the specific DOM nodes it concerns; a panel is never wholesale-rewritten in response to an event. This preserves user state — focused inputs, scroll position, drilled-in `<details>`, chip rails — across every update.
 
+## Relationship to the durable Events backbone
+
+This bus is the **lossy real-time UI** layer — drop-oldest, no durability, no dedup — and is **not** the durable delivery spine. The first-class `events` backbone (`work_buddy.events`) owns at-least-once, deduped, offset-tracked delivery of *event-shaped facts* to reacting consumers; it uses this bus only as its immediate, best-effort **UI projection** (its `publish()` fans out here via `publish_auto`). Rule of thumb: reliable *reactions* read the durable `events` log; live *UI* reads this bus.
+
 ## Surfaces
 
 * **Python**

--- a/knowledge/store/events.md
+++ b/knowledge/store/events.md
@@ -1,0 +1,65 @@
+---
+name: Events backbone
+kind: integration
+description: The durable, in-process delivery spine for event-shaped facts — a thing happened ("X happened"), emitted or received, published to 0..N consumers that may react asynchronously. A CloudEvents-superset envelope + a SQLite log (inbox-dedup + per-consumer offsets + DLQ) + one drain thread + a consent gate. RPC, observability, and supervision are excluded by category (the inclusion rule).
+entry_points:
+- work_buddy.events
+- work_buddy.events.dispatcher
+- work_buddy.events.store
+- work_buddy.events.envelope
+- work_buddy.events.protocol
+tags:
+- events
+- backbone
+- spine
+- cloudevents
+- dispatcher
+- pub-sub
+aliases:
+- event backbone
+- events system
+- event spine
+- durable event bus
+dev_notes: '**The inclusion rule is the boundary**: only *event-shaped* comms ride the spine — fire-and-forget facts, 0..N consumers, no response expected. RPC/commands (`wb_run`, embedding, broker), observability surfaces (the dashboard `EventBus`, the sidecar `EventLog`), and supervision (health/evictors) are excluded *by category*, not by omission — routing request/response through an at-least-once tick-drained log adds latency and breaks the return channel. **+1 thread, period**: one `event-drain` thread iterates ALL consumers; a consumer is a registry entry, not a thread (idle = one dict entry). A *blocking* handler would stall the single drain — keep handlers fast (offload to a shared bounded pool later if needed). **Cross-process is via the shared SQLite file**: an `event_publish` from the gateway appends to `db/events`; the sidecar drain reads it — no IPC. The lossy dashboard fan-out is the existing `dashboard.events.publish_auto` (sidecar → messaging bridge → SSE), best-effort. **Retention** is offset-aware: a row is kept while undelivered (`seq > min_live_offset`), in the DLQ, or — *external events only* — inside the 7-day replay window; everything else reaps on a per-type `expires_at` (noisy `schedule.tick` ~3h). **Activation**: a new op (`event_publish`) needs a one-time gateway+sidecar restart (new Op code is not picked up by the data-only `reload_capability_data`). **Threads is a sink, never a producer** (no `ThreadsAdapter`).'
+---
+
+## Why it exists
+
+work-buddy already had ~5 event-shaped mechanisms reinvented privately (scheduler ticks, message poller, source pipelines, the threads FSM log, the dashboard bus). The Events backbone is the **one canonical spine** those become producers/consumers of — so external webhooks and cron-poll-diffs are *just two more producers of the same `Event`*, not an Nth ad-hoc mechanism.
+
+## The inclusion rule (what is on the spine)
+
+An **Event** is a durable, fire-and-forget announcement that "X happened" — observed from outside (webhook, poll) **or declared by work-buddy itself** — published to 0..N consumers that react asynchronously. A piece of inter-component communication joins the spine only if it is fire-and-forget, broadcast (0..N), a past-fact (not "do Y"), and async-tolerant. The instant a response is required it is a command/query/RPC and stays on its existing rails (CloudEvents: "events represent facts and therefore do not include a destination").
+
+## Architecture (the spine)
+
+```
+producer ──publish()──►  EventStore.append (db/events, UNIQUE(source,id) = dedup)
+                          │                       └─ immediate lossy fan-out → dashboard bus (projection)
+                          ▼
+                 event-drain thread (~45s)  ──drain()──►  per-consumer: read_since(offset) →
+                          policy_check (consent gate) → Processor.run → commit offset
+                          (bounded retry → event_dlq on poison)
+```
+
+- **`envelope.py`** — frozen `Event` (CloudEvents core + work-buddy extension attrs). The general form of the in-tree `thread_events` / `work_item_events` logs; the envelope is kept field-compatible with `work_item_events`.
+- **`store.py`** — `EventStore` over `db/events`: `events` (the log + per-row `expires_at`), `consumer_offsets` (one watermark each — restart replay), `event_dlq`. `append` returns `None` on a `(source,id)` duplicate.
+- **`dispatcher.py`** — `publish()` (append + fan-out) and `drain()` (at-least-once delivery, offsets, bounded-retry→DLQ) + a consumer registry.
+- **`drain.py`** — the single `event-drain` daemon thread (the backbone's only added thread).
+- **`policy.py`** — `policy_check` at the processor boundary (consent enforced *between* dispatch and `Processor.run`, reusing `ConsentCache`).
+- **`artifact.py`** — registers `events` as an artifact so the existing `artifact_cleanup` sweep bounds it (offset-aware retention predicate).
+- **`protocol.py`** — `Source` / `Processor` / `Condition` ports (interfaces defined; concrete Sources/Conditions are not yet implemented).
+
+## Not the dashboard event-bus
+
+Distinct from `architecture/event-bus` (`dashboard/events.py`) — that is the *lossy SSE fan-out* for real-time UI. The durable spine *feeds* it as a projection; it is never the spine.
+
+## Producers and the demo consumer
+
+- `event_publish` capability — manual/agent emit (the controlled path).
+- thin `CronAdapter` (`producers/cron.py`) — emits `ai.workbuddy.schedule.tick` after `scheduler.tick()`; additive (the scheduler is unmodified), throttled, short-TTL.
+- `notify-demo` consumer (`consumers/notify_demo.py`) — writes a notification on `ai.workbuddy.demo.ping` (the visible end-to-end effect).
+
+## Extension points (not yet implemented)
+
+The `Source` and `Condition` protocols are the designed extension surface for *user-defined* events — polling/webhook sources with diff conditions (e.g. a stock-watcher), authored conversationally. Other internal mechanisms (`MessagePoller`, pipelines, the retry queue as the durable outbox) move onto the spine **only when a real second consumer needs their events**, not as a blanket migration. A webhook ingress and an n8n/Node-RED `external_flow` processor are designed-for but gated on a concrete consumer.

--- a/knowledge/store/events/event_publish.md
+++ b/knowledge/store/events/event_publish.md
@@ -1,0 +1,57 @@
+---
+name: Event Publish
+kind: capability
+description: Publish one event onto the work-buddy Events backbone — a fire-and-forget fact ("X happened") delivered to 0..N consumers. For manual or agent-initiated emits. The type is reverse-DNS (ai.workbuddy.<domain>.<thing>.<verb>).
+capability_name: event_publish
+category: events
+op: op.wb.event_publish
+schema_version: wb-capability/v1
+parameters:
+  type:
+    type: str
+    description: Reverse-DNS event type, e.g. ai.workbuddy.demo.ping
+    required: true
+  data:
+    type: dict
+    description: Opaque JSON-serializable payload
+    required: false
+  source:
+    type: str
+    description: URI-ref identifying the producer (default /wb/agent)
+    required: false
+  durable:
+    type: bool
+    description: If true (default), the event is logged + delivered at-least-once; if false it is a lossy UI-only fan-out
+    required: false
+  subject:
+    type: str
+    description: Optional CloudEvents subject
+    required: false
+mutates_state: true
+retry_policy: manual
+is_action: true
+intrinsic_amplifiers:
+  irreversibility: low
+  regret_potential: low
+tags:
+- events
+- event
+- publish
+- emit
+aliases:
+- emit event
+- publish event
+- fire event
+parents:
+- events
+---
+
+Publish a single event onto the Events backbone. Durable events are appended to
+`db/events` (deduped on `(source, id)`) and delivered at-least-once to any
+registered consumers whose type filter matches; they also fan out immediately to
+the lossy dashboard projection. `durable=false` events skip the log entirely
+(lossy fan-out only — for UI refresh / heartbeats).
+
+This is the controlled producer used to exercise the spine end-to-end. It is a
+*fact* emitter, not a command — to make something happen, a consumer reacts to
+the event.

--- a/tests/component/test_events_end_to_end.py
+++ b/tests/component/test_events_end_to_end.py
@@ -1,0 +1,78 @@
+"""End-to-end (in-process) test of the assembled events spine.
+
+Wires the REAL EventStore + dispatcher + notify-demo consumer against temp
+paths, with only the two external side effects stubbed (the dashboard fan-out
+and the notification write are recorded, not performed). Covers acceptance-gate
+items (a) log+dedup, (b) delivered exactly once, and the type-filter behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import work_buddy.dashboard.events as dash_events
+import work_buddy.notifications.dispatcher as ndisp
+import work_buddy.notifications.store as nstore
+from work_buddy.events import dispatcher
+from work_buddy.events import store as evstore
+from work_buddy.events.consumers.notify_demo import (
+    CONSUMER_ID,
+    PING_TYPE,
+    register_notify_demo,
+)
+from work_buddy.events.envelope import new_event
+
+
+@pytest.fixture
+def spine(tmp_path, monkeypatch):
+    monkeypatch.setattr(evstore, "_db_path", lambda: tmp_path / "events.db")
+    dispatcher.set_store(evstore.EventStore())
+    dispatcher.clear_consumers()
+    fan: list[str] = []
+    notes: list = []
+    monkeypatch.setattr(dash_events, "publish_auto", lambda t, p=None: fan.append(t))
+    monkeypatch.setattr(nstore, "create_notification", lambda n: notes.append(n) or n)
+
+    # Keep the test hermetic: stub surface delivery so the consumer never makes
+    # a real network call to Telegram/dashboard.
+    class _NoDeliver:
+        def deliver(self, notif, mark_delivered_fn=None):
+            return {}
+
+    monkeypatch.setattr(
+        ndisp.SurfaceDispatcher, "from_config", classmethod(lambda cls: _NoDeliver())
+    )
+    register_notify_demo()
+    yield dispatcher._store(), fan, notes
+    dispatcher.clear_consumers()
+    dispatcher.set_store(None)
+
+
+@pytest.mark.component
+def test_demo_ping_end_to_end(spine):
+    store, fan, notes = spine
+
+    dispatcher.publish(new_event("/wb/agent", PING_TYPE, {"message": "hi"}, id="e1"))
+    assert store.count() == 1            # (a) landed in db/events
+    assert fan == [PING_TYPE]            # fanned out to the projection
+
+    dispatcher.drain()
+    assert len(notes) == 1               # (b) delivered → notification written
+    assert "hi" in notes[0].body
+
+    dispatcher.drain()                   # re-drain must not re-deliver
+    assert len(notes) == 1               # (b) exactly once
+
+    dispatcher.publish(new_event("/wb/agent", PING_TYPE, {}, id="e1"))
+    assert store.count() == 1            # (a) dedup on (source, id)
+
+
+@pytest.mark.component
+def test_schedule_tick_advances_offset_without_notifying(spine):
+    store, _fan, notes = spine
+
+    dispatcher.publish(new_event("/wb/scheduler", "ai.workbuddy.schedule.tick", {}))
+    dispatcher.drain()
+
+    assert notes == []                                       # type-filtered out
+    assert store.get_offset(CONSUMER_ID) == store.max_seq()  # but offset advanced

--- a/tests/unit/events/test_artifact.py
+++ b/tests/unit/events/test_artifact.py
@@ -1,0 +1,92 @@
+"""Unit tests for the events artifact retention predicate."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from work_buddy.events import store as evstore
+from work_buddy.events.artifact import _make_events_keep, _older_than_days
+from work_buddy.events.store import EventStore, _expires_at_for, _now_iso
+
+
+def _iso_days_ago(days: float) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setattr(evstore, "_db_path", lambda: tmp_path / "events.db")
+    return evstore.EventStore()
+
+
+def test_keep_undelivered(store):
+    store.ensure_offset("c1", 5)  # min_live_offset = 5
+    keep = _make_events_keep(store)
+    assert keep({"seq": 6, "modality": "internal", "received_at": _now_iso()}) is True
+
+
+def test_reap_delivered_internal(store):
+    store.ensure_offset("c1", 5)
+    keep = _make_events_keep(store)
+    rec = {"seq": 3, "modality": "internal", "received_at": _iso_days_ago(10)}
+    assert keep(rec) is False
+
+
+def test_keep_external_within_replay_window(store):
+    store.ensure_offset("c1", 5)
+    keep = _make_events_keep(store)
+    assert keep({"seq": 3, "modality": "push", "received_at": _now_iso()}) is True
+
+
+def test_reap_external_past_replay_window(store):
+    store.ensure_offset("c1", 5)
+    keep = _make_events_keep(store)
+    assert keep({"seq": 3, "modality": "push", "received_at": _iso_days_ago(10)}) is False
+
+
+def test_keep_dlq_row(store):
+    store.ensure_offset("c1", 5)
+    store.dead_letter(3, "c1", 3, "boom")
+    keep = _make_events_keep(store)
+    rec = {"seq": 3, "modality": "internal", "received_at": _iso_days_ago(10)}
+    assert keep(rec) is True  # DLQ rows are pinned until triaged
+
+
+def test_older_than_days_helper():
+    assert _older_than_days(_iso_days_ago(10), 7.0) is True
+    assert _older_than_days(_now_iso(), 7.0) is False
+    assert _older_than_days(None, 7.0) is True  # missing → not pinned
+
+
+def test_expires_at_per_type_ordering():
+    now = _now_iso()
+    tick = _expires_at_for("ai.workbuddy.schedule.tick", now)  # ~3h
+    default = _expires_at_for("ai.workbuddy.demo.ping", now)   # 14d
+    assert tick < default  # noisy type self-reaps sooner (ISO sorts lexically)
+
+
+def test_artifact_composition_is_coherent(tmp_path):
+    # PerRecordTtl + SqliteRowsStorage must not raise IncoherentComposition.
+    from work_buddy.artifacts import (
+        Artifact,
+        Delete,
+        Lifecycle,
+        PerRecordTtl,
+        SqliteRowsStorage,
+    )
+
+    art = Artifact(
+        name="events-test",
+        storage=SqliteRowsStorage(
+            db_path=tmp_path / "events.db", table="events", id_column="seq"
+        ),
+        lifecycle=Lifecycle(
+            trigger=PerRecordTtl(ttl_field="expires_at"),
+            action=Delete(),
+            retention_predicate=_make_events_keep(EventStore()),
+        ),
+    )
+    assert art.lifecycle.retention_predicate is not None
+    assert "events" in art.name

--- a/tests/unit/events/test_dispatcher.py
+++ b/tests/unit/events/test_dispatcher.py
@@ -1,0 +1,134 @@
+"""Unit tests for the events dispatcher — publish + drain."""
+
+from __future__ import annotations
+
+import pytest
+
+import work_buddy.dashboard.events as dash_events
+from work_buddy.events import dispatcher
+from work_buddy.events import store as evstore
+from work_buddy.events.dispatcher import DurableConsumer
+from work_buddy.events.envelope import new_event
+from work_buddy.events.protocol import ProcessorManifest, ProcessorResult
+
+
+class _Recorder:
+    def __init__(self):
+        self.manifest = ProcessorManifest(name="rec")
+        self.seen: list[str] = []
+
+    def run(self, event, ctx):
+        self.seen.append(event.id)
+        return ProcessorResult(text="ok")
+
+
+class _Exploder:
+    def __init__(self):
+        self.manifest = ProcessorManifest(name="boom")
+        self.calls = 0
+
+    def run(self, event, ctx):
+        self.calls += 1
+        raise RuntimeError("nope")
+
+
+@pytest.fixture
+def wired(tmp_path, monkeypatch):
+    monkeypatch.setattr(evstore, "_db_path", lambda: tmp_path / "events.db")
+    store = evstore.EventStore()
+    dispatcher.set_store(store)
+    dispatcher.clear_consumers()
+    fanout: list[tuple] = []
+    monkeypatch.setattr(
+        dash_events, "publish_auto", lambda t, p=None: fanout.append((t, p))
+    )
+    yield store, fanout
+    dispatcher.clear_consumers()
+    dispatcher.set_store(None)
+
+
+def _ping(id_: str | None = None):
+    return new_event("/wb/test", "ai.workbuddy.demo.ping", {"k": "v"}, id=id_)
+
+
+def test_publish_appends_and_fans_out(wired):
+    store, fanout = wired
+    dispatcher.publish(_ping("p1"))
+    assert store.count() == 1
+    assert fanout and fanout[0][0] == "ai.workbuddy.demo.ping"
+
+
+def test_publish_dedup_no_double_append(wired):
+    store, _ = wired
+    dispatcher.publish(_ping("dup"))
+    dispatcher.publish(_ping("dup"))
+    assert store.count() == 1
+
+
+def test_durable_false_skips_log_but_fans_out(wired):
+    store, fanout = wired
+    dispatcher.publish(
+        new_event("/wb/test", "ai.workbuddy.ui.refresh", {}, durable=False)
+    )
+    assert store.count() == 0
+    assert len(fanout) == 1
+
+
+def test_drain_delivers_exactly_once(wired):
+    store, _ = wired
+    proc = _Recorder()
+    dispatcher.register_consumer(
+        DurableConsumer(id="c1", processor=proc, types=frozenset({"ai.workbuddy.demo.ping"}))
+    )
+    e = _ping("p1")
+    dispatcher.publish(e)
+    assert dispatcher.drain()["delivered"] == 1
+    assert proc.seen == [e.id]
+    dispatcher.drain()  # re-drain must not re-deliver
+    assert proc.seen == [e.id]
+
+
+def test_drain_type_filter_advances_offset(wired):
+    store, _ = wired
+    proc = _Recorder()
+    dispatcher.register_consumer(
+        DurableConsumer(id="c1", processor=proc, types=frozenset({"ai.workbuddy.demo.ping"}))
+    )
+    dispatcher.publish(new_event("/wb/test", "ai.workbuddy.schedule.tick", {}))
+    dispatcher.publish(_ping("p1"))
+    dispatcher.drain()
+    assert len(proc.seen) == 1  # only the ping ran
+    assert store.get_offset("c1") == store.max_seq()  # but offset advanced past both
+
+
+def test_drain_poison_event_goes_to_dlq(wired, monkeypatch):
+    store, _ = wired
+    monkeypatch.setattr(dispatcher, "MAX_ATTEMPTS", 3)
+    proc = _Exploder()
+    dispatcher.register_consumer(
+        DurableConsumer(id="c1", processor=proc, types=frozenset({"ai.workbuddy.demo.ping"}))
+    )
+    seq = store.append(_ping("boom"))
+    for _ in range(3):  # attempt 1, 2, then 3 → DLQ
+        dispatcher.drain()
+    assert seq in store.dlq_seqs()
+    assert store.get_offset("c1") == seq  # advanced after dead-lettering
+    calls_before = proc.calls
+    dispatcher.drain()  # no further runs
+    assert proc.calls == calls_before
+
+
+def test_offset_survives_restart(wired):
+    store, _ = wired
+    proc = _Recorder()
+    dispatcher.register_consumer(DurableConsumer(id="c1", processor=proc, types=None))
+    dispatcher.publish(_ping("p1"))
+    dispatcher.drain()
+    assert len(proc.seen) == 1
+    # Simulate a restart: drop in-memory registry, re-register a fresh
+    # processor against the SAME store. Offsets live in the DB → no replay.
+    dispatcher.clear_consumers()
+    proc2 = _Recorder()
+    dispatcher.register_consumer(DurableConsumer(id="c1", processor=proc2, types=None))
+    dispatcher.drain()
+    assert proc2.seen == []

--- a/tests/unit/events/test_drain.py
+++ b/tests/unit/events/test_drain.py
@@ -1,0 +1,28 @@
+"""Unit test for the event-drain thread."""
+
+from __future__ import annotations
+
+import time
+
+from work_buddy.events import dispatcher
+from work_buddy.events.drain import EventDrain
+
+
+def test_drain_thread_ticks_then_stops(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_drain():
+        calls["n"] += 1
+        return {"delivered": 0, "dlq": 0}
+
+    monkeypatch.setattr(dispatcher, "drain", fake_drain)
+
+    d = EventDrain(interval_s=0.05)
+    d.start()
+    time.sleep(0.22)
+    d.stop()
+
+    assert calls["n"] >= 1  # the loop ticked
+    settled = calls["n"]
+    time.sleep(0.15)
+    assert calls["n"] == settled  # and stopped cleanly (no more ticks)

--- a/tests/unit/events/test_notify_demo.py
+++ b/tests/unit/events/test_notify_demo.py
@@ -1,0 +1,69 @@
+"""Unit test for the notify-demo consumer."""
+
+from __future__ import annotations
+
+import work_buddy.notifications.dispatcher as ndisp
+import work_buddy.notifications.store as nstore
+from work_buddy.events.consumers.notify_demo import NotifyDemoProcessor
+from work_buddy.events.envelope import new_event
+from work_buddy.events.protocol import RunContext
+
+
+def _fake_dispatcher(result, sink=None):
+    class _Fake:
+        def deliver(self, notif, mark_delivered_fn=None):
+            if sink is not None:
+                sink.append(notif)
+            return result
+
+    return classmethod(lambda cls: _Fake())
+
+
+def test_notify_demo_creates_and_dispatches(monkeypatch):
+    captured = []
+    delivered_to = []
+    monkeypatch.setattr(
+        nstore, "create_notification", lambda n: captured.append(n) or n
+    )
+    monkeypatch.setattr(
+        ndisp.SurfaceDispatcher,
+        "from_config",
+        _fake_dispatcher({"telegram": True, "dashboard": True}, sink=delivered_to),
+    )
+
+    proc = NotifyDemoProcessor()
+    res = proc.run(
+        new_event("/wb/agent", "ai.workbuddy.demo.ping", {"message": "hello spine"}),
+        RunContext(seq=3),
+    )
+
+    assert res.text == "notified"
+    assert res.is_error is False
+    assert len(captured) == 1
+    note = captured[0]
+    assert note.title == "Events backbone"
+    assert "hello spine" in note.body
+    assert "events" in note.tags
+    assert len(delivered_to) == 1                       # dispatched to surfaces
+    assert "telegram" in res.structured["delivered"]
+
+
+def test_notify_demo_delivery_failure_is_non_fatal(monkeypatch):
+    monkeypatch.setattr(nstore, "create_notification", lambda n: n)
+
+    def boom(cls):
+        raise RuntimeError("telegram down")
+
+    monkeypatch.setattr(
+        ndisp.SurfaceDispatcher, "from_config", classmethod(boom)
+    )
+
+    proc = NotifyDemoProcessor()
+    res = proc.run(
+        new_event("/wb/agent", "ai.workbuddy.demo.ping", {}), RunContext(seq=1)
+    )
+
+    # Notification is persisted regardless; a delivery failure must not raise
+    # (which would retry → DLQ). The consumer still reports success.
+    assert res.text == "notified"
+    assert res.structured["delivered"] == []

--- a/tests/unit/events/test_policy.py
+++ b/tests/unit/events/test_policy.py
@@ -1,0 +1,42 @@
+"""Unit tests for the events consent/policy gate."""
+
+from __future__ import annotations
+
+import work_buddy.consent as consent
+from work_buddy.events.policy import policy_check
+from work_buddy.events.protocol import RunContext
+
+
+def test_none_action_allows():
+    assert policy_check(None, RunContext(seq=1)) == "allow"
+
+
+def test_granted_allows(monkeypatch):
+    monkeypatch.setattr(consent._cache, "is_granted", lambda op, **k: True)
+    assert policy_check("evt.deliver", RunContext(seq=1)) == "allow"
+
+
+def test_ungranted_prompts(monkeypatch):
+    monkeypatch.setattr(consent._cache, "is_granted", lambda op, **k: False)
+    assert policy_check("evt.deliver", RunContext(seq=1)) == "prompt"
+
+
+def test_high_weight_is_passed_to_cache(monkeypatch):
+    seen: dict[str, str] = {}
+
+    def fake(op, *, consent_weight="low", **k):
+        seen["weight"] = consent_weight
+        return False
+
+    monkeypatch.setattr(consent._cache, "is_granted", fake)
+    decision = policy_check("evt.deliver", RunContext(seq=1), consent_weight="high")
+    assert decision == "prompt"
+    assert seen["weight"] == "high"
+
+
+def test_consent_error_prompts(monkeypatch):
+    def boom(op, **k):
+        raise RuntimeError("consent backend down")
+
+    monkeypatch.setattr(consent._cache, "is_granted", boom)
+    assert policy_check("evt.deliver", RunContext(seq=1)) == "prompt"

--- a/tests/unit/events/test_protocol.py
+++ b/tests/unit/events/test_protocol.py
@@ -1,0 +1,34 @@
+"""Unit tests for the events protocols."""
+
+from __future__ import annotations
+
+from work_buddy.events.envelope import new_event
+from work_buddy.events.protocol import (
+    Processor,
+    ProcessorManifest,
+    ProcessorResult,
+    RunContext,
+)
+
+
+class _DummyProcessor:
+    manifest = ProcessorManifest(name="dummy", consent_action=None)
+
+    def run(self, event, ctx):
+        return ProcessorResult(text="ok", structured={"type": event.type})
+
+
+def test_dummy_satisfies_processor_protocol():
+    d = _DummyProcessor()
+    assert isinstance(d, Processor)  # runtime_checkable structural check
+
+
+def test_processor_run_returns_result():
+    d = _DummyProcessor()
+    res = d.run(
+        new_event("/wb/test", "ai.workbuddy.test.ping", {}),
+        RunContext(seq=1, traceparent="tp"),
+    )
+    assert res.text == "ok"
+    assert res.is_error is False
+    assert res.structured == {"type": "ai.workbuddy.test.ping"}

--- a/tests/unit/events/test_store.py
+++ b/tests/unit/events/test_store.py
@@ -1,0 +1,91 @@
+"""Unit tests for the EventStore — durable log, dedup, offsets, DLQ."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from work_buddy.events import store as evstore
+from work_buddy.events.envelope import new_event
+
+
+@pytest.fixture
+def fresh_store(tmp_path, monkeypatch):
+    db = tmp_path / "events.db"
+    monkeypatch.setattr(evstore, "_db_path", lambda: db)
+    return evstore.EventStore()
+
+
+def test_append_returns_seq(fresh_store):
+    seq = fresh_store.append(new_event("/wb/test", "ai.workbuddy.test.ping", {"x": 1}))
+    assert isinstance(seq, int) and seq >= 1
+
+
+def test_dedup_same_source_id_returns_none(fresh_store):
+    s1 = fresh_store.append(
+        new_event("/wb/test", "ai.workbuddy.test.ping", {"x": 1}, id="fixed-1")
+    )
+    s2 = fresh_store.append(
+        new_event("/wb/test", "ai.workbuddy.test.ping", {"x": 2}, id="fixed-1")
+    )
+    assert s1 is not None
+    assert s2 is None  # (source, id) is the inbox dedup claim
+
+
+def test_read_since_ordered_tail(fresh_store):
+    for i in range(3):
+        fresh_store.append(new_event("/wb/test", "ai.workbuddy.test.ping", {"i": i}))
+    out = fresh_store.read_since(0, limit=10)
+    seqs = [s for s, _ in out]
+    assert seqs == sorted(seqs)
+    assert [e.data["i"] for _, e in out] == [0, 1, 2]
+    # read_since is exclusive of last_seq
+    assert [e.data["i"] for _, e in fresh_store.read_since(seqs[0])] == [1, 2]
+
+
+def test_offsets_roundtrip(fresh_store):
+    assert fresh_store.get_offset("c1") == 0  # default when absent
+    fresh_store.commit_offset("c1", 5)
+    assert fresh_store.get_offset("c1") == 5
+    fresh_store.commit_offset("c1", 9)  # upsert
+    assert fresh_store.get_offset("c1") == 9
+
+
+def test_min_live_offset(fresh_store):
+    assert fresh_store.min_live_offset() == sys.maxsize  # no consumers → pin nothing
+    fresh_store.ensure_offset("c1", 0)
+    assert fresh_store.min_live_offset() == 0  # registered but undelivered → pin all
+    fresh_store.commit_offset("c1", 3)
+    fresh_store.commit_offset("c2", 7)
+    assert fresh_store.min_live_offset() == 3  # the slowest consumer
+
+
+def test_event_roundtrips_full_envelope(fresh_store):
+    e = new_event(
+        "/wb/test",
+        "ai.workbuddy.test.ping",
+        {"a": "b"},
+        subject="subj",
+        modality="pull",
+        traceparent="tp-1",
+        idempotency_key="idem-1",
+        ext={"custom": "x"},
+    )
+    fresh_store.append(e)
+    [(seq, got)] = fresh_store.read_since(0)
+    assert seq >= 1
+    assert got.source == "/wb/test"
+    assert got.type == "ai.workbuddy.test.ping"
+    assert got.data == {"a": "b"}
+    assert got.subject == "subj"
+    assert got.modality == "pull"
+    assert got.traceparent == "tp-1"
+    assert got.idempotency_key == "idem-1"
+    assert got.ext.get("custom") == "x"
+    assert got.dedup_key == f"/wb/test::{e.id}"
+
+
+def test_dead_letter(fresh_store):
+    fresh_store.dead_letter(7, "c1", 3, "boom")
+    assert fresh_store.dlq_seqs() == {7}

--- a/work_buddy/artifacts/registry.py
+++ b/work_buddy/artifacts/registry.py
@@ -45,6 +45,7 @@ _CONSUMER_MODULES: tuple[str, ...] = (
     "work_buddy.conversation_observability",
     "work_buddy.summarization",
     "work_buddy.inference.metrics_store",
+    "work_buddy.events.artifact",
 )
 
 _consumers_loaded = False

--- a/work_buddy/events/__init__.py
+++ b/work_buddy/events/__init__.py
@@ -1,0 +1,50 @@
+"""work-buddy Events backbone — the durable, fire-and-forget delivery spine.
+
+A first-class system for *event-shaped* facts: a thing happened ("X happened")
+— observed from outside (webhook, poll) or declared by work-buddy itself —
+published to 0..N consumers that may react asynchronously. The producer does
+not know or care who reacts.
+
+This is the **inclusion-rule** boundary: the spine carries only fire-and-forget
+facts. Request/response (RPC), observability surfaces, and
+process supervision are excluded by category and stay on their existing rails.
+
+Public surface (kept deliberately small):
+
+- ``Event`` / ``new_event`` — the CloudEvents-superset envelope
+- ``EventStore`` — the durable SQLite log (inbox-dedup + offsets + DLQ)
+- ``publish`` — append (if durable) + immediate lossy fan-out to the dashboard
+- ``register_consumer`` / ``DurableConsumer`` — register a durable handler
+- protocols: ``Source`` / ``Processor`` / ``Condition`` (interfaces; concrete
+  sources/conditions are not yet implemented)
+
+See the ``events`` knowledge unit for the architecture.
+"""
+
+from __future__ import annotations
+
+from work_buddy.events.envelope import Event, new_event
+from work_buddy.events.store import EventStore
+
+__all__ = [
+    "Event",
+    "new_event",
+    "EventStore",
+    # Lazily exposed below to keep import light + avoid cycles.
+    "publish",
+    "drain",
+    "register_consumer",
+    "DurableConsumer",
+]
+
+
+def __getattr__(name: str):
+    """Lazily expose the dispatcher surface so importing the package stays
+    cheap and free of the dashboard/consent import cost until actually used."""
+    if name in ("publish", "drain", "register_consumer", "registered_durable_consumers"):
+        from work_buddy.events import dispatcher
+        return getattr(dispatcher, name)
+    if name == "DurableConsumer":
+        from work_buddy.events.dispatcher import DurableConsumer
+        return DurableConsumer
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/work_buddy/events/artifact.py
+++ b/work_buddy/events/artifact.py
@@ -1,0 +1,111 @@
+"""Artifact registration for the Events backbone log (offset-aware retention).
+
+Registers the ``events`` table as an artifact so the twice-daily
+``artifact_cleanup`` sweep bounds it — mirroring messaging
+(``work_buddy/messaging/models.py::_register_messages_artifact``). Imported by
+``artifacts.registry.ensure_consumers_loaded`` (this module is listed in
+``_CONSUMER_MODULES``) so registration happens wherever the sweep runs.
+
+The retention predicate is the safety constraint: a row is **KEPT** (never
+reaped despite its TTL) when it is undelivered to some consumer, sitting in the
+DLQ, or — for *external* events only — still inside the provider replay window.
+Everything else reaps on its per-row ``expires_at`` (computed at append from a
+per-type TTL; see ``store._expires_at_for``). The external-only replay window is
+why a high-volume internal type (``schedule.tick``) self-reaps by its short TTL
+instead of being pinned for the full replay window.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Callable
+
+from work_buddy.events.store import EventStore, _db_path
+
+logger = logging.getLogger(__name__)
+
+_DEDUP_WINDOW_DAYS = 7.0
+_SNAPSHOT_TTL_S = 30.0  # memoize min_live_offset + DLQ across a single sweep
+
+
+def _older_than_days(iso: str | None, days: float) -> bool:
+    if not iso:
+        return True
+    try:
+        ts = datetime.fromisoformat(iso)
+    except (ValueError, TypeError):
+        return True
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - ts) > timedelta(days=days)
+
+
+def _make_events_keep(store: EventStore) -> Callable[[dict], bool]:
+    """Build the retention predicate (**True = keep**) over a live ``EventStore``.
+
+    Snapshots ``min_live_offset`` + DLQ seqs and memoizes them for a few seconds
+    so a sweep over many rows stays O(1) in queries, not O(rows).
+    """
+    snap: dict[str, object] = {"t": None, "min_live": 0, "dlq": set()}
+
+    def _refresh() -> None:
+        now = time.monotonic()
+        last = snap["t"]
+        if last is None or (now - float(last)) > _SNAPSHOT_TTL_S:
+            snap["min_live"] = store.min_live_offset()
+            snap["dlq"] = store.dlq_seqs()
+            snap["t"] = now
+
+    def _events_keep(record: dict) -> bool:
+        _refresh()
+        try:
+            seq = int(record.get("seq", 0))
+        except (TypeError, ValueError):
+            return True  # unparseable → keep (fail safe)
+        if seq > int(snap["min_live"]):  # type: ignore[arg-type]
+            return True  # undelivered — TTL must never outrun a consumer
+        if seq in snap["dlq"]:  # type: ignore[operator]
+            return True  # un-triaged poison
+        # Replay window applies to EXTERNAL events only; internal types
+        # (e.g. schedule.tick) self-reap by their short TTL once delivered.
+        if record.get("modality") in ("push", "pull"):
+            if not _older_than_days(record.get("received_at"), _DEDUP_WINDOW_DAYS):
+                return True
+        return False
+
+    return _events_keep
+
+
+def _register_events_artifact() -> None:
+    try:
+        from work_buddy.artifacts import (
+            Artifact,
+            Delete,
+            Lifecycle,
+            PerRecordTtl,
+            register_artifact,
+            SqliteRowsStorage,
+        )
+
+        store = EventStore()
+        register_artifact(Artifact(
+            name="events",
+            storage=SqliteRowsStorage(
+                db_path=_db_path(),
+                table="events",
+                id_column="seq",
+                vacuum_on_delete=True,
+            ),
+            lifecycle=Lifecycle(
+                trigger=PerRecordTtl(ttl_field="expires_at"),  # absolute per-row expiry
+                action=Delete(),
+                retention_predicate=_make_events_keep(store),
+            ),
+        ))
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("Failed to register events artifact: %s", exc)
+
+
+_register_events_artifact()

--- a/work_buddy/events/consumers/__init__.py
+++ b/work_buddy/events/consumers/__init__.py
@@ -1,0 +1,1 @@
+"""Event consumers — durable handlers (sinks) the drain delivers events to."""

--- a/work_buddy/events/consumers/notify_demo.py
+++ b/work_buddy/events/consumers/notify_demo.py
@@ -1,0 +1,82 @@
+"""Demo consumer: turn ``ai.workbuddy.demo.ping`` events into a user
+notification — the visible end-to-end proof that the spine *delivers*.
+
+Low-risk: ``consent_action=None`` (no gate). It subscribes to a single type, so
+its offset advances past everything else (e.g. ``schedule.tick``) without acting.
+"""
+
+from __future__ import annotations
+
+from work_buddy.events.dispatcher import DurableConsumer, register_consumer
+from work_buddy.events.protocol import ProcessorManifest, ProcessorResult
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+CONSUMER_ID = "events.notify-demo"
+PING_TYPE = "ai.workbuddy.demo.ping"
+
+
+class NotifyDemoProcessor:
+    """Writes a notification for each delivered ``demo.ping`` event."""
+
+    manifest = ProcessorManifest(
+        name="notify-demo",
+        description="Demo: notify the user on ai.workbuddy.demo.ping",
+        consent_action=None,
+        consent_weight="low",
+    )
+
+    def run(self, event, ctx):
+        from work_buddy.notifications.models import Notification, SourceType
+        from work_buddy.notifications.store import create_notification, mark_delivered
+
+        data = event.data or {}
+        message = data.get("message") or "An event reached the Events backbone."
+        # Keep the reverse-DNS event *type* (e.g. ai.workbuddy.demo.ping) OUT of
+        # the body: it looks like a hostname, so Telegram auto-linkifies it. A
+        # short hex id + seq don't linkify; the full type rides the structured
+        # result for diagnostics.
+        notif = create_notification(Notification(
+            title="Events backbone",
+            body=f"{message}\n\n(spine event {event.id[:8]}, seq {ctx.seq})",
+            source="events:notify-demo",
+            source_type=SourceType.PROGRAMMATIC.value,
+            tags=["events", "demo"],
+        ))
+
+        # create_notification only *persists*; surface delivery (Telegram /
+        # dashboard / Obsidian) is a separate push via the dispatcher. Keep it
+        # **best-effort**: a blocking surface POST runs on the drain thread, and
+        # a delivery failure must never poison the consumer (→ DLQ) — the
+        # notification is already durably stored regardless.
+        delivered: dict = {}
+        try:
+            from work_buddy.notifications.dispatcher import SurfaceDispatcher
+
+            delivered = SurfaceDispatcher.from_config().deliver(
+                notif, mark_delivered_fn=mark_delivered
+            )
+        except Exception:  # pragma: no cover — defensive
+            logger.exception("notify-demo: surface delivery failed (non-fatal)")
+
+        return ProcessorResult(
+            text="notified",
+            structured={
+                "event_id": event.id,
+                "event_type": event.type,
+                "notification_id": notif.notification_id,
+                "delivered": [k for k, v in delivered.items() if v],
+            },
+        )
+
+
+def register_notify_demo() -> None:
+    """Register the demo consumer with the dispatcher (called at sidecar boot)."""
+    register_consumer(DurableConsumer(
+        id=CONSUMER_ID,
+        processor=NotifyDemoProcessor(),
+        consent_action=None,
+        types=frozenset({PING_TYPE}),
+    ))
+    logger.info("events: registered notify-demo consumer (%s)", PING_TYPE)

--- a/work_buddy/events/dispatcher.py
+++ b/work_buddy/events/dispatcher.py
@@ -1,0 +1,167 @@
+"""The in-process dispatcher — ``publish`` (append + fan-out) and ``drain``
+(durable, at-least-once delivery behind the consent gate).
+
+``publish(event)``: if the event is durable, append it (the ``UNIQUE(source,id)``
+insert is the dedup claim — a duplicate is silently dropped); then *immediately*
+fan out a lossy projection to the dashboard bus. Durable handler delivery is
+**not** inline — it happens on ``drain()``.
+
+``drain()``: for each registered durable consumer, read events ``since`` its
+committed offset (capped at ``READ_LIMIT``), run the consent gate, run the
+handler, and commit the offset *after* a successful run (at-least-once). A
+handler exception is retried up to ``MAX_ATTEMPTS`` times (bounded) before the
+event is dead-lettered and the offset advances, so one poison event can't wedge
+a consumer.
+
+Consumers are **registry entries, not threads**: a single
+``event-drain`` thread (see ``drain.py``) iterates them. An idle consumer costs
+one dict entry, not a wakeup.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from work_buddy.events.envelope import Event
+from work_buddy.events.policy import policy_check
+from work_buddy.events.protocol import Processor, RunContext
+from work_buddy.events.store import EventStore
+
+logger = logging.getLogger(__name__)
+
+MAX_ATTEMPTS = 5     # bounded retry before dead-lettering a poison event
+READ_LIMIT = 200     # per-consumer batch cap per drain tick (backpressure)
+
+
+@dataclass
+class DurableConsumer:
+    """A registered handler the drain delivers events to.
+
+    ``types=None`` means "all types"; otherwise the consumer only runs for
+    events whose ``type`` is in the set (its offset still advances past the
+    rest, so a narrow consumer never re-reads events it doesn't handle).
+    """
+
+    id: str
+    processor: Processor
+    consent_action: str | None = None
+    consent_weight: str = "low"
+    types: frozenset[str] | None = None
+
+
+# --- module state ----------------------------------------------------------
+
+_REGISTRY: dict[str, DurableConsumer] = {}
+_store_singleton: EventStore | None = None
+# Per-(consumer, seq) attempt counts. Transient by design: a restart resets
+# them, so a poison event gets MAX_ATTEMPTS fresh tries after a restart — an
+# acceptable trade vs. a DB column for purely in-flight retry state.
+_attempts: dict[tuple[str, int], int] = {}
+
+
+def _store() -> EventStore:
+    global _store_singleton
+    if _store_singleton is None:
+        _store_singleton = EventStore()
+    return _store_singleton
+
+
+def set_store(store: EventStore | None) -> None:
+    """Override the store singleton (tests)."""
+    global _store_singleton
+    _store_singleton = store
+
+
+def register_consumer(consumer: DurableConsumer) -> None:
+    """Register a durable consumer and pin the log from now (so retention can't
+    reap ahead of a freshly-registered consumer before it delivers)."""
+    _REGISTRY[consumer.id] = consumer
+    _store().ensure_offset(consumer.id, 0)
+
+
+def registered_durable_consumers() -> list[DurableConsumer]:
+    return list(_REGISTRY.values())
+
+
+def clear_consumers() -> None:
+    """Clear the registry + in-flight attempt state (tests)."""
+    _REGISTRY.clear()
+    _attempts.clear()
+
+
+# --- publish ---------------------------------------------------------------
+
+
+def publish(event: Event) -> None:
+    """Durable append (dedup) + immediate lossy fan-out. See module docstring."""
+    if event.durable:
+        seq = _store().append(event)
+        if seq is None:
+            return  # (source, id) duplicate — dropped
+    # Immediate, best-effort projection to the dashboard bus (never raises).
+    try:
+        from work_buddy.dashboard.events import publish_auto
+
+        publish_auto(event.type, event.projection_payload())
+    except Exception:  # pragma: no cover — defensive
+        logger.debug(
+            "events.publish: dashboard fan-out failed for %r (non-fatal)",
+            event.type,
+            exc_info=True,
+        )
+
+
+# --- drain -----------------------------------------------------------------
+
+
+def drain() -> dict[str, int]:
+    """Deliver queued durable events to each consumer. Returns a small summary
+    ``{"delivered": N, "dlq": M}``. Idempotent across ticks via offsets."""
+    store = _store()
+    delivered = 0
+    dead = 0
+    for consumer in registered_durable_consumers():
+        last = store.get_offset(consumer.id)
+        for seq, event in store.read_since(last, limit=READ_LIMIT):
+            # Type filter: advance past events this consumer doesn't handle.
+            if consumer.types is not None and event.type not in consumer.types:
+                store.commit_offset(consumer.id, seq)
+                continue
+
+            ctx = RunContext(
+                seq=seq, traceparent=event.traceparent, session=event.wb_session
+            )
+            decision = policy_check(
+                consumer.consent_action, ctx, consent_weight=consumer.consent_weight
+            )
+            if decision == "deny":
+                store.commit_offset(consumer.id, seq)
+                continue
+            if decision == "prompt":
+                break  # leave offset; consumer waits on consent, re-tick later
+
+            try:
+                consumer.processor.run(event, ctx)
+                store.commit_offset(consumer.id, seq)
+                _attempts.pop((consumer.id, seq), None)
+                delivered += 1
+            except Exception as exc:  # noqa: BLE001 — bounded-retry + DLQ
+                key = (consumer.id, seq)
+                _attempts[key] = _attempts.get(key, 0) + 1
+                if _attempts[key] >= MAX_ATTEMPTS:
+                    store.dead_letter(seq, consumer.id, _attempts[key], repr(exc))
+                    store.commit_offset(consumer.id, seq)
+                    _attempts.pop(key, None)
+                    dead += 1
+                    logger.warning(
+                        "events.drain: %s seq=%d dead-lettered after %d attempts: %s",
+                        consumer.id, seq, MAX_ATTEMPTS, exc,
+                    )
+                else:
+                    logger.warning(
+                        "events.drain: %s seq=%d failed (attempt %d/%d): %s",
+                        consumer.id, seq, _attempts[key], MAX_ATTEMPTS, exc,
+                    )
+                    break  # retry this seq next tick; do NOT advance the offset
+    return {"delivered": delivered, "dlq": dead}

--- a/work_buddy/events/drain.py
+++ b/work_buddy/events/drain.py
@@ -1,0 +1,53 @@
+"""The single ``event-drain`` daemon thread — the backbone's only added thread.
+
+Decoupled from the shared health-check loop, on its own cadence
+(``interval_s``, default 45s, **no jitter** — a single local drain gains
+nothing from jitter). Mirrors the existing ``health-monitor`` /
+``inference-poller`` threads in ``sidecar/daemon.py``. One thread iterates ALL
+registered consumers, so registering a consumer never adds a
+thread — the backbone stays a **+1-thread** system regardless of consumer count.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from work_buddy.events import dispatcher
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_INTERVAL_S = 45.0
+
+
+class EventDrain:
+    """Owns the background drain loop. ``start()`` / ``stop()`` mirror
+    ``JobsWatcher`` / ``HealthMonitor``."""
+
+    def __init__(self, *, interval_s: float = DEFAULT_INTERVAL_S) -> None:
+        self._interval = interval_s
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._run, name="event-drain", daemon=True
+        )
+        self._thread.start()
+        logger.info("event-drain started (interval %.0fs)", self._interval)
+
+    def stop(self, *, join_timeout: float = 2.0) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=join_timeout)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                dispatcher.drain()
+            except Exception:  # pragma: no cover — defensive; a tick must not die
+                logger.exception("event-drain tick failed (non-fatal)")
+            # Wake immediately on stop; otherwise sleep the interval (no jitter).
+            self._stop.wait(self._interval)

--- a/work_buddy/events/envelope.py
+++ b/work_buddy/events/envelope.py
@@ -1,0 +1,106 @@
+"""The ``Event`` envelope — a CloudEvents v1.0 superset (no SDK).
+
+A frozen dataclass: CloudEvents-core fields plus work-buddy extension
+attributes. This is the *general form* of the two in-tree domain logs
+(``thread_events`` / ``work_item_events``); the envelope is kept field-compatible
+with ``work_item_events``. Routing and dedup read context attributes only; the
+opaque ``data`` payload is never parsed to route.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class Event:
+    """One immutable event on the spine.
+
+    Identity is ``(source, id)`` → the dedup key. ``dedup_key`` defaults to
+    ``f"{source}::{id}"`` and is only overridden when a producer needs a
+    coarser identity (e.g. poll-diff emitting one event per changed field).
+    """
+
+    # --- CloudEvents core ---
+    id: str
+    source: str                       # URI-ref, e.g. "/wb/scheduler"
+    type: str                         # reverse-DNS, e.g. "ai.workbuddy.schedule.tick"
+    data: dict[str, Any]              # opaque, JSON-serializable
+    time: str                         # RFC3339; occurred (push) or observed (pull)
+    specversion: str = "1.0"
+    subject: str | None = None
+    datacontenttype: str = "application/json"
+    dataschema: str | None = None
+    # --- work-buddy extension attributes ---
+    modality: str = "internal"        # "push" | "pull" | "internal"
+    durable: bool = True              # False => lossy fan-out only, never logged
+    dedup_key: str | None = None      # defaults to f"{source}::{id}"
+    idempotency_key: str | None = None
+    traceparent: str | None = None    # W3C trace-context
+    wb_session: str | None = None
+    workflow_run_id: str | None = None
+    ext: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.dedup_key is None:
+            object.__setattr__(self, "dedup_key", f"{self.source}::{self.id}")
+
+    def projection_payload(self) -> dict[str, Any]:
+        """A small JSON-serializable dict for the lossy dashboard fan-out.
+
+        Deliberately *not* the full envelope — the projection is for live UI
+        display, not reliable reaction (which reads the durable log).
+        """
+        return {
+            "id": self.id,
+            "source": self.source,
+            "type": self.type,
+            "subject": self.subject,
+            "time": self.time,
+            "modality": self.modality,
+            "data": self.data,
+        }
+
+
+def new_event(
+    source: str,
+    type: str,  # noqa: A002 — mirrors the CloudEvents attribute name
+    data: dict[str, Any] | None = None,
+    *,
+    id: str | None = None,  # noqa: A002 — CloudEvents attribute name
+    time: str | None = None,
+    durable: bool = True,
+    modality: str = "internal",
+    subject: str | None = None,
+    dedup_key: str | None = None,
+    idempotency_key: str | None = None,
+    traceparent: str | None = None,
+    wb_session: str | None = None,
+    workflow_run_id: str | None = None,
+    ext: dict[str, Any] | None = None,
+) -> Event:
+    """Construct an :class:`Event`, filling ``id`` (uuid) and ``time`` (now)
+    when not supplied. The ergonomic way producers create events."""
+    return Event(
+        id=id or uuid.uuid4().hex,
+        source=source,
+        type=type,
+        data=data or {},
+        time=time or _now_iso(),
+        durable=durable,
+        modality=modality,
+        subject=subject,
+        dedup_key=dedup_key,
+        idempotency_key=idempotency_key,
+        traceparent=traceparent,
+        wb_session=wb_session,
+        workflow_run_id=workflow_run_id,
+        ext=ext or {},
+    )

--- a/work_buddy/events/policy.py
+++ b/work_buddy/events/policy.py
@@ -1,0 +1,52 @@
+"""Consent / policy hook at the processor boundary.
+
+The one behavioral change the backbone introduces: consent is enforced **between the dispatcher and ``Processor.run()``**, not
+only inside individual capabilities. Capabilities still *declare* their
+``consent_weight``; this boundary *enforces* it.
+
+``policy_check`` returns one of ``"allow" | "deny" | "prompt"``:
+- ``action is None``      → ``"allow"`` (the processor declares no gate)
+- a live grant exists      → ``"allow"``
+- no grant / cannot resolve → ``"prompt"`` (the consumer waits; re-checked next
+  drain tick once the user approves)
+
+``"deny"`` is reserved for source ``allowed_actions`` scoping (once event sources
+are implemented), where a source can hard-deny an action it isn't scoped for. ``consent_weight="high"``
+always re-prompts even inside an approved workflow (the cache enforces this).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from work_buddy.events.protocol import RunContext
+
+logger = logging.getLogger(__name__)
+
+Decision = Literal["allow", "deny", "prompt"]
+
+
+def policy_check(
+    action: str | None,
+    ctx: RunContext,
+    *,
+    consent_weight: str = "low",
+) -> Decision:
+    """Gate a processor invocation. See module docstring for the contract."""
+    if action is None:
+        return "allow"
+    try:
+        from work_buddy.consent import _cache
+
+        granted = _cache.is_granted(action, consent_weight=consent_weight)
+    except Exception as exc:  # pragma: no cover — defensive
+        # Fail safe: if consent can't be resolved, hold the event (prompt)
+        # rather than silently delivering it.
+        logger.warning(
+            "events.policy: consent check for %r failed (%s); holding (prompt)",
+            action,
+            exc,
+        )
+        return "prompt"
+    return "allow" if granted else "prompt"

--- a/work_buddy/events/producers/__init__.py
+++ b/work_buddy/events/producers/__init__.py
@@ -1,0 +1,1 @@
+"""Event producers — adapters that turn internal mechanisms into Events."""

--- a/work_buddy/events/producers/cron.py
+++ b/work_buddy/events/producers/cron.py
@@ -1,0 +1,50 @@
+"""Thin ``CronAdapter`` — emits ``ai.workbuddy.schedule.tick`` onto the spine.
+
+**Additive** — the scheduler is left unmodified (this is not a replacement for
+it); the daemon calls :func:`emit_schedule_tick` right after
+``scheduler.tick()``. The adapter only *reads* post-tick state and publishes a
+durable event. Throttled to a low-volume heartbeat (``_MIN_INTERVAL_S``), and
+its short per-type TTL (``store._TTL_DAYS_BY_TYPE``) self-reaps it — so it
+proves "an internal mechanism feeds the spine" without churn.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from work_buddy.events import dispatcher
+from work_buddy.events.envelope import new_event
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+SOURCE = "/wb/scheduler"
+TYPE = "ai.workbuddy.schedule.tick"
+_MIN_INTERVAL_S = 300.0  # at most one tick event every ~5 min
+
+_last_emit: float = 0.0
+
+
+def emit_schedule_tick(scheduler: Any = None, *, force: bool = False) -> bool:
+    """Publish a ``schedule.tick`` event, throttled. Returns True if emitted."""
+    global _last_emit
+    now = time.monotonic()
+    if not force and (now - _last_emit) < _MIN_INTERVAL_S:
+        return False
+    _last_emit = now
+
+    data: dict[str, Any] = {}
+    jobs = getattr(scheduler, "jobs", None)
+    if jobs is not None:
+        try:
+            data["job_count"] = len(jobs)
+        except Exception:  # pragma: no cover — defensive
+            pass
+
+    try:
+        dispatcher.publish(new_event(SOURCE, TYPE, data, modality="internal"))
+        return True
+    except Exception:  # pragma: no cover — defensive; producers never raise up
+        logger.debug("cron adapter: emit failed (non-fatal)", exc_info=True)
+        return False

--- a/work_buddy/events/protocol.py
+++ b/work_buddy/events/protocol.py
@@ -1,0 +1,94 @@
+"""Event backbone protocols — Source / Processor / Condition (interfaces only).
+
+This module defines the *contracts*; concrete Sources and Conditions are not
+yet implemented. The shapes are intentionally minimal so later backends (native
+capability / workflow, and eventually ``external_flow``) are implementations
+behind these ports rather than a redesign.
+
+A **Sink** is just a ``Processor`` whose effect is "land it in a thread /
+notification / task" — there is no separate type.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Protocol, runtime_checkable
+
+from work_buddy.events.envelope import Event
+
+
+@dataclass
+class RunContext:
+    """Correlation + provenance handed to a ``Processor`` — deliberately *not*
+    the execution semantics of any backend (no n8n ``msg`` / Node-RED state)."""
+
+    seq: int
+    traceparent: str | None = None
+    session: str | None = None
+    budget_usd: float | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ConditionContext:
+    """Context for ``Condition.evaluate``. Minimal until conditions are built."""
+
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ProcessorManifest:
+    """What a processor declares about itself — including what the policy gate
+    rules on (``consent_action``) and at what weight."""
+
+    name: str
+    description: str = ""
+    input_schema: dict[str, Any] = field(default_factory=dict)
+    output_schema: dict[str, Any] = field(default_factory=dict)
+    consent_action: str | None = None  # None => no gate (A5)
+    consent_weight: str = "low"        # "low" | "high"
+
+
+@dataclass
+class ProcessorResult:
+    """MCP-tool-shaped result of running a processor."""
+
+    structured: dict[str, Any] | None = None
+    text: str = ""
+    is_error: bool = False
+
+
+@runtime_checkable
+class Source(Protocol):
+    """Adapter that normalizes a delivery mechanism into ``Event``s."""
+
+    name: str
+    mode: str  # "push" | "pull"
+
+    def activate(self, emit: Callable[[Event], None]) -> None:
+        """Push sources: begin emitting via ``emit(event)``."""
+        ...
+
+    def deactivate(self) -> None: ...
+
+    def fetch(self) -> list[Event]:
+        """Pull sources: called on schedule; may return an empty list."""
+        ...
+
+
+@runtime_checkable
+class Processor(Protocol):
+    """The work a delivered event triggers (capability / workflow / sink)."""
+
+    manifest: ProcessorManifest
+
+    def run(self, event: Event, ctx: RunContext) -> ProcessorResult: ...
+
+
+@runtime_checkable
+class Condition(Protocol):
+    """A predicate over an event + its predecessor (used once conditions exist)."""
+
+    def evaluate(
+        self, event: Event, prev: Event | None, ctx: ConditionContext
+    ) -> bool: ...

--- a/work_buddy/events/store.py
+++ b/work_buddy/events/store.py
@@ -1,0 +1,299 @@
+"""``EventStore`` — the durable SQLite spine (log + dedup + offsets + DLQ).
+
+The only thing that touches ``db/events``. Three tables (created idempotently
+at connect time, the house pattern — there is no central migration ladder):
+
+* ``events``           — the append-only log; ``UNIQUE(source, id)`` is the
+                         inbox (the insert *is* the dedup claim). Carries a
+                         per-row ``expires_at`` (computed at append from a
+                         per-type TTL) so the artifact lifecycle can reap it.
+* ``consumer_offsets`` — one watermark per durable consumer (restart replay).
+* ``event_dlq``        — poison events, per consumer (skip-and-record).
+
+Thread-safety: a fresh connection per call (WAL + ``busy_timeout``) so the
+``event-drain`` thread and producers can hit the DB concurrently. Mirrors
+``work_buddy/llm/queue.py`` / ``work_buddy/threads/work_item_events.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from work_buddy.events.envelope import Event
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _db_path() -> Path:
+    """Resolve the events DB path. Tests monkeypatch this."""
+    from work_buddy.paths import resolve
+
+    return resolve("db/events")
+
+
+# --- Per-type retention ----------------------------------------------------
+# ``expires_at`` is computed at append time from this map, so a noisy internal
+# type self-reaps fast while meaningful domain events linger. The artifact's
+# retention predicate (see artifact.py) still pins undelivered / DLQ / (external)
+# in-dedup-window rows regardless of this TTL.
+_DEFAULT_TTL_DAYS = 14.0
+_TTL_DAYS_BY_TYPE: dict[str, float] = {
+    "ai.workbuddy.schedule.tick": 3.0 / 24.0,  # ~3h — high-volume, self-reaps
+}
+
+
+def _expires_at_for(event_type: str, received_at_iso: str) -> str:
+    days = _TTL_DAYS_BY_TYPE.get(event_type, _DEFAULT_TTL_DAYS)
+    base = datetime.fromisoformat(received_at_iso)
+    return (base + timedelta(days=days)).isoformat()
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS events (
+  seq          INTEGER PRIMARY KEY AUTOINCREMENT,  -- total order (single writer)
+  id           TEXT NOT NULL,
+  source       TEXT NOT NULL,
+  type         TEXT NOT NULL,
+  subject      TEXT,
+  time         TEXT NOT NULL,
+  received_at  TEXT NOT NULL,
+  modality     TEXT NOT NULL,
+  dedup_key    TEXT NOT NULL,
+  traceparent  TEXT,
+  expires_at   TEXT,
+  data         TEXT NOT NULL,             -- JSON
+  ext          TEXT NOT NULL DEFAULT '{}',-- JSON (non-promoted envelope fields)
+  UNIQUE(source, id)                      -- the inbox: insert IS the dedup claim
+);
+CREATE INDEX IF NOT EXISTS idx_events_type ON events(type);
+CREATE INDEX IF NOT EXISTS idx_events_dedup ON events(dedup_key);
+
+CREATE TABLE IF NOT EXISTS consumer_offsets (
+  consumer_id  TEXT PRIMARY KEY,
+  last_seq     INTEGER NOT NULL DEFAULT 0,
+  updated_at   TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS event_dlq (
+  seq          INTEGER NOT NULL,
+  consumer_id  TEXT NOT NULL,
+  attempts     INTEGER NOT NULL,
+  last_error   TEXT,
+  dead_at      TEXT NOT NULL,
+  PRIMARY KEY (seq, consumer_id)
+);
+"""
+
+
+def _to_row(event: Event, received_at: str, expires_at: str) -> dict[str, object]:
+    # Promoted columns drive routing/dedup; the rest of the envelope rides in
+    # the ``ext`` JSON blob so the row round-trips a full Event.
+    ext_blob: dict[str, object] = {
+        "specversion": event.specversion,
+        "datacontenttype": event.datacontenttype,
+        "dataschema": event.dataschema,
+        "idempotency_key": event.idempotency_key,
+        "wb_session": event.wb_session,
+        "workflow_run_id": event.workflow_run_id,
+    }
+    ext_blob.update(event.ext or {})
+    return {
+        "id": event.id,
+        "source": event.source,
+        "type": event.type,
+        "subject": event.subject,
+        "time": event.time,
+        "received_at": received_at,
+        "modality": event.modality,
+        "dedup_key": event.dedup_key,
+        "traceparent": event.traceparent,
+        "expires_at": expires_at,
+        "data": json.dumps(event.data, default=str),
+        "ext": json.dumps(ext_blob, default=str),
+    }
+
+
+def _from_row(row: sqlite3.Row) -> tuple[int, Event]:
+    d = dict(row)
+    ext = json.loads(d.get("ext") or "{}")
+    seq = int(d["seq"])
+    evt = Event(
+        id=d["id"],
+        source=d["source"],
+        type=d["type"],
+        data=json.loads(d.get("data") or "{}"),
+        time=d["time"],
+        subject=d.get("subject"),
+        modality=d.get("modality") or "internal",
+        dedup_key=d.get("dedup_key"),
+        traceparent=d.get("traceparent"),
+        specversion=ext.pop("specversion", "1.0") or "1.0",
+        datacontenttype=ext.pop("datacontenttype", "application/json")
+        or "application/json",
+        dataschema=ext.pop("dataschema", None),
+        idempotency_key=ext.pop("idempotency_key", None),
+        wb_session=ext.pop("wb_session", None),
+        workflow_run_id=ext.pop("workflow_run_id", None),
+        ext=ext,
+    )
+    return seq, evt
+
+
+class EventStore:
+    """All DB access for the spine. Stateless beyond the DB path."""
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        self._explicit_path = db_path
+
+    def _path(self) -> Path:
+        return self._explicit_path if self._explicit_path is not None else _db_path()
+
+    def _conn(self) -> sqlite3.Connection:
+        path = self._path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(path), timeout=10)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")  # cheap appends, safe under WAL
+        conn.executescript(_SCHEMA)
+        return conn
+
+    # ----------------------------------------------------------- the log
+
+    def append(self, event: Event) -> int | None:
+        """Append a durable event. Returns its ``seq``, or ``None`` if a row
+        with the same ``(source, id)`` already exists (the dedup claim)."""
+        received = _now_iso()
+        row = _to_row(event, received, _expires_at_for(event.type, received))
+        conn = self._conn()
+        try:
+            cur = conn.execute(
+                "INSERT OR IGNORE INTO events "
+                "(id, source, type, subject, time, received_at, modality, "
+                " dedup_key, traceparent, expires_at, data, ext) "
+                "VALUES (:id,:source,:type,:subject,:time,:received_at,:modality,"
+                ":dedup_key,:traceparent,:expires_at,:data,:ext)",
+                row,
+            )
+            conn.commit()
+            if cur.rowcount == 0:
+                return None  # (source, id) duplicate
+            return int(cur.lastrowid)
+        finally:
+            conn.close()
+
+    def read_since(self, last_seq: int, limit: int = 200) -> list[tuple[int, Event]]:
+        """Return up to ``limit`` events with ``seq > last_seq``, ascending."""
+        conn = self._conn()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM events WHERE seq > ? ORDER BY seq LIMIT ?",
+                (last_seq, limit),
+            ).fetchall()
+        finally:
+            conn.close()
+        return [_from_row(r) for r in rows]
+
+    # ------------------------------------------------------- offsets
+
+    def get_offset(self, consumer_id: str) -> int:
+        conn = self._conn()
+        try:
+            row = conn.execute(
+                "SELECT last_seq FROM consumer_offsets WHERE consumer_id = ?",
+                (consumer_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        return int(row["last_seq"]) if row else 0
+
+    def ensure_offset(self, consumer_id: str, default: int = 0) -> None:
+        """Create the offset row if absent — so a freshly-registered consumer
+        pins the log (retention must not reap ahead of it) before it delivers."""
+        conn = self._conn()
+        try:
+            conn.execute(
+                "INSERT OR IGNORE INTO consumer_offsets "
+                "(consumer_id, last_seq, updated_at) VALUES (?, ?, ?)",
+                (consumer_id, default, _now_iso()),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def commit_offset(self, consumer_id: str, seq: int) -> None:
+        conn = self._conn()
+        try:
+            conn.execute(
+                "INSERT INTO consumer_offsets (consumer_id, last_seq, updated_at) "
+                "VALUES (?, ?, ?) "
+                "ON CONFLICT(consumer_id) DO UPDATE SET "
+                "last_seq = excluded.last_seq, updated_at = excluded.updated_at",
+                (consumer_id, seq, _now_iso()),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def min_live_offset(self) -> int:
+        """Lowest committed offset across consumers — the high-water mark
+        below which every consumer has been delivered. With **no** registered
+        consumers, returns ``sys.maxsize`` so retention pins nothing."""
+        conn = self._conn()
+        try:
+            row = conn.execute(
+                "SELECT MIN(last_seq) AS m, COUNT(*) AS c FROM consumer_offsets"
+            ).fetchone()
+        finally:
+            conn.close()
+        if not row or row["c"] == 0:
+            return sys.maxsize
+        return int(row["m"])
+
+    # ------------------------------------------------------- DLQ
+
+    def dead_letter(self, seq: int, consumer_id: str, attempts: int, err: str) -> None:
+        conn = self._conn()
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO event_dlq "
+                "(seq, consumer_id, attempts, last_error, dead_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (seq, consumer_id, attempts, (err or "")[:2000], _now_iso()),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def dlq_seqs(self) -> set[int]:
+        """The set of seqs with a live DLQ row (for the retention predicate)."""
+        conn = self._conn()
+        try:
+            rows = conn.execute("SELECT DISTINCT seq FROM event_dlq").fetchall()
+        finally:
+            conn.close()
+        return {int(r["seq"]) for r in rows}
+
+    # ------------------------------------------------------- introspection
+
+    def max_seq(self) -> int:
+        conn = self._conn()
+        try:
+            row = conn.execute("SELECT MAX(seq) AS m FROM events").fetchone()
+        finally:
+            conn.close()
+        return int(row["m"]) if row and row["m"] is not None else 0
+
+    def count(self) -> int:
+        conn = self._conn()
+        try:
+            row = conn.execute("SELECT COUNT(*) AS c FROM events").fetchone()
+        finally:
+            conn.close()
+        return int(row["c"]) if row else 0

--- a/work_buddy/mcp_server/ops/events_ops.py
+++ b/work_buddy/mcp_server/ops/events_ops.py
@@ -1,0 +1,47 @@
+"""Events-backbone ops (agent-facing capabilities).
+
+Each op here is referenced by a ``kind: capability`` knowledge-store unit
+carrying a matching ``op`` field (``knowledge/store/events/``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from work_buddy.mcp_server.op_registry import register_op
+
+
+def event_publish(
+    type: str,  # noqa: A002 — mirrors the CloudEvents attribute name
+    data: dict[str, Any] | None = None,
+    source: str = "/wb/agent",
+    durable: bool = True,
+    subject: str | None = None,
+) -> dict[str, Any]:
+    """Publish one event onto the Events backbone (fire-and-forget).
+
+    Durable events are logged (deduped on ``(source, id)``) and delivered
+    at-least-once to registered consumers; ``durable=False`` is a lossy
+    UI-only fan-out that never hits the log.
+    """
+    from work_buddy.events.dispatcher import publish
+    from work_buddy.events.envelope import new_event
+
+    evt = new_event(
+        source, type, data or {}, durable=durable, subject=subject, modality="internal"
+    )
+    publish(evt)
+    return {
+        "ok": True,
+        "id": evt.id,
+        "type": evt.type,
+        "source": evt.source,
+        "durable": durable,
+    }
+
+
+def _register() -> None:
+    register_op("op.wb.event_publish", event_publish)
+
+
+_register()

--- a/work_buddy/paths.py
+++ b/work_buddy/paths.py
@@ -71,6 +71,7 @@ RESOURCES: dict[str, str] = {
     "db/threads":                "db/threads.db",  # Thread + thread_events
     "db/llm_queue":              "db/llm_call_queue.db",  # LLM-call priority queue
     "db/work_item_events":       "db/work_item_events.db",  # WorkItem audit/provenance log
+    "db/events":                 "db/events.db",  # Events backbone — durable spine (log + offsets + DLQ)
     "db/vault-index":            "db/vault-index.db",  # Vault semantic-index chunk store
     "db/index-consolidated":     "db/index-consolidated.db",  # Consolidated index (flag-gated; index.enabled)
     "db/broker-metrics":         "db/broker_metrics.db",  # Persisted LocalInferenceBroker call metrics

--- a/work_buddy/sidecar/daemon.py
+++ b/work_buddy/sidecar/daemon.py
@@ -961,6 +961,27 @@ def run(foreground: bool = True) -> None:
     jobs_watcher = JobsWatcher(scheduler)
     jobs_watcher.start()
 
+    # --- Events backbone: register the demo consumer + start the
+    # single event-drain thread + the thin cron producer. All best-effort —
+    # a backbone failure must never take down the rest of the sidecar.
+    event_drain = None
+    _emit_event_tick = None
+    try:
+        from work_buddy.events.consumers.notify_demo import register_notify_demo
+        from work_buddy.events.drain import EventDrain
+        from work_buddy.events.producers.cron import emit_schedule_tick
+
+        register_notify_demo()
+        event_drain = EventDrain()
+        event_drain.start()
+        _emit_event_tick = emit_schedule_tick
+        logger.info("events backbone started (drain + notify-demo + cron adapter)")
+    except Exception as _events_exc:  # pragma: no cover — defensive
+        logger.warning(
+            "events backbone failed to start (non-fatal): %s",
+            _events_exc, exc_info=True,
+        )
+
     # --- Initialize message poller ---
     from work_buddy.sidecar.dispatch.router import MessagePoller
 
@@ -1020,6 +1041,16 @@ def run(foreground: bool = True) -> None:
                 scheduler.tick()
                 scheduler.update_state(state)
 
+                # 2b. Events backbone — thin CronAdapter emits a (throttled)
+                # schedule.tick event onto the spine. Additive; never raises up.
+                if _emit_event_tick is not None:
+                    try:
+                        _emit_event_tick(scheduler)
+                    except Exception:
+                        logger.debug(
+                            "cron event adapter failed (non-fatal)", exc_info=True
+                        )
+
                 # 3. Message polling
                 poller.poll()
 
@@ -1063,6 +1094,8 @@ def run(foreground: bool = True) -> None:
         logger.info("Keyboard interrupt — shutting down.")
     finally:
         jobs_watcher.stop()
+        if event_drain is not None:
+            event_drain.stop()
         monitor.stop()
         event_log.emit("daemon_stop", "daemon", "Sidecar shutting down")
         state.events = event_log.recent(50)


### PR DESCRIPTION
## Summary
- Introduces `work_buddy/events/` — a first-class, in-process delivery **spine** for event-shaped facts: a CloudEvents-superset `Event` envelope + a durable SQLite log (inbox dedup on `(source,id)` + per-consumer offsets + DLQ) + a single `event-drain` thread + a consent gate at the processor boundary. Offset-aware retention is registered as an artifact.
- **Scope is bounded by the inclusion rule:** only fire-and-forget facts ride the spine; RPC/commands, observability surfaces, and supervision stay on their existing rails. The dashboard event-bus is reused as the lossy UI projection (not the spine).
- Ships the first producers/consumer to prove it end-to-end: an `event_publish` capability, a thin **additive** `CronAdapter` (`schedule.tick`, the scheduler is unmodified), and a `notify-demo` consumer.

## Test plan
- [x] 34 events tests (unit + in-process end-to-end) green; full `tests/unit` suite green (no regressions)
- [x] Live cross-process flow verified: gateway `event_publish` → shared `db/events` → sidecar `event-drain` → notify-demo consumer → notification (delivered to Telegram + dashboard)
- [x] `event_publish` op registered after gateway restart; DLQ / dedup / restart-replay covered by tests
- [ ] CI: DCO + test checks

## Not built here (designed-for)
Sources/Conditions + the stock-watcher, the webhook ingress, and the retry-queue-as-outbox — gated on a concrete consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)