### PR TITLE
fix(threads): bind thread_id for thread-scoped actions; show action switcher on child threads

### DIFF
--- a/knowledge/store/threads/fsm.md
+++ b/knowledge/store/threads/fsm.md
@@ -10,6 +10,13 @@ tags:
 parents:
 - threads
 - threads
+dev_notes: |-
+  ## Action parameter binding (EXECUTING)
+
+  `execution_runner._bind_runtime_parameters` fills parameters that depend on thread runtime state before dispatch:
+
+  - `tab_ids` — for the `chrome_tab_*` actions, collected from the thread's context items.
+  - `thread_id` — injected for any action whose **declaration** includes a `thread_id` parameter, gated on `is_action`. The op callable is a `**kwargs` wrapper whose signature can't be introspected, so the declared parameter schema is the authoritative source. A thread-scoped action (`journal_*`, `email_*`, `chrome_route_*`, the universal `thread_*`) therefore needs no execution_runner change — declaring `thread_id` is sufficient for the host thread to be bound at dispatch. The `is_action` gate excludes non-action capabilities (e.g. the messaging tools) that declare an unrelated `thread_id`.
 ---
 
 ## State catalog

--- a/knowledge/store/threads/grouping.md
+++ b/knowledge/store/threads/grouping.md
@@ -42,6 +42,10 @@ dev_notes: |-
   ## Per-matter routing for inline captures
 
   `pipelines/inline.py:inline_capture` segments the captured text into matters via the `clarify/text-segmenter` SubCall BEFORE running the verdict, then calls `pipelines/singular.py:spawn_thread_for_matter` once per matter. The text-segmenter biases toward 'one matter' and a coverage check rejects hallucinated boundaries; on segmenter soft-fail or short-text bypass the input is treated as a single matter. One matter → one root thread (flat or singular umbrella, depending on record count). N matters → N independent root threads with no umbrella conflation.
+
+  ## Inner-thread action switcher
+
+  The per-source action switcher (`scripts/tabs/threads/actions.py:_renderActionSwitcher`) renders on a child thread's right-pane editor, not only on the umbrella's group grid. It reads `window._groupState.actionOptionsByUmbrella[parentId]`. The group grid populates that cache only for group umbrellas, so a child opened directly lazy-fetches `GET /api/threads/<id>/action_options` and stores the result under the parent id. That endpoint is backed by `service._resolve_action_library_for_thread`, which resolves the library from the thread's own `inciting_event_summary` source (group children carry their pipeline's `source_pipeline`), so it works for any thread. The `/groups` endpoint stays group-umbrella-only; `/action_options` is the any-thread library surface.
 ---
 
 Three parent-child relationship patterns coexist. The discriminator is `Thread.parent_relationship` (free-string column on the threads table).

--- a/tests/unit/test_dashboard_threads.py
+++ b/tests/unit/test_dashboard_threads.py
@@ -331,3 +331,52 @@ def _make_child_under(parent, fsm_state="awaiting_confirmation"):
 # tests for those new endpoints live in the per-feature test
 # modules under ``tests/unit/threads/`` (group ops) and
 # ``tests/unit/pipelines/`` (pipeline-level integration).
+
+
+# ---------------------------------------------------------------------------
+# /api/threads/<id>/action_options
+# ---------------------------------------------------------------------------
+
+
+class TestActionOptionsEndpoint:
+    """The per-thread action library endpoint backs the inner-thread
+    action switcher (a child opened directly has no group grid to
+    populate the switcher's options)."""
+
+    def test_returns_source_library_for_journal_thread(self, client):
+        t = _make_thread(source="journal_backlog", description="meditation")
+        resp = client.get(f"/api/threads/{t.thread_id}/action_options")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        opts = data["action_options"]
+        by_name = {o["capability_name"]: o for o in opts}
+        assert "journal_route_to_tasks" in by_name
+        assert by_name["journal_route_to_tasks"]["cardinality"] == "per_group"
+
+    def test_unknown_source_returns_universal_actions(self, client):
+        t = _make_thread(source="unknown_source")
+        resp = client.get(f"/api/threads/{t.thread_id}/action_options")
+        assert resp.status_code == 200
+        names = {o["capability_name"] for o in resp.get_json()["action_options"]}
+        # Universal thread actions are always present, even with no
+        # registered source pipeline.
+        assert "thread_dismiss" in names
+
+    def test_resolves_from_child_own_inciting_summary(self, client):
+        """A group child carries its own ``source_pipeline``, so it
+        resolves to the real library without a parent lookup."""
+        from work_buddy.threads.enums import FSMState
+        child = Thread(
+            fsm_state=FSMState.AWAITING_CONFIRMATION,
+            parent_relationship="decompose",
+            inciting_event_summary={"source_pipeline": "journal_backlog"},
+        )
+        store.insert_thread(child)
+        resp = client.get(f"/api/threads/{child.thread_id}/action_options")
+        assert resp.status_code == 200
+        names = {o["capability_name"] for o in resp.get_json()["action_options"]}
+        assert "journal_route_to_tasks" in names
+
+    def test_missing_thread_404(self, client):
+        resp = client.get("/api/threads/th-does-not-exist/action_options")
+        assert resp.status_code == 404

--- a/tests/unit/threads/test_execution_runner.py
+++ b/tests/unit/threads/test_execution_runner.py
@@ -1,0 +1,123 @@
+"""Unit tests for ``execution_runner`` runtime parameter binding.
+
+The binding that fills in ``thread_id`` for thread-scoped actions is what
+keeps journal/email route actions from failing with "missing 1 required
+positional argument: 'thread_id'". It is driven by the declared parameter
+schema plus the ``is_action`` gate, so the binding logic is exercised here
+with fake registry entries, and a declaration-level guard confirms the real
+journal/email action declarations actually carry the schema the binding
+keys on (otherwise the fix would silently do nothing).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from work_buddy.threads import execution_runner, models
+
+
+def _entry(*, is_action: bool, params: dict):
+    """Minimal stand-in for a registry ``Capability`` entry — only the
+    attributes ``_bind_runtime_parameters`` reads."""
+    return SimpleNamespace(is_action=is_action, parameters=params)
+
+
+class TestBindRuntimeThreadId:
+    def test_binds_thread_id_for_action_declaring_it(self):
+        t = models.Thread()
+        entry = _entry(
+            is_action=True,
+            params={"thread_id": {"type": "str", "required": True}},
+        )
+        out = execution_runner._bind_runtime_parameters(
+            capability_name="journal_route_to_tasks",
+            thread=t, provided={}, entry=entry,
+        )
+        assert out["thread_id"] == t.thread_id
+
+    def test_does_not_overwrite_provided_thread_id(self):
+        t = models.Thread()
+        entry = _entry(is_action=True, params={"thread_id": {}})
+        out = execution_runner._bind_runtime_parameters(
+            capability_name="journal_route_to_tasks",
+            thread=t, provided={"thread_id": "explicit"}, entry=entry,
+        )
+        assert out["thread_id"] == "explicit"
+
+    def test_skips_when_thread_id_not_declared(self):
+        # chrome_tab_* actions declare tab_ids, not thread_id — the
+        # binding must not invent a thread_id for them.
+        t = models.Thread()
+        entry = _entry(is_action=True, params={"tab_ids": {}})
+        out = execution_runner._bind_runtime_parameters(
+            capability_name="chrome_tab_close",
+            thread=t, provided={}, entry=entry,
+        )
+        assert "thread_id" not in out
+
+    def test_skips_for_non_action_capability(self):
+        # Messaging tools declare a non-FSM thread_id but are never
+        # dispatched as actions — the is_action gate must exclude them.
+        t = models.Thread()
+        entry = _entry(is_action=False, params={"thread_id": {}})
+        out = execution_runner._bind_runtime_parameters(
+            capability_name="send_message",
+            thread=t, provided={}, entry=entry,
+        )
+        assert "thread_id" not in out
+
+    def test_skips_when_entry_unresolved(self):
+        t = models.Thread()
+        out = execution_runner._bind_runtime_parameters(
+            capability_name="journal_route_to_tasks",
+            thread=t, provided={}, entry=None,
+        )
+        assert "thread_id" not in out
+
+
+class TestRealDeclarationsCarryThreadId:
+    """Production-side guard: the actions that broke must actually
+    declare ``thread_id`` and be ``is_action`` in the live store, or the
+    schema-driven binding never fires for them.
+    """
+
+    def test_thread_scoped_actions_declare_thread_id(self):
+        from work_buddy.knowledge.capability_loader import (
+            load_declared_capabilities,
+        )
+        from work_buddy.knowledge.store import load_store
+        from work_buddy.mcp_server import op_registry
+
+        op_registry.clear_ops()
+        op_registry.load_builtin_ops()
+        caps, _issues = load_declared_capabilities(load_store())
+        by_name = {c.name: c for c in caps}
+
+        # Journal route actions load without optional deps — assert hard.
+        for name in (
+            "journal_route_to_tasks",
+            "journal_route_to_considerations",
+            "journal_append_to_note",
+        ):
+            cap = by_name.get(name)
+            assert cap is not None, f"{name} declaration not loaded"
+            assert cap.is_action, f"{name} must be is_action"
+            assert "thread_id" in cap.parameters, (
+                f"{name} must declare thread_id for the binding to fire"
+            )
+
+        # Email thread actions carry the identical shape, but their op
+        # module may not load in every environment — assert only when
+        # present so the test isn't environment-flaky.
+        for name in (
+            "email_create_tasks",
+            "email_close",
+            "email_create_umbrella_task",
+        ):
+            cap = by_name.get(name)
+            if cap is None:
+                continue
+            assert cap.is_action, f"{name} must be is_action"
+            assert "thread_id" in cap.parameters, (
+                f"{name} must declare thread_id for the binding to fire"
+            )

--- a/work_buddy/dashboard/frontend/scripts/tabs/threads/actions.py
+++ b/work_buddy/dashboard/frontend/scripts/tabs/threads/actions.py
@@ -149,19 +149,54 @@ def script() -> str:
         return html;
     }
 
+    // Lazy-fetch a thread's own action library when the group cache
+    // wasn't populated (the user opened a child directly rather than via
+    // the umbrella's group grid). Stores the result under the parent id
+    // — the key ``_renderActionSwitcher`` reads — then rerenders.
+    // Guarded so each umbrella is fetched at most once in flight; an
+    // empty/error result is cached as [] so we don't refetch in a loop.
+    function _lazyFetchActionOptions(threadId, parentId) {
+        const st = window._groupState;
+        if (!st._actionOptionsFetching) st._actionOptionsFetching = {};
+        if (st._actionOptionsFetching[parentId]) return;
+        st._actionOptionsFetching[parentId] = true;
+        fetch('/api/threads/' + encodeURIComponent(threadId)
+              + '/action_options')
+            .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+            .then(data => {
+                st.actionOptionsByUmbrella[parentId] =
+                    Array.isArray(data.action_options)
+                        ? data.action_options : [];
+            })
+            .catch(err => {
+                console.warn(
+                    '[action-switcher] options fetch failed:', err);
+                st.actionOptionsByUmbrella[parentId] = [];
+            })
+            .then(() => {
+                delete st._actionOptionsFetching[parentId];
+                if (typeof window._renderActiveThread === "function") {
+                    window._renderActiveThread();
+                }
+            });
+    }
+
     function _renderActionSwitcher(thread, action) {
-        // The action-switcher dropdown reuses the umbrella's
-        // ``action_options`` (cached in ``window._groupState``).
-        // Available only when the thread is a group child whose
-        // umbrella has been visited in this session — otherwise we
-        // skip the switcher rather than make a synchronous fetch
-        // from inside an HTML-string renderer.
+        // The action-switcher dropdown reuses the per-source
+        // ``action_options`` (cached in ``window._groupState``, keyed by
+        // the umbrella/parent id). When the cache is unpopulated — the
+        // user opened this child directly, so the umbrella's group grid
+        // never ran — lazy-fetch the thread's own library and rerender.
         const parentId = thread.parent_id;
         if (!parentId
             || !window._groupState
             || !window._groupState.actionOptionsByUmbrella) return '';
         const options = window._groupState.actionOptionsByUmbrella[parentId];
-        if (!Array.isArray(options) || options.length === 0) return '';
+        if (!Array.isArray(options)) {
+            _lazyFetchActionOptions(thread.thread_id, parentId);
+            return '';
+        }
+        if (options.length === 0) return '';
         const perGroup = options.filter(
             d => d.cardinality === "per_group",
         );

--- a/work_buddy/dashboard/service.py
+++ b/work_buddy/dashboard/service.py
@@ -3885,7 +3885,7 @@ def api_thread_groups(umbrella_id: str):
                 continue
             groups_out.append(rendered)
 
-        action_options, source_name = _resolve_action_library_for_umbrella(
+        action_options, source_name = _resolve_action_library_for_thread(
             umbrella,
         )
 
@@ -3902,16 +3902,19 @@ def api_thread_groups(umbrella_id: str):
         return jsonify({"groups": [], "error": str(exc)}), 500
 
 
-def _resolve_action_library_for_umbrella(umbrella) -> tuple[list[dict], str | None]:
-    """Resolve the umbrella's source name and merge per-source +
-    universal actions into a single ordered descriptor list for the
-    frontend.
+def _resolve_action_library_for_thread(thread) -> tuple[list[dict], str | None]:
+    """Resolve a thread's source name and merge per-source + universal
+    actions into a single ordered descriptor list for the frontend.
+
+    Works on any thread, not just group umbrellas: group children carry
+    their own ``source_pipeline`` in ``inciting_event_summary``, so a
+    child resolves to its real pipeline library directly.
 
     Returns ``(descriptor_list, source_name)``. Empty list if the
-    umbrella's source isn't registered or pipelines/universal-actions
+    thread's source isn't registered or pipelines/universal-actions
     fail to import (defensive).
     """
-    inciting = umbrella.inciting_event_summary or {}
+    inciting = thread.inciting_event_summary or {}
     source_name = (
         inciting.get("source_pipeline")
         or inciting.get("source")
@@ -3923,27 +3926,60 @@ def _resolve_action_library_for_umbrella(umbrella) -> tuple[list[dict], str | No
         )
     except Exception as e:
         logger.warning(
-            "groups endpoint: pipeline imports failed: %s", e,
+            "action library: pipeline imports failed: %s", e,
         )
         return [], source_name
 
     factory = PIPELINES.get(source_name)
     if factory is None:
         # Unknown source — surface universal actions only so the chip
-        # still works for legacy umbrellas.
+        # still works for threads without a registered pipeline.
         return UNIVERSAL_ACTION_LIBRARY.to_list(), source_name
 
     try:
         pipeline_lib = factory().action_library
     except Exception as e:
         logger.warning(
-            "groups endpoint: %s.action_library failed: %s",
+            "action library: %s.action_library failed: %s",
             source_name, e,
         )
         return UNIVERSAL_ACTION_LIBRARY.to_list(), source_name
 
     merged = UNIVERSAL_ACTION_LIBRARY.merged_with(pipeline_lib)
     return merged.to_list(), source_name
+
+
+@app.get("/api/threads/<thread_id>/action_options")
+def api_thread_action_options(thread_id: str):
+    """Return the action library (per-source + universal) for a single
+    thread, regardless of whether it is a group umbrella.
+
+    The ``/groups`` endpoint only serves group umbrellas, so a child
+    thread opened directly has no way to populate the action-switcher
+    options. This endpoint resolves the library for any thread from its
+    own ``inciting_event_summary`` source, letting the inner thread
+    pane fill the switcher without fetching the parent's group grid.
+
+    Returns ``{"thread_id", "source", "action_options"}``. Pure read.
+    """
+    try:
+        from work_buddy.threads import store
+        thread = store.get_thread(thread_id)
+        if thread is None:
+            return jsonify({"error": "thread not found"}), 404
+        action_options, source_name = _resolve_action_library_for_thread(
+            thread,
+        )
+        return jsonify({
+            "thread_id": thread_id,
+            "source": source_name,
+            "action_options": action_options,
+        })
+    except Exception as exc:
+        logger.exception(
+            "thread action_options failed for %s: %s", thread_id, exc,
+        )
+        return jsonify({"action_options": [], "error": str(exc)}), 500
 
 
 # ---------------------------------------------------------------------------

--- a/work_buddy/threads/execution_runner.py
+++ b/work_buddy/threads/execution_runner.py
@@ -70,6 +70,11 @@ def execution_state_entry_handler(transition_result) -> None:
     capability_name = proposal.get("name") or ""
     raw_parameters = dict(proposal.get("parameters") or {})
 
+    # Resolve the registry entry once and thread it through both the
+    # parameter binder (which reads the declared param schema) and the
+    # dispatcher (which calls the entry's callable).
+    entry = _get_capability_entry(capability_name)
+
     # Bind dynamic parameters that depend on the thread's runtime
     # state (e.g. tab_ids pulled from context_items for chrome_tab_*
     # actions). Static parameters set on the proposal at refine-time
@@ -78,6 +83,7 @@ def execution_state_entry_handler(transition_result) -> None:
         capability_name=capability_name,
         thread=thread,
         provided=raw_parameters,
+        entry=entry,
     )
 
     # Audit start.
@@ -98,7 +104,7 @@ def execution_state_entry_handler(transition_result) -> None:
 
     # Dispatch.
     success, result, error = _invoke_capability(
-        capability_name=capability_name, parameters=bound,
+        capability_name=capability_name, parameters=bound, entry=entry,
     )
 
     # Audit finish (always — both success + failure paths).
@@ -169,12 +175,14 @@ def _bind_runtime_parameters(
     capability_name: str,
     thread,
     provided: dict[str, Any],
+    entry=None,
 ) -> dict[str, Any]:
     """Fill in capability parameters that depend on thread runtime
     state. Static params from the proposal win.
 
-    Currently covers the Chrome-action capabilities (which all need
-    ``tab_ids`` extracted from the Thread's context items). Other
+    Covers the Chrome-action capabilities (which need ``tab_ids``
+    extracted from the Thread's context items) and any action whose
+    callable takes the host thread as a ``thread_id`` argument. Other
     capabilities pass through unchanged.
     """
     out = dict(provided)
@@ -185,19 +193,26 @@ def _bind_runtime_parameters(
         if "tab_ids" not in out:
             out["tab_ids"] = _collect_tab_ids(thread)
 
-    # Capabilities whose first argument is the thread the action is
-    # being run against. Includes the chrome route_* helpers and the
-    # universal thread_* actions surfaced via the column-header chip
-    # (thread_dismiss / thread_defer / thread_rename). Without this,
-    # picking a universal action via the chip and approving lands in
-    # AWAITING_REDIRECT with "missing thread_id" — exactly the error
-    # surfaced via the Telegram "Redirect needed" notification.
-    if capability_name in (
-        "chrome_route_to_tasks", "chrome_route_to_umbrella_task",
-        "thread_dismiss", "thread_defer", "thread_rename",
+    # Actions whose first argument is the thread they run against — the
+    # chrome route_* helpers, the universal thread_* actions, the
+    # per-source journal_*/email_* thread actions. Without this, picking
+    # such an action and approving lands in AWAITING_REDIRECT with
+    # "missing thread_id" — exactly the error surfaced via the Telegram
+    # "Redirect needed" notification.
+    #
+    # The binding is driven by the declared parameter schema, not a
+    # hardcoded capability list: the op callable is a ``**kwargs``
+    # wrapper whose signature can't be introspected, but the declaration
+    # names ``thread_id`` for exactly the actions that need it. The
+    # ``is_action`` gate excludes non-action capabilities (e.g. the
+    # messaging tools) that declare an unrelated ``thread_id``.
+    if (
+        entry is not None
+        and getattr(entry, "is_action", False)
+        and "thread_id" in (getattr(entry, "parameters", None) or {})
+        and "thread_id" not in out
     ):
-        if "thread_id" not in out:
-            out["thread_id"] = thread.thread_id
+        out["thread_id"] = thread.thread_id
 
     return out
 
@@ -218,22 +233,38 @@ def _collect_tab_ids(thread) -> list[int]:
     return out
 
 
+def _get_capability_entry(capability_name: str):
+    """Resolve a capability's registry entry, or ``None`` if the
+    registry can't be imported or the name isn't registered.
+
+    Used to look up the entry once per execution so both the parameter
+    binder (reads the declared schema) and the dispatcher (calls the
+    callable) share it.
+    """
+    try:
+        from work_buddy.mcp_server.registry import get_registry
+    except Exception:
+        logger.exception("execution_runner: registry import failed")
+        return None
+    return get_registry().get(capability_name)
+
+
 def _invoke_capability(
-    *, capability_name: str, parameters: dict[str, Any],
+    *, capability_name: str, parameters: dict[str, Any], entry=None,
 ) -> tuple[bool, Any, str | None]:
     """Look up the capability in the MCP registry and call it.
 
     Returns ``(success, result, error_msg)``. The capability's
     callable is called with ``**parameters``; any exception is caught
-    and surfaced as a failure.
+    and surfaced as a failure. ``entry`` may be passed pre-resolved to
+    avoid a second registry lookup; when omitted it is resolved here.
     """
-    try:
-        from work_buddy.mcp_server.registry import get_registry
-    except Exception as e:
-        return (False, None, f"registry import failed: {e}")
-
-    registry = get_registry()
-    entry = registry.get(capability_name)
+    if entry is None:
+        try:
+            from work_buddy.mcp_server.registry import get_registry
+        except Exception as e:
+            return (False, None, f"registry import failed: {e}")
+        entry = get_registry().get(capability_name)
     if entry is None:
         return (
             False, None,


### PR DESCRIPTION
## Summary

Two independent bugs in the journal/group thread surface:

- **Execution.** Approving a journal route action (`journal_route_to_tasks`, etc.) failed with `parameter mismatch: ... missing 1 required positional argument: 'thread_id'`. The execution runner bound `thread_id` only for a hardcoded capability allowlist that omitted the journal actions (and, latently, all four `email_*` thread actions). Replaced the allowlist with a schema-driven bind: inject `thread_id` for any capability whose **declaration** names a `thread_id` parameter, gated on `is_action`. The op callable is a `**kwargs` wrapper, so the declared schema is the authoritative source. Future thread-scoped actions need no execution-runner edit, and the latent email bug is fixed in the same move.
- **UI.** Opening a group child thread directly and clicking "Edit action" showed no options: the switcher reads `action_options` cached only by the group grid (group umbrellas only). Added `GET /api/threads/<id>/action_options`, backed by `_resolve_action_library_for_thread` (renamed from `_resolve_action_library_for_umbrella`; resolves from a thread's own inciting source, no group gate). The child pane lazy-fetches it and populates the cache under the parent id.

Docs: added `dev_notes` to `threads/fsm` (schema-driven binding) and `threads/grouping` (inner-thread switcher).

## Known follow-up (out of scope)

`journal_append_to_note` and `email_record_into_task` still need a param-capture renderer for their required `note_path` / `target_task_id`. The `thread_id` fix is necessary but not sufficient for those two; the `route_*` actions are fully fixed.

## Test plan

- [x] `pytest tests/unit/threads/test_execution_runner.py tests/unit/test_dashboard_threads.py` (23 passed)
- [x] Live: schema-driven bind injects `thread_id` and dispatch clears the argument error (verified on a throwaway thread)
- [x] Live: `/api/threads/<id>/action_options` returns all 7 options for the real stuck thread; 404 for missing
- [ ] After deploy: approve "Route to tasks" on a journal child and confirm tasks are created
- [ ] After deploy: drill into a child thread, "Edit action", confirm the switcher lists options

🤖 Generated with [Claude Code](https://claude.com/claude-code)