### PR TITLE
feat(events): user-authored pull sources + /wb-event-new authoring

### DIFF
--- a/.claude/commands/wb-event-new.md
+++ b/.claude/commands/wb-event-new.md
@@ -1,0 +1,4 @@
+---
+short: Author an event source in conversation — watch a URL/feed, react on a meaningful change, notify. Dry-run preview before it goes live.
+---
+Load directions via `mcp__work-buddy__wb_run("agent_docs", {"path": "events/event-new-directions", "depth": "full"})`, then start the workflow via `mcp__work-buddy__wb_run("event-new")`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ Every scope below is browsable with `mcp__work-buddy__wb_run("agent_docs", {"sco
 | `websearch/` | General web search via provider seam (Jina default + keyless ddgs fallback), trafilatura/Jina-reader extraction, evidence-cards, broker-admitted LOCAL_FAST classify |
 | `threads/` | Multi-turn agent-user threads |
 | `notifications/` | Notify, request, consent, surfaces |
-| `events/` | Durable in-process delivery spine for event-shaped facts — CloudEvents-superset envelope, SQLite log (dedup + offsets + DLQ), one drain thread, consent gate; `event_publish` to emit |
+| `events/` | Durable in-process delivery spine for event-shaped facts — CloudEvents-superset envelope, SQLite log (dedup + offsets + DLQ), one drain thread, consent gate; `event_publish` to emit, plus user-authored **pull sources** (poll → diff → CEL condition → notify) authored via `/wb-event-new` |
 | `services/` | Messaging, memory (Hindsight), dashboard, sidecar |
 | `features/` | Preferences and feature opt-in |
 | `operations/` | Gateway, agent sessions |

--- a/knowledge/store/events.md
+++ b/knowledge/store/events.md
@@ -20,7 +20,7 @@ aliases:
 - events system
 - event spine
 - durable event bus
-dev_notes: '**The inclusion rule is the boundary**: only *event-shaped* comms ride the spine — fire-and-forget facts, 0..N consumers, no response expected. RPC/commands (`wb_run`, embedding, broker), observability surfaces (the dashboard `EventBus`, the sidecar `EventLog`), and supervision (health/evictors) are excluded *by category*, not by omission — routing request/response through an at-least-once tick-drained log adds latency and breaks the return channel. **+1 thread, period**: one `event-drain` thread iterates ALL consumers; a consumer is a registry entry, not a thread (idle = one dict entry). A *blocking* handler would stall the single drain — keep handlers fast (offload to a shared bounded pool later if needed). **Cross-process is via the shared SQLite file**: an `event_publish` from the gateway appends to `db/events`; the sidecar drain reads it — no IPC. The lossy dashboard fan-out is the existing `dashboard.events.publish_auto` (sidecar → messaging bridge → SSE), best-effort. **Retention** is offset-aware: a row is kept while undelivered (`seq > min_live_offset`), in the DLQ, or — *external events only* — inside the 7-day replay window; everything else reaps on a per-type `expires_at` (noisy `schedule.tick` ~3h). **Activation**: a new op (`event_publish`) needs a one-time gateway+sidecar restart (new Op code is not picked up by the data-only `reload_capability_data`). **Threads is a sink, never a producer** (no `ThreadsAdapter`).'
+dev_notes: '**The inclusion rule is the boundary**: only *event-shaped* comms ride the spine — fire-and-forget facts, 0..N consumers, no response expected. RPC/commands (`wb_run`, embedding, broker), observability surfaces (the dashboard `EventBus`, the sidecar `EventLog`), and supervision (health/evictors) are excluded *by category*, not by omission — routing request/response through an at-least-once tick-drained log adds latency and breaks the return channel. **+1 thread, period**: one `event-drain` thread iterates ALL consumers; a consumer is a registry entry, not a thread (idle = one dict entry). A *blocking* handler would stall the single drain — keep handlers fast (offload to a shared bounded pool later if needed). **Cross-process is via the shared SQLite file**: an `event_publish` from the gateway appends to `db/events`; the sidecar drain reads it — no IPC. The lossy dashboard fan-out is the existing `dashboard.events.publish_auto` (sidecar → messaging bridge → SSE), best-effort. **Retention** is offset-aware: a row is kept while undelivered (`seq > min_live_offset`), in the DLQ, or — *external events only* — inside the 7-day replay window; everything else reaps on a per-type `expires_at` (noisy `schedule.tick` ~3h). **Activation**: a new op (`event_publish`) needs a one-time gateway+sidecar restart (new Op code is not picked up by the data-only `reload_capability_data`). **Threads is a sink, never a producer** (no `ThreadsAdapter`). **Source layer**: the producer/reaction split is load-bearing — the poller (`sources/poller.py`) only fetches→diffs→publishes `ai.workbuddy.source.<name>.changed`; condition eval + the scoped action live in `SourceActionProcessor` (`consumers/source_action.py`, a `type_prefix` subscriber), so the reaction inherits at-least-once + DLQ. The rate-limit fire-log (`<state>/<name>.fires.json`) is SEPARATE from the cursor file (`<name>.json`): different writers (consumer vs poller), so one shared file would clobber. celpy ships no `abs`/`math.*` — `conditions/cel.py:_cel_functions` registers a curated `abs`; the activation exposes `event.data`/`prev.data` (+ a `current` shorthand) with no bare `prev` scalar (it would collide with the `prev` map). `event_source_dry_run` takes `name` (saved) OR `proposal` (the unsaved `event_source_create` field set) so the `/wb-event-new` confirm gate precedes any write. Actions are `Action(name, run, consent_action, consent_weight)` records (not `Processor` instances) because an action needs the source def for `action_params`; `registry.known_actions()` must stay in sync with `definition.KNOWN_ACTIONS` (a test asserts it). The `event-source-poll` cron re-loads every source each tick, so a new/edited source needs no hot-reload hook.'
 ---
 
 ## Why it exists
@@ -44,22 +44,33 @@ producer ──publish()──►  EventStore.append (db/events, UNIQUE(source,i
 
 - **`envelope.py`** — frozen `Event` (CloudEvents core + work-buddy extension attrs). The general form of the in-tree `thread_events` / `work_item_events` logs; the envelope is kept field-compatible with `work_item_events`.
 - **`store.py`** — `EventStore` over `db/events`: `events` (the log + per-row `expires_at`), `consumer_offsets` (one watermark each — restart replay), `event_dlq`. `append` returns `None` on a `(source,id)` duplicate.
-- **`dispatcher.py`** — `publish()` (append + fan-out) and `drain()` (at-least-once delivery, offsets, bounded-retry→DLQ) + a consumer registry.
+- **`dispatcher.py`** — `publish()` (append + fan-out) and `drain()` (at-least-once delivery, offsets, bounded-retry→DLQ) + a consumer registry. A consumer subscribes by an exact `types` set OR a `type_prefix` (e.g. `ai.workbuddy.source.`).
 - **`drain.py`** — the single `event-drain` daemon thread (the backbone's only added thread).
 - **`policy.py`** — `policy_check` at the processor boundary (consent enforced *between* dispatch and `Processor.run`, reusing `ConsentCache`).
 - **`artifact.py`** — registers `events` as an artifact so the existing `artifact_cleanup` sweep bounds it (offset-aware retention predicate).
-- **`protocol.py`** — `Source` / `Processor` / `Condition` ports (interfaces defined; concrete Sources/Conditions are not yet implemented).
+- **`protocol.py`** — `Source` / `Processor` / `Condition` ports. Pull `Source`s and `Condition`s are implemented (see *Sources* below); `push` sources (webhook ingress) remain a designed-for extension.
 
 ## Not the dashboard event-bus
 
 Distinct from `architecture/event-bus` (`dashboard/events.py`) — that is the *lossy SSE fan-out* for real-time UI. The durable spine *feeds* it as a projection; it is never the spine.
 
-## Producers and the demo consumer
+## Producers and consumers
 
 - `event_publish` capability — manual/agent emit (the controlled path).
 - thin `CronAdapter` (`producers/cron.py`) — emits `ai.workbuddy.schedule.tick` after `scheduler.tick()`; additive (the scheduler is unmodified), throttled, short-TTL.
+- the **source poller** (`sources/poller.py`, fired by the `event-source-poll` cron) — the first real external producer: fetch → diff vs the stored cursor → publish `ai.workbuddy.source.<name>.changed`.
 - `notify-demo` consumer (`consumers/notify_demo.py`) — writes a notification on `ai.workbuddy.demo.ping` (the visible end-to-end effect).
+- the **source-action consumer** (`consumers/source_action.py`, a `type_prefix` subscriber on `ai.workbuddy.source.`) — reacts to a source change: evaluates the source's condition, then runs its scoped action.
 
-## Extension points (not yet implemented)
+## Sources — user-authored pull watchers
 
-The `Source` and `Condition` protocols are the designed extension surface for *user-defined* events — polling/webhook sources with diff conditions (e.g. a stock-watcher), authored conversationally. Other internal mechanisms (`MessagePoller`, pipelines, the retry queue as the durable outbox) move onto the spine **only when a real second consumer needs their events**, not as a blanket migration. A webhook ingress and an n8n/Node-RED `external_flow` processor are designed-for but gated on a concrete consumer.
+A **source** is a durable `.md` under `.data/event_sources/` that polls some state and fires a notification on a *meaningful change* (a diff, not every fetch). The split is deliberately spine-shaped: the **poller is the producer** (fetch → diff → publish on change) and the **reaction lives in a consumer on the drain** (condition + scoped action), so the reaction inherits at-least-once delivery + DLQ for free.
+
+- **Producer** (`sources/`): `http_poll` fetch → `extract` (JSONPath / CSS / whole-payload hash) → content-hash diff vs a per-source cursor → publish `ai.workbuddy.source.<name>.changed` carrying `{current, prev}`. The cursor advances only after a successful poll (crash-safe; the spine dedupes a re-emit). The first observation is a silent baseline unless the source sets `cursor.from: all`.
+- **Condition** (`conditions/cel.py`): a safe, non-Turing-complete CEL predicate over `event.data` / `prev.data` (with a `current` shorthand), evaluated **fail-closed** — any error means no fire.
+- **Action** (`processors/`): the scoped sink — only `notify` exists, gated by the source's `allowed_actions` + per-action consent, under `autonomy: notify_only`. A source that exceeds `max_per_hour` auto-suspends itself.
+- **Authoring**: `/wb-event-new` (workflow `events/event-new`) elicits → proposes a grounded draft → dry-runs it with zero side effects → confirms → activates. `event_source_create` / `event_source_dry_run` / `event_source_list` / `event_source_toggle` are the ops behind it.
+
+## Still designed-for (gated on a concrete consumer)
+
+A webhook ingress (`push` sources), `auto_execute` autonomy beyond `notify_only`, and an n8n/Node-RED `external_flow` processor are designed-for but not built. Other internal mechanisms (`MessagePoller`, pipelines, the retry queue as the durable outbox) move onto the spine **only when a real second consumer needs their events**, not as a blanket migration.

--- a/knowledge/store/events/event-new-directions.md
+++ b/knowledge/store/events/event-new-directions.md
@@ -1,0 +1,67 @@
+---
+name: Event New Directions
+kind: directions
+description: How to run /wb-event-new — author an event source in conversation (elicit → propose → dry-run → confirm → activate → monitor). Builds polling watchers on the events backbone via event_source_create, grounded to registered source types and actions.
+trigger: When the user invokes /wb-event-new or asks to watch a source, get notified when something changes, or create an event source / watcher
+command: wb-event-new
+workflow: events/event-new
+capabilities:
+- event_source_create
+- event_source_dry_run
+- event_source_list
+- event_source_toggle
+tags:
+- events
+- source
+- authoring
+- directions
+- watcher
+aliases:
+- event new directions
+- how to author an event source
+- watch a source directions
+parents:
+- events
+---
+
+Run `/wb-event-new` to author an event source — a durable watcher that polls some
+state, reacts on a *meaningful change*, evaluates a condition, and fires a notify
+action. The workflow walks elicit → propose → dry-run → confirm → activate →
+monitor, so the user sees a real preview before anything is written or fires.
+
+## When to run
+
+When the user wants to be notified when something out in the world changes — a
+price, a status page, a number on a JSON endpoint — without babysitting it. Not
+for one-off "check this now" questions (just fetch it); a source is for *standing*
+watches.
+
+## Stay grounded
+
+Propose only what the registry actually supports: `source.type: http_poll`,
+`extract.mode` in {`json_path`, `css`, `hash`}, `action: notify`, `autonomy:
+notify_only`. The condition is CEL over `event.data` / `prev.data`. If the user
+asks for something outside this set (a push webhook, an auto-executing action,
+another source type), say it isn't supported yet and stop — never fabricate a
+source that fails validation.
+
+## The dry-run is the safety gate
+
+`event_source_dry_run` previews the proposed source with **zero side effects** —
+no file, no publish, no action. Run it on the proposal *before* writing anything,
+and only call `event_source_create` after the user confirms. A brand-new source's
+first observation is a silent baseline, so `would_fire: false` on the preview is
+normal — read the dry-run as "the fetch, extraction, and condition are sound,"
+then activate.
+
+## Scope + autonomy
+
+A source runs only the actions in its `allowed_actions`, and `notify_only` means
+the action notifies — it never executes a state-changing capability on the user's
+behalf. The notification is the surface; the user decides what to do with it.
+
+## Managing sources
+
+`event_source_list` shows what's authored (and any that failed validation);
+`event_source_toggle` pauses or resumes one without deleting it (the cursor is
+preserved). A source that exceeds its `max_per_hour` auto-suspends itself.

--- a/knowledge/store/events/event-new.md
+++ b/knowledge/store/events/event-new.md
@@ -1,0 +1,247 @@
+---
+name: Event New
+kind: workflow
+description: Author an event source in conversation — elicit what to watch, propose a grounded EventSourceDef draft, dry-run it with zero side effects, confirm, then activate it. The conversational front end for event_source_create; builds polling watchers (e.g. a stock-watcher) without hand-editing .md files.
+workflow_name: event-new
+execution: main
+allow_override: false
+steps:
+- id: elicit
+  name: Understand what to watch, what change matters, and the reaction
+  step_type: reasoning
+  depends_on: []
+  result_schema:
+    required_keys:
+    - watch
+    - change
+    - reaction
+    key_types:
+      watch: str
+      change: str
+      reaction: str
+  invokes: []
+- id: propose
+  name: Draft a grounded EventSourceDef proposal
+  step_type: reasoning
+  depends_on:
+  - elicit
+  result_schema:
+    required_keys:
+    - name
+    - proposal
+    key_types:
+      name: str
+      proposal: dict
+  invokes: []
+- id: dry_run
+  name: Preview the proposed source with zero side effects
+  step_type: code
+  depends_on:
+  - propose
+  visibility:
+    mode: summary
+    include_keys:
+    - ok
+    - current
+    - changed
+    - would_fire
+    - condition_passed
+    - error
+  invokes:
+  - event_source_dry_run
+- id: confirm
+  name: Show the draft + preview; get explicit confirmation
+  step_type: reasoning
+  depends_on:
+  - dry_run
+  result_schema:
+    required_keys:
+    - confirmed
+    key_types:
+      confirmed: bool
+  invokes: []
+- id: activate
+  name: Write the validated source
+  step_type: code
+  depends_on:
+  - confirm
+  visibility:
+    mode: summary
+    include_keys:
+    - success
+    - file_path
+    - error
+  invokes:
+  - event_source_create
+- id: monitor
+  name: Surface the first firings and how to pause
+  step_type: reasoning
+  depends_on:
+  - activate
+  invokes: []
+command: wb-event-new
+tags:
+- events
+- source
+- authoring
+- workflow
+- watcher
+aliases:
+- new event source
+- author a watcher
+- watch a source
+- create event source workflow
+parents:
+- events
+dev_notes: |-
+  `dry_run` and `activate` are code steps that `invoke` events ops. The proposal
+  produced by `propose` is the structured `event_source_create` parameter set
+  (name + source_type + interval + extract + condition + action + ...); both
+  `event_source_dry_run(proposal=...)` and `event_source_create(**proposal)`
+  consume the same shape, so there is one draft object end-to-end. The dry-run
+  runs against an *unsaved* proposal (no file is written until `activate`), so
+  the confirm gate genuinely precedes any write.
+---
+
+Author an event source in conversation. The loop elicits what to watch, proposes
+a grounded draft, previews it with zero side effects, confirms, and only then
+writes the source — mirroring `/wb-dev-document`'s propose→confirm→apply gate.
+
+## Philosophy
+
+An event source is a small, durable watcher: it polls some state, reacts only on
+a *meaningful change* (a diff, not every fetch), evaluates a condition, and fires
+a scoped action. Hand-authoring the `.md` is error-prone; this loop keeps the
+draft grounded to what actually exists (registered source types and actions) and
+shows a real preview before anything is written or fires.
+
+## Grounding (propose only what exists)
+
+- **source.type**: `http_poll` (GET a URL). `fake` is test-only — don't propose it.
+- **extract.mode**: `json_path` (e.g. `$.quote.price`), `css`, or `hash` (whole-payload).
+- **action**: `notify` only. **autonomy**: `notify_only` only. No action that changes
+  state runs — a watcher notifies; the user acts.
+- **condition**: a CEL predicate over `event.data` / `prev.data` (and the `current`
+  shorthand). The action fires only when it is true. `abs()` is available for
+  threshold conditions.
+
+Never invent a source type, action, or autonomy the registry doesn't have. If the
+user wants something outside this set, say so plainly and stop — don't fabricate a
+source that will fail validation.
+
+## elicit
+
+Reasoning step. Draw out three things in plain language:
+- **watch** — what state to watch and where (a URL + the field, e.g. "NVDA's price
+  and CEO from this JSON quote endpoint").
+- **change** — what change is worth a notification (e.g. "the CEO changes, or the
+  price moves more than 5%").
+- **reaction** — what should happen (a notification — confirm the user wants
+  notify-only).
+
+Advance with `{"watch": "...", "change": "...", "reaction": "..."}`.
+
+---
+**Advance via** `wb_advance(workflow_run_id=..., step_result={...})`. The parameter is `step_result` (not `result`) — FastMCP silently drops unknown kwargs.
+
+## propose
+
+Reasoning step. Turn the elicited intent into a structured draft — the exact
+parameter set `event_source_create` takes. Translate "change" into a CEL condition
+grounded to the extracted fields. Example draft for the stock-watcher:
+
+```json
+{
+  "name": "nvda-watch",
+  "proposal": {
+    "name": "nvda-watch",
+    "source_type": "http_poll",
+    "url": "https://example.test/quote/NVDA.json",
+    "interval": "6h",
+    "extract_mode": "json_path",
+    "extract_path": "$",
+    "condition": "event.data.ceo != prev.data.ceo || abs(event.data.price - prev.data.price) / prev.data.price > 0.05",
+    "action": "notify",
+    "allowed_actions": ["notify"],
+    "autonomy": "notify_only"
+  }
+}
+```
+
+Notes:
+- `name` must be 1–64 chars, alphanumeric-start (it becomes the `.md` stem).
+- Use `extract_path: "$"` (whole object) when the condition reads multiple fields
+  (`event.data.ceo`, `event.data.price`); use a scalar path (`$.price`) plus
+  `event.data != prev.data` when watching a single value.
+- Keep `action` inside `allowed_actions` — the source is scoped to exactly the
+  actions you list.
+
+Advance with `{"name": "<name>", "proposal": { ...the full param set... }}`.
+
+---
+**Advance via** `wb_advance(workflow_run_id=..., step_result={...})`. The parameter is `step_result` (not `result`) — FastMCP silently drops unknown kwargs.
+
+## dry_run
+
+Code step. Preview the proposed source with **zero side effects** — no file is
+written, nothing is published, no action runs:
+
+```
+mcp__work-buddy__wb_run("event_source_dry_run", {"proposal": <propose.proposal>})
+```
+
+The result reports `current` (the sampled value), `changed`, the `would_emit`
+event, `condition_passed`, and `would_fire`. The first observation is a silent
+baseline — `would_fire` is normally `false` on a brand-new source (it fires on the
+*next* change), so read this step as "did the fetch + extraction + condition
+*compile and produce a sane value*," not "will it fire right now." If `ok` is
+`false`, surface the validation error and loop back to `propose` to fix the draft.
+
+Advance with the dry-run result.
+
+---
+**Advance via** `wb_advance(workflow_run_id=..., step_result={...})`. The parameter is `step_result` (not `result`) — FastMCP silently drops unknown kwargs.
+
+## confirm
+
+Reasoning step. Show the user the draft in plain language plus the dry-run sample
+(the value it read, and the condition it will fire on). Ask for an explicit yes.
+
+If the user wants changes, advance with `{"confirmed": false}` and loop back to
+`propose` with their edits. Only advance with `{"confirmed": true}` on a clear yes.
+
+---
+**Advance via** `wb_advance(workflow_run_id=..., step_result={...})`. The parameter is `step_result` (not `result`) — FastMCP silently drops unknown kwargs.
+
+## activate
+
+Code step. Only run this on `confirm.confirmed == true`. Write the source by
+calling `event_source_create` with the confirmed proposal:
+
+```
+mcp__work-buddy__wb_run("event_source_create", <propose.proposal>)
+```
+
+The op re-validates and writes `<event_sources>/<name>.md`. The poll tick re-loads
+sources each run, so the watcher activates on the next poll — no restart. If the
+result is `{"success": false}`, surface the errors and loop back to `propose`.
+
+Advance with the create result.
+
+---
+**Advance via** `wb_advance(workflow_run_id=..., step_result={...})`. The parameter is `step_result` (not `result`) — FastMCP silently drops unknown kwargs.
+
+## monitor
+
+Reasoning step. Confirm the source is live, tell the user its poll interval and
+what it will notify on, and remind them they can pause it any time:
+
+```
+mcp__work-buddy__wb_run("event_source_toggle", {"name": "<name>", "enabled": false})
+```
+
+Surface the first firing when it lands (it arrives as a normal notification). Wrap
+up the workflow.
+
+---
+**Advance via** `wb_advance(workflow_run_id=..., step_result={...})`. The parameter is `step_result` (not `result`) — FastMCP silently drops unknown kwargs.

--- a/knowledge/store/events/event_source_create.md
+++ b/knowledge/store/events/event_source_create.md
@@ -1,0 +1,105 @@
+---
+name: Event Source Create
+kind: capability
+description: Author an event source — validate the structured fields and write <event_sources>/<name>.md. Builds a polling watcher that fetches state, reacts on a meaningful change, evaluates a CEL condition, and fires a scoped action (notify). Refuses to overwrite unless overwrite=true; a malformed source returns its validation errors.
+capability_name: event_source_create
+category: events
+op: op.wb.event_source_create
+schema_version: wb-capability/v1
+parameters:
+  name:
+    type: str
+    description: Source name (1-64 chars, alphanumeric start; becomes the .md file stem)
+    required: true
+  source_type:
+    type: str
+    description: Delivery backend — http_poll (GET a URL) or fake (test/no-network)
+    required: true
+  interval:
+    type: str
+    description: Poll interval, e.g. '30s', '5m', '6h', '1d'
+    required: true
+  url:
+    type: str
+    description: URL to GET (required for http_poll)
+    required: false
+  extract_mode:
+    type: str
+    description: How to extract the watched value — json_path, css, or hash (whole-payload)
+    required: false
+  extract_path:
+    type: str
+    description: JSONPath (e.g. $.quote.price) or CSS selector for the watched value
+    required: false
+  condition:
+    type: str
+    description: Optional CEL predicate over event.data / prev.data; the action fires only when it is true
+    required: false
+  action:
+    type: str
+    description: Action to run on a firing change (only 'notify' is supported)
+    required: false
+  action_params:
+    type: dict
+    description: Parameters for the action (e.g. notify title/body overrides)
+    required: false
+  allowed_actions:
+    type: list
+    description: Actions this source is scoped to run; the action must be in this list (defaults to [action])
+    required: false
+  autonomy:
+    type: str
+    description: notify_only (default) or auto_execute (not yet supported)
+    required: false
+  max_per_hour:
+    type: int
+    description: Optional rate-limit; more firings than this in an hour suspends the source
+    required: false
+  cursor_from:
+    type: str
+    description: now (default; first observation is a silent baseline) or all (fire on the first observation too)
+    required: false
+  enabled:
+    type: bool
+    description: Whether the source polls immediately (default true)
+    required: false
+  event_type:
+    type: str
+    description: Override the emitted event type (defaults to ai.workbuddy.source.<name>.changed)
+    required: false
+  overwrite:
+    type: bool
+    description: Replace an existing source of the same name (default false)
+    required: false
+mutates_state: true
+retry_policy: manual
+is_action: true
+intrinsic_amplifiers:
+  irreversibility: low
+  regret_potential: low
+tags:
+- events
+- source
+- create
+- author
+- watcher
+aliases:
+- create event source
+- new event source
+- add a watcher
+- watch a source
+parents:
+- events
+---
+
+Author an event source by building its frontmatter from structured fields,
+validating it (known type, valid interval, valid JSONPath and CEL, action in
+`allowed_actions`, valid autonomy), and writing `<event_sources>/<name>.md`. The
+poller re-loads the directory each tick, so a new source activates on the next
+poll — no restart needed.
+
+This is the activate step behind `/wb-event-new`; prefer that conversational
+loop (it elicits the watch, proposes a grounded draft, and dry-runs it before
+calling this) over hand-filling the parameters. The action is scoped: only
+actions in `allowed_actions` may run, and only `notify` exists today
+(`autonomy: notify_only`).

--- a/knowledge/store/events/event_source_dry_run.md
+++ b/knowledge/store/events/event_source_dry_run.md
@@ -1,0 +1,42 @@
+---
+name: Event Source Dry Run
+kind: capability
+description: Preview an event source without any side effects — fetch, diff against the last value, and evaluate the condition, but never publish, run an action, or advance the cursor. Returns the sampled value, whether it changed, the would-emit event, and whether the condition would pass. The preview the /wb-event-new authoring loop shows before activating.
+capability_name: event_source_dry_run
+category: events
+op: op.wb.event_source_dry_run
+schema_version: wb-capability/v1
+parameters:
+  name:
+    type: str
+    description: The event source name (the .md file stem). Provide this to preview a saved source.
+    required: false
+  proposal:
+    type: dict
+    description: The structured event_source_create fields (name, source_type, interval, extract_*, condition, action, ...), to preview a not-yet-saved source — what /wb-event-new's dry-run step passes. Provide either name or proposal.
+    required: false
+mutates_state: false
+retry_policy: none
+is_action: false
+intrinsic_amplifiers:
+  irreversibility: low
+  regret_potential: low
+tags:
+- events
+- source
+- dry-run
+- preview
+aliases:
+- preview event source
+- dry run source
+parents:
+- events
+---
+
+Run a single source poll with **zero side effects**: fetch the payload, extract
+the watched value, diff it against the stored cursor, and — if it changed —
+evaluate the source's CEL condition over the would-emit event. Nothing is
+published, no action runs, and the cursor is not advanced, so this is safe to
+call repeatedly while authoring. Returns `{changed, current, prev, would_emit,
+condition_passed, would_fire}` so the author can see exactly what *would* happen
+before activating the source.

--- a/knowledge/store/events/event_source_list.md
+++ b/knowledge/store/events/event_source_list.md
@@ -1,0 +1,31 @@
+---
+name: Event Source List
+kind: capability
+description: List authored event sources — name, type, interval, enabled state, action, condition, and autonomy — plus any sources that failed validation and why. Read-only.
+capability_name: event_source_list
+category: events
+op: op.wb.event_source_list
+schema_version: wb-capability/v1
+parameters: {}
+mutates_state: false
+retry_policy: none
+is_action: false
+intrinsic_amplifiers:
+  irreversibility: low
+  regret_potential: low
+tags:
+- events
+- source
+- list
+aliases:
+- list event sources
+- list sources
+parents:
+- events
+---
+
+List every authored event source under `.data/event_sources/`. Valid sources are
+returned with their `name`, `type`, poll `interval_s`, `enabled` flag, `action`,
+`allowed_actions`, `condition`, and `autonomy`; sources that fail validation are
+returned in `errors` with the specific reasons, so a malformed `.md` is visible
+rather than silently skipped.

--- a/knowledge/store/events/event_source_toggle.md
+++ b/knowledge/store/events/event_source_toggle.md
@@ -1,0 +1,41 @@
+---
+name: Event Source Toggle
+kind: capability
+description: Enable or disable an authored event source by rewriting its .md. A disabled source is skipped by the poll tick (no fetch, no fire) but its definition and cursor are preserved.
+capability_name: event_source_toggle
+category: events
+op: op.wb.event_source_toggle
+schema_version: wb-capability/v1
+parameters:
+  name:
+    type: str
+    description: The event source name (the .md file stem)
+    required: true
+  enabled:
+    type: bool
+    description: True to enable polling, False to suspend it
+    required: true
+mutates_state: true
+retry_policy: manual
+is_action: true
+intrinsic_amplifiers:
+  irreversibility: low
+  regret_potential: low
+tags:
+- events
+- source
+- toggle
+- enable
+- disable
+aliases:
+- enable event source
+- disable event source
+- suspend source
+parents:
+- events
+---
+
+Flip an event source's `enabled` flag, rewriting its `.md` in place. A disabled
+source is skipped by the poll tick — no fetch, no diff, no fire — while its
+definition and cursor state are preserved, so re-enabling resumes from where it
+left off. Used by the rate-limit auto-suspend path and for manual pause/resume.

--- a/knowledge/store/events/event_sources_poll.md
+++ b/knowledge/store/events/event_sources_poll.md
@@ -1,0 +1,40 @@
+---
+name: Event Sources Poll
+kind: capability
+description: Poll every enabled, due event source once — fetch, diff against the last value, and publish ai.workbuddy.source.<name>.changed when a watched value changes. The periodic tick behind pull-based event sources; normally fired by the event-source-poll cron job, not called by hand.
+capability_name: event_sources_poll
+category: events
+op: op.wb.event_sources_poll
+schema_version: wb-capability/v1
+parameters: {}
+mutates_state: true
+retry_policy: manual
+is_action: true
+intrinsic_amplifiers:
+  irreversibility: low
+  regret_potential: low
+tags:
+- events
+- source
+- poll
+- tick
+aliases:
+- poll event sources
+- poll sources
+parents:
+- events
+---
+
+The reconciling poll tick for pull-based event sources. Loads every
+`event_source` unit under `.data/event_sources/`, and for each enabled source
+whose `interval` has elapsed since its last poll: fetches the payload, extracts
+the watched value, and compares its content hash to the stored cursor. On a
+**meaningful change** it publishes `ai.workbuddy.source.<name>.changed` onto the
+spine — the `source-action` consumer then evaluates the source's condition and
+runs its (scoped) action. The first observation is a silent baseline unless the
+source sets `cursor.from: all`.
+
+Idempotent and crash-safe: the cursor advances only after a successful poll, and
+the spine dedupes on `(source, id)`, so a replay re-fetches without double-firing.
+A single tick iterates all due sources — adding a watcher is one `.md`, never a
+new thread or cron job.

--- a/poetry.lock
+++ b/poetry.lock
@@ -765,6 +765,25 @@ files = [
 develop = ["aiomisc-pytest", "coveralls", "pylama[toml]", "pytest", "pytest-cov", "setuptools"]
 
 [[package]]
+name = "cel-python"
+version = "0.5.0"
+description = "Pure Python implementation of Google Common Expression Language"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "cel_python-0.5.0-py3-none-any.whl", hash = "sha256:d0f85008b89655c2bb18d797d2fa3f96f2ed80f4a3b43b0e8138c6646581e5f6"},
+    {file = "cel_python-0.5.0.tar.gz", hash = "sha256:3eb0a619e8df0f338d0430cda01427a742e77e3c433a1c7c3ebd409cd804c45a"},
+]
+
+[package.dependencies]
+google-re2 = ">=1.1.20240702"
+jmespath = ">=1.0.1"
+lark = ">=1.2.2"
+pendulum = ">=3.1.0"
+pyyaml = ">=6.0.2"
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -2450,6 +2469,71 @@ local-tokenizer = ["protobuf", "sentencepiece (>=0.2.0)"]
 pyopenssl = ["pyopenssl"]
 
 [[package]]
+name = "google-re2"
+version = "1.1.20251105"
+description = "RE2 Python bindings"
+optional = false
+python-versions = "~=3.9"
+groups = ["main"]
+files = [
+    {file = "google_re2-1.1.20251105-1-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:88bd426c1904f3562049bf766301bbc4f7a4bcb8f61e92f8cc833faac1cf2a92"},
+    {file = "google_re2-1.1.20251105-1-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:a486dc10bb07f3c34b9908541368e21ab6d77972569427200db077126668fbf3"},
+    {file = "google_re2-1.1.20251105-1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:a9aa02dc1345f0889c6ce1365d5f93d5b161b512f4c6df3cfadf3298493fb678"},
+    {file = "google_re2-1.1.20251105-1-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:032160ad8c05739370813bcb15099854cd50faa933e0fe9607a2380659c750df"},
+    {file = "google_re2-1.1.20251105-1-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:39a7013477c8778b1ddcc0d43eff0ee4a0f66b76c9db21f9e7b7d1f74852633f"},
+    {file = "google_re2-1.1.20251105-1-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:f886c88d56233483c5fd5ed1234e7e72389b8331250100983443fa30855deb63"},
+    {file = "google_re2-1.1.20251105-1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8beddf48857fd3767c553f0be7414a7a483f9b6374c91c02474a616fc7f5c5b3"},
+    {file = "google_re2-1.1.20251105-1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3a319dcb37b069d72d968862335197f460803b3a35f99445ea805f69fac58759"},
+    {file = "google_re2-1.1.20251105-1-cp310-cp310-win32.whl", hash = "sha256:420fe037ad77ab3d1a280c6823985b89160896f66ce601a3923d020690a1f9b4"},
+    {file = "google_re2-1.1.20251105-1-cp310-cp310-win_amd64.whl", hash = "sha256:462dfcf147d0f54d0c93a69c361225119a4987c3b0ecd77f0e21ad9ba8bf180e"},
+    {file = "google_re2-1.1.20251105-1-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:329efa209ea7baa44f0facf0402fa34e655dc97fdeb10d0b83fc06354f5575fd"},
+    {file = "google_re2-1.1.20251105-1-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:aa2ad5f6f48921ec137a7b7f1b1da903ddef8627a2dc30bc878a9a69d9925719"},
+    {file = "google_re2-1.1.20251105-1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:ac1cb2526cc88f050a0661fc7245ad009ee454bddc541b2e653f1d007585000d"},
+    {file = "google_re2-1.1.20251105-1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:50c7205182ad66c23c07abe8072f720ca2f7d595b61e28fd9b63623614f9afd6"},
+    {file = "google_re2-1.1.20251105-1-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:4cb5acee61e35772503b8b1db3c592a46b8e6a9bc0ab54d7d6233654ea2bf93d"},
+    {file = "google_re2-1.1.20251105-1-cp311-cp311-macosx_15_0_x86_64.whl", hash = "sha256:1617097d63620c2d46bdfc0e48f24f66cd341664fc75718636d234f67473fe7f"},
+    {file = "google_re2-1.1.20251105-1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18a5610b26742b90cb1d64ead2b16fe0e3bd7e67add03fd3779cd1b85e401661"},
+    {file = "google_re2-1.1.20251105-1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03156291269f145eccddff63118f2df02d395792f51fc039f09955818943815a"},
+    {file = "google_re2-1.1.20251105-1-cp311-cp311-win32.whl", hash = "sha256:54f51762b51dc238eceddf49b56cc2b64594fe72d9328c1c39d615aa990e1f87"},
+    {file = "google_re2-1.1.20251105-1-cp311-cp311-win_amd64.whl", hash = "sha256:f5f856ff5036a8f22b3bad57f376d4e3b97b59b64f311bdb1f83c8dabded2492"},
+    {file = "google_re2-1.1.20251105-1-cp311-cp311-win_arm64.whl", hash = "sha256:913864f97de4151eaa8bb7746ca230fd193656501e07fb658ce2cd46d4f6efcc"},
+    {file = "google_re2-1.1.20251105-1-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:b30f09b4d63249c72e65ccae4cbf6b331b48c22fc7cb439f1d85f347b9d07ceb"},
+    {file = "google_re2-1.1.20251105-1-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:9a77892c524b8bdf3d47d7cad1cc2ac3a0108bdd65007ef4c02888fa46baf8ee"},
+    {file = "google_re2-1.1.20251105-1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a3ac51b28cbf25c100dfd8849212d878d7005d1d4a7e129a10789043c56b6021"},
+    {file = "google_re2-1.1.20251105-1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:9f7158afc9825ac2654c6561aea94a1f7edb5b5b88e6e3639bb80bb817d102ac"},
+    {file = "google_re2-1.1.20251105-1-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:5320da07dc3b7ac7f407514f42ac17d67e771ac7c7562d449571185e6fb601b2"},
+    {file = "google_re2-1.1.20251105-1-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:5a4e5785bc30d52ce655d805b07ad2d8a4905429a5f690ae9c2f1caa76665709"},
+    {file = "google_re2-1.1.20251105-1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b7a3b90f747130310d4b3b8e19ebb845d0d97c1deb63b36f76c7242dacbd736"},
+    {file = "google_re2-1.1.20251105-1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:809c5fa5d08279413b29c2e2c5c528e85cd94a0e0fd897db595a0c09eeee2782"},
+    {file = "google_re2-1.1.20251105-1-cp312-cp312-win32.whl", hash = "sha256:d8424e63a9ec0fe5bde03d97876b2431f8a746af33eb475fa1ae39144bd05b2a"},
+    {file = "google_re2-1.1.20251105-1-cp312-cp312-win_amd64.whl", hash = "sha256:062313c309f93dfeb6966372f4c446580e98879133ec155522eea8aaf568a5cd"},
+    {file = "google_re2-1.1.20251105-1-cp312-cp312-win_arm64.whl", hash = "sha256:558f144b26a9555ae4e9467cc3aa3299a8ce13217f328b21ae326ca0633be19b"},
+    {file = "google_re2-1.1.20251105-1-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:9f3cf610e857a7d6f02916cf2b7fc159a5429b8bcb23164500d46e5e233f2924"},
+    {file = "google_re2-1.1.20251105-1-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:a21c2807bf4d5d00f206a4ecb3b043aad674e28c451b697b740280f608872078"},
+    {file = "google_re2-1.1.20251105-1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8314144eefeee7b88b742081c2038418f677e63901039ca9dbfbc0c5bb6d2911"},
+    {file = "google_re2-1.1.20251105-1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:28a46be978e53c772139d0f5c9ba69f53563fcdd4225407e4d34d51208b828f1"},
+    {file = "google_re2-1.1.20251105-1-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:83292e23963aa1b219d5f64a65365b0880448a6a060276027b55270bc5b18c7e"},
+    {file = "google_re2-1.1.20251105-1-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:1920b15dc9b1bdfeca5aa2c60900373c6f27cd1056d53cd299456ea5540a6fff"},
+    {file = "google_re2-1.1.20251105-1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b1458d9ca588124cd61aa1bf5388a216e1247e7d474f8e5e1530498044f5c87"},
+    {file = "google_re2-1.1.20251105-1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a52cb204e49d20cdbb66faf394d57f476e96c39c23a328442ab0194fc6bd1a2b"},
+    {file = "google_re2-1.1.20251105-1-cp313-cp313-win32.whl", hash = "sha256:67c5c73d7ebcf3f0e0a3b528b41bd8c6c04900f1598aebf05bbdf15a06cf5f9a"},
+    {file = "google_re2-1.1.20251105-1-cp313-cp313-win_amd64.whl", hash = "sha256:0bcba63ad3ea8926fb0c71bb5044e33d405bb9395f5b5444393cd5f28f0bf6d3"},
+    {file = "google_re2-1.1.20251105-1-cp313-cp313-win_arm64.whl", hash = "sha256:64ee189ea857f2126c5e42073cfa9b03e9f4cbaf073edbedb575059074841aa0"},
+    {file = "google_re2-1.1.20251105-1-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:cc151cf6a585d9ebe711da32b23683fcff40f78db8c8587c7f4b209ef4658809"},
+    {file = "google_re2-1.1.20251105-1-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:7e2186d2c90488c1e11895343941f35ca2f58e9ba6c6b034fd531abe22ef77cc"},
+    {file = "google_re2-1.1.20251105-1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:41be22359c3dceb582937739b4365dd8e279de24ad0a5b10e653503abaff2ed7"},
+    {file = "google_re2-1.1.20251105-1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:f3168d7bbac247c862ea85b2f3c011d3a04bedcb6892b37f14d488f4133b206e"},
+    {file = "google_re2-1.1.20251105-1-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:79ce664038194a31bbcf422137f9607ae3d9946a5cff98cf0efbeb7f9411e64b"},
+    {file = "google_re2-1.1.20251105-1-cp314-cp314-macosx_15_0_x86_64.whl", hash = "sha256:0476b07421b8882b279d5ceb5b760c15c62d581ded95274697fc1227e3869ee6"},
+    {file = "google_re2-1.1.20251105-1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85feec3161ffdc12f6b144e37a2f91f80b771c72ffadde60191e89a49f6d7e81"},
+    {file = "google_re2-1.1.20251105-1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7bfaa2cf55daf0c5c650e68526bb20b61e37d7f3ae53f6893013acc1c91c116"},
+    {file = "google_re2-1.1.20251105-1-cp314-cp314-win32.whl", hash = "sha256:214c1accdc60fff9ce1bf812b157147ca361844f496ed9e0d5f357b0e562ced8"},
+    {file = "google_re2-1.1.20251105-1-cp314-cp314-win_amd64.whl", hash = "sha256:6d4d5fdadd329a2ed193463899d00ef2fd126172f36a4c01c9def271f19801b6"},
+    {file = "google_re2-1.1.20251105-1-cp314-cp314-win_arm64.whl", hash = "sha256:1d27f3a2a947ec1f721d0f14f661108acfd4f4d34f357ce28db951cc036656e5"},
+    {file = "google_re2-1.1.20251105.tar.gz", hash = "sha256:1db14a292ee8303b91e91e7c37e05ac17d3c467f29416c79ac70a78be3e65bda"},
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.74.0"
 description = "Common protobufs used in Google APIs"
@@ -3230,10 +3314,9 @@ files = [
 name = "jmespath"
 version = "1.1.0"
 description = "JSON Matching Expressions"
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"memory\" or extra == \"all\""
 files = [
     {file = "jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64"},
     {file = "jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d"},
@@ -3266,6 +3349,18 @@ files = [
 
 [package.dependencies]
 jsonpointer = ">=1.9"
+
+[[package]]
+name = "jsonpath-ng"
+version = "1.8.0"
+description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
+]
 
 [[package]]
 name = "jsonpointer"
@@ -3469,6 +3564,24 @@ otel = ["opentelemetry-api (>=1.30.0)", "opentelemetry-exporter-otlp-proto-http 
 pytest = ["pytest (>=7.0.0)", "rich (>=13.9.4)", "vcrpy (>=7.0.0)"]
 sandbox = ["websockets (>=15.0)"]
 vcr = ["vcrpy (>=7.0.0)"]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+description = "a modern parsing library"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12"},
+    {file = "lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905"},
+]
+
+[package.extras]
+atomic-cache = ["atomicwrites"]
+interegular = ["interegular (>=0.3.1,<0.4.0)"]
+nearley = ["js2py"]
+regex = ["regex"]
 
 [[package]]
 name = "litellm"
@@ -5390,6 +5503,90 @@ files = [
 "pdfminer.six" = "20251230"
 Pillow = ">=9.1"
 pypdfium2 = ">=4.18.0"
+
+[[package]]
+name = "pendulum"
+version = "3.2.0"
+description = "Python datetimes made easy"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pendulum-3.2.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:4a6bf778c6b42830b001c714dae5b9dad78da38e2e08203a4b0f5d53f8fa5e63"},
+    {file = "pendulum-3.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:625209bb7133d990905e8935e1c04f0a82315ae777b67910969b16f665d62c0b"},
+    {file = "pendulum-3.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b6f1d8641e8bd48b9b6f77f96fd498d3ecec63611ba8e7207e63936307846042"},
+    {file = "pendulum-3.2.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a8d4212b1577ee3a034d18b360a9afa55bfc72789aeb805353be8b2ac132035"},
+    {file = "pendulum-3.2.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e398d9e3db42d17f0c2cd39663c1c873ea6f11763ed6d126e2dcc92fc340d0dc"},
+    {file = "pendulum-3.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:04310463879a8d84534756ef9820d433e88b879203b6e10a5b416899dc05e7f1"},
+    {file = "pendulum-3.2.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:5b4f7491951c11bbdb20893817352c9140d31d1ae333839c34c0bca081a50a86"},
+    {file = "pendulum-3.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:ffc169ad7595228d4dfc44d4e016846ff1bb5873b9f7ec70b0b1b51da0c77b3f"},
+    {file = "pendulum-3.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:446f63d84ef21281844ceb45141536d3aabe291a821b6505e21a0d0e3ea95d67"},
+    {file = "pendulum-3.2.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5d775cc608c909ad415c8e789c84a9f120bb6a794c4215b2d8d910893cf0ec6a"},
+    {file = "pendulum-3.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8de794a7f665aebc8c1ba4dd4b05ab8fe1a36ce9c0498366adf1d1edd79b2686"},
+    {file = "pendulum-3.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bac7df7696e1c942e17c0556b3a7bcdd1d7aa5b24faee7620cb071e754a0622"},
+    {file = "pendulum-3.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db0f6a8a04475d9cba26ce701e7d66d266fd97227f2f5f499270eba04be1c7e9"},
+    {file = "pendulum-3.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c352c63c1ff05f2198409b28498d7158547a8be23e1fbd4aa2cf5402fb239b55"},
+    {file = "pendulum-3.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de8c1ad1d1aa7d4ceae341528bab35a0f8c88a5aa63f2f5d84e16b517d1b32c2"},
+    {file = "pendulum-3.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1ba955511c12fec2252038b0c866c25c0c30b720bf74d3023710f121e42b1498"},
+    {file = "pendulum-3.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4115bf364a2ec6d5ddc476751ceaa4164a04f2c15589f0d29aa210ddb784b15d"},
+    {file = "pendulum-3.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:4151a903356413fdd9549de0997b708fb95a214ed97803ffb479ffd834088378"},
+    {file = "pendulum-3.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:acfdee9ddc56053cb7c8c075afbfde0857322d09e56a56195b9cd127fae87e4c"},
+    {file = "pendulum-3.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bf0b489def51202a39a2a665dcc4162d5e46934a740fe4c4fe3068979610156c"},
+    {file = "pendulum-3.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:937a529aa302efa18dcf25e53834964a87ffb2df8f80e3669ab7757a6126beaf"},
+    {file = "pendulum-3.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85c7689defc65c4dc29bf257f7cca55d210fabb455de9476e1748d2ab2ae80d7"},
+    {file = "pendulum-3.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d5e216e5a412563ea2ecf5de467dcf3d02717947fcdabe6811d5ee360726b02b"},
+    {file = "pendulum-3.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a2af22eeec438fbaac72bb7fba783e0950a514fba980d9a32db394b51afccec"},
+    {file = "pendulum-3.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3159cceb54f5aa8b85b141c7f0ce3fac8bdd1ffdc7c79e67dca9133eac7c4d11"},
+    {file = "pendulum-3.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c39ea5e9ffa20ea8bae986d00e0908bd537c8468b71d6b6503ab0b4c3d76e0ea"},
+    {file = "pendulum-3.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:e5afc753e570cce1f44197676371f68953f7d4f022303d141bb09f804d5fe6d7"},
+    {file = "pendulum-3.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:fd55c12560816d9122ca2142d9e428f32c0c083bf77719320b1767539c7a3a3b"},
+    {file = "pendulum-3.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:faef52a7ed99729f0838353b956f3fabf6c550c062db247e9e2fc2b48fcb9457"},
+    {file = "pendulum-3.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:addb0512f919fe5b70c8ee534ee71c775630d3efe567ea5763d92acff857cfc3"},
+    {file = "pendulum-3.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3aaa50342dc174acebdc21089315012e63789353957b39ac83cac9f9fc8d1075"},
+    {file = "pendulum-3.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:927e9c9ab52ff68e71b76dd410e5f1cd78f5ea6e7f0a9f5eb549aea16a4d5354"},
+    {file = "pendulum-3.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:249d18f5543c9f43aba3bd77b34864ec8cf6f64edbead405f442e23c94fce63d"},
+    {file = "pendulum-3.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c644cc15eec5fb02291f0f193195156780fd5a0affd7a349592403826d1a35e"},
+    {file = "pendulum-3.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:063ab61af953bb56ad5bc8e131fd0431c915ed766d90ccecd7549c8090b51004"},
+    {file = "pendulum-3.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:26a3ae26c9dd70a4256f1c2f51addc43641813574c0db6ce5664f9861cd93621"},
+    {file = "pendulum-3.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:2b10d91dc00f424444a42f47c69e6b3bfd79376f330179dc06bc342184b35f9a"},
+    {file = "pendulum-3.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:63070ff03e30a57b16c8e793ee27da8dac4123c1d6e0cf74c460ce9ee8a64aa4"},
+    {file = "pendulum-3.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:c8dde63e2796b62070a49ce813ce200aba9186130307f04ec78affcf6c2e8122"},
+    {file = "pendulum-3.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c17ac069e88c5a1e930a5ae0ef17357a14b9cc5a28abadda74eaa8106d241c8e"},
+    {file = "pendulum-3.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e1fbb540edecb21f8244aebfb05a1f2333ddc6c7819378c099d4a61cc91ae93c"},
+    {file = "pendulum-3.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8c67fb9a1fe8fc1adae2cc01b0c292b268c12475b4609ff4aed71c9dd367b4d"},
+    {file = "pendulum-3.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:baa9a66c980defda6cfe1275103a94b22e90d83ebd7a84cc961cee6cbd25a244"},
+    {file = "pendulum-3.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef8f783fa7a14973b0596d8af2a5b2d90858a55030e9b4c6885eb4284b88314f"},
+    {file = "pendulum-3.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7d2e9bfb065727d8676e7ada3793b47a24349500a5e9637404355e482c822be"},
+    {file = "pendulum-3.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:55d7ba6bb74171c3ee409bf30076ee3a259a3c2bb147ac87ebb76aaa3cf5d3a2"},
+    {file = "pendulum-3.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:a50d8cf42f06d3d8c3f8bb2a7ac47fa93b5145e69de6a7209be6a47afdd9cf76"},
+    {file = "pendulum-3.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e5bbb92b155cd5018b3cf70ee49ed3b9c94398caaaa7ed97fe41e5bb5a968418"},
+    {file = "pendulum-3.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:d53134418e04335c3029a32e9341cccc9b085a28744fb5ee4e6a8f5039363b1a"},
+    {file = "pendulum-3.2.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:70214f30114ee6de09b0abbb90e74f68682f194485200897930125de36024c21"},
+    {file = "pendulum-3.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d3cad6be303b4b9737f629191b73920e0e4c2fe1fbd5813b7a19b05f29d09a1c"},
+    {file = "pendulum-3.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2dd31fd46aa8fceaff5de674b8d57b0b659753986cb78fa9e24368da7f8e4eec"},
+    {file = "pendulum-3.2.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce87750e0a644e8ddafa3e9437f0ff35af8d17eb5c77824864246ccf6b44d24a"},
+    {file = "pendulum-3.2.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:326ef1baa8657c9c4aead5c4eac06a46355ba4e338816153e2929b0b548554b5"},
+    {file = "pendulum-3.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f00d033fe9b31c41deb6484f36a788b99b936cf8d10a994784e809a59b72d7db"},
+    {file = "pendulum-3.2.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:86029fd802c5650f2cbef3f9302608325a676d3a883d6a5782bc855e5d03918b"},
+    {file = "pendulum-3.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:dfbcd7a2a5ebabf5abaf07062555cd7bef9a472a6aa5281a6302afe66a481561"},
+    {file = "pendulum-3.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:38a300df5a82ebea8634a1aed3d98c92968ba856d2ca7ba2acf7228f0e0e99af"},
+    {file = "pendulum-3.2.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:9585594d32faa71efa5a78f576f1ee4f79e9c5340d7c6f0cd6c5dfe725effaaa"},
+    {file = "pendulum-3.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:26401e2de77c437e8f3b6160c08c6c5d45518d906f8f9b48fd7cb5aa0f4e2aff"},
+    {file = "pendulum-3.2.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:637e65af042f383a2764a886aa28ccc6f853bf7a142df18e41c720542934c13b"},
+    {file = "pendulum-3.2.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6e46c28f4d067233c4a4c42748f4ffa641d9289c09e0e81488beb6d4b3fab51"},
+    {file = "pendulum-3.2.0-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:71d46bcc86269f97bfd8c5f1475d55e717696a0a010b1871023605ca94624031"},
+    {file = "pendulum-3.2.0-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:5cd956d4176afc7bfe8a91bf3f771b46ff8d326f6c5bf778eb5010eb742ebba6"},
+    {file = "pendulum-3.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:39ef129d7b90aab49708645867abdd207b714ba7bff12dae549975b0aca09716"},
+    {file = "pendulum-3.2.0-py3-none-any.whl", hash = "sha256:f3a9c18a89b4d9ef39c5fa6a78722aaff8d5be2597c129a3b16b9f40a561acf3"},
+    {file = "pendulum-3.2.0.tar.gz", hash = "sha256:e80feda2d10fa3ff8b1526715f7d33dcb7e08494b3088f2c8a3ac92d4a4331ce"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.6"
+tzdata = ">=2020.1"
+
+[package.extras]
+test = ["time-machine (>=2.6.0,<3.0.0) ; implementation_name != \"pypy\""]
 
 [[package]]
 name = "pgvector"
@@ -8164,7 +8361,6 @@ description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 groups = ["main"]
-markers = "(extra == \"memory\" or extra == \"all\") and (sys_platform == \"win32\" or sys_platform == \"emscripten\") or platform_system == \"Windows\""
 files = [
     {file = "tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9"},
     {file = "tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98"},
@@ -9220,4 +9416,4 @@ telegram = ["python-telegram-bot"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "30f98b01ecd0362466e7be77e4e27be5789397136b247822fb6dd561ace68b6f"
+content-hash = "8efc55132592de1b56220efdd8a7a9b87b7b7817087a091b73a66a867ec37c0c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ google-auth-oauthlib = "^1.4.0"
 pathspec = "^1.1.1"
 ddgs = "^9.14.4"
 trafilatura = "^1.8"
+cel-python = "^0.5.0"
+jsonpath-ng = "^1.8.0"
 [tool.poetry.extras]
 memory = ["hindsight-api-slim", "hindsight-client"]
 telegram = ["python-telegram-bot"]

--- a/sidecar_jobs/event-source-poll.md
+++ b/sidecar_jobs/event-source-poll.md
@@ -1,0 +1,12 @@
+---
+schedule: "*/5 * * * *"  # every 5 minutes; each source fires only when its own interval has elapsed
+recurring: true
+type: capability
+capability: event_sources_poll
+params: {}
+---
+Event-source poll tick. Every 5 minutes, poll each enabled event source whose
+`interval` has elapsed: fetch → diff the watched value → publish
+`ai.workbuddy.source.<name>.changed` on a meaningful change. The per-source
+`interval` (not this cadence) governs how often any given source is actually
+fetched — this tick just wakes the poller up.

--- a/tests/component/test_events_end_to_end.py
+++ b/tests/component/test_events_end_to_end.py
@@ -76,3 +76,66 @@ def test_schedule_tick_advances_offset_without_notifying(spine):
 
     assert notes == []                                       # type-filtered out
     assert store.get_offset(CONSUMER_ID) == store.max_seq()  # but offset advanced
+
+
+def _source_fm(payload):
+    return {
+        "kind": "event_source",
+        "source": {"type": "fake", "url": "x", "interval": "5m"},
+        "extract": {"mode": "json_path", "path": "$.ceo"},
+        "condition": "event.data != prev.data",
+        "action": {"name": "notify"},
+        "allowed_actions": ["notify"],
+        "enabled": True,
+        "fake_payload": payload,
+    }
+
+
+@pytest.mark.component
+def test_source_change_reacts_end_to_end(tmp_path, monkeypatch):
+    """A real poll → publish source.changed → drain → source-action consumer
+    evaluates the condition and notifies — the full source reaction path."""
+    import work_buddy.events.sources.loader as loader_mod
+    from work_buddy.events.consumers.source_action import register_source_action
+    from work_buddy.events.sources import poller as P
+    from work_buddy.events.sources.definition import from_frontmatter
+
+    monkeypatch.setattr(evstore, "_db_path", lambda: tmp_path / "events.db")
+    dispatcher.set_store(evstore.EventStore())
+    dispatcher.clear_consumers()
+    notes: list = []
+    monkeypatch.setattr(dash_events, "publish_auto", lambda t, p=None: None)
+    monkeypatch.setattr(nstore, "create_notification", lambda n: notes.append(n) or n)
+
+    class _NoDeliver:
+        def deliver(self, notif, mark_delivered_fn=None):
+            return {}
+
+    monkeypatch.setattr(
+        ndisp.SurfaceDispatcher, "from_config", classmethod(lambda cls: _NoDeliver())
+    )
+
+    src_a = from_frontmatter("nvda", _source_fm({"ceo": "A"}))
+    src_b = from_frontmatter("nvda", _source_fm({"ceo": "B"}))
+    # The consumer resolves the def by name; condition/action are identical, so
+    # returning the baseline def is fine (only fetch uses fake_payload).
+    monkeypatch.setattr(loader_mod, "load_event_sources", lambda directory=None: ([src_a], []))
+    register_source_action()
+
+    state_dir = tmp_path / "state"
+    P.poll_source(src_a, state_directory=state_dir)   # baseline: silent, no emit
+    dispatcher.drain()
+    assert dispatcher._store().count() == 0
+    assert notes == []
+
+    P.poll_source(src_b, state_directory=state_dir)   # change: publishes source.changed
+    assert dispatcher._store().count() == 1
+    dispatcher.drain()                                # consumer reacts → notify
+    assert len(notes) == 1
+    assert "nvda" in notes[0].title
+
+    dispatcher.drain()                                # exactly once
+    assert len(notes) == 1
+
+    dispatcher.clear_consumers()
+    dispatcher.set_store(None)

--- a/tests/unit/events/test_cel_condition.py
+++ b/tests/unit/events/test_cel_condition.py
@@ -1,0 +1,49 @@
+"""Unit tests for CelCondition (safe predicate, fail-closed)."""
+
+from __future__ import annotations
+
+import pytest
+
+from work_buddy.events.conditions.cel import CelCondition
+from work_buddy.events.envelope import new_event
+from work_buddy.events.protocol import ConditionContext
+
+
+def _evt(current, prev):
+    return new_event(
+        "/wb/source/nvda",
+        "ai.workbuddy.source.nvda.changed",
+        data={"current": current, "prev": prev, "source_name": "nvda"},
+        modality="pull",
+    )
+
+
+def _eval(expr, current, prev):
+    return CelCondition(expr).evaluate(_evt(current, prev), None, ConditionContext())
+
+
+def test_object_field_inequality():
+    expr = "event.data.ceo != prev.data.ceo"
+    assert _eval(expr, {"ceo": "B"}, {"ceo": "A"}) is True
+    assert _eval(expr, {"ceo": "A"}, {"ceo": "A"}) is False
+
+
+def test_scalar_shorthand():
+    assert _eval("current != prev.data", "B", "A") is True
+    assert _eval("event.data != prev.data", "A", "A") is False
+
+
+def test_numeric_threshold_with_abs():
+    expr = "abs(event.data.price - prev.data.price) / prev.data.price > 0.05"
+    assert _eval(expr, {"price": 110.0}, {"price": 100.0}) is True   # 10% move
+    assert _eval(expr, {"price": 102.0}, {"price": 100.0}) is False  # 2% move
+
+
+def test_fail_closed_on_missing_field():
+    # `event.data` is a scalar here, so `.ceo` access errors → False, not a raise.
+    assert _eval("event.data.ceo != prev.data.ceo", "B", "A") is False
+
+
+def test_bad_syntax_raises_at_construction():
+    with pytest.raises(Exception):
+        CelCondition("a +")

--- a/tests/unit/events/test_dispatcher.py
+++ b/tests/unit/events/test_dispatcher.py
@@ -101,6 +101,20 @@ def test_drain_type_filter_advances_offset(wired):
     assert store.get_offset("c1") == store.max_seq()  # but offset advanced past both
 
 
+def test_drain_type_prefix_routes(wired):
+    store, _ = wired
+    proc = _Recorder()
+    dispatcher.register_consumer(
+        DurableConsumer(id="src", processor=proc, type_prefix="ai.workbuddy.source.")
+    )
+    changed = new_event("/wb/source/nvda", "ai.workbuddy.source.nvda.changed", {})
+    dispatcher.publish(new_event("/wb/test", "ai.workbuddy.schedule.tick", {}))
+    dispatcher.publish(changed)
+    dispatcher.drain()
+    assert proc.seen == [changed.id]  # only the prefixed type ran
+    assert store.get_offset("src") == store.max_seq()  # offset advanced past both
+
+
 def test_drain_poison_event_goes_to_dlq(wired, monkeypatch):
     store, _ = wired
     monkeypatch.setattr(dispatcher, "MAX_ATTEMPTS", 3)

--- a/tests/unit/events/test_extract.py
+++ b/tests/unit/events/test_extract.py
@@ -1,0 +1,25 @@
+"""Unit tests for source value extraction."""
+
+from __future__ import annotations
+
+from work_buddy.events.sources.extract import content_hash, extract_value
+
+
+def test_json_path_scalar():
+    assert extract_value("json_path", {"quote": {"price": 123}}, path="$.quote.price") == 123
+
+
+def test_json_path_multi_returns_list():
+    payload = {"items": [{"id": 1}, {"id": 2}]}
+    assert extract_value("json_path", payload, path="$.items[*].id") == [1, 2]
+
+
+def test_hash_differs_on_content():
+    a = extract_value("hash", {"x": 1})
+    b = extract_value("hash", {"x": 2})
+    assert a != b
+    assert len(a) == 64  # sha256 hex
+
+
+def test_content_hash_is_order_independent():
+    assert content_hash({"a": 1, "b": 2}) == content_hash({"b": 2, "a": 1})

--- a/tests/unit/events/test_poller.py
+++ b/tests/unit/events/test_poller.py
@@ -1,0 +1,74 @@
+"""Unit tests for the reconciling poller (producer side)."""
+
+from __future__ import annotations
+
+from work_buddy.events.sources import poller as P
+from work_buddy.events.sources.definition import from_frontmatter
+
+BASE_FM = {
+    "kind": "event_source",
+    "source": {"type": "fake", "url": "x", "interval": "5m"},
+    "extract": {"mode": "json_path", "path": "$.ceo"},
+    "action": {"name": "notify"},
+    "allowed_actions": ["notify"],
+    "enabled": True,
+}
+
+
+def _src(payload, **overrides):
+    fm = {**BASE_FM, "fake_payload": payload, **overrides}
+    return from_frontmatter("nvda", fm)
+
+
+def test_first_poll_is_baseline_no_emit(tmp_path):
+    published = []
+    r = P.poll_source(_src({"ceo": "A"}), publish=published.append, state_directory=tmp_path)
+    assert r["is_first"] is True
+    assert r["emitted"] is False
+    assert published == []
+
+
+def test_unchanged_then_changed(tmp_path):
+    published = []
+    pub = published.append
+    P.poll_source(_src({"ceo": "A"}), publish=pub, state_directory=tmp_path)         # baseline
+    r2 = P.poll_source(_src({"ceo": "A"}), publish=pub, state_directory=tmp_path)     # no change
+    assert r2["changed"] is False
+    assert published == []
+    r3 = P.poll_source(_src({"ceo": "B"}), publish=pub, state_directory=tmp_path)     # change
+    assert r3["changed"] is True and r3["emitted"] is True
+    assert len(published) == 1
+    evt = published[0]
+    assert evt.type == "ai.workbuddy.source.nvda.changed"
+    assert evt.data["current"] == "B" and evt.data["prev"] == "A"
+    assert evt.source == "/wb/source/nvda" and evt.modality == "pull"
+
+
+def test_dry_run_has_zero_side_effects(tmp_path):
+    published = []
+    P.poll_source(_src({"ceo": "A"}), publish=published.append, state_directory=tmp_path)  # baseline
+    r = P.dry_run(_src({"ceo": "B"}), publish=published.append, state_directory=tmp_path)
+    assert r["changed"] is True
+    assert "would_emit" in r and r["emitted"] is False
+    assert published == []  # nothing published
+    # State was NOT advanced — a real poll with B still registers the change.
+    r2 = P.poll_source(_src({"ceo": "B"}), publish=published.append, state_directory=tmp_path)
+    assert r2["changed"] is True and r2["emitted"] is True
+
+
+def test_cursor_from_all_fires_on_first(tmp_path):
+    published = []
+    r = P.poll_source(
+        _src({"ceo": "A"}, cursor={"from": "all"}),
+        publish=published.append,
+        state_directory=tmp_path,
+    )
+    assert r["is_first"] is True and r["emitted"] is True
+
+
+def test_fetch_failure_is_non_fatal(tmp_path):
+    def boom(_src):
+        raise RuntimeError("network down")
+
+    r = P.poll_source(_src({"ceo": "A"}), fetch=boom, publish=lambda e: None, state_directory=tmp_path)
+    assert r["emitted"] is False and "error" in r

--- a/tests/unit/events/test_ratelimit.py
+++ b/tests/unit/events/test_ratelimit.py
@@ -1,0 +1,31 @@
+"""Unit tests for per-source fire-rate tracking (rolling-window count)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from work_buddy.events.sources.ratelimit import fires_last_hour, record_fire
+
+
+def _t(h: int = 0, m: int = 0) -> datetime:
+    return datetime(2026, 6, 21, 12, 0, 0, tzinfo=timezone.utc) + timedelta(hours=h, minutes=m)
+
+
+def test_record_and_count(tmp_path):
+    assert fires_last_hour("s", _t(), tmp_path) == 0
+    assert record_fire("s", _t(0, 0), tmp_path) == 1
+    assert record_fire("s", _t(0, 10), tmp_path) == 2
+    assert fires_last_hour("s", _t(0, 20), tmp_path) == 2
+
+
+def test_window_prunes_old_fires(tmp_path):
+    record_fire("s", _t(0, 0), tmp_path)
+    record_fire("s", _t(0, 30), tmp_path)
+    # 90 minutes after the first fire, only fires within the trailing hour count.
+    assert fires_last_hour("s", _t(1, 30), tmp_path) == 1
+    # Recording prunes first, then appends → the 0:30 survivor + the new one.
+    assert record_fire("s", _t(1, 30), tmp_path) == 2
+
+
+def test_missing_log_is_zero(tmp_path):
+    assert fires_last_hour("nope", _t(), tmp_path) == 0

--- a/tests/unit/events/test_source_action.py
+++ b/tests/unit/events/test_source_action.py
@@ -1,0 +1,127 @@
+"""Unit tests for the source-action consumer (condition + allowed_actions + consent)."""
+
+from __future__ import annotations
+
+import work_buddy.events.processors.registry as registry
+import work_buddy.events.sources.loader as loader_mod
+from work_buddy.events.consumers.source_action import SourceActionProcessor
+from work_buddy.events.envelope import new_event
+from work_buddy.events.processors.registry import Action
+from work_buddy.events.protocol import ProcessorResult, RunContext
+from work_buddy.events.sources.definition import from_frontmatter
+
+BASE_FM = {
+    "kind": "event_source",
+    "source": {"type": "fake", "url": "x", "interval": "5m"},
+    "extract": {"mode": "json_path", "path": "$.ceo"},
+    "enabled": True,
+}
+
+
+def _src(*, condition=None, allowed=("notify",), action="notify", max_per_hour=None):
+    fm = {
+        **BASE_FM,
+        "condition": condition,
+        "action": {"name": action},
+        "allowed_actions": list(allowed),
+    }
+    if max_per_hour is not None:
+        fm["rate_limit"] = {"max_per_hour": max_per_hour}
+    return from_frontmatter("nvda", fm)
+
+
+def _evt(current, prev):
+    return new_event(
+        "/wb/source/nvda",
+        "ai.workbuddy.source.nvda.changed",
+        data={"current": current, "prev": prev, "source_name": "nvda"},
+        modality="pull",
+    )
+
+
+def _install(monkeypatch, src, recorder):
+    monkeypatch.setattr(loader_mod, "load_event_sources", lambda directory=None: ([src], []))
+
+    def fake_notify(event, source, ctx):
+        recorder.append((event, source))
+        return ProcessorResult(text="notified")
+
+    monkeypatch.setattr(
+        registry, "ACTIONS", {"notify": Action(name="notify", run=fake_notify)}
+    )
+
+
+def test_runs_action_when_no_condition(monkeypatch):
+    fired = []
+    _install(monkeypatch, _src(condition=None), fired)
+    SourceActionProcessor().run(_evt("B", "A"), RunContext(seq=1))
+    assert len(fired) == 1
+
+
+def test_runs_action_when_condition_passes(monkeypatch):
+    fired = []
+    _install(monkeypatch, _src(condition="event.data != prev.data"), fired)
+    SourceActionProcessor().run(_evt("B", "A"), RunContext(seq=1))
+    assert len(fired) == 1
+
+
+def test_skips_action_when_condition_fails(monkeypatch):
+    fired = []
+    _install(monkeypatch, _src(condition="event.data != prev.data"), fired)
+    SourceActionProcessor().run(_evt("A", "A"), RunContext(seq=1))
+    assert fired == []
+
+
+def test_denies_action_not_in_allowed(monkeypatch):
+    fired = []
+    _install(monkeypatch, _src(allowed=("task_create",)), fired)
+    r = SourceActionProcessor().run(_evt("B", "A"), RunContext(seq=1))
+    assert fired == []
+    assert "denied" in r.text
+
+
+def test_unknown_source_is_noop(monkeypatch):
+    fired = []
+    monkeypatch.setattr(loader_mod, "load_event_sources", lambda directory=None: ([], []))
+    monkeypatch.setattr(
+        registry, "ACTIONS", {"notify": Action(name="notify", run=lambda *a: fired.append(a))}
+    )
+    r = SourceActionProcessor().run(_evt("B", "A"), RunContext(seq=1))
+    assert fired == []
+    assert "not found" in r.text
+
+
+def test_rate_limit_suspends_at_threshold(monkeypatch):
+    import work_buddy.events.sources.ratelimit as rl
+
+    fired = []
+    _install(monkeypatch, _src(max_per_hour=2), fired)
+    monkeypatch.setattr(rl, "fires_last_hour", lambda name, now, directory=None: 2)
+    suspended = []
+    monkeypatch.setattr(
+        SourceActionProcessor, "_auto_suspend", lambda self, s: suspended.append(s.name)
+    )
+    r = SourceActionProcessor().run(_evt("B", "A"), RunContext(seq=1))
+    assert fired == []                       # action suppressed
+    assert suspended == ["nvda"]             # source auto-suspended
+    assert "auto-suspended" in r.text
+
+
+def test_rate_limit_under_threshold_fires_and_records(monkeypatch):
+    import work_buddy.events.sources.ratelimit as rl
+
+    fired = []
+    _install(monkeypatch, _src(max_per_hour=5), fired)
+    monkeypatch.setattr(rl, "fires_last_hour", lambda name, now, directory=None: 1)
+    recorded = []
+    monkeypatch.setattr(rl, "record_fire", lambda name, now, directory=None: recorded.append(name))
+    SourceActionProcessor().run(_evt("B", "A"), RunContext(seq=1))
+    assert len(fired) == 1                    # action ran
+    assert recorded == ["nvda"]              # and the fire was recorded
+
+
+def test_known_actions_match_validator_allowlist():
+    # The runtime registry and the validator's allow-list must not drift.
+    from work_buddy.events.sources.definition import KNOWN_ACTIONS
+
+    assert registry.known_actions() == KNOWN_ACTIONS

--- a/tests/unit/events/test_source_definition.py
+++ b/tests/unit/events/test_source_definition.py
@@ -1,0 +1,93 @@
+"""Unit tests for the event-source schema + validator."""
+
+from __future__ import annotations
+
+import pytest
+
+from work_buddy.events.sources.definition import (
+    EventSourceDef,
+    from_frontmatter,
+    parse_interval,
+    validate_source_fm,
+)
+
+VALID_FM = {
+    "kind": "event_source",
+    "source": {"type": "http_poll", "url": "https://x/q.json", "interval": "6h"},
+    "cursor": {"from": "now"},
+    "extract": {"mode": "json_path", "path": "$.ceo", "id_field": "filingId"},
+    "dedup": "unique",
+    "condition": "event.data.ceo != prev.data.ceo",
+    "action": {"name": "notify", "params": {}},
+    "allowed_actions": ["notify"],
+    "autonomy": "notify_only",
+    "rate_limit": {"max_per_hour": 6},
+    "enabled": True,
+}
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("30s", 30), ("5m", 300), ("6h", 21600), ("1d", 86400), (" 2h ", 7200)],
+)
+def test_parse_interval_ok(raw, expected):
+    assert parse_interval(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["", "nope", "6", "6x", 6, None, "-3h"])
+def test_parse_interval_bad(raw):
+    assert parse_interval(raw) is None
+
+
+def test_valid_source_has_no_errors():
+    assert validate_source_fm("nvda-watch", VALID_FM) == []
+
+
+def test_from_frontmatter_fields():
+    d = from_frontmatter("nvda-watch", VALID_FM)
+    assert isinstance(d, EventSourceDef)
+    assert d.name == "nvda-watch"
+    assert d.type == "http_poll"
+    assert d.interval_s == 21600
+    assert d.extract_mode == "json_path"
+    assert d.extract_path == "$.ceo"
+    assert d.condition == "event.data.ceo != prev.data.ceo"
+    assert d.allowed_actions == ("notify",)
+    assert d.source_uri == "/wb/source/nvda-watch"
+    assert d.event_type == "ai.workbuddy.source.nvda-watch.changed"
+
+
+def test_missing_url_for_http_poll():
+    fm = {**VALID_FM, "source": {"type": "http_poll", "interval": "6h"}}
+    errs = validate_source_fm("x", fm)
+    assert any("url" in e for e in errs)
+
+
+def test_bad_interval_flagged():
+    fm = {**VALID_FM, "source": {"type": "http_poll", "url": "u", "interval": "soon"}}
+    assert any("interval" in e for e in validate_source_fm("x", fm))
+
+
+def test_bad_cel_flagged():
+    fm = {**VALID_FM, "condition": "a +"}
+    assert any("CEL" in e for e in validate_source_fm("x", fm))
+
+
+def test_bad_jsonpath_flagged():
+    fm = {**VALID_FM, "extract": {"mode": "json_path", "path": "$.["}}
+    assert any("JSONPath" in e for e in validate_source_fm("x", fm))
+
+
+def test_action_not_in_allowed_actions():
+    fm = {**VALID_FM, "allowed_actions": ["task_create"]}
+    assert any("allowed_actions" in e for e in validate_source_fm("x", fm))
+
+
+def test_unknown_source_type():
+    fm = {**VALID_FM, "source": {"type": "carrier_pigeon", "interval": "6h"}}
+    assert any("source.type" in e for e in validate_source_fm("x", fm))
+
+
+def test_wrong_kind():
+    fm = {**VALID_FM, "kind": "event_sauce"}
+    assert any("kind" in e for e in validate_source_fm("x", fm))

--- a/tests/unit/events/test_source_loader.py
+++ b/tests/unit/events/test_source_loader.py
@@ -1,0 +1,56 @@
+"""Unit tests for the event-source loader."""
+
+from __future__ import annotations
+
+import yaml
+
+from work_buddy.events.sources.loader import load_event_sources
+
+VALID_FM = {
+    "kind": "event_source",
+    "source": {"type": "http_poll", "url": "https://x/q.json", "interval": "6h"},
+    "extract": {"mode": "json_path", "path": "$.ceo"},
+    "condition": "event.data.ceo != prev.data.ceo",
+    "action": {"name": "notify", "params": {}},
+    "allowed_actions": ["notify"],
+    "autonomy": "notify_only",
+    "enabled": True,
+}
+
+
+def _write_source(directory, name, fm):
+    (directory / f"{name}.md").write_text(
+        "---\n" + yaml.safe_dump(fm, sort_keys=False) + "---\n\nnotes\n",
+        encoding="utf-8",
+    )
+
+
+def test_loads_valid_source(tmp_path):
+    _write_source(tmp_path, "nvda-watch", VALID_FM)
+    defs, errors = load_event_sources(tmp_path)
+    assert errors == []
+    assert len(defs) == 1
+    assert defs[0].name == "nvda-watch"
+    assert defs[0].interval_s == 21600
+
+
+def test_rejects_malformed_source(tmp_path):
+    bad = {**VALID_FM, "source": {"type": "http_poll", "interval": "nope"}}  # no url + bad interval
+    _write_source(tmp_path, "bad-one", bad)
+    defs, errors = load_event_sources(tmp_path)
+    assert defs == []
+    assert len(errors) == 1
+    assert errors[0]["file"] == "bad-one.md"
+    assert any("url" in e for e in errors[0]["errors"])
+
+
+def test_mixed_valid_and_invalid(tmp_path):
+    _write_source(tmp_path, "good", VALID_FM)
+    _write_source(tmp_path, "bad", {**VALID_FM, "condition": "a +"})
+    defs, errors = load_event_sources(tmp_path)
+    assert [d.name for d in defs] == ["good"]
+    assert [e["file"] for e in errors] == ["bad.md"]
+
+
+def test_empty_dir_is_clean(tmp_path):
+    assert load_event_sources(tmp_path) == ([], [])

--- a/tests/unit/events/test_source_ops.py
+++ b/tests/unit/events/test_source_ops.py
@@ -1,0 +1,152 @@
+"""Unit tests for the source authoring helpers + ops (create / dry-run)."""
+
+from __future__ import annotations
+
+import work_buddy.events.sources.loader as loader_mod
+from work_buddy.events.sources.definition import build_source_fm, from_frontmatter, validate_source_fm
+from work_buddy.events.sources.loader import load_event_sources, write_event_source
+
+
+def test_build_source_fm_validates():
+    fm = build_source_fm(
+        source_type="fake",
+        interval="6h",
+        extract_mode="json_path",
+        extract_path="$.ceo",
+        condition="event.data != prev.data",
+        action="notify",
+        allowed_actions=["notify"],
+    )
+    assert validate_source_fm("nvda", fm) == []
+
+
+def test_write_event_source_roundtrips(tmp_path):
+    fm = build_source_fm(
+        source_type="http_poll",
+        url="https://example.test/quote.json",
+        interval="6h",
+        extract_mode="json_path",
+        extract_path="$.price",
+    )
+    res = write_event_source(tmp_path, "nvda", fm)
+    assert res["success"] is True
+
+    defs, errors = load_event_sources(tmp_path)
+    assert errors == []
+    assert [d.name for d in defs] == ["nvda"]
+    assert defs[0].extract_path == "$.price"
+    assert defs[0].url == "https://example.test/quote.json"
+
+
+def test_write_refuses_overwrite(tmp_path):
+    fm = build_source_fm(source_type="fake", interval="5m", extract_mode="hash")
+    assert write_event_source(tmp_path, "s", fm)["success"] is True
+    again = write_event_source(tmp_path, "s", fm)
+    assert again["success"] is False and "exists" in again["error"]
+    assert write_event_source(tmp_path, "s", fm, overwrite=True)["success"] is True
+
+
+def test_write_rejects_unknown_type(tmp_path):
+    res = write_event_source(tmp_path, "s", build_source_fm(source_type="bogus", interval="6h"))
+    assert res["success"] is False
+    assert any("unknown" in e for e in res["errors"])
+
+
+def test_write_rejects_bad_condition(tmp_path):
+    fm = build_source_fm(source_type="fake", interval="5m", extract_mode="hash", condition="a +")
+    res = write_event_source(tmp_path, "s", fm)
+    assert res["success"] is False
+    assert any("CEL" in e for e in res["errors"])
+
+
+# --- event_source_dry_run op (condition eval over the would-emit event) -------
+
+def _dry_run_src():
+    return from_frontmatter(
+        "nvda",
+        {
+            "kind": "event_source",
+            "source": {"type": "fake", "url": "x", "interval": "5m"},
+            "extract": {"mode": "json_path", "path": "$.ceo"},
+            "condition": "event.data != prev.data",
+            "action": {"name": "notify"},
+            "allowed_actions": ["notify"],
+            "enabled": True,
+        },
+    )
+
+
+def test_dry_run_would_fire_when_condition_passes(monkeypatch):
+    import work_buddy.events.sources.poller as P
+    import work_buddy.mcp_server.ops.events_ops as ops
+
+    src = _dry_run_src()
+    monkeypatch.setattr(loader_mod, "load_event_sources", lambda directory=None: ([src], []))
+    monkeypatch.setattr(
+        P, "dry_run",
+        lambda s, **kw: {"changed": True, "is_first": False, "value": "B", "prev": "A",
+                         "would_emit": {"type": s.event_type}},
+    )
+    out = ops.event_source_dry_run("nvda")
+    assert out["ok"] is True
+    assert out["condition_passed"] is True
+    assert out["would_fire"] is True
+
+
+def test_dry_run_no_fire_when_condition_fails(monkeypatch):
+    import work_buddy.events.sources.poller as P
+    import work_buddy.mcp_server.ops.events_ops as ops
+
+    src = _dry_run_src()
+    monkeypatch.setattr(loader_mod, "load_event_sources", lambda directory=None: ([src], []))
+    monkeypatch.setattr(
+        P, "dry_run",
+        lambda s, **kw: {"changed": True, "is_first": False, "value": "A", "prev": "A",
+                         "would_emit": {"type": s.event_type}},
+    )
+    out = ops.event_source_dry_run("nvda")
+    assert out["condition_passed"] is False
+    assert out["would_fire"] is False
+
+
+def test_dry_run_unknown_source(monkeypatch):
+    import work_buddy.mcp_server.ops.events_ops as ops
+
+    monkeypatch.setattr(loader_mod, "load_event_sources", lambda directory=None: ([], []))
+    out = ops.event_source_dry_run("nope")
+    assert out["ok"] is False
+
+
+def test_dry_run_from_unsaved_proposal(monkeypatch):
+    import work_buddy.events.sources.poller as P
+    import work_buddy.mcp_server.ops.events_ops as ops
+
+    monkeypatch.setattr(
+        P, "dry_run",
+        lambda s, **kw: {"changed": True, "is_first": False, "value": "B", "prev": "A",
+                         "would_emit": {"type": s.event_type}},
+    )
+    proposal = {
+        "name": "nvda",
+        "source_type": "http_poll",
+        "url": "https://example.test/quote.json",
+        "interval": "6h",
+        "extract_mode": "json_path",
+        "extract_path": "$.ceo",
+        "condition": "event.data != prev.data",
+        "action": "notify",
+        "allowed_actions": ["notify"],
+    }
+    out = ops.event_source_dry_run(proposal=proposal)
+    assert out["ok"] is True
+    assert out["condition_passed"] is True
+    assert out["would_fire"] is True
+
+
+def test_dry_run_proposal_rejects_invalid():
+    import work_buddy.mcp_server.ops.events_ops as ops
+
+    out = ops.event_source_dry_run(
+        proposal={"name": "s", "source_type": "bogus", "interval": "6h"}
+    )
+    assert out["ok"] is False

--- a/tests/unit/events/test_source_state.py
+++ b/tests/unit/events/test_source_state.py
@@ -1,0 +1,21 @@
+"""Unit tests for per-source cursor state."""
+
+from __future__ import annotations
+
+from work_buddy.events.sources.state import load_state, save_state
+
+
+def test_missing_state_is_empty(tmp_path):
+    assert load_state("nope", tmp_path) == {}
+
+
+def test_state_roundtrip(tmp_path):
+    save_state("s", {"last_hash": "abc", "last_value": 1, "last_polled": "t"}, tmp_path)
+    got = load_state("s", tmp_path)
+    assert got["last_hash"] == "abc"
+    assert got["last_value"] == 1
+
+
+def test_corrupt_state_degrades_to_empty(tmp_path):
+    (tmp_path / "bad.json").write_text("{not json", encoding="utf-8")
+    assert load_state("bad", tmp_path) == {}

--- a/work_buddy/events/conditions/__init__.py
+++ b/work_buddy/events/conditions/__init__.py
@@ -1,0 +1,10 @@
+"""Event conditions — predicates over a delivered event and its predecessor.
+
+A `Condition` (see `events/protocol.py`) decides whether a source's action should
+fire. `CelCondition` is the safe, non-Turing-complete default; later tiers (a
+semantic-LLM gate) sit behind the same port.
+"""
+
+from work_buddy.events.conditions.cel import CelCondition
+
+__all__ = ["CelCondition"]

--- a/work_buddy/events/conditions/cel.py
+++ b/work_buddy/events/conditions/cel.py
@@ -1,0 +1,80 @@
+"""CEL conditions — a safe, non-Turing-complete predicate over a delivered event
+and its predecessor.
+
+Compiled once at construction (malformed syntax raises, so the loader/validator
+can reject a bad source before it ever runs); evaluated **fail-closed** — any
+runtime error yields ``False`` so a watcher never fires on an inconclusive or
+malformed condition (the same posture as `classify_evidence`).
+
+The activation exposes the extracted value under both a nested and a flat name,
+so an author can write either the object form or the scalar shorthand:
+
+    event.data        the just-extracted value (scalar OR object)
+    prev.data         the previously-extracted value
+    current           shorthand for event.data
+    event.type        the event type (e.g. ai.workbuddy.source.nvda.changed)
+    event.source      the source URI (e.g. /wb/source/nvda)
+
+So a scalar watch reads ``event.data != prev.data`` and an object watch reads
+``event.data.price != prev.data.price``. (There is deliberately no bare ``prev``
+scalar — it would collide with the ``prev`` map; use ``prev.data``.)
+
+celpy ships only CEL's standard built-ins (no ``abs``/``math.*``); `_cel_functions`
+registers a small curated, pure extra set so threshold conditions like
+``abs(event.data.price - prev.data.price) / prev.data.price > 0.05`` read cleanly.
+"""
+
+from __future__ import annotations
+
+from work_buddy.events.envelope import Event
+from work_buddy.events.protocol import ConditionContext
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _cel_functions() -> dict:
+    """Curated extras beyond CEL's built-ins — pure + deterministic. Extend
+    deliberately (each addition widens the author-facing DSL surface)."""
+    import celpy.celtypes as ct
+
+    def _abs(x):
+        return ct.DoubleType(abs(float(x)))
+
+    return {"abs": _abs}
+
+
+class CelCondition:
+    """A compiled CEL predicate. ``evaluate`` always returns a plain ``bool``."""
+
+    def __init__(self, expr: str) -> None:
+        import celpy
+
+        self.expr = expr
+        self._env = celpy.Environment()
+        ast = self._env.compile(expr)  # raises CELParseError on bad syntax
+        self._program = self._env.program(ast, functions=_cel_functions())
+
+    def evaluate(self, event: Event, prev: Event | None, ctx: ConditionContext) -> bool:
+        import celpy
+
+        data = event.data or {}
+        current = data.get("current")
+        prev_value = data.get("prev")
+        activation = celpy.json_to_cel(
+            {
+                "event": {"data": current, "type": event.type, "source": event.source},
+                "prev": {"data": prev_value},
+                "current": current,
+            }
+        )
+        try:
+            result = self._program.evaluate(activation)
+        except Exception as exc:  # noqa: BLE001 — fail-closed: never fire on error
+            logger.debug("CEL %r eval raised (%s) — treating as False", self.expr, exc)
+            return False
+        # celpy may *return* a CELEvalError object rather than raise it.
+        if type(result).__name__ == "CELEvalError":
+            logger.debug("CEL %r returned an eval-error — treating as False", self.expr)
+            return False
+        return bool(result)

--- a/work_buddy/events/consumers/source_action.py
+++ b/work_buddy/events/consumers/source_action.py
@@ -1,0 +1,180 @@
+"""SourceActionConsumer — the reaction half of a pull source.
+
+The poller (the *producer*) publishes ``ai.workbuddy.source.<name>.changed`` when
+a watched value changes. This durable consumer reacts: resolve the source def,
+evaluate its CEL condition (fail-closed), then run its action — gated by
+``allowed_actions`` (the reserved policy ``deny`` path) and per-action consent.
+
+Putting the reaction on the drain (rather than inline in the poller) means it
+inherits the spine's at-least-once delivery + bounded-retry + DLQ for free; the
+poller stays a pure fetch→diff→publish loop.
+"""
+
+from __future__ import annotations
+
+from work_buddy.events.conditions.cel import CelCondition
+from work_buddy.events.dispatcher import DurableConsumer, register_consumer
+from work_buddy.events.policy import policy_check
+from work_buddy.events.processors.registry import get_action
+from work_buddy.events.protocol import (
+    ConditionContext,
+    ProcessorManifest,
+    ProcessorResult,
+)
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+CONSUMER_ID = "events.source-action"
+SOURCE_TYPE_PREFIX = "ai.workbuddy.source."
+
+
+class SourceActionProcessor:
+    """React to a ``source.changed`` event: condition gate → scoped action."""
+
+    manifest = ProcessorManifest(
+        name="source-action",
+        description="Evaluate a source's condition and run its action",
+        consent_action=None,  # the per-action consent is checked below, per-fire
+        consent_weight="low",
+    )
+
+    def __init__(self) -> None:
+        # CEL programs are reusable + the drain is single-threaded; cache by expr.
+        self._cel_cache: dict[str, CelCondition] = {}
+
+    def run(self, event, ctx) -> ProcessorResult:
+        data = event.data or {}
+        name = data.get("source_name")
+        if not name:
+            return ProcessorResult(text="no source_name on event", is_error=True)
+
+        source = self._resolve(name)
+        if source is None:
+            logger.warning("source-action: no enabled def for source %r", name)
+            return ProcessorResult(text=f"source {name!r} not found")
+
+        # Condition gate (fail-closed): never fire on an inconclusive/bad condition.
+        if source.condition and not self._condition_passes(source, event):
+            return ProcessorResult(text="condition not met")
+
+        # allowed_actions scope — the reserved policy `deny` path, made concrete.
+        if source.action_name not in source.allowed_actions:
+            logger.warning(
+                "source-action: %s action %r not in allowed_actions %s — denied",
+                name,
+                source.action_name,
+                source.allowed_actions,
+            )
+            return ProcessorResult(
+                text=f"action {source.action_name!r} denied (allowed_actions)"
+            )
+
+        action = get_action(source.action_name)
+        if action is None:
+            return ProcessorResult(
+                text=f"unknown action {source.action_name!r}", is_error=True
+            )
+
+        # Per-action consent. `notify` declares no gate (consent_action=None →
+        # allow); a future high-weight action would prompt here, holding the event.
+        decision = policy_check(
+            action.consent_action, ctx, consent_weight=action.consent_weight
+        )
+        if decision != "allow":
+            logger.info(
+                "source-action: %s action %s gated: %s", name, source.action_name, decision
+            )
+            return ProcessorResult(text=f"action gated: {decision}")
+
+        # Rate-limit + auto-suspend: a flapping watcher is notification spam.
+        now = None
+        if source.max_per_hour is not None:
+            from datetime import datetime, timezone
+
+            from work_buddy.events.sources.ratelimit import fires_last_hour
+
+            now = datetime.now(timezone.utc)
+            if fires_last_hour(source.name, now) >= source.max_per_hour:
+                self._auto_suspend(source)
+                return ProcessorResult(
+                    text=f"rate-limited (>= {source.max_per_hour}/h) — {source.name} auto-suspended"
+                )
+
+        result = action.run(event, source, ctx)
+
+        if source.max_per_hour is not None:
+            from work_buddy.events.sources.ratelimit import record_fire
+
+            record_fire(source.name, now)
+        return result
+
+    def _auto_suspend(self, source) -> None:
+        """Disable a flapping source (rewrite its ``.md`` with ``enabled: false``)
+        and notify the user once. The cursor is preserved, so a later re-enable
+        resumes cleanly."""
+        from work_buddy.events.sources.loader import sources_dir, write_event_source
+
+        fm = dict(source.raw)
+        fm["enabled"] = False
+        write_event_source(sources_dir(), source.name, fm, overwrite=True)
+        logger.warning(
+            "source-action: %s auto-suspended (rate limit %s/h)",
+            source.name,
+            source.max_per_hour,
+        )
+        try:
+            from work_buddy.notifications.dispatcher import SurfaceDispatcher
+            from work_buddy.notifications.models import Notification, SourceType
+            from work_buddy.notifications.store import create_notification, mark_delivered
+
+            notif = create_notification(
+                Notification(
+                    title=f"Watcher paused: {source.name}",
+                    body=(
+                        f"{source.name} fired more than {source.max_per_hour} times in "
+                        "an hour and was auto-suspended. Re-enable it once the source "
+                        "settles."
+                    ),
+                    source=f"events:source:{source.name}",
+                    source_type=SourceType.PROGRAMMATIC.value,
+                    tags=["events", "source", source.name, "auto-suspend"],
+                )
+            )
+            SurfaceDispatcher.from_config().deliver(notif, mark_delivered_fn=mark_delivered)
+        except Exception:  # pragma: no cover — defensive
+            logger.exception("source-action: auto-suspend notify failed for %s", source.name)
+
+    def _resolve(self, name: str):
+        from work_buddy.events.sources.loader import load_event_sources
+
+        defs, _ = load_event_sources()
+        return next((d for d in defs if d.name == name and d.enabled), None)
+
+    def _condition_passes(self, source, event) -> bool:
+        cond = self._cel_cache.get(source.condition)
+        if cond is None:
+            try:
+                cond = CelCondition(source.condition)
+            except Exception:  # noqa: BLE001 — invalid CEL → fail-closed
+                logger.warning(
+                    "source-action: %s has invalid CEL %r — treating as not-met",
+                    source.name,
+                    source.condition,
+                )
+                return False
+            self._cel_cache[source.condition] = cond
+        return cond.evaluate(event, None, ConditionContext())
+
+
+def register_source_action() -> None:
+    """Register the source-action consumer with the dispatcher (sidecar boot)."""
+    register_consumer(
+        DurableConsumer(
+            id=CONSUMER_ID,
+            processor=SourceActionProcessor(),
+            consent_action=None,
+            type_prefix=SOURCE_TYPE_PREFIX,
+        )
+    )
+    logger.info("events: registered source-action consumer (%s*)", SOURCE_TYPE_PREFIX)

--- a/work_buddy/events/dispatcher.py
+++ b/work_buddy/events/dispatcher.py
@@ -38,9 +38,11 @@ READ_LIMIT = 200     # per-consumer batch cap per drain tick (backpressure)
 class DurableConsumer:
     """A registered handler the drain delivers events to.
 
-    ``types=None`` means "all types"; otherwise the consumer only runs for
-    events whose ``type`` is in the set (its offset still advances past the
-    rest, so a narrow consumer never re-reads events it doesn't handle).
+    ``types=None`` and ``type_prefix=None`` means "all types"; otherwise the
+    consumer only runs for events whose ``type`` is in ``types`` OR starts with
+    ``type_prefix`` (its offset still advances past the rest, so a narrow
+    consumer never re-reads events it doesn't handle). ``type_prefix`` suits a
+    family of dynamically-named types, e.g. ``ai.workbuddy.source.``.
     """
 
     id: str
@@ -48,6 +50,7 @@ class DurableConsumer:
     consent_action: str | None = None
     consent_weight: str = "low"
     types: frozenset[str] | None = None
+    type_prefix: str | None = None
 
 
 # --- module state ----------------------------------------------------------
@@ -90,6 +93,17 @@ def clear_consumers() -> None:
     _attempts.clear()
 
 
+def _consumer_handles(consumer: DurableConsumer, event_type: str) -> bool:
+    """Whether ``consumer`` should run for ``event_type`` (exact-set OR prefix)."""
+    if consumer.types is None and consumer.type_prefix is None:
+        return True
+    if consumer.types is not None and event_type in consumer.types:
+        return True
+    if consumer.type_prefix is not None and event_type.startswith(consumer.type_prefix):
+        return True
+    return False
+
+
 # --- publish ---------------------------------------------------------------
 
 
@@ -125,7 +139,7 @@ def drain() -> dict[str, int]:
         last = store.get_offset(consumer.id)
         for seq, event in store.read_since(last, limit=READ_LIMIT):
             # Type filter: advance past events this consumer doesn't handle.
-            if consumer.types is not None and event.type not in consumer.types:
+            if not _consumer_handles(consumer, event.type):
                 store.commit_offset(consumer.id, seq)
                 continue
 

--- a/work_buddy/events/processors/__init__.py
+++ b/work_buddy/events/processors/__init__.py
@@ -1,0 +1,10 @@
+"""Action processors (sinks) for event sources.
+
+An action is the effect a source fires when its condition passes — this slice
+ships only `notify` (a pure notification sink). The `registry` maps a source's
+declared `action.name` to its handler + consent spec.
+"""
+
+from work_buddy.events.processors.registry import Action, get_action, known_actions
+
+__all__ = ["Action", "get_action", "known_actions"]

--- a/work_buddy/events/processors/notify.py
+++ b/work_buddy/events/processors/notify.py
@@ -1,0 +1,67 @@
+"""The ``notify`` action — surface a notification when a source's condition fires.
+
+Mirrors `send_notification` (notifications_ops.py): `create_notification` only
+*persists*; surface delivery (Telegram / dashboard / Obsidian) is a separate push
+via `SurfaceDispatcher.deliver`, kept **best-effort** — a blocking surface POST
+runs on the drain thread, and a delivery failure must never poison the consumer
+(→ DLQ). The notification is durably stored regardless.
+"""
+
+from __future__ import annotations
+
+from work_buddy.events.envelope import Event
+from work_buddy.events.protocol import ProcessorResult, RunContext
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def notify_action(event: Event, source, ctx: RunContext) -> ProcessorResult:
+    """Notify the user that ``source`` changed. ``source`` is an EventSourceDef
+    (passed in because the action composes its message from `action_params`)."""
+    from work_buddy.notifications.models import Notification, SourceType
+    from work_buddy.notifications.store import create_notification, mark_delivered
+
+    data = event.data or {}
+    params = source.action_params or {}
+    title = params.get("title") or f"Watch: {source.name}"
+    body = params.get("body") or _default_body(source, data)
+
+    notif = create_notification(
+        Notification(
+            title=title,
+            body=body,
+            source=f"events:source:{source.name}",
+            source_type=SourceType.PROGRAMMATIC.value,
+            tags=["events", "source", source.name],
+        )
+    )
+
+    delivered: dict = {}
+    try:
+        from work_buddy.notifications.dispatcher import SurfaceDispatcher
+
+        delivered = SurfaceDispatcher.from_config().deliver(
+            notif, mark_delivered_fn=mark_delivered
+        )
+    except Exception:  # pragma: no cover — defensive
+        logger.exception(
+            "notify action: surface delivery failed (non-fatal) for source %s", source.name
+        )
+
+    return ProcessorResult(
+        text="notified",
+        structured={
+            "source": source.name,
+            "notification_id": notif.notification_id,
+            "delivered": [k for k, v in delivered.items() if v],
+        },
+    )
+
+
+def _default_body(source, data: dict) -> str:
+    # Keep the reverse-DNS event *type* OUT of the body — a dotted string gets
+    # auto-linkified on Telegram. Just the readable diff.
+    current = data.get("current")
+    prev = data.get("prev")
+    return f"{source.name} changed.\n\nnow: {current}\nwas: {prev}"

--- a/work_buddy/events/processors/registry.py
+++ b/work_buddy/events/processors/registry.py
@@ -1,0 +1,45 @@
+"""Action registry: a source's declared ``action.name`` → the handler that runs it.
+
+Each action carries its own consent spec. Most sinks are no-gate (the effect is
+itself a surface the user sees and can act on); a *future* state-changing action
+would set ``consent_action`` + ``consent_weight="high"`` to re-prompt per fire.
+``notify`` is a pure notification sink — no gate. Only ``notify`` exists this
+slice (``autonomy: notify_only``).
+
+The set of registered names must stay in sync with `definition.KNOWN_ACTIONS`
+(the validator's allow-list); `test_source_action` asserts they match.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from work_buddy.events.envelope import Event
+from work_buddy.events.processors.notify import notify_action
+from work_buddy.events.protocol import ProcessorResult, RunContext
+
+
+@dataclass(frozen=True)
+class Action:
+    """A source action: its handler plus the consent it requires at fire time."""
+
+    name: str
+    run: Callable[[Event, object, RunContext], ProcessorResult]
+    consent_action: str | None = None  # None => no gate (a pure sink)
+    consent_weight: str = "low"
+
+
+ACTIONS: dict[str, Action] = {
+    "notify": Action(name="notify", run=notify_action, consent_action=None),
+}
+
+
+def get_action(name: str) -> Action | None:
+    """Return the registered `Action` for ``name``, or None if unknown."""
+    return ACTIONS.get(name)
+
+
+def known_actions() -> set[str]:
+    """The set of registered action names."""
+    return set(ACTIONS)

--- a/work_buddy/events/sources/__init__.py
+++ b/work_buddy/events/sources/__init__.py
@@ -1,0 +1,23 @@
+"""Event Sources — adapters that normalize external state into ``Event``s.
+
+A source is a user-authored ``.md`` file (``kind: event_source``) under
+``.data/event_sources/``, validated like a user job and hot-reloaded. The
+loader turns it into an :class:`EventSourceDef`; the poller drives the
+reconciling fetch → diff → emit loop.
+"""
+
+from __future__ import annotations
+
+from work_buddy.events.sources.definition import (
+    EventSourceDef,
+    parse_interval,
+    parse_source_md,
+    validate_source_fm,
+)
+
+__all__ = [
+    "EventSourceDef",
+    "parse_interval",
+    "parse_source_md",
+    "validate_source_fm",
+]

--- a/work_buddy/events/sources/definition.py
+++ b/work_buddy/events/sources/definition.py
@@ -1,0 +1,223 @@
+"""``EventSourceDef`` — the typed contract for a user-authored event source.
+
+The schema is deliberately shallow (≤2 levels) so an LLM can fill it reliably
+in the ``/wb-event-new`` authoring loop. Validation is shared between the loader
+(read side) and the ``event_source_create`` op (write side), mirroring the
+``create_user_job_file`` discipline: reject a malformed source at author/load
+time with a specific message rather than failing silently at poll time.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from work_buddy.frontmatter import parse_frontmatter
+
+NAME_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{0,63}")
+
+# ``fake`` is the no-network backend used by tests / dry runs.
+KNOWN_SOURCE_TYPES = frozenset({"http_poll", "fake"})
+EXTRACT_MODES = frozenset({"json_path", "css", "hash"})
+DEDUP_MODES = frozenset({"unique", "greatest", "last", "hash"})
+AUTONOMY = frozenset({"notify_only", "auto_execute"})
+# Actions a source may declare. Extends as new Processors are registered.
+KNOWN_ACTIONS = frozenset({"notify"})
+
+_UNIT_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+
+
+def parse_interval(value: Any) -> int | None:
+    """``"6h"`` → ``21600`` seconds. Returns ``None`` on anything invalid."""
+    if not isinstance(value, str):
+        return None
+    m = re.fullmatch(r"\s*(\d+)\s*([smhd])\s*", value.lower())
+    if not m:
+        return None
+    return int(m.group(1)) * _UNIT_SECONDS[m.group(2)]
+
+
+@dataclass(frozen=True)
+class EventSourceDef:
+    """A loaded, validated event source. ``name`` is the ``.md`` file stem."""
+
+    name: str
+    type: str
+    interval_s: int
+    url: str | None = None
+    auth: Any = None
+    cursor_from: str = "now"            # now | all | <iso-date>
+    extract_mode: str = "hash"          # json_path | css | hash
+    extract_path: str | None = None
+    id_field: str | None = None
+    dedup: str = "hash"
+    condition: str | None = None        # CEL expression (optional)
+    action_name: str = "notify"
+    action_params: dict[str, Any] = field(default_factory=dict)
+    allowed_actions: tuple[str, ...] = ("notify",)
+    autonomy: str = "notify_only"
+    max_per_hour: int | None = None
+    enabled: bool = True
+    event_type: str = ""                # reverse-DNS; derived if unset
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def source_uri(self) -> str:
+        return f"/wb/source/{self.name}"
+
+
+def from_frontmatter(name: str, fm: dict[str, Any]) -> EventSourceDef:
+    """Build an ``EventSourceDef`` from a parsed frontmatter dict (no validation
+    — call :func:`validate_source_fm` first)."""
+    source = fm.get("source") or {}
+    extract = fm.get("extract") or {}
+    cursor = fm.get("cursor") or {}
+    action = fm.get("action") or {}
+    rate = fm.get("rate_limit") or {}
+    action_name = str(action.get("name", "notify"))
+    allowed = fm.get("allowed_actions") or [action_name]
+    return EventSourceDef(
+        name=name,
+        type=str(source.get("type", "")).strip(),
+        interval_s=parse_interval(source.get("interval")) or 0,
+        url=source.get("url"),
+        auth=source.get("auth"),
+        cursor_from=str(cursor.get("from", "now")),
+        extract_mode=str(extract.get("mode", "hash")),
+        extract_path=extract.get("path"),
+        id_field=extract.get("id_field"),
+        dedup=str(fm.get("dedup", "hash")),
+        condition=fm.get("condition"),
+        action_name=action_name,
+        action_params=action.get("params") or {},
+        allowed_actions=tuple(allowed),
+        autonomy=str(fm.get("autonomy", "notify_only")),
+        max_per_hour=rate.get("max_per_hour"),
+        enabled=bool(fm.get("enabled", True)),
+        event_type=str(fm.get("event_type") or f"ai.workbuddy.source.{name}.changed"),
+        raw=fm,
+    )
+
+
+def parse_source_md(path: Path) -> EventSourceDef:
+    fm, _ = parse_frontmatter(path)
+    return from_frontmatter(path.stem, fm)
+
+
+def build_source_fm(
+    *,
+    source_type: str,
+    interval: str,
+    url: str | None = None,
+    extract_mode: str = "hash",
+    extract_path: str | None = None,
+    condition: str | None = None,
+    action: str = "notify",
+    action_params: dict[str, Any] | None = None,
+    allowed_actions: list[str] | None = None,
+    autonomy: str = "notify_only",
+    max_per_hour: int | None = None,
+    cursor_from: str = "now",
+    enabled: bool = True,
+    event_type: str | None = None,
+) -> dict[str, Any]:
+    """Build an ``event_source`` frontmatter dict from structured fields — the
+    inverse of :func:`from_frontmatter`, used by the ``event_source_create`` op
+    and the ``/wb-event-new`` authoring loop. Validate the result with
+    :func:`validate_source_fm` before writing it."""
+    fm: dict[str, Any] = {
+        "kind": "event_source",
+        "source": {"type": source_type, "interval": interval},
+        "extract": {"mode": extract_mode},
+        "action": {"name": action},
+        "allowed_actions": list(allowed_actions or [action]),
+        "autonomy": autonomy,
+        "enabled": bool(enabled),
+    }
+    if url:
+        fm["source"]["url"] = url
+    if extract_path:
+        fm["extract"]["path"] = extract_path
+    if condition:
+        fm["condition"] = condition
+    if action_params:
+        fm["action"]["params"] = action_params
+    if max_per_hour is not None:
+        fm["rate_limit"] = {"max_per_hour": int(max_per_hour)}
+    if cursor_from and cursor_from != "now":
+        fm["cursor"] = {"from": cursor_from}
+    if event_type:
+        fm["event_type"] = event_type
+    return fm
+
+
+def validate_source_fm(name: str, fm: dict[str, Any]) -> list[str]:
+    """Return validation errors (empty list = valid). Shared by the loader and
+    the write op so a bad source is caught at author/load time."""
+    errors: list[str] = []
+
+    if not NAME_PATTERN.fullmatch(name or ""):
+        errors.append(
+            f"name {name!r} must be 1-64 chars, start alphanumeric, "
+            "and contain only letters, digits, hyphens, or underscores."
+        )
+    if fm.get("kind") != "event_source":
+        errors.append("frontmatter `kind` must be 'event_source'.")
+
+    source = fm.get("source") or {}
+    src_type = str(source.get("type", "")).strip()
+    if src_type not in KNOWN_SOURCE_TYPES:
+        errors.append(
+            f"source.type {src_type!r} unknown (known: {sorted(KNOWN_SOURCE_TYPES)})."
+        )
+    if src_type == "http_poll" and not source.get("url"):
+        errors.append("source.type=http_poll requires source.url.")
+    if parse_interval(source.get("interval")) is None:
+        errors.append(
+            f"source.interval {source.get('interval')!r} is invalid "
+            "(use e.g. '30s', '5m', '6h', '1d')."
+        )
+
+    extract = fm.get("extract") or {}
+    mode = str(extract.get("mode", "hash"))
+    if mode not in EXTRACT_MODES:
+        errors.append(f"extract.mode {mode!r} invalid (known: {sorted(EXTRACT_MODES)}).")
+    if mode in ("json_path", "css") and not extract.get("path"):
+        errors.append(f"extract.mode={mode} requires extract.path.")
+    if mode == "json_path" and extract.get("path"):
+        try:
+            import jsonpath_ng
+
+            jsonpath_ng.parse(str(extract["path"]))
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"extract.path is not valid JSONPath: {exc}")
+
+    cond = fm.get("condition")
+    if cond:
+        try:
+            import celpy
+
+            celpy.Environment().compile(str(cond))
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"condition is not valid CEL ({type(exc).__name__}): {exc}")
+
+    action = fm.get("action") or {}
+    action_name = action.get("name")
+    if not action_name:
+        errors.append("action.name is required.")
+    elif action_name not in KNOWN_ACTIONS:
+        errors.append(f"action.name {action_name!r} unknown (known: {sorted(KNOWN_ACTIONS)}).")
+
+    allowed = fm.get("allowed_actions")
+    if allowed is not None and not isinstance(allowed, list):
+        errors.append("allowed_actions must be a list.")
+    elif action_name and isinstance(allowed, list) and action_name not in allowed:
+        errors.append(f"action.name {action_name!r} is not in allowed_actions {allowed}.")
+
+    autonomy = str(fm.get("autonomy", "notify_only"))
+    if autonomy not in AUTONOMY:
+        errors.append(f"autonomy {autonomy!r} invalid (known: {sorted(AUTONOMY)}).")
+
+    return errors

--- a/work_buddy/events/sources/extract.py
+++ b/work_buddy/events/sources/extract.py
@@ -1,0 +1,45 @@
+"""Pull the watched value out of a fetched payload.
+
+Three modes (the design's catalog): ``json_path`` (JSONPath over parsed JSON),
+``css`` (CSS selector over HTML text), or ``hash`` (a content hash of the whole
+body — the catch-all "did anything change"). Returns a JSON-serializable value;
+the poller diffs ``content_hash(value)`` against the stored hash.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+def content_hash(value: Any) -> str:
+    """Stable SHA-256 of a JSON-serializable value (the diff key)."""
+    raw = json.dumps(value, sort_keys=True, default=str).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def extract_value(mode: str, payload: Any, *, path: str | None = None) -> Any:
+    """Extract the watched value. A single match returns the scalar; multiple
+    matches return a list (so a collection watch diffs the whole set)."""
+    if mode == "json_path":
+        import jsonpath_ng
+
+        matches = [m.value for m in jsonpath_ng.parse(path).find(payload)]
+        return matches[0] if len(matches) == 1 else matches
+    if mode == "css":
+        from lxml import html as lxml_html
+
+        text = payload if isinstance(payload, str) else json.dumps(payload, default=str)
+        doc = lxml_html.fromstring(text)
+        nodes = doc.cssselect(path)  # needs the `cssselect` package
+        out = [n.text_content().strip() for n in nodes]
+        return out[0] if len(out) == 1 else out
+    if mode == "hash":
+        raw = payload if isinstance(payload, (str, bytes)) else json.dumps(
+            payload, sort_keys=True, default=str
+        )
+        if isinstance(raw, str):
+            raw = raw.encode("utf-8")
+        return hashlib.sha256(raw).hexdigest()
+    raise ValueError(f"unknown extract mode {mode!r}")

--- a/work_buddy/events/sources/http_poll.py
+++ b/work_buddy/events/sources/http_poll.py
@@ -1,0 +1,35 @@
+"""Fetch the raw payload for a source.
+
+``http_poll`` GETs the URL with ``httpx`` (mirroring the websearch fetch
+pattern); ``fake`` returns a fixture from the source's frontmatter
+(``fake_payload``) for tests / dry runs with no network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from work_buddy.events.sources.definition import EventSourceDef
+
+_TIMEOUT_S = 15.0
+
+
+def fetch_payload(source: EventSourceDef) -> Any:
+    """Return the raw payload: parsed JSON for ``json_path`` extraction, else
+    the response text. Raises on a network/HTTP error (the poller catches it)."""
+    if source.type == "fake":
+        return source.raw.get("fake_payload")
+    if source.type == "http_poll":
+        import httpx
+
+        with httpx.Client(
+            timeout=_TIMEOUT_S,
+            follow_redirects=True,
+            headers={"User-Agent": "work-buddy-events/1.0"},
+        ) as client:
+            resp = client.get(source.url)
+        resp.raise_for_status()
+        if source.extract_mode == "json_path":
+            return resp.json()
+        return resp.text
+    raise ValueError(f"source type {source.type!r} cannot be polled")

--- a/work_buddy/events/sources/loader.py
+++ b/work_buddy/events/sources/loader.py
@@ -1,0 +1,96 @@
+"""Discover + validate ``event_source`` ``.md`` files under
+``.data/event_sources/``.
+
+Loading is read-only and best-effort: an invalid source is skipped with a
+logged reason and surfaced in the returned ``errors`` list (so the dashboard /
+authoring loop can show *why*), never crashing the poll tick.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from work_buddy.events.sources.definition import (
+    EventSourceDef,
+    from_frontmatter,
+    validate_source_fm,
+)
+from work_buddy.frontmatter import parse_frontmatter
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def sources_dir() -> Path:
+    """The directory holding event-source ``.md`` files (created on resolve)."""
+    from work_buddy.paths import resolve
+
+    d = resolve("event_sources")
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def load_event_sources(
+    directory: Path | None = None,
+) -> tuple[list[EventSourceDef], list[dict]]:
+    """Return ``(valid_defs, errors)``. ``errors`` is a list of
+    ``{"file": <name>, "errors": [<msg>, ...]}``. Tests pass ``directory``
+    explicitly (mirrors ``create_user_job_file``'s pure-function shape)."""
+    d = directory if directory is not None else sources_dir()
+    valid: list[EventSourceDef] = []
+    errors: list[dict] = []
+    if not d.exists():
+        return valid, errors
+
+    for path in sorted(d.glob("*.md")):
+        fm, _ = parse_frontmatter(path)
+        errs = validate_source_fm(path.stem, fm)
+        if errs:
+            errors.append({"file": path.name, "errors": errs})
+            logger.warning("event source %s invalid: %s", path.name, "; ".join(errs))
+            continue
+        valid.append(from_frontmatter(path.stem, fm))
+    return valid, errors
+
+
+def write_event_source(
+    target_dir: Path,
+    name: str,
+    fm: dict,
+    *,
+    overwrite: bool = False,
+) -> dict:
+    """Validate ``fm`` and write it as ``<target_dir>/<name>.md``.
+
+    Mirrors ``create_user_job_file``: a pure function (explicit ``target_dir``,
+    so tests need no path monkeypatching), refuses to overwrite an existing file
+    unless ``overwrite=True``, and returns ``{"success": bool, ...}``. The next
+    poll tick re-loads the directory, so a new source needs no hot-reload hook.
+    """
+    import yaml
+
+    name = (name or "").strip()
+    errors = validate_source_fm(name, fm)
+    if errors:
+        return {"success": False, "error": "; ".join(errors), "errors": errors}
+
+    target_dir = Path(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / f"{name}.md"
+    if target.exists() and not overwrite:
+        return {
+            "success": False,
+            "error": f"event source {name!r} already exists at {target}.",
+        }
+
+    block = yaml.safe_dump(fm, sort_keys=False, default_flow_style=False).strip()
+    target.write_text(f"---\n{block}\n---\n", encoding="utf-8")
+    return {
+        "success": True,
+        "name": name,
+        "file_path": str(target),
+        "message": (
+            f"Event source {name!r} written. The poller re-loads sources each "
+            "tick, so it activates on the next poll."
+        ),
+    }

--- a/work_buddy/events/sources/poller.py
+++ b/work_buddy/events/sources/poller.py
@@ -1,0 +1,130 @@
+"""The reconciling poll loop for pull sources.
+
+`poll_source`: fetch → extract the watched value → diff its content hash vs the
+stored cursor → on a **meaningful change** (and not the baseline first
+observation, unless ``cursor.from == all``) publish an
+``ai.workbuddy.source.<name>.changed`` Event and advance the cursor. The cursor
+advances only *after* the poll completes, so a crash re-fetches (idempotent via
+the spine's inbox dedup).
+
+`dry_run` runs the whole path with **zero side effects** (no publish, no state
+write) — the preview the `/wb-event-new` authoring loop shows before activating.
+
+`poll_due_sources` is the tick the cron job fires: load all sources, poll each
+enabled one whose interval has elapsed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from work_buddy.events.sources.definition import EventSourceDef
+from work_buddy.events.sources.extract import content_hash, extract_value
+from work_buddy.events.sources.http_poll import fetch_payload
+from work_buddy.events.sources.state import load_state, save_state
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _is_due(last_polled_iso: str | None, interval_s: int, now: datetime | None = None) -> bool:
+    if not last_polled_iso:
+        return True
+    try:
+        last = datetime.fromisoformat(last_polled_iso)
+    except (ValueError, TypeError):
+        return True
+    if last.tzinfo is None:
+        last = last.replace(tzinfo=timezone.utc)
+    return ((now or _now()) - last).total_seconds() >= interval_s
+
+
+def poll_source(
+    source: EventSourceDef,
+    *,
+    fetch: Callable[[EventSourceDef], Any] = fetch_payload,
+    publish: Callable[[Any], None] | None = None,
+    state_directory=None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Poll one source once. See module docstring for semantics."""
+    if publish is None:
+        from work_buddy.events import dispatcher
+
+        publish = dispatcher.publish
+
+    state = load_state(source.name, state_directory)
+    prev_value = state.get("last_value")
+    prev_hash = state.get("last_hash")
+    is_first = prev_hash is None
+
+    try:
+        payload = fetch(source)
+    except Exception as exc:  # noqa: BLE001 — a fetch failure is non-fatal
+        logger.warning("event source %s: fetch failed: %s", source.name, exc)
+        return {"polled": True, "error": f"fetch failed: {exc}", "changed": False, "emitted": False}
+
+    value = extract_value(source.extract_mode, payload, path=source.extract_path)
+    new_hash = content_hash(value)
+    changed = new_hash != prev_hash
+    fire = changed and (not is_first or source.cursor_from == "all")
+
+    result: dict[str, Any] = {
+        "polled": True,
+        "changed": changed,
+        "is_first": is_first,
+        "value": value,
+        "prev": prev_value,
+        "emitted": False,
+    }
+
+    if fire:
+        from work_buddy.events.envelope import new_event
+
+        evt = new_event(
+            source.source_uri,
+            source.event_type,
+            data={"current": value, "prev": prev_value, "source_name": source.name},
+            modality="pull",
+        )
+        result["would_emit"] = evt.projection_payload()
+        if not dry_run:
+            publish(evt)
+            result["emitted"] = True
+            result["event_id"] = evt.id
+
+    if not dry_run:
+        save_state(
+            source.name,
+            {"last_polled": _now().isoformat(), "last_value": value, "last_hash": new_hash},
+            state_directory,
+        )
+    return result
+
+
+def dry_run(source: EventSourceDef, **kwargs) -> dict[str, Any]:
+    """Poll once with zero side effects — the `/wb-event-new` preview."""
+    return poll_source(source, dry_run=True, **kwargs)
+
+
+def poll_due_sources(now: datetime | None = None, **kwargs) -> dict[str, Any]:
+    """Load all sources; poll each enabled one whose interval has elapsed.
+    The tick the `event-source-poll` cron job fires."""
+    from work_buddy.events.sources.loader import load_event_sources
+
+    defs, errors = load_event_sources()
+    now = now or _now()
+    polled: dict[str, dict] = {}
+    for source in defs:
+        if not source.enabled:
+            continue
+        st = load_state(source.name)
+        if not _is_due(st.get("last_polled"), source.interval_s, now):
+            continue
+        polled[source.name] = poll_source(source, **kwargs)
+    return {"sources": len(defs), "errors": errors, "polled": polled}

--- a/work_buddy/events/sources/ratelimit.py
+++ b/work_buddy/events/sources/ratelimit.py
@@ -1,0 +1,73 @@
+"""Per-source fire-rate tracking + auto-suspend.
+
+A source's firings are logged to ``<state>/<name>.fires.json`` — deliberately
+**separate** from the poller's cursor file (``<name>.json``): the poller and the
+reaction consumer are different writers with different lifecycles, and sharing one
+file would clobber. The log is a list of ISO timestamps, pruned to a rolling
+window on every touch, so it never grows unbounded.
+
+If a source fires more than ``max_per_hour`` times in the window, the reaction
+consumer suspends it (a flapping watcher is notification spam) and tells the user.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+WINDOW_S = 3600
+
+
+def _fires_path(name: str, directory: Path | None = None) -> Path:
+    from work_buddy.events.sources.state import state_dir
+
+    d = Path(directory) if directory is not None else state_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    return d / f"{name}.fires.json"
+
+
+def _load(name: str, directory: Path | None = None) -> list[str]:
+    p = _fires_path(name, directory)
+    if not p.exists():
+        return []
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return []
+    return data if isinstance(data, list) else []
+
+
+def _prune(fires: list[str], now: datetime, window_s: int = WINDOW_S) -> list[str]:
+    cutoff = now - timedelta(seconds=window_s)
+    kept: list[str] = []
+    for ts in fires:
+        try:
+            t = datetime.fromisoformat(ts)
+        except (ValueError, TypeError):
+            continue
+        if t.tzinfo is None:
+            t = t.replace(tzinfo=timezone.utc)
+        if t >= cutoff:
+            kept.append(ts)
+    return kept
+
+
+def fires_last_hour(name: str, now: datetime, directory: Path | None = None) -> int:
+    """How many times ``name`` has fired within the rolling window ending at ``now``."""
+    return len(_prune(_load(name, directory), now))
+
+
+def record_fire(name: str, now: datetime, directory: Path | None = None) -> int:
+    """Record a firing at ``now`` and return the new in-window count."""
+    fires = _prune(_load(name, directory), now)
+    fires.append(now.isoformat())
+    try:
+        _fires_path(name, directory).write_text(json.dumps(fires), encoding="utf-8")
+    except OSError:  # pragma: no cover — defensive
+        logger.warning("ratelimit: could not persist fire-log for %s", name)
+    return len(fires)

--- a/work_buddy/events/sources/state.py
+++ b/work_buddy/events/sources/state.py
@@ -1,0 +1,38 @@
+"""Per-source cursor + last-seen value — a small JSON file under
+``.data/event_sources/state/<name>.json``.
+
+State carries ``{last_polled, last_value, last_hash}``. The cursor (the hash)
+is advanced **after** a successful poll, so a crash mid-poll just re-fetches
+(the spine's inbox makes the re-emit idempotent).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def state_dir() -> Path:
+    from work_buddy.events.sources.loader import sources_dir
+
+    d = sources_dir() / "state"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def load_state(name: str, directory: Path | None = None) -> dict[str, Any]:
+    d = directory if directory is not None else state_dir()
+    p = d / f"{name}.json"
+    if not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return {}
+
+
+def save_state(name: str, state: dict[str, Any], directory: Path | None = None) -> None:
+    d = directory if directory is not None else state_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{name}.json").write_text(json.dumps(state, default=str), encoding="utf-8")

--- a/work_buddy/mcp_server/ops/events_ops.py
+++ b/work_buddy/mcp_server/ops/events_ops.py
@@ -40,8 +40,196 @@ def event_publish(
     }
 
 
+def event_sources_poll() -> dict[str, Any]:
+    """Poll every enabled, due event source once — the cron-fired tick.
+
+    For each source whose ``interval`` has elapsed: fetch → diff the watched value
+    vs. the stored cursor → on a meaningful change, publish
+    ``ai.workbuddy.source.<name>.changed`` onto the spine (the ``source-action``
+    consumer reacts). Runs **in-process in the sidecar**, so it fetches and
+    publishes directly — no gateway round-trip.
+    """
+    from work_buddy.events.sources.poller import poll_due_sources
+
+    return poll_due_sources()
+
+
+_DRY_RUN_BUILD_KEYS = frozenset({
+    "source_type", "interval", "url", "extract_mode", "extract_path", "condition",
+    "action", "action_params", "allowed_actions", "autonomy", "max_per_hour",
+    "cursor_from", "enabled", "event_type",
+})
+
+
+def event_source_dry_run(
+    name: str | None = None, proposal: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Preview a source without side effects: fetch → diff → evaluate condition,
+    but **never** publish, run an action, or advance the cursor. Returns the
+    sampled value, whether it changed, the would-emit event, and whether the
+    condition would pass. This is what the ``/wb-event-new`` dry-run step shows.
+
+    Pass ``proposal`` (the structured ``event_source_create`` fields) to preview a
+    not-yet-written source; otherwise pass ``name`` to preview a saved one.
+    """
+    from work_buddy.events.conditions.cel import CelCondition
+    from work_buddy.events.envelope import new_event
+    from work_buddy.events.protocol import ConditionContext
+    from work_buddy.events.sources import poller
+    from work_buddy.events.sources.definition import (
+        build_source_fm,
+        from_frontmatter,
+        validate_source_fm,
+    )
+    from work_buddy.events.sources.loader import load_event_sources
+
+    if proposal is not None:
+        pname = proposal.get("name") or name or "preview"
+        build_kwargs = {k: v for k, v in proposal.items() if k in _DRY_RUN_BUILD_KEYS}
+        try:
+            fm = build_source_fm(**build_kwargs)
+        except TypeError as exc:  # missing required field (source_type / interval)
+            return {"ok": False, "error": f"proposal is missing required fields: {exc}"}
+        errs = validate_source_fm(pname, fm)
+        if errs:
+            return {"ok": False, "error": "; ".join(errs), "errors": errs}
+        src = from_frontmatter(pname, fm)
+    else:
+        defs, errors = load_event_sources()
+        src = next((d for d in defs if d.name == name), None)
+        if src is None:
+            return {"ok": False, "error": f"no event source named {name!r}", "errors": errors}
+
+    result = poller.dry_run(src)
+    would_emit = result.get("would_emit")
+    out: dict[str, Any] = {
+        "ok": True,
+        "source": name,
+        "type": src.type,
+        "changed": result.get("changed"),
+        "is_first": result.get("is_first"),
+        "current": result.get("value"),
+        "prev": result.get("prev"),
+        "would_emit": would_emit,
+        "error": result.get("error"),
+    }
+
+    cond_passed = True
+    if src.condition and would_emit is not None:
+        evt = new_event(
+            src.source_uri,
+            src.event_type,
+            data={
+                "current": result.get("value"),
+                "prev": result.get("prev"),
+                "source_name": src.name,
+            },
+            modality="pull",
+        )
+        try:
+            cond_passed = CelCondition(src.condition).evaluate(evt, None, ConditionContext())
+        except Exception as exc:  # noqa: BLE001
+            cond_passed = False
+            out["condition_error"] = str(exc)
+        out["condition_passed"] = cond_passed
+
+    out["would_fire"] = bool(would_emit is not None and cond_passed)
+    return out
+
+
+def event_source_create(
+    name: str,
+    source_type: str,
+    interval: str,
+    url: str | None = None,
+    extract_mode: str = "hash",
+    extract_path: str | None = None,
+    condition: str | None = None,
+    action: str = "notify",
+    action_params: dict[str, Any] | None = None,
+    allowed_actions: list[str] | None = None,
+    autonomy: str = "notify_only",
+    max_per_hour: int | None = None,
+    cursor_from: str = "now",
+    enabled: bool = True,
+    event_type: str | None = None,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Author an event source: build + validate its frontmatter, then write
+    ``<event_sources>/<name>.md``. Refuses to overwrite unless ``overwrite=True``;
+    a malformed source returns ``{"success": false, "errors": [...]}``."""
+    from work_buddy.events.sources.definition import build_source_fm
+    from work_buddy.events.sources.loader import sources_dir, write_event_source
+
+    fm = build_source_fm(
+        source_type=source_type,
+        interval=interval,
+        url=url,
+        extract_mode=extract_mode,
+        extract_path=extract_path,
+        condition=condition,
+        action=action,
+        action_params=action_params,
+        allowed_actions=allowed_actions,
+        autonomy=autonomy,
+        max_per_hour=max_per_hour,
+        cursor_from=cursor_from,
+        enabled=enabled,
+        event_type=event_type,
+    )
+    return write_event_source(sources_dir(), name, fm, overwrite=overwrite)
+
+
+def event_source_list() -> dict[str, Any]:
+    """List authored event sources (valid + invalid). Read-only."""
+    from work_buddy.events.sources.loader import load_event_sources
+
+    defs, errors = load_event_sources()
+    return {
+        "ok": True,
+        "sources": [
+            {
+                "name": d.name,
+                "type": d.type,
+                "interval_s": d.interval_s,
+                "enabled": d.enabled,
+                "action": d.action_name,
+                "allowed_actions": list(d.allowed_actions),
+                "condition": d.condition,
+                "autonomy": d.autonomy,
+            }
+            for d in defs
+        ],
+        "errors": errors,
+    }
+
+
+def event_source_toggle(name: str, enabled: bool) -> dict[str, Any]:
+    """Enable or disable an authored event source (rewrites its ``.md``)."""
+    from work_buddy.events.sources.loader import (
+        load_event_sources,
+        sources_dir,
+        write_event_source,
+    )
+
+    defs, errors = load_event_sources()
+    src = next((d for d in defs if d.name == name), None)
+    if src is None:
+        return {"ok": False, "error": f"no event source named {name!r}", "errors": errors}
+
+    fm = dict(src.raw)
+    fm["enabled"] = bool(enabled)
+    res = write_event_source(sources_dir(), name, fm, overwrite=True)
+    return {"ok": bool(res.get("success")), "enabled": bool(enabled), **res}
+
+
 def _register() -> None:
     register_op("op.wb.event_publish", event_publish)
+    register_op("op.wb.event_sources_poll", event_sources_poll)
+    register_op("op.wb.event_source_dry_run", event_source_dry_run)
+    register_op("op.wb.event_source_create", event_source_create)
+    register_op("op.wb.event_source_list", event_source_list)
+    register_op("op.wb.event_source_toggle", event_source_toggle)
 
 
 _register()

--- a/work_buddy/paths.py
+++ b/work_buddy/paths.py
@@ -62,6 +62,7 @@ RESOURCES: dict[str, str] = {
     # Vault recon — periodic reconnaissance ledger
     "vault_recon":               "vault_recon",
     "user_jobs":                 "user_jobs",
+    "event_sources":             "event_sources",  # user-authored event-source .md files
 
     # Databases — persistent stores
     "db/messages":               "db/messages.db",

--- a/work_buddy/sidecar/daemon.py
+++ b/work_buddy/sidecar/daemon.py
@@ -968,14 +968,18 @@ def run(foreground: bool = True) -> None:
     _emit_event_tick = None
     try:
         from work_buddy.events.consumers.notify_demo import register_notify_demo
+        from work_buddy.events.consumers.source_action import register_source_action
         from work_buddy.events.drain import EventDrain
         from work_buddy.events.producers.cron import emit_schedule_tick
 
         register_notify_demo()
+        register_source_action()
         event_drain = EventDrain()
         event_drain.start()
         _emit_event_tick = emit_schedule_tick
-        logger.info("events backbone started (drain + notify-demo + cron adapter)")
+        logger.info(
+            "events backbone started (drain + notify-demo + source-action + cron adapter)"
+        )
     except Exception as _events_exc:  # pragma: no cover — defensive
         logger.warning(
             "events backbone failed to start (non-fatal): %s",


### PR DESCRIPTION
## Summary

Builds the **Source / Condition / Processor** layer on the durable Events spine (the spine shipped in #206). A user authors a polling watcher; the **poller (producer)** fetches state, diffs vs a per-source cursor, and publishes `ai.workbuddy.source.<name>.changed`; a **`type_prefix` consumer** (`SourceActionProcessor`) reacts — CEL condition (fail-closed) → `allowed_actions` scope → per-action consent → notify sink, with a per-hour rate-limit + auto-suspend. The reaction lives on the drain, so it inherits at-least-once + DLQ for free.

- **Sources** (`work_buddy/events/sources/`): `EventSourceDef` schema + loader/validator, `http_poll` fetch, JSONPath/CSS/hash extract, content-hash diff + cursor state, the reconciling poller.
- **Conditions** (`conditions/cel.py`): safe non-Turing-complete CEL over `event.data`/`prev.data`; celpy ships no `abs`, so a curated `abs` is registered.
- **Reaction** (`consumers/source_action.py` + `processors/`): notify action + registry, gated by `allowed_actions` + consent + `autonomy: notify_only` + rate-limit/auto-suspend.
- **Ops**: `event_sources_poll` (cron tick), `event_source_dry_run` (a saved name OR an unsaved proposal), `event_source_create`/`_list`/`_toggle`; the `event-source-poll` cron job.
- **`/wb-event-new`**: conversational authoring (elicit → propose → dry-run → confirm → activate → monitor) + directions + launcher.
- **Spine touch**: consumers can subscribe by `type_prefix`; the daemon registers the source-action consumer.
- **Deps**: `cel-python`, `jsonpath-ng` (both Apache-2.0, GPL-3.0-only-compatible).

The stock-watcher is a **validation fixture**, not a first-class system. Scoped to `http_poll` + `notify_only`; webhook/push ingress, `auto_execute`, and the semantic-LLM condition tier are deferred (the planned "2b" follow-up).

## Test plan

- [x] `99` events tests green — `pytest tests/unit/events/ tests/component/test_events_end_to_end.py` (unit: schema/validate, extract, poller diff+cursor, CEL, source-action gating, rate-limit, source ops; component: real poll → publish → drain → condition → notify).
- [x] **Live-verified end-to-end** via `/wb-dev-live-testing`: authored an `http_poll` source, polled (baseline → fire), confirmed the `source.changed` row in `db/events`, the `source-action` consumer drained it (offset advanced, DLQ empty), and the notification reached **Telegram**.
- [x] Knowledge store validates (`docs_validate` passed); `events` unit + `CLAUDE.md` updated.
- [ ] Reviewer: confirm the `feat/events-sources-slice2` branch is the intended base for any "2b" semantic-LLM follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)