### PR TITLE
fix(workflow): retry transient auto_run timeouts; surface workflow_blocked

### DIFF
--- a/knowledge/store/architecture/workflow-run-lifecycle.md
+++ b/knowledge/store/architecture/workflow-run-lifecycle.md
@@ -22,7 +22,20 @@ parents:
 - architecture/workflows
 ---
 
-The conductor holds in-flight runs in an in-memory map — `_ACTIVE_RUNS` in `work_buddy/mcp_server/conductor.py`, keyed by `workflow_run_id`. A run is added at `start_workflow` and, left alone, removed only when it completes. Three mechanisms keep that map bounded and recoverable.
+The conductor holds in-flight runs in an in-memory map — `_ACTIVE_RUNS` in `work_buddy/mcp_server/conductor.py`, keyed by `workflow_run_id`. A run is added at `start_workflow` and removed on any **terminal state**: successful completion, blocked-by-failure, or explicit cancel. Three mechanisms keep that map bounded and recoverable.
+
+## Terminal states
+
+A run is terminal when no step is available to advance. Two flavors:
+
+- **Complete** (`type: "workflow_complete"`) — every node in completed / skipped / failed AND `dag.is_complete()` is true. Triggers `_build_complete_response`.
+- **Blocked** (`type: "workflow_blocked"`) — at least one step failed and its descendants are unreachable. Triggers `_build_blocked_response`, which surfaces honest progress counts (`<done>/<total> steps completed (blocked: <n> failed)`), a `failed_steps` list, and an `error` field naming the first failure.
+
+Both states share lifecycle cleanup: persist the DAG, revoke the `workflow_run` consent grant, pop from `_ACTIVE_RUNS`. The distinction matters to consumers — agents, dispatchers, the sidecar executor — who should treat blocked workflows as failures (retry, escalate) rather than successes. `executor.py`'s DAG-walking dispatch loop exits on both states.
+
+## fail_task cascades
+
+When `fail_task` marks a step FAILED, it re-runs `_update_availability` so pending downstream nodes flip to BLOCKED. This keeps the DAG's per-node status, the rendered Mermaid diagram, and the `summary()` markdown consistent: no node sits in PENDING once an upstream has failed.
 
 ## Cancel
 

--- a/knowledge/store/architecture/workflows.md
+++ b/knowledge/store/architecture/workflows.md
@@ -57,9 +57,10 @@ steps:
     step_type: code
     auto_run:
       callable: work_buddy.morning.get_morning_config  # dotted import path
-      kwargs: {}         # optional static keyword args
-      input_map: {}      # optional: {kwarg_name: step_id} wires prior results into kwargs
-      timeout: 30        # seconds (default 30)
+      kwargs: {}              # optional static keyword args
+      input_map: {}           # optional: {kwarg_name: step_id} wires prior results into kwargs
+      timeout: 30             # seconds (default 30)
+      retry_on_timeout: true  # default true; set false for non-idempotent steps
 ```
 
 **When to use auto_run:** The step is deterministic, has no side effects, needs no agent reasoning, and produces data consumed by later steps. Examples: config loading, phase resolution, data formatting.
@@ -67,6 +68,8 @@ steps:
 **When NOT to use auto_run:** The step requires LLM reasoning, user interaction, consent, or calls external services that may fail and need agent-mediated recovery.
 
 **Safety:** Only `work_buddy.*` import paths are allowed. Failed auto_run steps are marked FAILED with the error surfaced to the agent. A 30s default timeout prevents runaway calls.
+
+**Transient-timeout retry:** Subprocess timeouts (`subprocess.TimeoutExpired`) are usually transient — cold imports, concurrent registry rebuilds, antivirus scans. The conductor retries the subprocess once before failing the step, so a single contended host doesn't surface a flake to the agent. Each attempt gets the full `timeout`; worst-case wall time is two attempts. Crashes and invalid-JSON failures never retry — they signal real bugs. Set `retry_on_timeout: false` for steps that mutate external state (git commits, outbound message sends, source-pipeline drives) where a second attempt would not be idempotent.
 
 **Data threading:** Every response from the conductor includes `step_results: {step_id: result}` — a map of all completed step results (auto_run and agent-completed). The `input_map` field lets auto_run steps consume upstream results declaratively: `input_map: {cfg: load-config}` passes the `load-config` result as the `cfg` kwarg.
 
@@ -145,6 +148,17 @@ Starting a workflow grants blanket consent for all its steps (grant_workflow_con
 - Step results over 50K chars are capped with a summary (_cap_step_results)
 - Timed-out auto_run steps produce timeout_recovery hints with re-poll instructions
 - Smart trimming: only relevant predecessor results are sent to each step (not all results)
+
+## Terminal response types
+
+A workflow ends in one of two terminal envelopes, returned by `start_workflow` / `advance_workflow` / `wb_advance` when no step is available to run next:
+
+- `type: "workflow_complete"` — every node reached `completed` (or `skipped`). The work was done. Field `progress: "N/N steps completed"`.
+- `type: "workflow_blocked"` — a step failed and its descendants are unreachable. Fields: `progress: "<done>/<total> steps completed (blocked: <n> failed)"`, `failed_steps: [<step_id>, …]`, `error: "<first_failed_id>: <first_error_message>"`. The work was not done; the caller needs to act on the failure (retry the workflow, fix the underlying cause, or escalate).
+
+Both states are terminal — the active-run entry is cleaned up and the workflow-run consent grant is revoked. They share `summary`, `step_results`, and `diagram` fields, so non-discriminating consumers (e.g. read-only logs) can use either uniformly; discriminating consumers (agents, dispatchers) should branch on `type`.
+
+`fail_task` cascades downstream `pending` nodes to `blocked` so the embedded diagram and `summary()` markdown agree about why those nodes won't run — no node sits in `pending` once an upstream has failed.
 
 ## Slash commands
 

--- a/knowledge/store/browser/chrome-triage.md
+++ b/knowledge/store/browser/chrome-triage.md
@@ -18,6 +18,10 @@ steps:
       engagement_window: 24h
       include_summaries: true
     timeout: 240
+    # The source pipeline drives outbound effects (summary persistence,
+    # downstream task creation) whose idempotency under partial completion
+    # is not audited — disable retry until that audit lands.
+    retry_on_timeout: false
   visibility:
     mode: summary
   invokes: []

--- a/knowledge/store/context/docs-edit.md
+++ b/knowledge/store/context/docs-edit.md
@@ -49,6 +49,10 @@ steps:
     input_map:
       resolve: resolve
     timeout: 60
+    # Commit mutates the knowledge store (git commit, index rebuild) — a
+    # second attempt after a timeout could duplicate the commit. Fail the
+    # step instead of retrying.
+    retry_on_timeout: false
 tags:
 - docs
 - editing

--- a/knowledge/store/daily-journal/process-backlog.md
+++ b/knowledge/store/daily-journal/process-backlog.md
@@ -15,6 +15,9 @@ steps:
     callable: work_buddy.pipelines.run_source_pipeline
     kwargs:
       source: journal_backlog
+    # The source pipeline drives outbound effects whose idempotency under
+    # partial completion is not audited — disable retry until that lands.
+    retry_on_timeout: false
   visibility:
     mode: summary
   invokes: []

--- a/knowledge/store/daily-journal/update-journal.md
+++ b/knowledge/store/daily-journal/update-journal.md
@@ -19,7 +19,7 @@ steps:
     kwargs: {}
     input_map:
       target: __params__.target
-    timeout: 30
+    timeout: 90
   invokes: []
 - id: collect
   name: Collect fresh context (scoped to activity window)

--- a/knowledge/store/dev/dev-mode.md
+++ b/knowledge/store/dev/dev-mode.md
@@ -59,7 +59,7 @@ Three core constructs, with design heuristics for deciding between them:
 
 - **Capabilities** — atomic Python functions registered in `registry.py`. Single operation, reusable from anywhere. Invoked via `wb_run("name", params)`, executes immediately.
 - **Workflows** — `kind: workflow` units, one Markdown file per workflow under `knowledge/store/`. Multi-step procedures requiring ordering, user decisions, or state threading. Started via `wb_run("name")`, advanced via `wb_advance(run_id, result)`.
-- **Auto-run steps** — workflow steps marked `auto_run` in the unit's frontmatter. The conductor executes these transparently in a subprocess; the agent never sees them. Use for deterministic code (config loading, data formatting) that needs no agent reasoning.
+- **Auto-run steps** — workflow steps marked `auto_run` in the unit's frontmatter. The conductor executes these transparently in a subprocess; the agent never sees them. Use for deterministic code (config loading, data formatting) that needs no agent reasoning. A subprocess that times out is retried once automatically (transient host contention is the dominant cause); set `auto_run.retry_on_timeout: false` for steps that mutate external state where a second attempt would not be idempotent (git commits, outbound message sends, source-pipeline drives).
 
 **Decision heuristic.** Can you write a unit test with a fixed expected output? → Capability. Does the "correct" output depend on interpretation, user input, or synthesis? → Workflow step. Is the step itself deterministic with no side effects? → Auto-run step.
 

--- a/knowledge/store/email/email-triage.md
+++ b/knowledge/store/email/email-triage.md
@@ -19,6 +19,9 @@ steps:
       max_messages: 50
       unread_only: true
     timeout: 240
+    # The source pipeline drives outbound effects whose idempotency under
+    # partial completion is not audited — disable retry until that lands.
+    retry_on_timeout: false
   visibility:
     mode: summary
   invokes: []

--- a/tests/unit/test_conductor_response_invariants.py
+++ b/tests/unit/test_conductor_response_invariants.py
@@ -385,3 +385,101 @@ def test_auto_ran_ledger_has_corresponding_step_results_in_real_response(
         )
     finally:
         conductor._ACTIVE_RUNS.pop(resp.get("workflow_run_id"), None)
+
+
+# ---------------------------------------------------------------------------
+# Blocked-workflow response invariants
+# ---------------------------------------------------------------------------
+#
+# When an auto_run step fails and its descendants are unreachable, the
+# conductor emits ``type: "workflow_blocked"`` instead of
+# ``"workflow_complete"``. The envelope carries honest progress counts and
+# names the failed step(s) so callers can act on the failure rather than
+# treat it as a successful finish.
+
+
+@pytest.fixture
+def failing_auto_run_workflow():
+    """Register a 2-step workflow whose auto_run step always raises.
+
+    Same shape as ``minimal_auto_run_workflow`` but the auto_run callable
+    raises a synthetic error, exercising the failure-path response.
+    """
+    from work_buddy.mcp_server.registry import (
+        AutoRun,
+        ResultVisibility,
+        WorkflowDefinition,
+        WorkflowStep,
+        get_registry,
+    )
+
+    name = "test_failing_auto_run"
+    wf = WorkflowDefinition(
+        name=name,
+        description="Test fixture: auto_run step always raises.",
+        workflow_file="test:in-memory",
+        execution="main",
+        steps=[
+            WorkflowStep(
+                id="scan",
+                name="Scan (auto_run that fails)",
+                step_type="code",
+                depends_on=[],
+                instruction="",
+                auto_run=AutoRun(
+                    callable="work_buddy.mcp_server._test_fakes.fake_scan_raises",
+                    kwargs={},
+                    input_map={},
+                    timeout=15,
+                    # Don't waste time retrying — a deterministic crash
+                    # would just fail twice.
+                    retry_on_timeout=False,
+                ),
+                visibility=ResultVisibility(mode="full"),
+            ),
+            WorkflowStep(
+                id="report",
+                name="Report (reasoning, never reached)",
+                step_type="reasoning",
+                depends_on=["scan"],
+                instruction="Read scan and report.",
+            ),
+        ],
+    )
+    registry = get_registry()
+    registry[name] = wf
+    yield name
+    registry.pop(name, None)
+
+
+def test_blocked_response_after_auto_run_failure(failing_auto_run_workflow):
+    """A failing auto_run leaves the workflow blocked, not complete.
+
+    Before the fix, this case returned ``type: "workflow_complete"`` with
+    ``progress: "N/N steps completed"`` because the conductor routed on
+    ``next_available() == []`` rather than ``is_complete()``. The new
+    envelope honestly labels the workflow blocked and names the failed
+    step in the ``error`` and ``failed_steps`` fields.
+    """
+    from work_buddy.mcp_server import conductor
+
+    resp = conductor.start_workflow(failing_auto_run_workflow)
+    try:
+        assert resp.get("type") == "workflow_blocked", (
+            f"failed auto_run must yield workflow_blocked, got: {resp.get('type')!r}"
+        )
+        assert "scan" in (resp.get("failed_steps") or []), (
+            f"failed_steps must name the failed step: {resp.get('failed_steps')}"
+        )
+        # The progress string carries honest counts.
+        progress = resp.get("progress", "")
+        assert "0/2 steps completed" in progress, progress
+        assert "blocked: 1 failed" in progress, progress
+        # The error field surfaces the first failure with the underlying
+        # subprocess error message.
+        err = resp.get("error", "")
+        assert err.startswith("scan:"), err
+        # And the standard tree-shape invariant still holds.
+        assert_no_duplicated_subtrees(resp)
+    finally:
+        conductor._ACTIVE_RUNS.pop(resp.get("workflow_run_id"), None)

--- a/tests/unit/test_conductor_session_plumbing.py
+++ b/tests/unit/test_conductor_session_plumbing.py
@@ -9,6 +9,7 @@ own bootstrap session.
 from __future__ import annotations
 
 import json
+import subprocess
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -140,3 +141,115 @@ def test_execute_auto_run_falls_back_to_env_when_no_session(monkeypatch):
 # the agent_session_id kwarg, and start_workflow stores it on the DAG,
 # and advance_workflow reads dag.agent_session_id, the chain holds.
 # The live E2E verification in session transcripts covers that path.
+
+
+# ---------------------------------------------------------------------------
+# Transient-timeout retry
+# ---------------------------------------------------------------------------
+#
+# When a subprocess hits ``subprocess.TimeoutExpired``, the conductor retries
+# the call once before failing the step. This absorbs transient host
+# contention (cold imports, concurrent registry rebuilds, antivirus scans).
+# Crashes, invalid-JSON outputs, and other failure modes never retry — they
+# signal real bugs. Per-step ``retry_on_timeout: false`` disables the retry
+# for non-idempotent callables (git commits, outbound message sends).
+
+
+def _spec(retry_on_timeout: bool = True) -> dict:
+    """Minimal AutoRun spec for these tests."""
+    return {
+        "callable": "work_buddy.obsidian.tasks.store.counts_by_state",
+        "kwargs": {},
+        "timeout": 5,
+        "retry_on_timeout": retry_on_timeout,
+    }
+
+
+def _timeout_exc(stderr: str = "") -> subprocess.TimeoutExpired:
+    return subprocess.TimeoutExpired(
+        cmd=["python", "-m", "subprocess_runner"], timeout=5, stderr=stderr,
+    )
+
+
+def test_execute_auto_run_retries_once_on_timeout(monkeypatch):
+    """First attempt times out; second returns success — overall success."""
+    calls = {"n": 0}
+
+    def _fake_run(cmd, input=None, **_kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _timeout_exc()
+        return _FakeCompletedProcess()
+
+    monkeypatch.setattr(conductor.subprocess, "run", _fake_run)
+
+    result = conductor._execute_auto_run(
+        step_id="dummy", spec=_spec(), step_results={},
+    )
+
+    assert calls["n"] == 2, "transient timeout should be retried once"
+    assert result["success"] is True
+
+
+def test_execute_auto_run_fails_after_second_timeout(monkeypatch):
+    """Both attempts time out; step fails with a timeout error."""
+    calls = {"n": 0}
+
+    def _fake_run(cmd, input=None, **_kwargs):
+        calls["n"] += 1
+        raise _timeout_exc()
+
+    monkeypatch.setattr(conductor.subprocess, "run", _fake_run)
+
+    result = conductor._execute_auto_run(
+        step_id="dummy", spec=_spec(), step_results={},
+    )
+
+    assert calls["n"] == 2, "both attempts must run before the step fails"
+    assert result["success"] is False
+    assert "timed out" in result["error"]
+    assert "2 attempts" in result["error"], (
+        "error message should disclose that retries were exhausted"
+    )
+
+
+def test_execute_auto_run_respects_retry_on_timeout_false(monkeypatch):
+    """retry_on_timeout=false makes the timeout terminal on the first try."""
+    calls = {"n": 0}
+
+    def _fake_run(cmd, input=None, **_kwargs):
+        calls["n"] += 1
+        raise _timeout_exc()
+
+    monkeypatch.setattr(conductor.subprocess, "run", _fake_run)
+
+    result = conductor._execute_auto_run(
+        step_id="dummy",
+        spec=_spec(retry_on_timeout=False),
+        step_results={},
+    )
+
+    assert calls["n"] == 1, "opt-out must skip the retry"
+    assert result["success"] is False
+    assert "timed out" in result["error"]
+
+
+def test_execute_auto_run_does_not_retry_on_crash(monkeypatch):
+    """A non-timeout failure (subprocess crash) is terminal — no retry."""
+    calls = {"n": 0}
+
+    def _fake_run(cmd, input=None, **_kwargs):
+        calls["n"] += 1
+        return _FakeCompletedProcess(
+            stdout="", stderr="Traceback (most recent call last):\nBoom", returncode=1,
+        )
+
+    monkeypatch.setattr(conductor.subprocess, "run", _fake_run)
+
+    result = conductor._execute_auto_run(
+        step_id="dummy", spec=_spec(), step_results={},
+    )
+
+    assert calls["n"] == 1, "crashes signal real bugs and must not retry"
+    assert result["success"] is False
+    assert "crashed" in result["error"]

--- a/tests/unit/test_workflow_dag.py
+++ b/tests/unit/test_workflow_dag.py
@@ -125,6 +125,53 @@ class TestDAGTransitions:
         dag.complete_task("b")
         assert dag.is_complete()
 
+    def test_fail_task_cascades_pending_to_blocked(self):
+        """A failed upstream re-classifies its PENDING descendants as BLOCKED.
+
+        Without this cascade, ``b`` would sit at PENDING after ``a`` fails —
+        an inconsistent state where the diagram says "blocked" but the
+        node status says "pending." The conductor's ``next_available()``
+        returns [] in either case, so the cascade is mainly about
+        consumer-visible honesty.
+        """
+        dag = WorkflowDAG(name="test:t-fail-cascade", description="test")
+        dag.add_task("a", name="A")
+        dag.add_task("b", name="B", depends_on=["a"])
+        dag.start_task("a")
+        dag.fail_task("a", error="boom")
+        assert dag.get_task("a")["status"] == TaskStatus.FAILED.value
+        assert dag.get_task("b")["status"] == TaskStatus.BLOCKED.value
+
+    def test_is_complete_false_after_failure_with_blocked_downstream(self):
+        """``is_complete`` must NOT return True when a step failed and a
+        downstream step is sitting at BLOCKED (it never ran). This is the
+        strict predicate the conductor uses to distinguish a successful
+        workflow from one that died on a failed step.
+        """
+        dag = WorkflowDAG(name="test:t-not-complete-on-fail", description="test")
+        dag.add_task("a", name="A")
+        dag.add_task("b", name="B", depends_on=["a"])
+        dag.start_task("a")
+        dag.fail_task("a", error="boom")
+        # ``b`` is BLOCKED (cascaded above), not in the accepted set.
+        assert not dag.is_complete()
+
+    def test_is_complete_true_when_all_terminal(self):
+        """``is_complete`` is True when every node is completed, skipped, or
+        failed — even if some failed. The conductor branches on this to
+        emit ``workflow_complete`` (all-success) vs ``workflow_blocked``
+        (has-failure) and adjusts terminal counters accordingly.
+        """
+        dag = WorkflowDAG(name="test:t-complete-with-failure", description="test")
+        dag.add_task("a", name="A")
+        dag.add_task("b", name="B")  # independent, no dep on a
+        dag.start_task("a")
+        dag.fail_task("a", error="boom")
+        dag.start_task("b")
+        dag.complete_task("b")
+        # a=FAILED, b=COMPLETED — every node terminal — is_complete is True.
+        assert dag.is_complete()
+
     def test_get_all_results(self):
         dag = WorkflowDAG(name="test:t13", description="test")
         dag.add_task("a", name="A")

--- a/work_buddy/mcp_server/_test_fakes.py
+++ b/work_buddy/mcp_server/_test_fakes.py
@@ -26,3 +26,14 @@ def fake_scan_changes() -> dict[str, Any]:
         "summary": "fifty items",
         "meta": {"total": 50, "kind": "fake"},
     }
+
+
+def fake_scan_raises() -> dict[str, Any]:
+    """Always raise — used to drive the conductor's failure response path.
+
+    The subprocess runner converts the exception into a ``{"success":
+    False, "error": ..., "traceback": ...}`` reply, which the conductor
+    then routes to ``fail_task`` and, when no downstream step can run,
+    to ``_build_blocked_response``.
+    """
+    raise RuntimeError("synthetic scan failure")

--- a/work_buddy/mcp_server/conductor.py
+++ b/work_buddy/mcp_server/conductor.py
@@ -202,6 +202,7 @@ def start_workflow(
                 "kwargs": step.auto_run.kwargs,
                 "input_map": step.auto_run.input_map,
                 "timeout": step.auto_run.timeout,
+                "retry_on_timeout": step.auto_run.retry_on_timeout,
             }
         if step.result_schema is not None:
             meta["result_schema"] = step.result_schema
@@ -263,6 +264,15 @@ def start_workflow(
     if dag.initial_params:  # type: ignore[attr-defined]
         response["initial_params"] = dag.initial_params  # type: ignore[attr-defined]
 
+    # If the first ``_build_response`` already terminated the workflow
+    # (e.g. a single auto_run step that succeeded or failed), pop the
+    # active-run entry. ``advance_workflow`` does this cleanup on its own
+    # terminal path; ``start_workflow`` needs the same hook so a workflow
+    # that ends synchronously doesn't leak into ``_ACTIVE_RUNS``.
+    if response.get("type") in ("workflow_complete", "workflow_blocked"):
+        with _ACTIVE_RUNS_LOCK:
+            _ACTIVE_RUNS.pop(run_id, None)
+
     return response
 
 
@@ -297,7 +307,13 @@ def advance_workflow(
     if not running:
         available = dag.next_available()
         if not available:
-            return _build_complete_response(workflow_run_id, dag)
+            # ``next_available() == []`` covers two distinct end states:
+            # all nodes reached a terminal state (true completion), or a
+            # failed step left its descendants unreachable. ``is_complete``
+            # is the strict predicate that distinguishes them.
+            if dag.is_complete():
+                return _build_complete_response(workflow_run_id, dag)
+            return _build_blocked_response(workflow_run_id, dag)
         task = available[0]
         dag.start_task(task["task_id"])
         return _build_response(workflow_run_id, dag)
@@ -381,14 +397,16 @@ def advance_workflow(
         return result
 
     # Build response — auto_run steps are consumed transparently inside.
-    # The auto_run chain may complete the workflow, producing a
-    # ``workflow_complete`` response.  Pass ``prior_step_id`` so
-    # ``_build_response`` includes the just-completed step's result in
-    # ``step_results`` for continuity (no post-hoc override needed).
+    # The auto_run chain may complete the workflow (``workflow_complete``)
+    # or wedge it on a failed step (``workflow_blocked``); both are
+    # terminal and the active-run entry can be cleaned up.  Pass
+    # ``prior_step_id`` so ``_build_response`` includes the just-completed
+    # step's result in ``step_results`` for continuity (no post-hoc
+    # override needed).
     response = _build_response(workflow_run_id, dag, prior_step_id=current_id)
 
-    if response.get("type") == "workflow_complete":
-        # Auto-run chain finished the workflow — clean up
+    if response.get("type") in ("workflow_complete", "workflow_blocked"):
+        # Auto-run chain reached a terminal state — clean up
         with _ACTIVE_RUNS_LOCK:
             _ACTIVE_RUNS.pop(workflow_run_id, None)
         return response
@@ -1116,7 +1134,12 @@ def _build_response(
     while True:
         available = dag.next_available()
         if not available:
-            resp = _build_complete_response(run_id, dag)
+            # Distinguish true completion from a blocked workflow — see
+            # the comment in ``advance_workflow``.
+            if dag.is_complete():
+                resp = _build_complete_response(run_id, dag)
+            else:
+                resp = _build_blocked_response(run_id, dag)
             if auto_ran:
                 resp["auto_ran"] = auto_ran
                 resp["step_results"] = _visibility_filter_results(dag)
@@ -1505,6 +1528,7 @@ def _execute_auto_run(
     dotted_path = spec.get("callable", "")
     kwargs = dict(spec.get("kwargs") or {})
     timeout = spec.get("timeout", 30)
+    retry_on_timeout = spec.get("retry_on_timeout", True)
 
     # --- Safety: only allow work_buddy.* imports ---
     if not dotted_path.startswith("work_buddy."):
@@ -1562,30 +1586,56 @@ def _execute_auto_run(
         step_id, dotted_path, timeout,
     )
 
-    # --- Launch subprocess ---
-    try:
-        proc = subprocess.run(
-            cmd,
-            input=json.dumps(payload),
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            cwd=str(repo_root),
-        )
-    except subprocess.TimeoutExpired as exc:
-        stderr_text = getattr(exc, "stderr", "") or ""
-        if stderr_text:
-            logger.warning(
-                "auto_run[%s]: stderr before timeout:\n%s",
-                step_id, stderr_text.strip(),
+    # --- Launch subprocess (with one retry on TimeoutExpired) ---
+    # A timeout typically signals transient host contention (cold imports,
+    # concurrent registry rebuilds, antivirus scans) rather than a real bug
+    # in the callable. Retrying once absorbs that transient and keeps the
+    # workflow advancing. Other failure modes (subprocess crash, invalid
+    # JSON output) signal real bugs and never retry.
+    #
+    # Set ``retry_on_timeout: false`` on the AutoRun spec for steps that
+    # mutate external state where a second attempt would not be idempotent.
+    max_attempts = 2 if retry_on_timeout else 1
+    proc = None
+    last_timeout_exc: subprocess.TimeoutExpired | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            proc = subprocess.run(
+                cmd,
+                input=json.dumps(payload),
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=str(repo_root),
             )
-        logger.warning(
-            "auto_run[%s]: %s timed out after %ds", step_id, dotted_path, timeout,
-        )
-        return {
-            "success": False,
-            "error": f"auto_run {dotted_path!r} timed out after {timeout}s",
-        }
+            break
+        except subprocess.TimeoutExpired as exc:
+            last_timeout_exc = exc
+            stderr_text = getattr(exc, "stderr", "") or ""
+            if stderr_text:
+                logger.warning(
+                    "auto_run[%s]: stderr before timeout (attempt %d/%d):\n%s",
+                    step_id, attempt, max_attempts, stderr_text.strip(),
+                )
+            if attempt < max_attempts:
+                logger.warning(
+                    "auto_run[%s]: %s timed out after %ds — retrying once",
+                    step_id, dotted_path, timeout,
+                )
+                continue
+            logger.warning(
+                "auto_run[%s]: %s timed out after %ds (%d attempts)",
+                step_id, dotted_path, timeout, attempt,
+            )
+            return {
+                "success": False,
+                "error": (
+                    f"auto_run {dotted_path!r} timed out after {timeout}s "
+                    f"({attempt} attempt{'s' if attempt > 1 else ''})"
+                ),
+            }
+    # Loop always either breaks with proc set or returns; this is defensive.
+    assert proc is not None, "subprocess loop exited without proc or return"
 
     # --- Log subprocess stderr (diagnostics) ---
     if proc.stderr:
@@ -1666,6 +1716,70 @@ def _build_complete_response(run_id: str, dag: WorkflowDAG) -> dict[str, Any]:
         "workflow_run_id": run_id,
         "summary": dag.summary(),
         "progress": f"{total}/{total} steps completed",
+        "step_results": _visibility_filter_results(dag),
+        "diagram": _dag_to_mermaid(dag),
+    }
+
+
+def _build_blocked_response(run_id: str, dag: WorkflowDAG) -> dict[str, Any]:
+    """Build the response for a workflow that terminated with a failed step.
+
+    Distinguished from ``_build_complete_response`` so callers (agents,
+    sidecar dispatchers, dashboards) can tell "workflow finished
+    successfully" apart from "workflow died because a step failed and
+    everything downstream is unreachable." Both states share the property
+    that no step is currently AVAILABLE, but only the first one means the
+    work was done.
+    """
+    # Persist DAG state and revoke the run grant — same lifecycle hygiene
+    # as the success path. A blocked run is just as "over" as a complete
+    # one from a consent / cleanup perspective.
+    dag.save()
+
+    from work_buddy.consent import revoke_workflow_run
+    wf_name = getattr(dag, "workflow_name", None) or (
+        (getattr(dag, "name", "") or "").split(":", 1)[0] if ":" in (getattr(dag, "name", "") or "") else getattr(dag, "name", "")
+    )
+    revoke_workflow_run(
+        wf_name,
+        run_id,
+        session_id=getattr(dag, "agent_session_id", None),
+        reason="blocked",
+    )
+
+    # Honest counts for the response envelope (the embedded ``summary``
+    # markdown already carries per-node status; this surfaces it to
+    # callers that don't parse the markdown).
+    total = dag._graph.number_of_nodes()
+    completed = 0
+    failed_ids: list[str] = []
+    for node_id, data in dag._graph.nodes(data=True):
+        status = data.get("status")
+        if status == "completed":
+            completed += 1
+        elif status == "failed":
+            failed_ids.append(node_id)
+
+    # First failure message — read the ``result`` field, which ``fail_task``
+    # writes as ``"FAILED: <error>"``. Surface the cleanest version we can.
+    first_error = ""
+    if failed_ids:
+        first_failed = failed_ids[0]
+        result_str = str(dag._graph.nodes[first_failed].get("result", "")).strip()
+        if result_str.startswith("FAILED: "):
+            result_str = result_str[len("FAILED: "):]
+        first_error = f"{first_failed}: {result_str}" if result_str else first_failed
+
+    return {
+        "type": "workflow_blocked",
+        "workflow_run_id": run_id,
+        "summary": dag.summary(),
+        "progress": (
+            f"{completed}/{total} steps completed "
+            f"(blocked: {len(failed_ids)} failed)"
+        ),
+        "failed_steps": failed_ids,
+        "error": first_error,
         "step_results": _visibility_filter_results(dag),
         "diagram": _dag_to_mermaid(dag),
     }

--- a/work_buddy/mcp_server/registry.py
+++ b/work_buddy/mcp_server/registry.py
@@ -177,6 +177,12 @@ class AutoRun:
     kwargs: dict[str, Any] = field(default_factory=dict)
     input_map: dict[str, str] = field(default_factory=dict)  # kwarg_name → step_id
     timeout: int = 30  # seconds
+    # When the subprocess hits the timeout, the conductor retries it once
+    # before failing the step. Set ``False`` for steps that mutate external
+    # state where a second attempt would not be idempotent (e.g. git commits,
+    # outbound message sends). Read-only and overwrite-idempotent callables
+    # — the common case — leave this at the default.
+    retry_on_timeout: bool = True
 
 
 @dataclass
@@ -1428,6 +1434,7 @@ def _discover_workflows_from_store() -> list[WorkflowDefinition]:
                     kwargs=auto_run_raw.get("kwargs") or {},
                     input_map=auto_run_raw.get("input_map") or {},
                     timeout=auto_run_raw.get("timeout", 30),
+                    retry_on_timeout=auto_run_raw.get("retry_on_timeout", True),
                 )
 
             # Reconstruct ResultVisibility from dict

--- a/work_buddy/sidecar/dispatch/executor.py
+++ b/work_buddy/sidecar/dispatch/executor.py
@@ -160,7 +160,12 @@ def _execute_workflow(name: str, params: dict[str, Any] | None = None) -> dict[s
         # Walk the DAG, auto-advancing what we can
         while True:
             current = response.get("current_step")
-            if current is None or response.get("type") == "workflow_complete":
+            # Exit on either terminal state: ``workflow_complete`` (all
+            # steps succeeded) or ``workflow_blocked`` (a step failed and
+            # downstream is unreachable). Both mean no more work to drive.
+            if current is None or response.get("type") in (
+                "workflow_complete", "workflow_blocked",
+            ):
                 break
 
             step_id = current["id"]

--- a/work_buddy/workflow.py
+++ b/work_buddy/workflow.py
@@ -302,6 +302,11 @@ class WorkflowDAG:
         data["status"] = TaskStatus.FAILED.value
         data["completed_at"] = datetime.now(timezone.utc).isoformat()
         data["result"] = f"FAILED: {error}"
+        # Re-classify downstream PENDING nodes as BLOCKED so the DAG's
+        # diagram, summary, and any consumer that inspects per-node status
+        # agree about why those nodes won't run. ``complete_task`` and
+        # ``skip_task`` already do this for the success path.
+        self._update_availability()
         logger.error(f"Task failed: {task_id} — {error}")
         self._save()
 


### PR DESCRIPTION
## Summary

- **Bug fix:** When an auto_run step failed, the conductor returned `type: workflow_complete` with `progress: N/N steps completed` because it routed on `dag.next_available() == []` rather than `dag.is_complete()`. A failed step with pending downstream produced "no available task" — the conductor read that as success. Surfaced when `/wb-journal-update`'s `read-journal` timed out (transient 30s budget overrun during a concurrent registry rebuild + 105s alias-vector embedding) and the workflow falsely reported the whole journal-update done.
- **Resilience:** Same path was fragile under transient host contention — cold subprocess starts on Windows + Bitdefender + heavy concurrent gateway work blew through 30s budgets repeatedly (3 `read-journal` timeouts + 6 `scan_changes-at-90s` timeouts observed in the gateway log over time).
- **Fix is three layers:** (1) Conductor retries auto_run subprocesses once on `TimeoutExpired` — transient flakes become invisible to the agent. Per-step opt-out (`retry_on_timeout: false`) preserved on the two non-idempotent callables (`commit_edit`, `run_source_pipeline` x3). (2) New `_build_blocked_response` distinguished from `_build_complete_response`: emits `type: workflow_blocked`, honest progress counts, `failed_steps`, and a first-failure `error` field. Both `_build_response` and `advance_workflow` branch on `dag.is_complete()`. Sidecar executor's dispatch loop exits on either terminal state. (3) `fail_task` cascades pending → blocked (matching `complete_task`/`skip_task`), and `start_workflow` cleans up `_ACTIVE_RUNS` on synchronous termination (pre-existing leak for single-step auto_run workflows that the new path made visible).
- **Read-journal timeout** bumped 30s → 90s (matches `scan_changes` precedent; absorbs the contention envelope without retry alone).

## Test plan

- [x] Focused pytest: \`tests/unit/test_conductor_session_plumbing.py\` (4 new retry-path tests), \`test_workflow_dag.py\` (3 new DAG-cascade tests), \`test_conductor_response_invariants.py\` (1 new blocked-response integration test). **51 passed, 0 failed.**
- [x] Live verification: synthetic throwaway workflow with a raising auto_run callable, executed via the real gateway. Response envelope verified verbatim:
  - \`type: "workflow_blocked"\`
  - \`progress: "0/2 steps completed (blocked: 1 failed)"\`
  - \`failed_steps: ["scan"]\`
  - \`error: "scan: RuntimeError: synthetic scan failure"\`
  - summary \`[!!]\` confirms \`fail_task\` cascade to BLOCKED
- [x] Doc-validate: 434 units, 0 failures after edits to \`architecture/workflows\`, \`architecture/workflow-run-lifecycle\`, \`dev/dev-mode\`.

## Out of scope

Architectural rework of the auto_run subprocess model (warm worker pool, in-process fast-path for deterministic ops) — meaningful but bigger; separate task. The retry + envelope fix here is the proximate-cause patch.