### PR TITLE
test(notifications): neutralize outbound delivery in the test harness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,5 +104,6 @@ markers = [
     "integration: CLI smoke tests and HTTP endpoint tests",
     "real_task_store: opt out of the autouse task-store temp-DB isolation (see _isolate_task_store_and_vault)",
     "real_obsidian_bridge: opt out of the autouse Obsidian-bridge neutralization (see _isolate_task_store_and_vault)",
+    "real_notification_delivery: opt out of the autouse notification-delivery stub (see _isolate_notification_delivery)",
 ]
 addopts = "-q --tb=short"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,41 @@ def _isolate_task_store_and_vault(tmp_path, monkeypatch, request):
             monkeypatch.setattr(bridge, "urlopen", _refuse_bridge_connection)
 
 
+@pytest.fixture(autouse=True)
+def _isolate_notification_delivery(monkeypatch, request):
+    """Neutralize outbound notification delivery for every test.
+
+    ``SurfaceDispatcher.deliver`` is the single fan-out point where a
+    notification reaches Telegram / Obsidian / dashboard surfaces. Several
+    capabilities emit fire-and-forget notifications as a side effect
+    (e.g. ``tasks.archive_completed`` -> ``_send_archive_summary_notification``).
+    Without this, any unmocked call from a test sends a *real* message (the
+    "Archived N completed tasks" Telegram leak). Stubbing ``deliver`` at the
+    class level is surface-agnostic and construction-agnostic: it blocks every
+    surface regardless of how the dispatcher instance was built, and the
+    consequential helpers import the dispatcher lazily inside the function, so
+    a class-attribute patch is what intercepts them.
+
+    Mirrors ``_isolate_task_store_and_vault``. Best-effort import so a module
+    move never breaks collection. Test-local patches of ``SurfaceDispatcher``
+    / ``from_config`` take precedence over this autouse default.
+
+    Opt out per-test with ``@pytest.mark.real_notification_delivery`` to drive
+    the real dispatcher against the test's own fakes.
+    """
+    if request.node.get_closest_marker("real_notification_delivery") is not None:
+        return
+    try:
+        import work_buddy.notifications.dispatcher as disp
+    except Exception:  # pragma: no cover - defensive
+        return
+
+    def _no_deliver(self, notification, mark_delivered_fn=None):
+        return {}  # matches deliver()'s dict[str, bool] contract
+
+    monkeypatch.setattr(disp.SurfaceDispatcher, "deliver", _no_deliver)
+
+
 @pytest.fixture
 def tmp_agents_dir(tmp_path, monkeypatch):
     """Redirect agent_session to write into a temp directory.

--- a/tests/unit/test_bridge_read_transient.py
+++ b/tests/unit/test_bridge_read_transient.py
@@ -147,6 +147,15 @@ class TestArchiveCompleted:
         )
         assert wrote_fresh_header, mb.write_file.call_args_list
 
+        # Regression guard for the "Archived N completed tasks" Telegram leak:
+        # archive_completed fires a fire-and-forget summary notification, and
+        # this single-task fixture makes count == 1. Under the default harness
+        # the dispatcher fan-out point must be neutralized (autouse
+        # _isolate_notification_delivery in tests/conftest.py), so no real
+        # surface (Telegram included) is ever contacted.
+        from work_buddy.notifications.dispatcher import SurfaceDispatcher
+        assert SurfaceDispatcher.deliver.__name__ != "deliver"
+
 
 # ── 4. Secondary consumers: transient ≠ false absent ─────────────────────
 

--- a/tests/unit/test_notification_isolation.py
+++ b/tests/unit/test_notification_isolation.py
@@ -1,0 +1,32 @@
+"""Guards for the autouse notification-delivery isolation.
+
+The test harness neutralizes outbound notification delivery by default
+(``_isolate_notification_delivery`` in ``tests/conftest.py``) so that a
+capability emitting a fire-and-forget notification (for example
+``tasks.archive_completed`` -> ``_send_archive_summary_notification``) cannot
+send a real message during a test run. These tests pin both halves of that
+contract: stubbed by default, restorable via the opt-out marker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from work_buddy.notifications.dispatcher import SurfaceDispatcher
+from work_buddy.notifications.models import Notification
+
+
+def test_delivery_stubbed_by_default():
+    """With no marker, the autouse fixture replaces ``deliver`` with a no-op.
+
+    A dispatch returns the empty result dict and never reaches a real surface,
+    no matter how the dispatcher was constructed.
+    """
+    dispatcher = SurfaceDispatcher()
+    assert dispatcher.deliver(Notification(title="probe", body="probe")) == {}
+
+
+@pytest.mark.real_notification_delivery
+def test_opt_out_restores_real_deliver():
+    """The opt-out marker bypasses the stub, leaving the real method in place."""
+    assert SurfaceDispatcher.deliver.__name__ == "deliver"


### PR DESCRIPTION
## Summary
- The test suite was sending real "Archived N completed tasks" Telegram messages on every run. Root cause: `tasks.archive_completed` fires a fire-and-forget summary notification via the real `SurfaceDispatcher`, and the autouse isolation in `tests/conftest.py` covered the task store and Obsidian bridge but not notification delivery (which travels through the dispatcher / messaging service, not the bridge). `TestArchiveCompleted.test_genuine_absent_creates_fresh_no_regression` mocks `bridge` and `store` but not the notification path, and its one-task fixture makes `count == 1`.
- Adds an autouse fixture `_isolate_notification_delivery` that stubs `SurfaceDispatcher.deliver` (the universal surface fan-out point) to a no-op for every test, gated by a `real_notification_delivery` opt-out marker, mirroring the existing `real_task_store` / `real_obsidian_bridge` pattern. The marker is registered in `pyproject.toml`.
- Adds `tests/unit/test_notification_isolation.py` (stubbed-by-default + opt-out-restores-real) and a regression assertion in the archive test that drove the leak.
- Test-only change; no `work_buddy/` source touched.

## Test plan
- [x] `pytest tests/unit/test_notification_isolation.py --strict-markers` (marker registered, both halves of the contract)
- [x] `pytest tests/unit/test_bridge_read_transient.py` passes with no Telegram message emitted
- [x] The 5 test-local `SurfaceDispatcher`/`from_config` patches still pass (no conflict with the autouse default): `test_consent_composable`, `test_gateway_consent_wait_hint`, `test_resolution_surface`, `test_notify_demo`
- [x] 99 relevant tests green

## Out of scope (follow-up)
`create_notification` still writes a JSON record into the real consent/notifications dir during tests (no phone buzz, just a stray on-disk record). Redirecting that dir has a large blast radius (the consent system shares it), so it is left as a separate narrowly-scoped change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)