### PR TITLE
feat(tasks): add task_list capability + /wb-task-completeness-sweep

### DIFF
--- a/.claude/commands/wb-task-completeness-sweep.md
+++ b/.claude/commands/wb-task-completeness-sweep.md
@@ -1,0 +1,4 @@
+---
+short: Audit the whole task list for already-done tasks
+---
+Load directions via `mcp__work-buddy__wb_run("agent_docs", {"path": "tasks/completeness-sweep-directions", "depth": "full"})`, then follow them: enumerate open tasks with `task_list`, warn about cost and get a go/no-go, fan out the `task-completeness` investigator over every open task (deferring all mutations to a reviewable `AUDIT.md`), then apply backdated toggles only on the user's sign-off. Pass `$ARGUMENTS` as an optional scope hint (e.g. "older than 30 days").

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ Every scope below is browsable with `mcp__work-buddy__wb_run("agent_docs", {"sco
 
 | Scope | Contents |
 |---|---|
-| `tasks/` | Create, assign, toggle, triage, archive, weekly review, namespace tags |
+| `tasks/` | Create, assign, toggle, list, triage, archive, weekly review, completeness sweep, namespace tags |
 | `contracts/` | Commitments, health, WIP limits, constraints |
 | `projects/` | Registry, observations, memory bank |
 | `entities/` | Entity registry — authored names, hierarchical tags, aliases, federated `entity_resolve`, append-only reference index |

--- a/knowledge/store/tasks/completeness-sweep-directions.md
+++ b/knowledge/store/tasks/completeness-sweep-directions.md
@@ -1,0 +1,161 @@
+---
+name: Task Completeness Sweep Directions
+kind: directions
+description: How to run a full-list completeness sweep — audit every open task for whether it is already done, warn about cost upfront, fan out the per-task task-completeness investigator over the whole list, defer all mutations to a reviewable AUDIT.md, and apply backdated toggles only on user sign-off.
+trigger: user runs /wb-task-completeness-sweep or asks to audit/sweep the whole task list for tasks that are already done
+command: wb-task-completeness-sweep
+capabilities:
+- tasks/task_list
+- tasks/task-completeness
+- tasks/task_toggle
+tags:
+- tasks
+- completeness
+- sweep
+- audit
+- batch
+- retroactive
+- directions
+aliases:
+- audit all tasks
+- sweep the task list
+- which tasks are already done
+- bulk completeness check
+- full task audit
+parents:
+- tasks
+---
+
+Audit the WHOLE open-task list for tasks that are secretly already done (fully, differently, or partially), so stale "open" tasks get closed with the correct prior completion date. This is the bulk form of `/wb-task-completeness`: that command investigates one `task_id`; this one enumerates every open task and runs the same per-task investigator over all of them, then synthesizes one reviewable audit.
+
+The whole sweep is READ-ONLY until the user signs off. You produce an `AUDIT.md` of verdicts; you mutate nothing until the user approves specific task ids.
+
+## When this fits
+
+- "Which of my open tasks are already done?"
+- "Audit the whole task list, I think a lot of these are stale."
+- A periodic backlog hygiene pass.
+
+For a single task the user already suspects is done, use `/wb-task-completeness` instead — do not spin up the full sweep for one id.
+
+## Step 1 — Enumerate
+
+Call `task_list` (no arguments) to get every live, non-archived, OPEN task, bridge-independent:
+
+```
+mcp__work-buddy__wb_run("task_list", {})
+```
+
+Read `count` and the `tasks` list. Each row is a full `task_metadata` record, so for a large backlog the result can be sizable and your harness may save it to a file rather than inline it. You only need `task_id`, `description`, `state`, and `created_at` per task: extract just those (e.g. with `jq`/a small script over the saved file) rather than carrying every column. If the user passed a scope hint (e.g. "older than 30 days", "just the inbox ones"), apply it by filtering the returned list, or pass `state=`/`limit=` to `task_list`. Optionally split out empty-shell rows (no `description` and no linked note) as non-auditable and report them separately rather than spending an investigator on them.
+
+## Step 2 — Cost gate (the upfront warning)
+
+This is the required confirmation. Before spawning anything, tell the user plainly:
+
+> This audits N open tasks by spawning roughly ceil(N / 4) sub-agents, each reading code and git history. Expect several minutes and non-trivial token cost.
+
+Then wait for an explicit go. Name the cost, do not moralize, let the user decide (the house style for expensive operations). Two extra rules:
+
+- If N is large (more than ~150 tasks), do not just proceed on a bare "go." Recommend narrowing scope (by age or state) or running in confirmed batches, and get a second explicit confirmation for the full run.
+- If N is 0, say so and stop. There is nothing to audit.
+
+Do not start any `task-completeness` run before the user says go.
+
+## Step 3 — Partition
+
+Group the tasks into shards of about 4 (`S = 4`). Default to simple sequential chunking in `created_at` order (adjacent tasks tend to share a subsystem, which helps a sub-agent reuse what it reads). For a large list (more than ~40 tasks) you may optionally run a single cheap clustering pass first (one sub-agent that groups task ids by subsystem/theme from their descriptions) so each shard is thematically coherent. Clustering is polish, not correctness; skip it for small runs.
+
+Write each shard's task ids to its own input file and decide a per-shard append-only output file, under a dated audit directory:
+
+```
+.data/designs/task-completeness-audit-<YYYY-MM-DD>/
+  shards/shard-01.json      (input: the shard's task records)
+  shards/shard-01.jsonl     (output: one verdict line per task, append-only)
+  ...
+  AUDIT.md                  (your final synthesis)
+```
+
+Use today's date from your context for `<YYYY-MM-DD>`.
+
+## Step 4 — Fan out
+
+Spawn one sub-agent per shard using your harness sub-agent tool (the built-in Task/Agent tool — this does NOT require any external batch skill). A capable reasoning model is appropriate per sub-agent; this is code-reading judgment, not a lightweight extraction. Hand each sub-agent the brief below, its shard input path, and its append-only output path. Do not let sub-agents spawn further sub-agents.
+
+Each sub-agent works through its shard and appends one verdict line per task. Collect their brief summaries; the real output is the JSONL.
+
+### Embedded sub-agent brief (copy into each sub-agent verbatim, filling the three placeholders)
+
+```
+You are ONE worker in a batch completeness audit. Investigate a SHARD of work-buddy tasks and decide, for each, whether it is ALREADY done. You DO NOT mutate anything; the orchestrator synthesizes all shards and the user signs off before any task is toggled.
+
+Inputs (given to you):
+- SHARD_FILE: <path to your shard-NN.json — your assigned task ids + descriptions>
+- OUT_JSONL:  <path to your shard-NN.jsonl — append ONE JSON line per task as you finish it; never overwrite>
+- SESSION_ID: <the orchestrator's WORK_BUDDY_SESSION_ID>
+
+Setup (once): register the SHARED session FIRST:
+  mcp__work-buddy__wb_run("wb_init", {"session_id": "<SESSION_ID>"})
+Consent is pre-authorized for this session (a workflow_class:task-completeness grant is live), so the workflow runs without prompting you. If a call ever blocks on consent or times out, do NOT hang: record that task with disposition "error" and move on.
+
+Per task (repeat for each task id in your shard):
+1. Start the investigator:  mcp__work-buddy__wb_run("task-completeness", {"task_id": "<TID>"})  (param key is "capability"/positional as your gateway expects; it is a workflow). Capture workflow_run_id. The gather-evidence step auto-runs as an ELIDED manifest.
+2. Pull evidence (cheapest first, do NOT pull everything):
+     mcp__work-buddy__wb_step_result(workflow_run_id="<wf>", step_id="gather-evidence", key="task")        # intent: task text + note_content
+     mcp__work-buddy__wb_step_result(workflow_run_id="<wf>", step_id="gather-evidence", key="provenance")  # created_by / assigned / developed_by (small)
+   Pull session_evidence (large) only if provenance is empty AND you need a developer session's rationale; prefer session_search into a named developer session over pulling the whole blob.
+3. Investigate, judging the SPIRIT not the letter. STEP 0 FIRST: restate the INTENT from note_content (what was asked + any prescribed how-to), then, cheapest-first: provenance -> session_search into a developer session / git log --grep=<TID> / gh PR search -> READ the actual code/tests to confirm behavior is present now -> run a targeted test only if still ambiguous. Inactivity is NOT completion.
+4. Advance the investigate step (param name is step_result) with exactly:
+     {"disposition": "<done|done-differently|partial|consciously-descoped|not-done>",
+      "evidence": ["<concrete citation: SHA / PR / path:line / test / note excerpt>", ...],   # non-empty
+      "completion_date": "YYYY-MM-DD or null",   # date of the LANDING COMMIT, cite its SHA in evidence
+      "divergence": "<better|lateral|worse|na>", # na unless done-differently with a prescribed how-to
+      "confidence": "<high|medium|low> — <one clause keyed to signal strength>",
+      "recommended_action": "<one sentence>"}
+5. Advance the resolve step DEFERRED (never toggle):
+     step_result = {"action": "deferred", "note": "batch sweep — mutations deferred to user review"}
+6. Append one JSON line to OUT_JSONL (append-only; survives interruption) with:
+     task_id, shard_id, disposition, confidence, divergence, completion_date, recommended_action,
+     intent_summary (1-2 sentences: what was asked + prescribed how-to),
+     situation_summary (1-3 sentences: who/when developed it, how the impl compares to intent, any deferred follow-up),
+     evidence (list), deferred_followup (text or empty), workflow_run_id
+
+Disposition rubric: done (intent met as written, or a blessed v1 shipped — surface any deferred follow-up) / done-differently (intent met by a different design; set divergence better|lateral|worse and justify from rationale + code) / partial (some shipped, some remains — delineate which) / consciously-descoped (a sub-part deliberately dropped) / not-done (no satisfying implementation; inactivity lands here).
+Confidence: high = structural developed_by link AND you read the code; medium = Rung-3 intent-only inference backed by code reading; low = weak/ambiguous. Be honest.
+
+HARD RULES: read-only except appending to YOUR OUT_JSONL. Never task_toggle/task_create/edit repo files/edit other shards. If you query the store raw, liveness = deleted_at IS NULL (prefer capabilities). NO fan-out — do not spawn sub-agents. Return ONLY a brief recap (one line per task: <TID> <disposition>/<confidence> — <=10-word gist; plus uncertainties and blockers). Evidence lives in the JSONL.
+```
+
+Note for non-fan-out harnesses: if you have no sub-agent tool, skip the fan-out and run the per-task loop above yourself, sequentially, appending to a single JSONL. Slower and more context, same correctness.
+
+## Step 5 — Synthesize
+
+Aggregate every shard JSONL into `AUDIT.md`. Validate coverage first (line count equals the audited count, no duplicate task ids). Then write:
+
+- Headline counts by disposition + confidence.
+- Section A: mark-done backdated candidates (done / done-differently), each with the backdate date, divergence verdict, intent, what was found, and evidence.
+- Section B: partials, each split into shipped-vs-remainder with a next move.
+- Section C: not-done (a compact table).
+- Section D: flags for human review — medium-confidence verdicts to check before backdating, done-differently divergence sign-offs, deadline-bearing not-done tasks, and likely duplicates.
+- An action queue: backdate wins / spin-off remainders / leave-open.
+
+## Step 6 — Sign-off and apply
+
+Present the backdate candidates and the headline counts. Act ONLY on explicit user approval, never mutate first. On approval, apply each confirmed completion with the LANDING-COMMIT date:
+
+```
+mcp__work-buddy__wb_run("task_toggle", {"task_id": "<id>", "done": true, "done_date": "<YYYY-MM-DD>"})
+```
+
+For partials, offer to finish the remainder, spin it off as a fresh task, or backdate only the shipped portion if separable. For deadline-bearing not-done tasks, surface the deadline regardless of audit bookkeeping.
+
+## Consent
+
+Starting `task-completeness` raises a one-time `workflow:task-completeness` consent prompt. Have the user grant "Allow always (this session, 24h)" on it BEFORE the fan-out, so the session's `workflow_class:task-completeness` grant lets all sub-agents (which share your session id via `wb_init`) run unprompted. Because every `resolve` is deferred, no high-weight toggle consent is hit during the sweep itself; the only mutating consent is the user-approved backdated toggles in Step 6.
+
+## Do NOT
+
+- Do not mutate anything before the user signs off in Step 6.
+- Do not spawn the full sweep for a single task — use `/wb-task-completeness`.
+- Do not let a consent stall hang a sub-agent — record it as `error` and move on.
+- Do not skip the cost gate, and do not proceed on a bare "go" for a very large list.
+- Do not have sub-agents toggle, create, or edit anything except their own append-only JSONL.

--- a/knowledge/store/tasks/task-search-directions.md
+++ b/knowledge/store/tasks/task-search-directions.md
@@ -27,6 +27,8 @@ parents:
 
 There are TWO ways to search tasks. Pick by what you want to find.
 
+Note: to *list* tasks (the whole filtered set) rather than search by text, use `task_list`. `task_search` with an empty query intentionally returns nothing.
+
 ## task_search - search by description text (Slice 3, store-only)
 
 Looks at the `description` column of `task_metadata` - the human-readable task line text (`Fix the auth bug`, `Refactor the dashboard`, ...). Bridge-independent: works even when Obsidian isn't running. Cheap, deterministic, no embedding service.

--- a/knowledge/store/tasks/task_list.md
+++ b/knowledge/store/tasks/task_list.md
@@ -1,0 +1,41 @@
+---
+name: Task List
+kind: capability
+description: List tasks from the SQLite store (bridge-independent — works even when Obsidian isn't running). With no arguments returns every live, non-archived, OPEN task, oldest-created first. The enumeration complement to task_search, which matches by text — use task_list to pull the whole open backlog (e.g. for a full-list review) rather than a single lookup.
+capability_name: task_list
+category: tasks
+op: op.wb.task_list
+schema_version: wb-capability/v1
+parameters:
+  state:
+    type: str
+    description: Exact state filter ('inbox' / 'focused' / 'done'). Omit for no state filter (subject to include_done). An explicit state overrides include_done.
+    required: false
+  include_done:
+    type: bool
+    description: When false (default) and no state is given, exclude completed tasks.
+    required: false
+  include_archived:
+    type: bool
+    description: Include archived tasks (default False).
+    required: false
+  limit:
+    type: int
+    description: Max results (default 500 — high so a full-list sweep is not silently truncated).
+    required: false
+tags:
+- tasks
+- task
+- list
+- enumerate
+aliases:
+- list open tasks
+- list all tasks
+- all open tasks
+- enumerate tasks
+- open task backlog
+- every open task
+- task list
+parents:
+- tasks
+---

--- a/tests/unit/test_task_list.py
+++ b/tests/unit/test_task_list.py
@@ -1,0 +1,122 @@
+"""task_list capability — store-backed bridge-independent enumeration.
+
+The "give me the whole (filtered) set" complement to ``task_search``.
+Sits at the manager layer (`task_list`) above `store.list_tasks`. These
+test the capability shape (response envelope, filter defaults, the
+liveness/done/archived predicates) and registration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from work_buddy.obsidian.tasks import store
+from work_buddy.obsidian.tasks.manager import task_list
+
+
+@pytest.fixture
+def isolated_store(tmp_path: Path, monkeypatch) -> Path:
+    db_dir = tmp_path / "db"
+    db_dir.mkdir()
+    db_path = db_dir / "tasks.sqlite"
+    monkeypatch.setattr(store, "_db_path", lambda: db_path)
+    return db_path
+
+
+def _ids(result) -> set[str]:
+    return {t["task_id"] for t in result["tasks"]}
+
+
+def test_list_returns_envelope(isolated_store):
+    store.create(
+        task_id="t-l001", state="inbox", urgency="medium",
+        description="open one",
+    )
+    result = task_list()
+    assert result["count"] == 1
+    assert isinstance(result["tasks"], list)
+    assert result["tasks"][0]["task_id"] == "t-l001"
+    assert result["tasks"][0]["description"] == "open one"
+
+
+def test_list_default_excludes_done(isolated_store):
+    store.create(task_id="t-open", state="inbox", urgency="medium",
+                 description="open")
+    store.create(task_id="t-done", state="done", urgency="medium",
+                 description="finished")
+    # Default: open-only.
+    assert _ids(task_list()) == {"t-open"}
+    # include_done surfaces the completed row too.
+    assert _ids(task_list(include_done=True)) == {"t-open", "t-done"}
+
+
+def test_list_default_excludes_archived(isolated_store):
+    store.create(task_id="t-live", state="inbox", urgency="medium",
+                 description="live")
+    store.create(task_id="t-arch", state="inbox", urgency="medium",
+                 description="to archive")
+    store.mark_archived("t-arch")
+    assert _ids(task_list()) == {"t-live"}
+    assert _ids(task_list(include_archived=True)) == {"t-live", "t-arch"}
+
+
+def test_list_excludes_soft_deleted(isolated_store):
+    """Soft-deleted rows (deleted_at set) are never live."""
+    store.create(task_id="t-keep", state="inbox", urgency="medium",
+                 description="keep")
+    store.create(task_id="t-del", state="inbox", urgency="medium",
+                 description="gone")
+    store.delete("t-del")
+    assert _ids(task_list()) == {"t-keep"}
+    # Even include_done / include_archived must not resurrect a soft-delete.
+    assert _ids(task_list(include_done=True, include_archived=True)) == {"t-keep"}
+
+
+def test_list_explicit_state_filter(isolated_store):
+    store.create(task_id="t-inbox", state="inbox", urgency="medium",
+                 description="i")
+    store.create(task_id="t-focus", state="focused", urgency="medium",
+                 description="f")
+    store.create(task_id="t-done", state="done", urgency="medium",
+                 description="d")
+    assert _ids(task_list(state="focused")) == {"t-focus"}
+    # An explicit state is authoritative — state='done' returns done rows
+    # even though include_done defaults False.
+    assert _ids(task_list(state="done")) == {"t-done"}
+
+
+def test_list_respects_limit(isolated_store):
+    for i in range(8):
+        store.create(
+            task_id=f"t-n{i:03d}", state="inbox", urgency="medium",
+            description=f"task {i}",
+        )
+    result = task_list(limit=3)
+    assert result["count"] == 3
+    assert len(result["tasks"]) == 3
+
+
+def test_list_empty_store(isolated_store):
+    result = task_list()
+    assert result["count"] == 0
+    assert result["tasks"] == []
+
+
+# ---------------------------------------------------------------------------
+# Registration smoke test
+# ---------------------------------------------------------------------------
+
+
+def test_capability_registered():
+    """Capability is discoverable via the registry."""
+    from work_buddy.mcp_server.registry import get_registry
+    registry = get_registry()
+    cap = registry.get("task_list")
+    assert cap is not None
+    assert cap.callable is task_list
+    # No bridge required — store-only.
+    assert cap.requires == []
+    # Search aliases are populated for discoverability.
+    assert any("open task" in alias for alias in cap.search_aliases)

--- a/work_buddy/mcp_server/ops/tasks_ops.py
+++ b/work_buddy/mcp_server/ops/tasks_ops.py
@@ -67,6 +67,7 @@ def _register() -> None:
     register_op("op.wb.task_review_inbox", manager.review_inbox)
     register_op("op.wb.task_stale_check", manager.stale_check)
     register_op("op.wb.task_search", manager.task_search)
+    register_op("op.wb.task_list", manager.task_list)
     register_op("op.wb.weekly_review_data", manager.weekly_review_data)
     # Mutator ops route through the WorkItem write port (``work_item.task_adapter``
     # — the surface ``Task`` instance methods also delegate to) so no task

--- a/work_buddy/obsidian/tasks/manager.py
+++ b/work_buddy/obsidian/tasks/manager.py
@@ -503,6 +503,47 @@ def task_search(
     }
 
 
+def task_list(
+    *,
+    state: str | None = None,
+    include_done: bool = False,
+    include_archived: bool = False,
+    limit: int = 500,
+) -> dict[str, Any]:
+    """List tasks from the SQLite store (bridge-independent).
+
+    The enumeration complement to :func:`task_search`: instead of a text
+    match it returns the whole (filtered) set. With no arguments it
+    returns every LIVE, non-archived, OPEN task — the natural input to a
+    full-list review such as the completeness sweep. Works even when the
+    Obsidian bridge is down, since it reads the store directly.
+
+    Args:
+        state: Exact ``state`` filter ('inbox' / 'focused' / 'done' / …).
+            None applies no state filter, subject to ``include_done``. An
+            explicit ``state`` overrides ``include_done``.
+        include_done: When False (default) and ``state`` is None, exclude
+            completed tasks.
+        include_archived: Include archived tasks (default False).
+        limit: Maximum results (default 500 — high so a full-list sweep is
+            not silently truncated).
+
+    Returns:
+        Dict with ``count`` and ``tasks`` keys. ``tasks`` are full
+        ``task_metadata`` rows ordered oldest-created first.
+    """
+    rows = store.list_tasks(
+        state=state,
+        include_done=include_done,
+        include_archived=include_archived,
+        limit=limit,
+    )
+    return {
+        "count": len(rows),
+        "tasks": rows,
+    }
+
+
 def get_inbox_count() -> int:
     """Get total inbox task count from both store and inline tags."""
     return len(get_tasks_by_state("inbox"))

--- a/work_buddy/obsidian/tasks/store.py
+++ b/work_buddy/obsidian/tasks/store.py
@@ -995,6 +995,66 @@ def search_by_description(
         conn.close()
 
 
+def list_tasks(
+    *,
+    state: str | None = None,
+    include_done: bool = False,
+    include_archived: bool = False,
+    include_deleted: bool = False,
+    limit: int = 500,
+) -> list[dict[str, Any]]:
+    """Enumerate task records from the store, oldest-created first.
+
+    The "give me the whole (filtered) set" complement to
+    :func:`search_by_description`'s text match. With its defaults it
+    returns every LIVE, non-archived, OPEN task — the natural input to a
+    full-list review. Bridge-independent: reads the store directly, so a
+    stale bridge or an Obsidian that isn't running doesn't block it.
+
+    Args:
+        state: Exact ``state`` filter (e.g. ``'inbox'``, ``'focused'``,
+            ``'done'``). None applies no state filter, subject to
+            ``include_done`` below. An explicit ``state`` is authoritative
+            (it overrides ``include_done``).
+        include_done: When False (default) and ``state`` is None, exclude
+            ``state='done'`` rows.
+        include_archived: Include rows with ``archived_at`` set.
+        include_deleted: Include soft-deleted rows (``deleted_at`` set).
+        limit: Maximum rows (default 500 — high so a full-list sweep is
+            not silently truncated).
+
+    Returns:
+        List of full ``task_metadata`` row dicts, ordered ``created_at``
+        ascending (backlog oldest-first).
+    """
+    clauses: list[str] = []
+    params: list[Any] = []
+
+    if state is not None:
+        clauses.append("state = ?")
+        params.append(state)
+    elif not include_done:
+        clauses.append("state != 'done'")
+
+    if not include_archived:
+        clauses.append("archived_at IS NULL")
+    if not include_deleted:
+        clauses.append("deleted_at IS NULL")
+
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            f"""SELECT * FROM task_metadata{where}
+                ORDER BY created_at ASC LIMIT ?""",
+            params + [int(limit)],
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
 def get_history(task_id: str) -> list[dict[str, Any]]:
     """Get state change history for a task, newest first."""
     conn = get_connection()


### PR DESCRIPTION
## Summary
- Add `task_list`, a bridge-independent enumeration over the SQLite task store (`store.list_tasks` -> `manager.task_list` -> `op.wb.task_list`, mirroring `task_search`). With no arguments it returns every live, non-archived, open task; filters for `state` / `include_done` / `include_archived` / `limit`. It is the enumeration complement to `task_search`'s text match.
- Add `/wb-task-completeness-sweep`: a directions-led command that audits the whole open-task list for tasks that are already done. It enumerates via `task_list`, warns about cost upfront, fans out the per-task `task-completeness` investigator (one sub-agent per shard) with every mutation deferred to a reviewable `AUDIT.md`, and applies backdated toggles only on user sign-off. The fan-out uses the built-in sub-agent tool, with a sequential fallback for harnesses without one.
- Cross-reference `task_list` from `task-search-directions` and the CLAUDE.md `tasks/` domain map.

## Test plan
- [x] `pytest tests/unit/test_task_list.py tests/unit/test_task_search.py` — 16 pass (envelope, open-only default, include_done/include_archived, deleted_at exclusion, explicit-state authority, limit, registration; plus task_search regression)
- [x] Live: after MCP restart, `wb_search("task_list")` shows the schema and `wb_run("task_list", {})` returns the real open-task list; `requires: []` (bridge-independent)
- [ ] Reviewer: optionally run `/wb-task-completeness-sweep` and confirm it stops at the cost gate before spawning

🤖 Generated with [Claude Code](https://claude.com/claude-code)