### PR TITLE
fix(journal): replay-safe writes, loader date anchoring, MIT-summary rule

### DIFF
--- a/knowledge/store/morning/directions.md
+++ b/knowledge/store/morning/directions.md
@@ -79,6 +79,7 @@ Return 'None detected' or pattern names with one-line evidence.
 - Each MIT is a concrete, completable action.
 - Present proposed MITs for review before creating.
 - Include `#tasker/state/focused` in task_text (interim workaround for Dataview visibility, see t-abe6ea4b).
+- Pass `summary` with a context paragraph for each MIT: what it is, why it is the right focus today, and any handoff notes a future agent will need. A focused task without a note is a continuity gap.
 
 ## Persist-Briefing guidelines
 

--- a/knowledge/store/tasks/task-new-directions.md
+++ b/knowledge/store/tasks/task-new-directions.md
@@ -37,6 +37,10 @@ The master-list line for a task carries up to four kinds of `#tag`:
 
 The inline-todo markers `#wb/todo` / `#wb/done` are workflow-internal and not user-modifiable through this surface.
 
+## MIT tasks require a summary
+
+When creating a task that includes `#tasker/state/focused` in `task_text` (a Most Important Task), `summary` is required. Pass a handoff-quality note: what needs to be done, why, and any relevant context, so a future agent picking up the task does not need to ask. A focused task without a note is a continuity gap.
+
 ## Slice 2 GTD vocabulary (optional)
 
 `task_create` accepts 12 optional kwargs for GTD-shaped metadata: `task_kind` (`task` / `periodic` / `habit`), `density` (`sparse` / `developed`), `outcome_text`, `next_action_text`, `definition_of_done`, `creation_effort`, `user_involvement`, `creation_provenance` (open enum — use `manual` / `agent_inferred_from_journal` / `agent_inferred_from_chrome` / `agent_inferred_from_inline`), `has_deadline`, `deadline_date`, `has_dependency`, `dependency_hint`. Defaults match the legacy assumption (manual, sparse, developed effort, high involvement).

--- a/tests/unit/test_journal_append.py
+++ b/tests/unit/test_journal_append.py
@@ -112,3 +112,114 @@ def test_append_refuses_direct_write_when_obsidian_running(tmp_path, monkeypatch
 
     # Disk untouched — the open editor cannot have diverged.
     assert journal_file.read_text(encoding="utf-8") == before
+
+
+def test_append_idempotent_on_replay(tmp_path, monkeypatch):
+    """Replay safety: calling _append_to_journal_locked twice with identical
+    entries must land each entry only once. This is the regression guard for
+    the post-write-uncertain replay-duplication failure mode: a bridge write
+    that actually landed but reported ObsidianPostWriteUncertain triggers a
+    retry, and without this guard the retry re-inserts every entry.
+
+    The first call lands the entries. The second call sees them already in
+    the file via the formatted_line-in-file check and short-circuits to a
+    success response with already_present populated and entries_written=0.
+    """
+    import work_buddy.obsidian.bridge as bridge_mod
+
+    monkeypatch.setattr(bridge_mod, "is_available", lambda: False, raising=False)
+    monkeypatch.setattr(bridge_mod, "is_obsidian_running", lambda: False, raising=False)
+
+    journal_file = _make_journal(tmp_path)
+    entries = [
+        ("2:15 PM", "Idempotent test entry one"),
+        ("3:30 PM", "Idempotent test entry two"),
+    ]
+
+    first = _append_to_journal_locked(entries, journal_file, "2026-04-16")
+    assert first["success"] is True
+    assert first["entries_written"] == 2
+    assert first.get("already_present", []) == []
+
+    # Simulate a PWU-triggered replay: same entries, same file (which now
+    # already contains them).
+    second = _append_to_journal_locked(entries, journal_file, "2026-04-16")
+    assert second["success"] is True
+    assert second["entries_written"] == 0
+    assert second.get("already_present") == ["2:15 PM", "3:30 PM"]
+
+    # File must contain each entry exactly once.
+    content = journal_file.read_text(encoding="utf-8")
+    assert content.count("Idempotent test entry one") == 1
+    assert content.count("Idempotent test entry two") == 1
+
+
+def test_append_mixed_already_present_and_new(tmp_path, monkeypatch):
+    """A replay that includes a partial overlap with file state: some entries
+    are already present (from a prior write that landed), some are genuinely
+    new. The new ones must land; the already-present ones must be reported in
+    already_present without producing duplicates.
+    """
+    import work_buddy.obsidian.bridge as bridge_mod
+
+    monkeypatch.setattr(bridge_mod, "is_available", lambda: False, raising=False)
+    monkeypatch.setattr(bridge_mod, "is_obsidian_running", lambda: False, raising=False)
+
+    journal_file = _make_journal(tmp_path)
+    # Pre-seed one entry as if a prior write had landed it.
+    _append_to_journal_locked(
+        [("2:15 PM", "Already there")],
+        journal_file,
+        "2026-04-16",
+    )
+
+    mixed = [
+        ("2:15 PM", "Already there"),
+        ("4:00 PM", "Genuinely new"),
+    ]
+    result = _append_to_journal_locked(mixed, journal_file, "2026-04-16")
+    assert result["success"] is True
+    assert result["entries_written"] == 1
+    assert result.get("already_present") == ["2:15 PM"]
+
+    content = journal_file.read_text(encoding="utf-8")
+    assert content.count("Already there") == 1
+    assert content.count("Genuinely new") == 1
+
+
+def test_append_passes_insert_mode_witness_to_vault_write(tmp_path, monkeypatch):
+    """The vault_write call must use write_mode='insert' with an explicit
+    content_hint drawn from the first inserted line. The default insert hint
+    (first 256 chars of the file content) would always be stable journal
+    frontmatter and would cause the post-write verifier to always return
+    'verified' regardless of whether the write landed.
+    """
+    from work_buddy import journal as jmod
+
+    captured: dict = {}
+
+    def fake_vault_write(vault_rel_path, abs_path, content, *, write_mode, content_hint=None):
+        captured["write_mode"] = write_mode
+        captured["content_hint"] = content_hint
+        # Mimic a successful filesystem write so the rest of the function
+        # proceeds normally.
+        abs_path.write_text(content, encoding="utf-8")
+        return True
+
+    # Patch the import inside _append_to_journal_locked (it does a local
+    # `from work_buddy.obsidian.vault_writer import vault_write`).
+    import work_buddy.obsidian.vault_writer as vw
+    monkeypatch.setattr(vw, "vault_write", fake_vault_write, raising=False)
+
+    journal_file = _make_journal(tmp_path)
+    entries = [("2:15 PM", "Witness check entry")]
+    result = _append_to_journal_locked(entries, journal_file, "2026-04-16")
+
+    assert result["success"] is True
+    assert captured["write_mode"] == "insert"
+    # Witness should be the formatted line for our new entry, which contains
+    # the bullet, the timestamp, and the description.
+    assert captured["content_hint"] is not None
+    assert "2:15 PM" in captured["content_hint"]
+    assert "Witness check entry" in captured["content_hint"]
+    assert "#wb/journal/log" in captured["content_hint"]

--- a/work_buddy/collectors/obsidian_collector.py
+++ b/work_buddy/collectors/obsidian_collector.py
@@ -138,8 +138,16 @@ def _get_journal_entries(
             content = file_path.read_text(encoding="utf-8", errors="replace")
             sections = _extract_sections(content)
             if sections:
+                # Carry the weekday alongside the ISO date so downstream
+                # renderers can disambiguate the journal even when surfaced
+                # out of file-context (e.g. quoted in a briefing read after
+                # midnight). The file name carries the date implicitly, but
+                # the rendered context surface usually loses that anchor.
+                weekday = current.strftime("%A")
                 entries.append({
                     "date": current.isoformat(),
+                    "weekday": weekday,
+                    "header": f"Journal for {current.isoformat()} ({weekday})",
                     "sections": sections,
                 })
         current -= timedelta(days=1)
@@ -512,7 +520,11 @@ def collect(cfg: dict[str, Any]) -> tuple[str, str]:
             lines.append(f"## Journal (last {journal_days} days)")
         lines.append("")
         for entry in journal_entries:
-            lines.append(f"### {entry['date']}")
+            # Header carries date + weekday so this block is unambiguous when
+            # read in isolation. Falls back to the raw date for entries that
+            # predate the header field (defensive against partial updates).
+            heading = entry.get("header") or entry["date"]
+            lines.append(f"### {heading}")
             lines.append("")
             for sec_name, sec_body in entry["sections"].items():
                 lines.append(f"**{sec_name}:**")

--- a/work_buddy/journal.py
+++ b/work_buddy/journal.py
@@ -437,6 +437,19 @@ def read_journal_state(target: str | None = None) -> dict[str, Any]:
     else:
         collect_until = user_now().strftime("%Y-%m-%dT%H:%M:%S")
 
+    # Anchor non-empty section text with the target date and weekday so the
+    # content stays unambiguous when surfaced outside this dict (e.g. quoted
+    # in a briefing read after midnight). Empty sections are passed through
+    # so callers can still distinguish "missing section" from "section with
+    # only the header." target_date is also returned as its own field, so
+    # callers that read this dict whole still get the date as structured data.
+    weekday = target_date_obj.strftime("%A")
+    journal_header = f"Journal for {resolved.date} ({weekday})\n\n"
+    if log_section:
+        log_section = journal_header + log_section
+    if sign_in_section:
+        sign_in_section = journal_header + sign_in_section
+
     return {
         "target_date": resolved.date,
         "ambiguous": False,

--- a/work_buddy/journal.py
+++ b/work_buddy/journal.py
@@ -657,11 +657,25 @@ def _append_to_journal_locked(
     sorted_entries = sorted(entries, key=lambda e: _effective_minutes(e[0]))
 
     # Insert each entry chronologically — re-read content after each insert
-    # because offsets shift
+    # because offsets shift. Two skip paths:
+    #   - already_present: the formatted line is already in the file. This is
+    #     the replay-safety guard: if the original write actually landed but
+    #     the post-write verifier returned ObsidianPostWriteUncertain, a retry
+    #     sees the entries in the file and skips them. No duplicate is written.
+    #     The file is the source of truth; no separate cache needed because
+    #     journal entries have no minted identity to preserve.
+    #   - skipped: no valid chronological insertion point. Distinct from
+    #     already_present so callers can distinguish "we already did this"
+    #     from "we could not figure out where to insert this."
     inserted_count = 0
-    skipped = []
+    skipped: list[str] = []
+    already_present: list[str] = []
+    first_inserted_line: str | None = None
     for time_str, description in sorted_entries:
         formatted_line = _format_log_entry(time_str, description)
+        if formatted_line in file_content:
+            already_present.append(time_str)
+            continue
         insertion_point = _find_chronological_insertion_point(file_content, time_str)
         if insertion_point is None:
             skipped.append(time_str)
@@ -680,8 +694,29 @@ def _append_to_journal_locked(
 
         file_content = before + formatted_line + after
         inserted_count += 1
+        if first_inserted_line is None:
+            first_inserted_line = formatted_line.strip("\n")
 
     if inserted_count == 0:
+        # All entries already in the file -> success (the work is done, this
+        # is the replay-safety guard firing). All entries unfindable -> failure.
+        # Mixed -> still success if any landed previously, since the caller's
+        # intent (those lines exist in the journal) is satisfied.
+        if already_present:
+            result: dict[str, Any] = {
+                "success": True,
+                "file": str(journal_file),
+                "entries_written": 0,
+                "already_present": already_present,
+                "message": (
+                    f"All {len(already_present)} entries already in the journal "
+                    f"(replay-safe no-op). Times: {already_present}"
+                ),
+            }
+            if skipped:
+                result["skipped"] = skipped
+                result["message"] += f" {len(skipped)} entries had no insertion point: {skipped}"
+            return result
         return {
             "success": False,
             "file": str(journal_file),
@@ -699,11 +734,31 @@ def _append_to_journal_locked(
     # be swallowed into a direct write: a blanket ``except Exception`` that
     # falls back to disk would diverge an open editor from disk and wedge the
     # note with a persistent 409 editor_dirty.
+    #
+    # write_mode='insert' is verifier-only: the bridge call still PUTs the
+    # full file content; we change the post-write verification semantics from
+    # "the file's full sha256 must match what we sent" to "this substring must
+    # be present in the file." The journal is concurrently touched by Obsidian
+    # itself, the Tasks plugin, Datacore, and the Linter, all of which can
+    # mutate unrelated regions of the file between the bridge write and the
+    # verifier's read-back. Full-file sha256 mismatches in that case and the
+    # PWU recovery path needlessly re-runs this capability, which without the
+    # already_present guard above used to land duplicate entries. See the
+    # explicit guidance in obsidian/bridge.py write_file docstring (the master
+    # task list, archives, journals).
+    #
+    # content_hint MUST be set explicitly: the default for insert mode is the
+    # first 256 chars of the file content, which for a journal is stable
+    # frontmatter identical across writes -> the verifier would always falsely
+    # return "verified." We pass the first inserted line, which is by
+    # construction not in the pre-write file (the already_present check above
+    # filtered it out), so verify succeeds iff our write actually landed.
     vault_rel_path = f"journal/{date_str}.md"
     from work_buddy.obsidian.vault_writer import vault_write
 
     ok = vault_write(
-        vault_rel_path, journal_file, file_content, write_mode="replace",
+        vault_rel_path, journal_file, file_content,
+        write_mode="insert", content_hint=first_inserted_line,
     )
     if not ok:
         # Only reachable when Obsidian was down AND the direct filesystem
@@ -728,9 +783,14 @@ def _append_to_journal_locked(
         "entries_written": inserted_count,
         "message": f"Appended {inserted_count} entries to Log section of {date_str} journal.",
     }
+    if already_present:
+        result["already_present"] = already_present
+        result["message"] += (
+            f" Skipped {len(already_present)} already-present: {already_present}"
+        )
     if skipped:
         result["skipped"] = skipped
-        result["message"] += f" Skipped {len(skipped)}: {skipped}"
+        result["message"] += f" Skipped {len(skipped)} (no insertion point): {skipped}"
     return result
 
 


### PR DESCRIPTION
Closes three journal-hygiene gaps surfaced in a session retro and confirmed still-open on re-audit.

## 1. Replay-safe `append_to_journal`
A bridge write that lands but reports `ObsidianPostWriteUncertain` triggers a retry that used to re-insert every entry (the duplicate-Log-entry failure mode). Two coordinated changes:
- An `already_present` guard: before inserting each formatted line, check whether it is already in the file. The formatted line is the entry's identity, so reading the file is sufficient and no idempotency cache is needed. A pure-replay call now returns `success` with `already_present` populated and `entries_written=0`.
- Switch the `vault_write` call to `write_mode="insert"` with an explicit, linter-resistant `content_hint` (the first newly-inserted line). The default insert hint is the first 256 chars of the file (stable frontmatter), which would make the verifier always falsely report "verified"; the explicit hint verifies the write actually landed.

`persist_briefing_to_journal` is intentionally left on its direct-write path (it does not go through the bridge `write_mode` seam).

## 2. Loader-layer date anchoring
Journal content surfaced as agent context lost its date when quoted out of file context. Both loader seams now emit `Journal for <date> (<weekday>)`:
- `obsidian_collector._get_journal_entries` adds `header` / `weekday` fields, rendered as the per-day heading.
- `journal.read_journal_state` prepends the header to non-empty `log_section` / `sign_in_section`.

The vault-index path is intentionally untouched (search results already surface the filename).

## 3. MIT-summary rule
Directions now require `summary` when creating a `#tasker/state/focused` task, so MITs carry handoff context for the next agent. Directions-only, since the tag is raw inline text in `task_text` by design and a code-level tag-scan would fight that.

## Verification
- 35 journal unit tests + a 261-test broad sweep across journal + context surfaces pass.
- Knowledge-store validation: 434 units, 0 errors.
- Live end-to-end: replay no-op confirmed on disk (entry count stayed at 1); date header confirmed through the live gateway on both seams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)