### PR TITLE
refactor(runtime): decouple child-process spawning from conda (uv groundwork)

### DIFF
--- a/knowledge/store/operations/agent-sessions.md
+++ b/knowledge/store/operations/agent-sessions.md
@@ -19,7 +19,7 @@ aliases:
 parents:
 - operations
 - operations
-dev_notes: Use work_buddy.compat.conda_activate_command(repo_root, module) for OS-portable Python execution. Never hardcode 'powershell.exe' in knowledge content or code — it breaks on macOS/Linux. The compat function handles Windows (PowerShell) and Unix (bash + conda hook) automatically. See work_buddy/compat.py lines 151-170. The hardcoded powershell.exe command in this unit's own content is a known Windows-only shortcut for the user — agent-facing code and docs should use compat instead.
+dev_notes: To spawn a work-buddy Python module OS-portably, resolve the interpreter with work_buddy.compat.resolve_child_python() (honors the sidecar.python_executable pin, else sys.executable) and run [python, '-u', '-m', module] with compat.build_child_env() and compat.detached_process_kwargs(). Never hardcode 'powershell.exe' or 'conda activate' in knowledge content or code; it breaks off-conda and on macOS/Linux. The hardcoded powershell.exe command in this unit's own content is a known Windows-only shortcut for the user; agent-facing code and docs should use the compat helpers instead.
 ---
 
 WORK_BUDDY_SESSION_ID is set automatically by a SessionStart hook (.claude/hooks/session-init.sh). On Claude Code Desktop, the hook outputs it as context.

--- a/knowledge/store/services/sidecar.md
+++ b/knowledge/store/services/sidecar.md
@@ -66,29 +66,29 @@ dev_notes: |-
 
   ### Defense 2 — children spawn under a pinned interpreter
 
-  `work_buddy/sidecar/daemon.py:_resolve_child_python(cfg)` is the single chokepoint for which Python children get spawned with: `cfg['sidecar']['python_executable']` if set and existing, else `sys.executable`.
+  `work_buddy/compat.py:resolve_child_python(cfg)` is the single chokepoint for which Python children get spawned with: `cfg['sidecar']['python_executable']` if set and existing, else `sys.executable`. Shared by the sidecar daemon and the messaging client's auto-start.
 
-  **Why a config pin and not a startup guard**: `sys.executable` is locked in by the launch context (scheduled task, shell activation, etc.) — the daemon can't change it once it's running. What the daemon *can* control is which interpreter its children inherit. Moving the pin from "how the daemon launched" to "what the daemon spawns" puts it inside our authority. A daemon accidentally booted on the wrong interpreter (e.g. a Windows scheduled task whose `conda activate` no-op'd in headless context) still spawns children on the right one.
+  **Why a config pin and not a startup guard**: `sys.executable` is locked in by the launch context (scheduled task, shell activation, etc.) — the daemon can't change it once it's running. What the daemon *can* control is which interpreter its children inherit. Moving the pin from "how the daemon launched" to "what the daemon spawns" puts it inside our authority. A parent accidentally launched on the wrong interpreter (e.g. a Windows login task started on the base env in a headless context) still spawns children on the right one.
 
   Mismatch between pin and `sys.executable` logs a WARNING; missing pinned file logs an ERROR and falls back. **Warn-only, not refuse-to-start** — hard-stop would brick boot for users who haven't opted in. Easy to escalate to `raise` if you want fail-closed.
 
-  Do not bypass `_resolve_child_python` by reading `sys.executable` directly in `_start_child`. The config pin is the user's only knob for fixing a misconfigured launch context; bypassing it silently invalidates the knob.
+  Do not bypass `resolve_child_python` by reading `sys.executable` directly in `_start_child`. The config pin is the user's only knob for fixing a misconfigured launch context; bypassing it silently invalidates the knob.
 
   ## Child-process encoding: PYTHONUTF8 chokepoint
 
   A third spawn-time invariant, sibling to the interpreter pin in Defense 2 above. The class of bug is `UnicodeEncodeError` from `logging.StreamHandler` — children on Windows wrap their `sys.stdout`/`sys.stderr` in a `TextIOWrapper(encoding="cp1252")` at interpreter init, and any non-Latin-1 codepoint reaching a log line raises. Python's logging module catches the exception and falls back to a `--- Logging error ---` stack trace, so the function completes but the log file fills with noise. The bug recurs anywhere a `logger.*` call interpolates non-ASCII data — vault content, task descriptions, log glyphs (`→`, `—`, `×`).
 
-  `work_buddy/sidecar/daemon.py:_build_child_env()` is the chokepoint that fixes this by setting `PYTHONUTF8=1` in the child's env before `Popen`, flipping the child interpreter into UTF-8 mode (every stream — std, subprocess pipes, file ops — encodes via UTF-8). Lives adjacent to `_resolve_child_python` so the two spawn invariants are obviously paired.
+  `work_buddy/compat.py:build_child_env()` is the chokepoint that fixes this by setting `PYTHONUTF8=1` in the child's env before `Popen`, flipping the child interpreter into UTF-8 mode (every stream — std, subprocess pipes, file ops — encodes via UTF-8). Lives adjacent to `resolve_child_python` so the two spawn invariants are obviously paired.
 
   **`setdefault` semantics.** An explicit user override (`PYTHONUTF8=0` to debug a bytes-vs-str regression) is preserved. The helper adds, it doesn't clobber.
 
-  **Returns a copy, not `os.environ`.** Mutating `os.environ` would leak `PYTHONUTF8` into the parent and into any subprocess spawn that bypasses `_build_child_env`. Test `test_build_child_env_does_not_mutate_os_environ` in `tests/unit/test_sidecar_child_env.py` enforces this.
+  **Returns a copy, not `os.environ`.** Mutating `os.environ` would leak `PYTHONUTF8` into the parent and into any subprocess spawn that bypasses `build_child_env`. Test `test_build_child_env_does_not_mutate_os_environ` in `tests/unit/test_sidecar_child_env.py` enforces this.
 
   **Forward-compat with PEP 686.** Python 3.15 makes UTF-8 mode the default on all platforms; once we upgrade, the env injection becomes a no-op (the runtime is already in UTF-8 mode regardless of the env var). Don't rip the helper out at upgrade time — it remains the user-override knob for `PYTHONUTF8=0`.
 
   **Layer 2 fallback in `work_buddy/logging_config.py:setup_logging()`.** Layer 1 (the env injection) only covers sidecar-spawned children. Standalone launches (`python -m work_buddy.<service>` directly, tests, dev one-offs) bypass the sidecar path. As a fallback, `setup_logging()` calls `sys.stdout.reconfigure(encoding="utf-8", errors="backslashreplace")` (and same for stderr) at first invocation. `errors="backslashreplace"` is the never-crash policy: any unencodable codepoint becomes `→` text instead of raising. Class-level regression sentinel: `tests/unit/test_logging_config.py::test_log_with_non_ascii_under_cp1252_does_not_crash` installs a cp1252 stream and proves the bug class is dead.
 
-  Do not bypass `_build_child_env` by passing `env=os.environ.copy()` directly in the `Popen` call. Same rule as `_resolve_child_python`: the chokepoint is the single knob; bypassing it silently invalidates future env additions.
+  Do not bypass `build_child_env` by passing `env=os.environ.copy()` directly in the `Popen` call. Same rule as `resolve_child_python`: the chokepoint is the single knob; bypassing it silently invalidates future env additions.
 
   ## Scheduler jitter: pending-fire layer
 

--- a/tests/unit/test_sidecar_child_env.py
+++ b/tests/unit/test_sidecar_child_env.py
@@ -1,39 +1,38 @@
-"""Tests for the sidecar's child-spawn env injection.
+"""Tests for the child-spawn env injection shared by work-buddy's launchers.
 
-_build_child_env() must emit PYTHONUTF8=1 so every spawned service
+``compat.build_child_env()`` must emit PYTHONUTF8=1 so every spawned service
 starts in UTF-8 mode and cannot crash on non-ASCII log output.
 """
 
 import os
 
-from work_buddy.sidecar import daemon
+from work_buddy import compat
 
 
 def test_build_child_env_sets_pythonutf8(monkeypatch):
     monkeypatch.delenv("PYTHONUTF8", raising=False)
-    env = daemon._build_child_env()
+    env = compat.build_child_env()
     assert env["PYTHONUTF8"] == "1"
 
 
 def test_build_child_env_preserves_user_override(monkeypatch):
-    """If the user explicitly set PYTHONUTF8=0 (e.g. debugging a
-    bytes-vs-str regression), don't clobber it."""
+    """If the user explicitly set PYTHONUTF8=0 (e.g. debugging a bytes-vs-str
+    regression), don't clobber it."""
     monkeypatch.setenv("PYTHONUTF8", "0")
-    env = daemon._build_child_env()
+    env = compat.build_child_env()
     assert env["PYTHONUTF8"] == "0"
 
 
 def test_build_child_env_does_not_mutate_os_environ(monkeypatch):
-    """Returning a copy is load-bearing - mutating os.environ would
-    leak PYTHONUTF8 into the parent and any subprocess that bypasses
-    this helper."""
+    """Returning a copy is load-bearing: mutating os.environ would leak
+    PYTHONUTF8 into the parent and any subprocess that bypasses this helper."""
     monkeypatch.delenv("PYTHONUTF8", raising=False)
     snapshot = dict(os.environ)
-    _ = daemon._build_child_env()
+    _ = compat.build_child_env()
     assert dict(os.environ) == snapshot
 
 
 def test_build_child_env_inherits_parent_env(monkeypatch):
     monkeypatch.setenv("WB_TEST_MARKER", "present")
-    env = daemon._build_child_env()
+    env = compat.build_child_env()
     assert env.get("WB_TEST_MARKER") == "present"

--- a/tests/unit/test_sidecar_resolve_child_python.py
+++ b/tests/unit/test_sidecar_resolve_child_python.py
@@ -1,9 +1,9 @@
-"""Tests for ``daemon._resolve_child_python``.
+"""Tests for ``compat.resolve_child_python``.
 
-Children spawned by the sidecar inherit the daemon's interpreter
-unless ``sidecar.python_executable`` is set. The pin matters most on
-Windows scheduled tasks where ``conda activate`` can silently no-op,
-leaving the daemon (and therefore every child) on the base interpreter.
+Children spawned by work-buddy inherit the parent's interpreter unless
+``sidecar.python_executable`` is set. The pin matters most when the parent is
+launched on the wrong interpreter (e.g. a login task started on the base env),
+which would otherwise leave the parent and every child on it.
 """
 
 from __future__ import annotations
@@ -11,64 +11,58 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
-from work_buddy.sidecar import daemon
+from work_buddy import compat
 
 
 def test_resolve_returns_sys_executable_when_unset():
-    """No config field set → fall back to the daemon's own interpreter."""
-    assert daemon._resolve_child_python(cfg={}) == sys.executable
-    assert daemon._resolve_child_python(cfg={"sidecar": {}}) == sys.executable
+    """No config field set: fall back to the current interpreter."""
+    assert compat.resolve_child_python(cfg={}) == sys.executable
+    assert compat.resolve_child_python(cfg={"sidecar": {}}) == sys.executable
 
 
 def test_resolve_uses_pinned_path_when_set_and_exists(tmp_path):
-    """Config pin points at a real file → use it."""
+    """Config pin points at a real file: use it."""
     fake_python = tmp_path / "python.exe"
     fake_python.write_bytes(b"")  # exists
     cfg = {"sidecar": {"python_executable": str(fake_python)}}
-    assert daemon._resolve_child_python(cfg=cfg) == str(fake_python)
+    assert compat.resolve_child_python(cfg=cfg) == str(fake_python)
 
 
 def test_resolve_falls_back_when_pinned_path_missing(tmp_path, caplog):
-    """Pinned path doesn't exist → fall back to sys.executable AND log
-    an error so the misconfiguration is visible. The previous silent
-    inheritance of sys.executable was the failure mode that let a
-    base-env scheduled task spawn base-env children for weeks."""
+    """Pinned path doesn't exist: fall back to sys.executable AND log an error
+    so the misconfiguration is visible. Silent inheritance of sys.executable was
+    the failure mode that let a base-env launch spawn base-env children."""
     bogus = tmp_path / "does-not-exist" / "python.exe"
     cfg = {"sidecar": {"python_executable": str(bogus)}}
     with caplog.at_level("ERROR"):
-        result = daemon._resolve_child_python(cfg=cfg)
+        result = compat.resolve_child_python(cfg=cfg)
     assert result == sys.executable
     messages = [rec.getMessage() for rec in caplog.records]
-    # The logger uses %r which escapes backslashes on Windows, so we
-    # compare against a unique fragment of the path rather than the
-    # whole stringified Path.
+    # The logger uses %r which escapes backslashes on Windows, so compare
+    # against a unique fragment of the path rather than the whole Path.
     assert any(
         "does not exist" in m and "does-not-exist" in m for m in messages
     ), f"must log an error naming the bogus path; got: {messages}"
 
 
 def test_resolve_warns_when_pinned_differs_from_sys_executable(tmp_path, caplog):
-    """Pinned path is valid but != sys.executable → log a warning. This
-    is intentional in some setups, but unintentional cases (daemon
-    booted on base, config pins work-buddy env) need the diagnostic."""
+    """Pinned path is valid but != sys.executable: log a warning. Intentional in
+    some setups, but unintentional cases (parent on base, config pins the
+    work-buddy env) need the diagnostic."""
     fake_python = tmp_path / "different_python.exe"
     fake_python.write_bytes(b"")
     cfg = {"sidecar": {"python_executable": str(fake_python)}}
     with caplog.at_level("WARNING"):
-        result = daemon._resolve_child_python(cfg=cfg)
+        result = compat.resolve_child_python(cfg=cfg)
     assert result == str(fake_python)
     messages = [rec.getMessage() for rec in caplog.records]
     assert any(
         "differs from sys.executable" in m for m in messages
-    ), f"must surface the daemon-vs-children interpreter mismatch; got: {messages}"
+    ), f"must surface the parent-vs-children interpreter mismatch; got: {messages}"
 
 
 def test_resolve_silent_when_pinned_matches_sys_executable():
-    """Pin matches the daemon's interpreter → no warning, return
-    sys.executable. Common case: user pinned and is running cleanly."""
+    """Pin matches the current interpreter: no warning, return sys.executable."""
     cfg = {"sidecar": {"python_executable": sys.executable}}
-    # Should resolve without error.
-    result = daemon._resolve_child_python(cfg=cfg)
+    result = compat.resolve_child_python(cfg=cfg)
     assert Path(result).resolve() == Path(sys.executable).resolve()

--- a/work_buddy/compat.py
+++ b/work_buddy/compat.py
@@ -11,9 +11,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+from work_buddy.logging_config import get_logger
+
 IS_WINDOWS = sys.platform == "win32"
 IS_MACOS = sys.platform == "darwin"
 IS_LINUX = sys.platform.startswith("linux")
+
+logger = get_logger(__name__)
 
 
 def subprocess_creation_flags() -> int:
@@ -46,6 +50,69 @@ def detached_process_kwargs() -> dict:
     if IS_WINDOWS:
         return {"creationflags": subprocess.CREATE_NO_WINDOW}
     return {"start_new_session": True}
+
+
+def resolve_child_python(cfg: dict | None = None) -> str:
+    """Resolve the Python interpreter child processes should be spawned with.
+
+    Resolution order:
+    1. ``sidecar.python_executable`` from config, when set and pointing at an
+       existing file. This pins the interpreter independently of how the parent
+       was launched, so a parent accidentally started on the wrong interpreter
+       still spawns children on the right one.
+    2. ``sys.executable`` — the current process's own interpreter.
+
+    When (1) is set but the file is missing, fall back to ``sys.executable`` and
+    log an error so the misconfiguration is visible. When (1) and
+    ``sys.executable`` disagree, log a warning: a useful diagnostic, not a hard
+    failure, since the explicit pin is the user's intent.
+
+    Shared by the sidecar daemon (for its supervised children) and the messaging
+    client's auto-start path, so both honor the same interpreter pin.
+    """
+    if cfg is None:
+        from work_buddy.config import load_config
+
+        try:
+            cfg = load_config()
+        except Exception:
+            cfg = {}
+    pinned = (cfg.get("sidecar", {}) or {}).get("python_executable")
+    if not pinned:
+        return sys.executable
+    if not Path(pinned).is_file():
+        logger.error(
+            "sidecar.python_executable=%r does not exist; falling back to "
+            "sys.executable=%r. Children may spawn on the wrong interpreter.",
+            pinned, sys.executable,
+        )
+        return sys.executable
+    if Path(pinned).resolve() != Path(sys.executable).resolve():
+        logger.warning(
+            "sidecar.python_executable=%r differs from sys.executable=%r; the "
+            "parent and its children will run on different interpreters. This is "
+            "intentional only if you explicitly pinned an env different from the "
+            "parent's own.",
+            pinned, sys.executable,
+        )
+    return pinned
+
+
+def build_child_env() -> dict[str, str]:
+    """Build the environment dict for a subprocess spawned by work-buddy.
+
+    Sets ``PYTHONUTF8=1`` so child interpreters wrap stdout/stderr in UTF-8
+    ``TextIOWrapper``s. Without it, on Windows the child picks cp1252 (the system
+    ANSI code page) and ``logging.StreamHandler`` raises ``UnicodeEncodeError``
+    on any non-Latin-1 codepoint reaching a log line, a recurring bug class since
+    log messages routinely interpolate vault content and other user data.
+
+    ``setdefault`` preserves an explicit user override (e.g. ``PYTHONUTF8=0``).
+    Returns a fresh dict; never mutates ``os.environ``.
+    """
+    env = os.environ.copy()
+    env.setdefault("PYTHONUTF8", "1")
+    return env
 
 
 def kill_process_on_port(port: int, *, wait_seconds: float = 5.0) -> bool:
@@ -490,25 +557,3 @@ def chrome_native_messaging_dir() -> Path:
         return Path.home() / "Library" / "Application Support" / "Google" / "Chrome" / "NativeMessagingHosts"
     else:
         return Path.home() / ".config" / "google-chrome" / "NativeMessagingHosts"
-
-
-def conda_activate_command(repo_root: str, module: str) -> list[str]:
-    """Build a command to run a Python module in the work-buddy conda env.
-
-    On Windows: uses powershell.exe with conda activate.
-    On Unix: uses bash with conda activate (assumes conda init has been done).
-    """
-    if IS_WINDOWS:
-        return [
-            "powershell.exe", "-Command",
-            f"cd '{repo_root}'; conda activate work-buddy; "
-            f"python -m {module}",
-        ]
-    else:
-        return [
-            "bash", "-c",
-            f"cd '{repo_root}' && "
-            f"eval \"$(conda shell.bash hook 2>/dev/null)\" && "
-            f"conda activate work-buddy && "
-            f"python -m {module}",
-        ]

--- a/work_buddy/messaging/client.py
+++ b/work_buddy/messaging/client.py
@@ -35,12 +35,19 @@ def _ensure_service_running() -> bool:
     if is_service_running():
         return True
 
-    logger.info("Messaging service not running — auto-starting...")
+    logger.info("Messaging service not running, auto-starting...")
     try:
-        from work_buddy.compat import conda_activate_command, detached_process_kwargs
-        cmd = conda_activate_command(str(_REPO_ROOT), "work_buddy.messaging.service")
+        from work_buddy.compat import (
+            build_child_env,
+            detached_process_kwargs,
+            resolve_child_python,
+        )
+
+        cmd = [resolve_child_python(), "-u", "-m", "work_buddy.messaging.service"]
         subprocess.Popen(
             cmd,
+            cwd=str(_REPO_ROOT),
+            env=build_child_env(),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             **detached_process_kwargs(),

--- a/work_buddy/sidecar/daemon.py
+++ b/work_buddy/sidecar/daemon.py
@@ -24,7 +24,12 @@ from typing import Any
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
-from work_buddy.compat import assign_process_to_job, create_kill_on_close_job
+from work_buddy.compat import (
+    assign_process_to_job,
+    build_child_env,
+    create_kill_on_close_job,
+    resolve_child_python,
+)
 from work_buddy.config import load_config
 from work_buddy.logging_config import get_logger
 from work_buddy.sidecar.pid import (
@@ -264,71 +269,6 @@ def _kill_process_on_port(port: int, *, service_name: str = "") -> bool:
     return freed
 
 
-def _resolve_child_python(cfg: dict[str, Any] | None = None) -> str:
-    """Resolve the Python interpreter children should be spawned with.
-
-    Resolution order:
-    1. ``sidecar.python_executable`` from config, when set and pointing
-       at an existing file. This pins the env independently of how the
-       daemon itself was launched — so a daemon accidentally booted on
-       the wrong interpreter (e.g. a Windows scheduled task whose
-       ``conda activate`` no-op'd) still spawns children on the right one.
-    2. ``sys.executable`` — the daemon's own interpreter.
-
-    When (1) is set but the file is missing, we fall back to ``sys.executable``
-    and log an error so the misconfiguration is visible. When (1) and
-    ``sys.executable`` disagree (daemon and children would run different
-    Pythons), we log a warning — that's a useful diagnostic but not a
-    hard failure, since the explicit pin is the user's intent.
-    """
-    if cfg is None:
-        try:
-            cfg = load_config()
-        except Exception:
-            cfg = {}
-    pinned = (cfg.get("sidecar", {}) or {}).get("python_executable")
-    if not pinned:
-        return sys.executable
-    if not Path(pinned).is_file():
-        logger.error(
-            "sidecar.python_executable=%r does not exist; falling back to "
-            "sys.executable=%r. Children may spawn on the wrong interpreter.",
-            pinned, sys.executable,
-        )
-        return sys.executable
-    if Path(pinned).resolve() != Path(sys.executable).resolve():
-        logger.warning(
-            "sidecar.python_executable=%r differs from sys.executable=%r; "
-            "the daemon and its children will run on different interpreters. "
-            "This is intentional only if you explicitly pinned an env "
-            "different from the daemon's own.",
-            pinned, sys.executable,
-        )
-    return pinned
-
-
-def _build_child_env() -> dict[str, str]:
-    """Build the env dict children inherit when spawned by the sidecar.
-
-    Sets ``PYTHONUTF8=1`` so child interpreters wrap stdout/stderr in
-    UTF-8 ``TextIOWrapper``s. Without this, on Windows the child picks
-    cp1252 (the system ANSI code page) and ``logging.StreamHandler``
-    raises ``UnicodeEncodeError`` on any non-Latin-1 codepoint reaching
-    a log line — a recurring class of bug since log messages routinely
-    interpolate vault content, task descriptions, and other user data.
-
-    ``setdefault`` semantics: an explicit user override (e.g. setting
-    ``PYTHONUTF8=0`` to debug a bytes-vs-str regression) is preserved.
-
-    Returns a fresh dict — must not mutate ``os.environ`` itself, or
-    the override would leak into the parent and into any subprocess
-    spawn that bypasses this helper.
-    """
-    env = os.environ.copy()
-    env.setdefault("PYTHONUTF8", "1")
-    return env
-
-
 # ---------------------------------------------------------------------------
 # Startup banner
 # ---------------------------------------------------------------------------
@@ -504,7 +444,7 @@ def _start_child(svc: ChildService) -> None:
         )
         return
 
-    python = _resolve_child_python()
+    python = resolve_child_python()
     # ``-u`` forces unbuffered stdio so child output lands in the log
     # file immediately — critical for debugging slow/silent startups.
     cmd = [python, "-u", "-m", svc.module] + svc.args
@@ -551,7 +491,7 @@ def _start_child(svc: ChildService) -> None:
         svc.process = subprocess.Popen(
             cmd,
             cwd=str(_REPO_ROOT),
-            env=_build_child_env(),
+            env=build_child_env(),
             stdout=log_fh if log_fh else subprocess.DEVNULL,
             stderr=subprocess.STDOUT if log_fh else subprocess.DEVNULL,
             creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
@@ -881,7 +821,7 @@ def run(foreground: bool = True) -> None:
     # log catches is a Windows scheduled task whose ``conda activate``
     # silently no-op'd, leaving the daemon and all its children on the
     # base interpreter (and serving stale code) for days.
-    resolved_python = _resolve_child_python(cfg)
+    resolved_python = resolve_child_python(cfg)
     logger.info(
         "Children will spawn with: %s (daemon sys.executable=%s)",
         resolved_python, sys.executable,


### PR DESCRIPTION
First PR of the native-installer + uv-runtime series (plan approved 2026-07-01). This one is the runtime groundwork; it does not add the installer yet.

## Summary
- Move `resolve_child_python()` and `build_child_env()` from `sidecar/daemon.py` into `work_buddy/compat.py` (beside `detached_process_kwargs`), so the sidecar daemon and the messaging client share one interpreter-pin path.
- Rewrite the messaging client's auto-start (`_ensure_service_running`) to spawn `[resolve_child_python(), "-u", "-m", "work_buddy.messaging.service"]` directly instead of shelling through `conda activate work-buddy`.
- Delete `compat.conda_activate_command` (its only caller was that auto-start).
- Repoint the two moved-function tests and the `sidecar.md` / `agent-sessions.md` references.

Net: nothing in the spawn path assumes conda anymore, so a uv venv (or any interpreter) works. Behavior is unchanged for the current conda setup, since `resolve_child_python()` falls back to `sys.executable`.

## Test plan
- [x] `test_sidecar_resolve_child_python`, `test_sidecar_child_env`, `test_compat_detached_flags`, `test_compat_port_cleanup`, `test_wb_cli` (53 passed)
- [x] Imports clean; `conda_activate_command` gone; no other callers of the old names

## Note
Committed with a manual audit (transient-label + secret scan, DCO sign-off) rather than `/wb-dev-pr`, because the sidecar gateway was down when this landed. Re-run `/wb-dev-pr`'s audit if you want the richer doc-sync pass; the knowledge-unit references were updated by hand here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)