### PR TITLE
perf(sidecar): stagger the 5-minute index-rebuild crons across the cycle

### DIFF
--- a/sidecar_jobs/ir-index-rebuild.md
+++ b/sidecar_jobs/ir-index-rebuild.md
@@ -1,7 +1,7 @@
 ---
-schedule: "*/5 * * * *"  # every 5 minutes
+schedule: "*/5 * * * *"  # minute 0 of each 5-min cycle — the anchor that sibling index crons offset off
 recurring: true
-jitter_seconds: 90  # spread 5-minute pile-ups; lands at name+schedule-derived offset
+jitter_seconds: 45  # intra-minute de-sync only; kept under 60s so it stays within minute 0 (sibling crons own minutes 1-4)
 type: capability
 capability: ir_index
 params:

--- a/sidecar_jobs/summary-index-rebuild.md
+++ b/sidecar_jobs/summary-index-rebuild.md
@@ -1,7 +1,7 @@
 ---
-schedule: "*/5 * * * *"  # every 5 minutes
+schedule: "1-59/5 * * * *"  # minute 1 of each 5-min cycle — staggered off ir-index (min 0) and vault-index (min 4)
 recurring: true
-jitter_seconds: 105  # spread 5-minute pile-ups; lands off the other index crons
+jitter_seconds: 45  # intra-minute de-sync only; the minute-1 offset does the coarse spread
 type: capability
 capability: ir_index
 params:

--- a/sidecar_jobs/vault-index-rebuild.md
+++ b/sidecar_jobs/vault-index-rebuild.md
@@ -1,7 +1,7 @@
 ---
-schedule: "*/5 * * * *"  # every 5 minutes
+schedule: "4-59/5 * * * *"  # minute 4 of each 5-min cycle — heaviest index build, isolated on its own minute
 recurring: true
-jitter_seconds: 75  # distinct offset from ir-index's 90 so the two 5-min jobs don't pile up
+jitter_seconds: 45  # intra-minute de-sync only; the minute-4 offset does the coarse spread off the other index crons
 type: capability
 capability: vault_index
 params:


### PR DESCRIPTION
## Summary
- `ir-index-rebuild`, `summary-index-rebuild`, and `vault-index-rebuild` all ran on `*/5` (minute 0), so the three heaviest index builds landed in the same ~90s window every five minutes — a thundering herd that spikes CPU, memory, and contention on the single-writer consolidated SQLite DB.
- Spread them across the cycle using the existing minute-offset convention (the same one `conversation-observability-refresh` and `summarization-worker` already use), so one heavy build runs per minute instead of four at once:

  | min | job |
  |---|---|
  | 0 | `ir-index-rebuild` (anchor) + `task-note-index` + `event-source-poll` |
  | 1 | `summary-index-rebuild` |
  | 2 | `conversation-observability-refresh` *(unchanged)* |
  | 3 | `summarization-worker` *(unchanged)* |
  | 4 | `vault-index-rebuild` (heaviest, isolated) |

- **Cadence is unchanged** — still every 5 minutes; this only shifts the phase. Jitter dropped to 45s on the moved jobs so each stays inside its assigned minute (the 30s scheduler tick quantizes finer spread away anyway, so the minute-offset is the real lever).
- This is load *spreading*, not load *reduction*: same total work per cycle, lower peak concurrency — which is what cuts the periodic stutter on a memory-constrained host.

## Test plan
- [x] `tests/test_sidecar_cron.py`, `tests/test_scheduler_jitter.py`, `tests/unit/test_index_refresh_jobs.py` — 53 passed / 0 failed
- [x] Re-loaded the three edited files via `load_jobs()` to confirm the new `N-59/5` schedules + jitter parse
- [ ] Confirm in the dashboard Jobs tab that `effective_at` lands one heavy build per minute across a 5-minute window