### PR TITLE
feat(journal): make journal creation opt-in on read (create_on_read)

### DIFF
--- a/knowledge/store/daily-journal/update-journal.md
+++ b/knowledge/store/daily-journal/update-journal.md
@@ -16,7 +16,8 @@ steps:
   depends_on: []
   auto_run:
     callable: work_buddy.journal.read_journal_state
-    kwargs: {}
+    kwargs:
+      create_on_read: true
     input_map:
       target: __params__.target
     timeout: 90

--- a/knowledge/store/journal/journal_state.md
+++ b/knowledge/store/journal/journal_state.md
@@ -11,6 +11,10 @@ parameters:
     type: str
     description: 'Date target: ''today'', ''yesterday'', or YYYY-MM-DD'
     required: false
+  create_on_read:
+    type: bool
+    description: When true, ensure the journal exists (creates today's note via Obsidian if missing). Default false - a missing journal reads as exists=false with no file created. Creation is only possible for today.
+    required: false
 param_aliases:
   target_date: target
   date: target

--- a/knowledge/store/morning/morning-routine.md
+++ b/knowledge/store/morning/morning-routine.md
@@ -146,7 +146,7 @@ parents:
 
 **Procedure:**
 
-0. **Ensure today's journal exists.** Call `mcp__work-buddy__wb_run("journal_state", {"target": "today"})` â€” if the result shows `exists: false`, the journal needs creating via Obsidian.
+0. **Ensure today's journal exists.** Call `mcp__work-buddy__wb_run("journal_state", {"target": "today", "create_on_read": true})` â€” if the result shows `exists: false`, the journal needs creating via Obsidian.
 
 1. Get the configured lookback window: `hours = step_results["load-config"].get("morning", {}).get("context_hours", 24)` (default: 24).
 

--- a/tests/unit/test_journal_create_on_read.py
+++ b/tests/unit/test_journal_create_on_read.py
@@ -1,0 +1,147 @@
+"""Tests for the ``create_on_read`` contract: reading journal state must not
+create a file unless the caller opts in, and opting in can only create today
+(a missing non-today date is a "needed but impossible" error).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import work_buddy.journal as jmod
+from work_buddy.journal import ensure_journal_exists, read_journal_state
+
+
+class _SpyObsidian:
+    """Stand-in for ObsidianCommands that never touches a real vault."""
+
+    def __init__(self, vault_root):  # noqa: D401 - test stub
+        self.vault_root = vault_root
+
+
+def _spy_daily(record: list[str], *, creates: Path | None = None):
+    """Build a DailyNotesCommands stand-in that records open_today() calls.
+
+    If ``creates`` is given, open_today() writes that file (simulating
+    Obsidian materialising today's note from template).
+    """
+
+    class _SpyDaily:
+        def __init__(self, client):  # noqa: D401 - test stub
+            self.client = client
+
+        def open_today(self):
+            record.append("open_today")
+            if creates is not None:
+                creates.parent.mkdir(parents=True, exist_ok=True)
+                creates.write_text("---\n---\n\n# **Log**\n", encoding="utf-8")
+
+    return _SpyDaily
+
+
+def _patch_obsidian(monkeypatch, daily_cls):
+    import work_buddy.obsidian.commands as cmds_mod
+    import work_buddy.obsidian.commands.daily_notes as daily_mod
+
+    monkeypatch.setattr(cmds_mod, "ObsidianCommands", _SpyObsidian, raising=False)
+    monkeypatch.setattr(daily_mod, "DailyNotesCommands", daily_cls, raising=False)
+
+
+# --- ensure_journal_exists -------------------------------------------------
+
+
+def test_ensure_create_false_missing_is_benign_and_skips_obsidian(tmp_path, monkeypatch):
+    calls: list[str] = []
+    _patch_obsidian(monkeypatch, _spy_daily(calls))
+
+    result = ensure_journal_exists(tmp_path, "2026-01-01", create=False)
+
+    assert result["exists"] is False
+    assert result["created"] is False
+    assert result["error"] is None
+    # No file written, Obsidian never invoked.
+    assert not (tmp_path / "journal" / "2026-01-01.md").exists()
+    assert calls == []
+
+
+def test_ensure_create_true_non_today_missing_errors_and_skips_obsidian(tmp_path, monkeypatch):
+    # Pin "today" so the target date is unambiguously a non-today date.
+    import datetime as _dt
+
+    fixed = _dt.datetime(2026, 6, 26, 10, 0, 0)
+    monkeypatch.setattr(jmod, "user_now", lambda: fixed)
+    calls: list[str] = []
+    _patch_obsidian(monkeypatch, _spy_daily(calls))
+
+    result = ensure_journal_exists(tmp_path, "2026-05-01", create=True)
+
+    assert result["exists"] is False
+    assert result["created"] is False
+    assert result["error"] is not None  # needed but impossible
+    assert "2026-05-01" in result["error"]
+    assert not (tmp_path / "journal" / "2026-05-01.md").exists()
+    assert calls == []  # Obsidian can't template a past date, so we don't try
+
+
+def test_ensure_create_true_existing_past_date_reads_without_error(tmp_path, monkeypatch):
+    import datetime as _dt
+
+    fixed = _dt.datetime(2026, 6, 26, 10, 0, 0)
+    monkeypatch.setattr(jmod, "user_now", lambda: fixed)
+    past = tmp_path / "journal" / "2026-05-01.md"
+    past.parent.mkdir(parents=True)
+    past.write_text("---\n---\n", encoding="utf-8")
+
+    result = ensure_journal_exists(tmp_path, "2026-05-01", create=True)
+
+    assert result["exists"] is True
+    assert result["error"] is None
+
+
+def test_ensure_create_true_today_missing_creates(tmp_path, monkeypatch):
+    import datetime as _dt
+
+    fixed = _dt.datetime(2026, 6, 26, 10, 0, 0)
+    monkeypatch.setattr(jmod, "user_now", lambda: fixed)
+    monkeypatch.setattr("time.sleep", lambda *a, **k: None)
+    today_file = tmp_path / "journal" / "2026-06-26.md"
+    calls: list[str] = []
+    _patch_obsidian(monkeypatch, _spy_daily(calls, creates=today_file))
+
+    result = ensure_journal_exists(tmp_path, "2026-06-26", create=True)
+
+    assert result["exists"] is True
+    assert result["created"] is True
+    assert result["error"] is None
+    assert calls == ["open_today"]
+    assert today_file.exists()
+
+
+# --- read_journal_state ----------------------------------------------------
+
+
+def test_read_journal_state_default_does_not_create(tmp_path, monkeypatch):
+    monkeypatch.setattr(jmod, "load_config", lambda: {"vault_root": str(tmp_path)})
+    calls: list[str] = []
+    _patch_obsidian(monkeypatch, _spy_daily(calls))
+
+    # A far-future, never-journaled date: unambiguous and missing.
+    state = read_journal_state(target="2099-01-01")
+
+    assert state["exists"] is False
+    assert state["created"] is False
+    assert state["error"] is None  # benign absence, default create_on_read=False
+    assert not (tmp_path / "journal" / "2099-01-01.md").exists()
+    assert calls == []
+
+
+def test_read_journal_state_create_on_read_true_non_today_surfaces_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(jmod, "load_config", lambda: {"vault_root": str(tmp_path)})
+    calls: list[str] = []
+    _patch_obsidian(monkeypatch, _spy_daily(calls))
+
+    state = read_journal_state(target="2099-01-01", create_on_read=True)
+
+    assert state["exists"] is False
+    assert state["error"] is not None  # needed but impossible bubbles up
+    assert calls == []

--- a/work_buddy/journal.py
+++ b/work_buddy/journal.py
@@ -53,20 +53,28 @@ def journal_path_for_date(date_str: str | None = None, vault_root: Path | None =
 # ---------------------------------------------------------------------------
 
 def ensure_journal_exists(
-    vault_root: Path, date_str: str | None = None,
+    vault_root: Path, date_str: str | None = None, create: bool = True,
 ) -> dict[str, Any]:
     """Ensure the journal file for the target date exists.
 
-    For today: triggers the Obsidian "Daily notes: Open today's daily note"
-    command, which creates the file from template if it doesn't exist.
+    When ``create`` is True (the default) and the file is missing:
+      - For today: triggers the Obsidian "Daily notes: Open today's daily note"
+        command, which creates the file from template.
+      - For any other date: creation is impossible (Obsidian's daily-notes
+        command only works for today), so this returns an ``error`` describing
+        the "needed but impossible" situation.
 
-    For other dates: checks if the file exists. If not, reports that it must
-    be created manually (Obsidian's daily-notes command only works for today).
+    When ``create`` is False, a missing file is reported as a benign absence
+    (``exists=False`` with ``error=None``) and Obsidian is never invoked --
+    reading journal state must not have the side effect of creating a file.
 
-    Requires Obsidian to be running with the Local REST API plugin.
+    Requires Obsidian to be running with the Local REST API plugin (only when
+    ``create`` is True and today's note must be created).
 
     Returns:
-        Dict with ``exists``, ``file``, ``created``, ``message`` keys.
+        Dict with ``exists``, ``file``, ``created``, ``message``, ``error``
+        keys. ``error`` is None unless creation was needed but failed or was
+        impossible.
     """
     if date_str is None:
         date_str = user_now().strftime("%Y-%m-%d")
@@ -80,9 +88,24 @@ def ensure_journal_exists(
             "file": str(journal_file),
             "created": False,
             "message": f"Journal for {date_str} already exists.",
+            "error": None,
         }
 
-    # File doesn't exist — try to create it via Obsidian
+    # File doesn't exist.
+    if not create:
+        # Read-only path: a missing journal is fine, nothing to grab.
+        return {
+            "exists": False,
+            "file": str(journal_file),
+            "created": False,
+            "message": (
+                f"Journal for {date_str} does not exist and was not "
+                "auto-created (create disabled for this read)."
+            ),
+            "error": None,
+        }
+
+    # create=True: the caller needs the journal present.
     if date_str == today_str:
         try:
             from work_buddy.obsidian.commands import ObsidianCommands
@@ -103,16 +126,19 @@ def ensure_journal_exists(
                     "file": str(journal_file),
                     "created": True,
                     "message": f"Created today's journal ({date_str}) via Obsidian daily notes command.",
+                    "error": None,
                 }
             else:
+                msg = (
+                    f"Triggered Obsidian daily notes command but journal file "
+                    f"for {date_str} was not created. Check Obsidian."
+                )
                 return {
                     "exists": False,
                     "file": str(journal_file),
                     "created": False,
-                    "message": (
-                        f"Triggered Obsidian daily notes command but journal file "
-                        f"for {date_str} was not created. Check Obsidian."
-                    ),
+                    "message": msg,
+                    "error": msg,
                 }
         except (RuntimeError, ObsidianError) as e:
             return {
@@ -120,18 +146,21 @@ def ensure_journal_exists(
                 "file": str(journal_file),
                 "created": False,
                 "message": str(e),
+                "error": str(e),
             }
     else:
-        # Past date — can't auto-create from template
+        # Non-today date: needed but impossible (Obsidian templates today only).
+        msg = (
+            f"Journal for {date_str} doesn't exist and can't be auto-created. "
+            "Obsidian only templates today's note, so journals for any other "
+            "date can't be auto-created."
+        )
         return {
             "exists": False,
             "file": str(journal_file),
             "created": False,
-            "message": (
-                f"Journal for {date_str} does not exist. "
-                f"Obsidian can only auto-create today's note from template. "
-                f"Open Obsidian and manually create the note, or target a date that exists."
-            ),
+            "message": msg,
+            "error": msg,
         }
 
 
@@ -327,7 +356,9 @@ def collect_scoped_context(journal_state: dict[str, Any] | None = None) -> dict[
     }
 
 
-def read_journal_state(target: str | None = None) -> dict[str, Any]:
+def read_journal_state(
+    target: str | None = None, create_on_read: bool = False,
+) -> dict[str, Any]:
     """Read the journal for a target date and return everything needed for the DAG.
 
     This is the programmatic entry point for the ``read-journal`` DAG task.
@@ -336,6 +367,14 @@ def read_journal_state(target: str | None = None) -> dict[str, Any]:
 
     Args:
         target: "today", "yesterday", YYYY-MM-DD, or None (auto-detect).
+        create_on_read: When True, ensure the journal exists (creating today's
+            note via Obsidian if missing); callers that need a journal present
+            (update-journal, /wb-morning) opt in. When False (the default), a
+            missing journal is reported as a benign absence (``exists=False``,
+            ``error=None``) and no file is created -- ad-hoc reads must not
+            pollute the vault with empty journals. Creation is only possible for
+            today; ``create_on_read=True`` on a missing non-today date returns
+            an ``error`` ("needed but impossible").
 
     Returns:
         Dict with keys:
@@ -372,8 +411,10 @@ def read_journal_state(target: str | None = None) -> dict[str, Any]:
             "sign_in_section": None,
         }
 
-    # 2. Ensure journal file exists
-    ensure_result = ensure_journal_exists(vault_root, resolved.date)
+    # 2. Ensure journal file exists (only when the caller opts in)
+    ensure_result = ensure_journal_exists(
+        vault_root, resolved.date, create=create_on_read,
+    )
 
     if not ensure_result["exists"]:
         return {
@@ -382,7 +423,7 @@ def read_journal_state(target: str | None = None) -> dict[str, Any]:
             "hint": "",
             "exists": False,
             "created": False,
-            "error": ensure_result["message"],
+            "error": ensure_result.get("error"),
             "collect_since": None,
             "collect_until": None,
             "last_log_ts": None,


### PR DESCRIPTION
## Summary
- `read_journal_state` no longer creates the target journal as a side effect of reading it. New `create_on_read` param (default `False`); a default read of a missing journal returns `exists=false, created=false` with no file written, so ad-hoc info-grabs stop leaving empty journals behind.
- Callers that need a journal present opt in: `update-journal`'s read step and the morning routine's today-snapshot pass `create_on_read=true`.
- Creation is only possible for **today** (Obsidian templates today's note only). `create_on_read=true` on a missing non-today date returns an explicit "needed but impossible" error instead of silently no-op'ing; existing journals of any date still read fine (so `update-journal {target: <existing past day>}` is preserved).
- `journal_state` capability declares the new param; behavior covered by `tests/unit/test_journal_create_on_read.py`.

This is the journal-hygiene half of the work behind `t-3cc5ea01`; the separate target-honoring defect (the task's original intent) already landed.

## Test plan
- [x] `tests/unit/test_journal_create_on_read.py` + `tests/unit/test_journal_append.py` — 13/13 pass
- [x] Live MCP op check (post-reload): `journal_state {target: <future never-journaled date>, create_on_read: true}` returns the needed-but-impossible `error` and creates no file; default-off read of a missing date returns `exists=false` with `error=null`. Verified no files written for either date.
- [ ] CI: DCO + test suite green

Task: t-3cc5ea01 (closed; this is the follow-on hygiene change)