### PR TITLE
feat(packaging): native installer artifacts + release CI (Windows primary; Linux/macOS fast-follow)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 # breaks the `#!/bin/bash` shebang ("bad interpreter: /bin/bash^M"), so pin LF
 # regardless of a contributor's core.autocrlf setting or platform.
 *.sh text eol=lf
+# macOS installer launcher (packaging/macos/install.command) is bash too; a CRLF
+# shebang breaks it identically, and .command is not covered by *.sh.
+*.command text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version label for a manual test build (no tag needed)"
+      version_override:
+        description: "Optional version label for a manual test build (default: pyproject version)"
         required: false
-        default: "0.0.0-manual"
+        default: ""
 
 permissions:
   contents: write # create/upload the draft release
@@ -30,20 +30,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Resolve version
-        id: ver
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-          else
-            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Resolve and verify version
+        id: ver
+        shell: bash
+        run: |
+          # pyproject.toml is the single source of truth for the version.
+          PYPROJECT=$(python packaging/version.py)
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAG="${GITHUB_REF_NAME}"
+            if [ "$TAG" != "$PYPROJECT" ]; then
+              echo "::error::release tag ($TAG) does not match pyproject version ($PYPROJECT). Bump pyproject.toml and commit before tagging." >&2
+              exit 1
+            fi
+            echo "version=$TAG" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ github.event.inputs.version_override }}" ]; then
+            echo "version=${{ github.event.inputs.version_override }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$PYPROJECT" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Install uv (pinned to the bundled version)
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+name: Release
+
+# Builds the native installers on a version tag (e.g. 1.4.0) and attaches them to
+# a DRAFT GitHub Release for a human to review and publish. workflow_dispatch also
+# builds (no release) for manual verification.
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version label for a manual test build (no tag needed)"
+        required: false
+        default: "0.0.0-manual"
+
+permissions:
+  contents: write # create/upload the draft release
+
+env:
+  # Keep in sync with packaging/vendor_uv.py UV_VERSION so the bundled uv and the
+  # CI-resolved uv are the same build.
+  UV_VERSION: "0.11.26"
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: ver
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv (pinned to the bundled version)
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Build source-tree payload
+        run: python packaging/build_payload.py --out dist/payload
+
+      - name: Vendor uv into the payload
+        run: python packaging/vendor_uv.py --target windows --out dist/payload/vendor --version ${{ env.UV_VERSION }}
+
+      - name: Install Inno Setup
+        run: choco install innosetup --no-progress -y
+
+      - name: Compile installer
+        shell: pwsh
+        run: |
+          & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" /DAppVersion=${{ steps.ver.outputs.version }} packaging\windows\work-buddy.iss
+
+      - name: Upload installer as a workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: work-buddy-windows-setup
+          path: dist/work-buddy-*-setup.exe
+          if-no-files-found: error
+
+      - name: Attach to draft release
+        if: github.event_name == 'push'
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          name: work-buddy ${{ steps.ver.outputs.version }}
+          tag_name: ${{ github.ref_name }}
+          files: dist/work-buddy-*-setup.exe
+
+  # ---------------------------------------------------------------------------
+  # Phase E fast-follow (architecture ready; build scripts not yet written).
+  # Uncomment once packaging/macos/build_pkg.sh and packaging/linux/build_tarball.sh
+  # exist, and add their outputs to the draft-release `files:` globs.
+  #
+  # macos:
+  #   runs-on: macos-latest
+  #   timeout-minutes: 30
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: astral-sh/setup-uv@v5
+  #       with: { version: "${{ env.UV_VERSION }}" }
+  #     - run: python packaging/build_payload.py --out dist/payload
+  #     - run: python packaging/vendor_uv.py --target macos --out dist/payload/vendor --version ${{ env.UV_VERSION }}
+  #     - run: bash packaging/macos/build_pkg.sh
+  #
+  # linux:
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 30
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: astral-sh/setup-uv@v5
+  #       with: { version: "${{ env.UV_VERSION }}" }
+  #     - run: python packaging/build_payload.py --out dist/payload
+  #     - run: python packaging/vendor_uv.py --target linux --out dist/payload/vendor --version ${{ env.UV_VERSION }}
+  #     - run: bash packaging/linux/build_tarball.sh

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ A **sidecar supervisor** manages long-running services — starts them on demand
 
 ### Fastest path to first value
 
-1. Install and connect the MCP server
+1. Download and run the installer, then open the install folder in Claude Code
 2. Run `/wb-setup guided`
 3. Open the dashboard
 4. Try `/wb-morning` or `/wb-task-triage`
@@ -292,50 +292,29 @@ A **sidecar supervisor** manages long-running services — starts them on demand
 ### Prerequisites
 
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (CLI or Desktop)
-- Python 3.11 (via [Miniforge](https://github.com/conda-forge/miniforge) or similar)
 - [Obsidian](https://obsidian.md/) (recommended, not strictly required for core functionality)
+
+work-buddy bundles its own Python, so there is nothing else to install first. No system Python, conda, or package manager is required.
 
 ### Install
 
-```bash
-git clone https://github.com/KadenMc/work-buddy.git
-cd work-buddy
+Download the installer for your platform from the [latest release](https://github.com/KadenMc/work-buddy/releases/latest), then run it.
 
-conda create -n work-buddy python=3.11 -y
-conda activate work-buddy
+| Platform | Installer | How to run it |
+|----------|-----------|---------------|
+| Windows | `work-buddy-<version>-setup.exe` | Double-click and follow the prompts |
+| macOS | *(planned)* | |
+| Linux | *(planned)* | |
 
-pip install poetry
-poetry install
+The installer sets up a private Python environment (using [uv](https://docs.astral.sh/uv/), which it bundles), downloads work-buddy's dependencies (about 1 GB, one time), creates a per-user data folder, and registers work-buddy to start at login. Everything installs under your own user account, and no system Python is touched.
 
-# Optional features
-poetry install --extras memory    # Persistent memory (Hindsight)
-poetry install --extras telegram  # Telegram bot
-poetry install --extras all       # Everything
-```
-
-### Configure
-
-```bash
-cp config.example.yaml config.yaml
-# Edit: vault path, timezone, enabled services
-
-cp config.local.yaml.example config.local.yaml
-# Edit: machine-specific overrides (Tailscale URL, Hindsight bank, feature preferences)
-```
-
-Machine-specific overrides (e.g., `hindsight.bank_id`) go in `config.local.yaml` (gitignored).
-
-**First-time setup:** After connecting to Claude Code, run `/wb-setup guided` for an interactive walkthrough that validates your configuration, lets you choose which features to enable, and checks that everything is wired correctly. The wizard will flag missing requirements with fix instructions.
+When it finishes, open the install folder in Claude Code and run `/wb-setup guided`. That walkthrough lets you choose which features to enable and completes the integrations (vault path, timezone, optional services), flagging anything missing with fix instructions.
 
 ### Connect to Claude Code
 
-work-buddy runs its MCP gateway as an HTTP service supervised by the sidecar, so start the sidecar first:
+The installer writes a project-level `.mcp.json` into the install folder, so opening that folder in Claude Code discovers the work-buddy gateway automatically. There is nothing to wire up by hand.
 
-```bash
-wbuddy start      # or: python -m work_buddy.sidecar
-```
-
-Then add this to your Claude Code MCP config (or run `wbuddy mcp print` to emit it):
+To connect a different Claude Code setup, point it at the gateway directly (or run `wbuddy mcp print` to emit this):
 
 ```json
 {
@@ -348,7 +327,7 @@ Then add this to your Claude Code MCP config (or run `wbuddy mcp print` to emit 
 }
 ```
 
-Then:
+Your settings live in `config.yaml` in the install folder (vault path, timezone, enabled features); `/wb-setup guided` fills them in interactively, and machine-specific overrides go in `config.local.yaml` (gitignored). Then, inside Claude Code:
 
 ```
 > /wb-morning    # Run the morning routine
@@ -357,261 +336,67 @@ Then:
 
 ### GPU Acceleration
 
-The default install uses CPU-only PyTorch from PyPI. If you have an NVIDIA GPU, installing CUDA-enabled PyTorch will significantly speed up embeddings, semantic search, and anything that touches `sentence-transformers`.
+The installer sets up CPU-only PyTorch. If you have an NVIDIA GPU, installing the CUDA build significantly speeds up embeddings, semantic search, and anything that touches `sentence-transformers`.
 
 <details>
 <summary><strong>[Windows/Linux] NVIDIA CUDA</strong></summary>
 
-After `poetry install`, override torch with the CUDA wheel:
+Replace the CPU wheel in the install environment (swap your install folder in for `<install-folder>`):
 
 ```bash
-# Install CUDA-enabled PyTorch (replaces the CPU-only wheel)
-pip install torch --index-url https://download.pytorch.org/whl/cu126 --force-reinstall
+"<install-folder>\.venv\Scripts\python" -m pip install torch --index-url https://download.pytorch.org/whl/cu126 --force-reinstall
 ```
 
-Verify GPU access:
+On macOS/Linux the interpreter is `<install-folder>/.venv/bin/python` instead. Verify GPU access:
+
 ```bash
-python -c "import torch; print(torch.cuda.is_available(), torch.cuda.get_device_name(0))"
+"<install-folder>\.venv\Scripts\python" -c "import torch; print(torch.cuda.is_available(), torch.cuda.get_device_name(0))"
 # Expected: True NVIDIA GeForce RTX ...
 ```
-
-This replaces the CPU wheel in your virtualenv with the CUDA 12.6 build. The `poetry.lock` stays clean (CPU-only) so CI and other environments aren't affected.
 </details>
 
 <details>
 <summary><strong>[macOS] Apple Silicon (MPS)</strong></summary>
 
-The default PyPI torch wheel includes MPS support on Apple Silicon. No extra step needed.
+The default PyTorch wheel includes MPS support on Apple Silicon, so no extra step is needed.
 
 ```bash
-python -c "import torch; print(torch.backends.mps.is_available())"
+"<install-folder>/.venv/bin/python" -c "import torch; print(torch.backends.mps.is_available())"
 ```
 </details>
 
-> **Note:** `pyproject.toml` pins `python = ">=3.11,<3.12"` because `triton` (a torch dependency) doesn't declare support for Python 3.14+, and Poetry's resolver rejects ranges that *could* include unsupported versions.
+> **Note:** work-buddy pins `python = ">=3.11,<3.12"` because `triton` (a torch dependency) does not declare support for Python 3.14+, and the resolver rejects ranges that could include unsupported versions.
 
 ### Optional: Persistent Memory (Hindsight)
 
-If you installed with `--extras memory`, you need PostgreSQL with pgvector and the Hindsight server.
+work-buddy runs fully without persistent memory. Memory is an advanced, optional add-on: it needs the `memory` Python extra, a PostgreSQL server with the pgvector extension, and the Hindsight API server running alongside work-buddy.
 
-<details>
-<summary><strong>1. Install PostgreSQL and pgvector via conda</strong></summary>
-
-These are compiled server processes, not Python packages — install through conda:
-
-```bash
-conda install -c conda-forge postgresql pgvector -y
-```
-</details>
-
-<details>
-<summary><strong>2. Initialize PostgreSQL (first time only)</strong></summary>
-
-```bash
-# Create a database cluster with UTF-8 encoding
-initdb -D ~/hindsight-pgdata -U postgres -E UTF8 --locale=en_US.UTF-8
-
-# Start the server
-pg_ctl -D ~/hindsight-pgdata -l ~/hindsight-pgdata/logfile start
-
-# Create the hindsight database and enable pgvector
-createdb -U postgres hindsight
-psql -U postgres -d hindsight -c "CREATE EXTENSION IF NOT EXISTS vector;"
-```
-
-To stop the server later: `pg_ctl -D ~/hindsight-pgdata stop`
-</details>
-
-<details>
-<summary><strong>3. Configure and start Hindsight</strong></summary>
-
-Set environment variables (or add to a `.env` file):
-
-```bash
-export HINDSIGHT_API_LLM_PROVIDER=anthropic
-export HINDSIGHT_API_LLM_API_KEY=<your-anthropic-api-key>
-export HINDSIGHT_API_LLM_MODEL=claude-haiku-4-5-20251001
-export HINDSIGHT_API_DATABASE_URL=postgresql://postgres@localhost/hindsight
-```
-
-Start the server:
-```bash
-hindsight-api   # Runs at http://localhost:8888
-```
-
-Verify: `curl http://localhost:8888/health`
-</details>
-
-<details>
-<summary><strong>4. Bootstrap the memory bank (first time only)</strong></summary>
-
-```bash
-python -c "from work_buddy.memory.setup import ensure_bank; ensure_bank()"
-```
-
-This creates the personal memory bank (configured as `hindsight.bank_id` in config) with missions, directives, and mental models.
-</details>
-
-<details>
-<summary><strong>5. Inspect memories (optional)</strong></summary>
-
-To browse memories, entities, observations, and mental models in a browser:
-
-```bash
-npx @vectorize-io/hindsight-control-plane --api-url http://localhost:8888
-```
-
-Then open **http://localhost:9999**. This is an on-demand inspection tool — run it when you want to browse, not always-on.
-</details>
+This is a manual, from-source setup rather than a one-click feature. Install the extra with `uv pip install -e ".[memory]"` (see [CONTRIBUTING.md](CONTRIBUTING.md) for the from-source environment), provide a PostgreSQL instance with pgvector (through your platform's package manager, [Postgres.app](https://postgresapp.com/), or Docker), and run the Hindsight API per its documentation. Inside work-buddy, `agent_docs path=memory/hindsight` describes how memory is wired, including the bank bootstrap and the `hindsight.bank_id` setting.
 
 ### Running Services
 
-Three background services should run when using work-buddy: **PostgreSQL** (if using Hindsight), **Hindsight API** (`:8888`), and the **WB-Sidecar** (supervises messaging `:5123`, embedding `:5124`, dashboard `:5127`, and optionally Telegram `:5125`).
-
-**One-off start/stop:**
+The installer registers work-buddy to start at login, so normally nothing needs to be run by hand. To control it manually:
 
 ```bash
-# Sidecar (supervises messaging + embedding + dashboard)
-conda activate work-buddy && python -m work_buddy.sidecar &
-
-# Hindsight API (if using memory)
-conda activate work-buddy && hindsight-api &
-
-# PostgreSQL (if using memory)
-pg_ctl -D ~/hindsight-pgdata -l ~/hindsight-pgdata/logfile start
+wbuddy start     # start the sidecar (MCP gateway, messaging, embedding, dashboard)
+wbuddy stop      # stop it
+wbuddy status    # health check
 ```
 
-**Verify all services:**
-
-```bash
-curl http://localhost:8888/health    # Hindsight API
-curl http://127.0.0.1:5123/health   # Messaging
-curl http://127.0.0.1:5124/health   # Embedding
-curl http://127.0.0.1:5127/health   # Dashboard
-```
-
-Or from within Claude Code: `/wb-setup` runs the setup wizard with automated diagnostics, requirement validation, and feature preference management. Use `/wb-setup-help` for targeted component diagnostics.
+The sidecar supervises messaging (`:5123`), embedding (`:5124`), the dashboard (`:5127`), and optionally Telegram (`:5125`); the MCP gateway itself runs at `:5126`. From within Claude Code, `/wb-setup` runs the setup wizard with diagnostics and requirement validation, and `/wb-setup-help` gives targeted component checks.
 
 <details>
 <summary><strong>Auto-start on login</strong></summary>
 
-#### [Windows] Windows Task Scheduler
+The installer sets this up for you: a per-user login task that starts the work-buddy sidecar, with no administrator rights required. To manage it by hand:
 
-Run all commands in an **elevated PowerShell** (right-click → Run as Administrator).
-
-<details>
-<summary>Hindsight PostgreSQL</summary>
-
-```powershell
-$pgAction = New-ScheduledTaskAction -Execute (Get-Command pg_ctl).Source -Argument "-D $HOME\hindsight-pgdata -l $HOME\hindsight-pgdata\logfile start"
-$pgTrigger = New-ScheduledTaskTrigger -AtLogon
-$pgSettings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit 0
-Register-ScheduledTask -TaskName "Hindsight-PostgreSQL" -Action $pgAction -Trigger $pgTrigger -Settings $pgSettings -Description "Start PostgreSQL for Hindsight memory" -RunLevel Limited
-```
-</details>
-
-<details>
-<summary>Hindsight API (10s delay for PG readiness)</summary>
-
-```powershell
-$hsAction = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-WindowStyle Hidden -ExecutionPolicy Bypass -Command `"conda activate work-buddy; Get-Content <repo-path>\.env | ForEach-Object { if (`$_ -match '^([^#][^=]*)=(.*)$') { [Environment]::SetEnvironmentVariable(`$matches[1].Trim(), `$matches[2].Trim(), 'Process') } }; `$env:PYTHONIOENCODING='utf-8'; hindsight-api`""
-$hsTrigger = New-ScheduledTaskTrigger -AtLogon
-$hsTrigger.Delay = "PT10S"
-$hsSettings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit 0
-Register-ScheduledTask -TaskName "Hindsight-API" -Action $hsAction -Trigger $hsTrigger -Settings $hsSettings -Description "Start Hindsight memory server" -RunLevel Limited
-```
-</details>
-
-<details>
-<summary>WB-Sidecar (15s delay — supervises messaging + embedding)</summary>
-
-Invoke the env's `python.exe` directly rather than going through `conda activate`. Activation can silently no-op in headless contexts (where conda's PowerShell hook hasn't loaded), which leaves `python` resolving to the base interpreter — the daemon then spawns every child on the wrong env, and orphaned children can survive across restarts. A direct path makes that class of bug impossible.
-
-```powershell
-$envPython = "$HOME\miniforge3\envs\work-buddy\python.exe"  # adjust if your env lives elsewhere
-$scAction = New-ScheduledTaskAction -Execute $envPython -Argument "-m work_buddy.sidecar"
-$scTrigger = New-ScheduledTaskTrigger -AtLogon
-$scTrigger.Delay = "PT15S"
-$scSettings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit 0
-Register-ScheduledTask -TaskName "WB-Sidecar" -Action $scAction -Trigger $scTrigger -Settings $scSettings -Description "work-buddy sidecar daemon (supervises messaging + embedding, runs scheduler)" -RunLevel Limited
-```
-
-If you've previously registered WB-Sidecar with the `conda activate` form, replace it with the above — or set `sidecar.python_executable` in `config.yaml` to your env's `python.exe`, which pins the interpreter children spawn with regardless of how the daemon was launched.
-</details>
-
-#### [Linux] systemd user services
-
-Create service files under `~/.config/systemd/user/`:
-
-<details>
-<summary>hindsight-postgres.service</summary>
-
-```ini
-[Unit]
-Description=PostgreSQL for Hindsight memory
-
-[Service]
-Type=forking
-ExecStart=%h/miniforge3/envs/work-buddy/bin/pg_ctl -D %h/hindsight-pgdata -l %h/hindsight-pgdata/logfile start
-ExecStop=%h/miniforge3/envs/work-buddy/bin/pg_ctl -D %h/hindsight-pgdata stop
-Restart=on-failure
-
-[Install]
-WantedBy=default.target
-```
-</details>
-
-<details>
-<summary>hindsight-api.service</summary>
-
-```ini
-[Unit]
-Description=Hindsight memory API server
-After=hindsight-postgres.service
-
-[Service]
-Type=simple
-EnvironmentFile=%h/path-to-repo/.env
-ExecStart=%h/miniforge3/envs/work-buddy/bin/hindsight-api
-Restart=on-failure
-RestartSec=5
-
-[Install]
-WantedBy=default.target
-```
-</details>
-
-<details>
-<summary>wb-sidecar.service</summary>
-
-```ini
-[Unit]
-Description=work-buddy sidecar daemon
-After=hindsight-api.service
-
-[Service]
-Type=simple
-WorkingDirectory=%h/path-to-repo
-ExecStart=%h/miniforge3/envs/work-buddy/bin/python -m work_buddy.sidecar
-Restart=on-failure
-RestartSec=10
-
-[Install]
-WantedBy=default.target
-```
-</details>
-
-Enable and start:
 ```bash
-systemctl --user daemon-reload
-systemctl --user enable hindsight-postgres hindsight-api wb-sidecar
-systemctl --user start hindsight-postgres hindsight-api wb-sidecar
+wbuddy autostart enable    # register the login task
+wbuddy autostart disable   # remove it
+wbuddy autostart status    # check whether it is registered
 ```
 
-#### [macOS] launchd agents
-
-Create plist files under `~/Library/LaunchAgents/`. The pattern is similar to systemd — each plist specifies the program, arguments, and `RunAtLoad=true`. See Apple's `launchd.plist(5)` man page for the full schema.
-
+This uses the platform's per-user login mechanism (Task Scheduler on Windows, a systemd user service on Linux, a launchd agent on macOS).
 </details>
 
 ### Remote Access
@@ -628,11 +413,11 @@ Set `dashboard.external_url` in `config.yaml` to enable "View in dashboard" link
 
 | Layer | Managed by | What it provides |
 |-------|-----------|-----------------|
-| conda | `conda install` | PostgreSQL server, pgvector extension |
-| Poetry | `poetry install` | All Python packages (hindsight, mcp, flask, etc.) |
-| Environment vars | Shell config / `.env` | Anthropic API key, DB URL, Telegram token |
-| config.yaml | Checked into repo | Vault path, timezone, service ports, enabled features |
-| config.local.yaml | Gitignored | Machine-specific overrides (bank IDs, paths) |
+| Install folder | the installer | Code, assets, `config.yaml`, secrets (`.env`) |
+| `.venv` | uv (bundled) | All Python packages (torch, mcp, flask, etc.) |
+| Data folder | the installer | Databases, caches, logs, consent (hidden per-user dir) |
+| `config.yaml` | you / `/wb-setup` | Vault path, timezone, service ports, enabled features |
+| `config.local.yaml` | you (gitignored) | Machine-specific overrides (bank IDs, paths) |
 
 ---
 

--- a/packaging/build_payload.py
+++ b/packaging/build_payload.py
@@ -10,6 +10,12 @@ The payload is a plain source tree (no .git); Model A's git-working-copy nature
 is set up by the update lifecycle later. The heavy dependencies are NOT bundled:
 uv downloads them at install time.
 
+Build from a CLEAN CHECKOUT only (CI checkouts are; locally use a git worktree).
+A live working tree hides gitignored private files inside shipped directories
+(e.g. the personal knowledge store at knowledge/store.local), and copytree would
+sweep them into the installer. build_payload refuses to run when it detects the
+telltale local-only files.
+
 Usage:  python packaging/build_payload.py --out dist/payload [--root <repo>]
 """
 
@@ -44,6 +50,16 @@ INCLUDE = [
 PRUNE_DIRS = {"__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache"}
 PRUNE_SUFFIXES = {".pyc", ".pyo"}
 
+# Presence of any of these marks a LIVE working tree (all are gitignored, so a
+# clean checkout has none). Refuse to build: private local state must never be
+# swept into an installer payload.
+LIVE_TREE_MARKERS = [
+    "knowledge/store.local",
+    ".claude/settings.local.json",
+    "config.local.yaml",
+    ".env",
+]
+
 
 def _ignore(_dir: str, names: list[str]) -> list[str]:
     return [
@@ -55,6 +71,12 @@ def _ignore(_dir: str, names: list[str]) -> list[str]:
 
 def build_payload(root: Path, out: Path) -> dict:
     """Copy the installer payload from ``root`` into ``out``. Returns a summary."""
+    found = [m for m in LIVE_TREE_MARKERS if (root / m).exists()]
+    if found:
+        raise ValueError(
+            f"refusing to build from a live working tree ({', '.join(found)} present); "
+            "build from a clean checkout (CI) or a git worktree"
+        )
     out = out.resolve()
     if out.exists():
         shutil.rmtree(out)

--- a/packaging/build_payload.py
+++ b/packaging/build_payload.py
@@ -1,0 +1,97 @@
+"""Assemble the work-buddy source-tree payload for the native installers.
+
+Copies the files the installer lays down in the user's HOME working copy: the
+work_buddy package, the shipped asset trees (knowledge/store, prompts,
+sidecar_jobs, .claude), config templates, docs, and the project metadata
+(pyproject/README/LICENSE/CHANGELOG). Prunes dev-only trees (tests, .data,
+exploration, .git, caches) and bytecode by way of an allowlist.
+
+The payload is a plain source tree (no .git); Model A's git-working-copy nature
+is set up by the update lifecycle later. The heavy dependencies are NOT bundled:
+uv downloads them at install time.
+
+Usage:  python packaging/build_payload.py --out dist/payload [--root <repo>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+# Top-level items shipped into the user's HOME. An allowlist (safer than a
+# denylist): anything not named here is simply not shipped.
+INCLUDE = [
+    "work_buddy",
+    "knowledge",
+    "prompts",
+    "sidecar_jobs",
+    ".claude",
+    "docs",
+    "config.example.yaml",
+    "config.local.yaml.example",
+    "config.local.example.yaml",
+    "pyproject.toml",
+    "poetry.lock",
+    "README.md",
+    "LICENSE",
+    "CONTRIBUTING.md",
+    "CHANGELOG.md",
+    ".mcp.json",
+]
+
+# Pruned wherever they appear inside the copied trees.
+PRUNE_DIRS = {"__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache"}
+PRUNE_SUFFIXES = {".pyc", ".pyo"}
+
+
+def _ignore(_dir: str, names: list[str]) -> list[str]:
+    return [
+        n
+        for n in names
+        if n in PRUNE_DIRS or any(n.endswith(s) for s in PRUNE_SUFFIXES)
+    ]
+
+
+def build_payload(root: Path, out: Path) -> dict:
+    """Copy the installer payload from ``root`` into ``out``. Returns a summary."""
+    out = out.resolve()
+    if out.exists():
+        shutil.rmtree(out)
+    out.mkdir(parents=True)
+
+    copied: list[str] = []
+    missing: list[str] = []
+    for name in INCLUDE:
+        src = root / name
+        if not src.exists():
+            missing.append(name)
+            continue
+        dst = out / name
+        if src.is_dir():
+            shutil.copytree(src, dst, ignore=_ignore)
+        else:
+            shutil.copy2(src, dst)
+        copied.append(name)
+    return {"out": str(out), "copied": copied, "missing": missing}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Assemble the work-buddy installer payload.")
+    ap.add_argument("--out", required=True, help="output payload directory (recreated)")
+    ap.add_argument(
+        "--root", default=None,
+        help="repo root to copy from (default: two levels up from this script)",
+    )
+    args = ap.parse_args(argv)
+    root = Path(args.root).resolve() if args.root else Path(__file__).resolve().parent.parent
+    summary = build_payload(root, Path(args.out))
+    print(f"payload -> {summary['out']}")
+    print(f"copied: {', '.join(summary['copied'])}")
+    if summary["missing"]:
+        print(f"skipped (absent): {', '.join(summary['missing'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packaging/linux/build_tarball.sh
+++ b/packaging/linux/build_tarball.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Build the Linux release tarball: source-tree payload + vendored uv + install.sh.
+# Runs in CI (or on a Linux box). Usage: packaging/linux/build_tarball.sh [VERSION]
+set -euo pipefail
+
+VERSION="${1:-0.0.0}"
+UV_VERSION="${UV_VERSION:-0.11.26}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+STAGE="$REPO/dist/linux/work-buddy"
+
+rm -rf "$STAGE"
+mkdir -p "$STAGE"
+
+python "$REPO/packaging/build_payload.py" --out "$STAGE/payload" --root "$REPO"
+python "$REPO/packaging/vendor_uv.py" --target linux --out "$STAGE/payload/vendor" --version "$UV_VERSION"
+cp "$HERE/install.sh" "$STAGE/install.sh"
+chmod +x "$STAGE/install.sh"
+
+OUT="$REPO/dist/work-buddy-${VERSION}-linux-x86_64.tar.gz"
+tar -C "$REPO/dist/linux" -czf "$OUT" work-buddy
+echo "built $OUT"

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# work-buddy Linux installer (per-user, no sudo).
+#
+# Lays the source-tree payload into a HOME, runs the uv bootstrap (managed
+# Python 3.11 + venv + editable install with CPU torch, retried) + provision,
+# and registers a systemd --user login service. Idempotent; re-run repairs.
+#
+# Run from the extracted tarball:  ./install.sh [--home DIR] [--data-dir DIR]
+#                                              [--vault-root DIR] [--anthropic-key KEY]
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_HOME="$HOME/work-buddy"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/work-buddy"
+VAULT_ROOT=""
+ANTHROPIC_KEY=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --home)         APP_HOME="$2"; shift 2 ;;
+    --data-dir)     DATA_DIR="$2"; shift 2 ;;
+    --vault-root)   VAULT_ROOT="$2"; shift 2 ;;
+    --anthropic-key) ANTHROPIC_KEY="$2"; shift 2 ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+UV="$HERE/payload/vendor/uv"
+VENV_PY="$APP_HOME/.venv/bin/python"
+chmod +x "$UV"
+
+echo "==> Installing work-buddy into $APP_HOME"
+mkdir -p "$APP_HOME" "$DATA_DIR"
+cp -a "$HERE/payload/." "$APP_HOME/"
+
+echo "==> Installing Python 3.11 (uv)"
+"$UV" python install 3.11
+
+echo "==> Creating the virtual environment"
+"$UV" venv --python 3.11 "$APP_HOME/.venv"
+
+echo "==> Downloading dependencies (this can take several minutes)"
+attempt=1
+until "$UV" pip install --python "$VENV_PY" --extra-index-url https://download.pytorch.org/whl/cpu -e "$APP_HOME"; do
+  if [ "$attempt" -ge 3 ]; then
+    echo "Dependency install failed after $attempt attempts. Re-run ./install.sh to resume (downloads are cached)." >&2
+    exit 1
+  fi
+  sleep "$((2 ** attempt))"; attempt="$((attempt + 1))"
+done
+
+echo "==> Provisioning work-buddy"
+prov=(-m work_buddy.cli provision --home "$APP_HOME" --data-dir "$DATA_DIR")
+[ -n "$VAULT_ROOT" ]    && prov+=(--vault-root "$VAULT_ROOT")
+[ -n "$ANTHROPIC_KEY" ] && prov+=(--anthropic-key "$ANTHROPIC_KEY")
+"$VENV_PY" "${prov[@]}"
+
+echo "==> Registering login auto-start (systemd --user)"
+"$VENV_PY" -m work_buddy.cli autostart enable
+
+DESKTOP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+mkdir -p "$DESKTOP_DIR"
+cat > "$DESKTOP_DIR/work-buddy.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=work-buddy dashboard
+Exec=$APP_HOME/.venv/bin/wbuddy dashboard --open
+Terminal=false
+Categories=Utility;
+EOF
+
+echo "==> work-buddy install complete."
+echo "    Open Claude Code in $APP_HOME and run /wb-setup guided."

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -28,8 +28,12 @@ done
 UV="$HERE/payload/vendor/uv"
 VENV_PY="$APP_HOME/.venv/bin/python"
 chmod +x "$UV"
-# Install the managed Python inside the HOME (self-contained; removed on uninstall).
-export UV_PYTHON_INSTALL_DIR="$APP_HOME/.uv/python"
+# Keep uv's data dir + managed Python under the per-user DATA dir (off any
+# cloud-synced location; consistent with the Windows OneDrive-448 fix). Setting
+# UV_DATA_DIR (not just UV_PYTHON_INSTALL_DIR) is what actually relocates the
+# version-link uv creates.
+export UV_DATA_DIR="$DATA_DIR/uv"
+export UV_PYTHON_INSTALL_DIR="$DATA_DIR/uv/python"
 
 echo "==> Installing work-buddy into $APP_HOME"
 mkdir -p "$APP_HOME" "$DATA_DIR"

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -28,10 +28,17 @@ done
 UV="$HERE/payload/vendor/uv"
 VENV_PY="$APP_HOME/.venv/bin/python"
 chmod +x "$UV"
+# Install the managed Python inside the HOME (self-contained; removed on uninstall).
+export UV_PYTHON_INSTALL_DIR="$APP_HOME/.uv/python"
 
 echo "==> Installing work-buddy into $APP_HOME"
 mkdir -p "$APP_HOME" "$DATA_DIR"
 cp -a "$HERE/payload/." "$APP_HOME/"
+
+echo "==> work-buddy runs a private semantic-search engine on your machine, so this"
+echo "    downloads its own Python and machine-learning libraries (about 1 GB, one"
+echo "    time). Search models download later, on first use. Nothing is sent to a"
+echo "    cloud service."
 
 echo "==> Installing Python 3.11 (uv)"
 "$UV" python install 3.11

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -37,11 +37,11 @@ echo "==> Installing Python 3.11 (uv)"
 "$UV" python install 3.11
 
 echo "==> Creating the virtual environment"
-"$UV" venv --python 3.11 "$APP_HOME/.venv"
+"$UV" venv --clear --python 3.11 "$APP_HOME/.venv"
 
 echo "==> Downloading dependencies (this can take several minutes)"
 attempt=1
-until "$UV" pip install --python "$VENV_PY" --extra-index-url https://download.pytorch.org/whl/cpu -e "$APP_HOME"; do
+until "$UV" pip install --python "$VENV_PY" --index-strategy unsafe-best-match --extra-index-url https://download.pytorch.org/whl/cpu -e "$APP_HOME"; do
   if [ "$attempt" -ge 3 ]; then
     echo "Dependency install failed after $attempt attempts. Re-run ./install.sh to resume (downloads are cached)." >&2
     exit 1

--- a/packaging/macos/build_tarball.sh
+++ b/packaging/macos/build_tarball.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Build the macOS release tarball: source-tree payload + vendored uv +
+# install.command (double-clickable; opens Terminal and shows progress).
+#
+# A .pkg was considered and rejected: its postinstall would have to run the
+# multi-minute, network-heavy uv dependency download inside Installer.app, which
+# offers no progress UI and can time out. A Terminal-driven install.command gives
+# the user visible progress and resumable retries. See AFK-DECISIONS.md.
+#
+# Runs in CI (or on a Mac). Usage: packaging/macos/build_tarball.sh [VERSION]
+set -euo pipefail
+
+VERSION="${1:-0.0.0}"
+UV_VERSION="${UV_VERSION:-0.11.26}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+STAGE="$REPO/dist/macos/work-buddy"
+
+rm -rf "$STAGE"
+mkdir -p "$STAGE"
+
+python "$REPO/packaging/build_payload.py" --out "$STAGE/payload" --root "$REPO"
+python "$REPO/packaging/vendor_uv.py" --target macos --out "$STAGE/payload/vendor" --version "$UV_VERSION"
+cp "$HERE/install.command" "$STAGE/install.command"
+chmod +x "$STAGE/install.command"
+
+OUT="$REPO/dist/work-buddy-${VERSION}-macos-arm64.tar.gz"
+tar -C "$REPO/dist/macos" -czf "$OUT" work-buddy
+echo "built $OUT"

--- a/packaging/macos/install.command
+++ b/packaging/macos/install.command
@@ -34,11 +34,11 @@ echo "==> Installing Python 3.11 (uv)"
 "$UV" python install 3.11
 
 echo "==> Creating the virtual environment"
-"$UV" venv --python 3.11 "$APP_HOME/.venv"
+"$UV" venv --clear --python 3.11 "$APP_HOME/.venv"
 
 echo "==> Downloading dependencies (this can take several minutes)"
 attempt=1
-until "$UV" pip install --python "$VENV_PY" --extra-index-url https://download.pytorch.org/whl/cpu -e "$APP_HOME"; do
+until "$UV" pip install --python "$VENV_PY" --index-strategy unsafe-best-match --extra-index-url https://download.pytorch.org/whl/cpu -e "$APP_HOME"; do
   if [ "$attempt" -ge 3 ]; then
     echo "Dependency install failed after $attempt attempts. Re-run install.command to resume (downloads are cached)." >&2
     exit 1

--- a/packaging/macos/install.command
+++ b/packaging/macos/install.command
@@ -25,10 +25,17 @@ done
 UV="$HERE/payload/vendor/uv"
 VENV_PY="$APP_HOME/.venv/bin/python"
 chmod +x "$UV"
+# Install the managed Python inside the HOME (self-contained; removed on uninstall).
+export UV_PYTHON_INSTALL_DIR="$APP_HOME/.uv/python"
 
 echo "==> Installing work-buddy into $APP_HOME"
 mkdir -p "$APP_HOME" "$DATA_DIR"
 cp -a "$HERE/payload/." "$APP_HOME/"
+
+echo "==> work-buddy runs a private semantic-search engine on your machine, so this"
+echo "    downloads its own Python and machine-learning libraries (about 1 GB, one"
+echo "    time). Search models download later, on first use. Nothing is sent to a"
+echo "    cloud service."
 
 echo "==> Installing Python 3.11 (uv)"
 "$UV" python install 3.11

--- a/packaging/macos/install.command
+++ b/packaging/macos/install.command
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# work-buddy macOS installer (per-user, no sudo). Double-click to run in Terminal.
+#
+# Lays the source-tree payload into a HOME, runs the uv bootstrap (managed
+# Python 3.11 + venv + editable install with CPU torch, retried) + provision,
+# and registers a launchd login agent. Idempotent; re-run repairs.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_HOME="$HOME/work-buddy"
+DATA_DIR="$HOME/Library/Application Support/work-buddy"
+VAULT_ROOT=""
+ANTHROPIC_KEY=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --home)         APP_HOME="$2"; shift 2 ;;
+    --data-dir)     DATA_DIR="$2"; shift 2 ;;
+    --vault-root)   VAULT_ROOT="$2"; shift 2 ;;
+    --anthropic-key) ANTHROPIC_KEY="$2"; shift 2 ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+UV="$HERE/payload/vendor/uv"
+VENV_PY="$APP_HOME/.venv/bin/python"
+chmod +x "$UV"
+
+echo "==> Installing work-buddy into $APP_HOME"
+mkdir -p "$APP_HOME" "$DATA_DIR"
+cp -a "$HERE/payload/." "$APP_HOME/"
+
+echo "==> Installing Python 3.11 (uv)"
+"$UV" python install 3.11
+
+echo "==> Creating the virtual environment"
+"$UV" venv --python 3.11 "$APP_HOME/.venv"
+
+echo "==> Downloading dependencies (this can take several minutes)"
+attempt=1
+until "$UV" pip install --python "$VENV_PY" --extra-index-url https://download.pytorch.org/whl/cpu -e "$APP_HOME"; do
+  if [ "$attempt" -ge 3 ]; then
+    echo "Dependency install failed after $attempt attempts. Re-run install.command to resume (downloads are cached)." >&2
+    exit 1
+  fi
+  sleep "$((2 ** attempt))"; attempt="$((attempt + 1))"
+done
+
+echo "==> Provisioning work-buddy"
+prov=(-m work_buddy.cli provision --home "$APP_HOME" --data-dir "$DATA_DIR")
+[ -n "$VAULT_ROOT" ]    && prov+=(--vault-root "$VAULT_ROOT")
+[ -n "$ANTHROPIC_KEY" ] && prov+=(--anthropic-key "$ANTHROPIC_KEY")
+"$VENV_PY" "${prov[@]}"
+
+echo "==> Registering login auto-start (launchd)"
+"$VENV_PY" -m work_buddy.cli autostart enable
+
+echo "==> work-buddy install complete."
+echo "    Open Claude Code in $APP_HOME and run /wb-setup guided."

--- a/packaging/macos/install.command
+++ b/packaging/macos/install.command
@@ -25,8 +25,12 @@ done
 UV="$HERE/payload/vendor/uv"
 VENV_PY="$APP_HOME/.venv/bin/python"
 chmod +x "$UV"
-# Install the managed Python inside the HOME (self-contained; removed on uninstall).
-export UV_PYTHON_INSTALL_DIR="$APP_HOME/.uv/python"
+# Keep uv's data dir + managed Python under the per-user DATA dir (off any
+# cloud-synced location; consistent with the Windows OneDrive-448 fix). Setting
+# UV_DATA_DIR (not just UV_PYTHON_INSTALL_DIR) is what actually relocates the
+# version-link uv creates.
+export UV_DATA_DIR="$DATA_DIR/uv"
+export UV_PYTHON_INSTALL_DIR="$DATA_DIR/uv/python"
 
 echo "==> Installing work-buddy into $APP_HOME"
 mkdir -p "$APP_HOME" "$DATA_DIR"

--- a/packaging/vendor_uv.py
+++ b/packaging/vendor_uv.py
@@ -1,0 +1,82 @@
+"""Fetch a pinned uv binary to bundle into a native installer.
+
+Downloads the uv release archive for a target OS and extracts the ``uv`` (or
+``uv.exe``) binary into ``--out``. Runs in CI (which has network); the installer
+bundles the result so the user's install needs no separate uv-acquisition step
+before the bootstrap can run.
+
+The pinned version MUST be a real uv release; keep it in sync with the
+``astral-sh/setup-uv`` version the release CI uses. Bump deliberately.
+
+Usage:  python packaging/vendor_uv.py --target windows --out dist/payload/vendor
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import tarfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+UV_VERSION = "0.5.29"
+
+# target -> (release triple, archive extension, binary name inside the archive)
+TARGETS = {
+    "windows": ("x86_64-pc-windows-msvc", "zip", "uv.exe"),
+    "linux": ("x86_64-unknown-linux-gnu", "tar.gz", "uv"),
+    "linux-arm64": ("aarch64-unknown-linux-gnu", "tar.gz", "uv"),
+    "macos": ("aarch64-apple-darwin", "tar.gz", "uv"),
+    "macos-x86": ("x86_64-apple-darwin", "tar.gz", "uv"),
+}
+
+
+def release_url(target: str, version: str = UV_VERSION) -> str:
+    triple, ext, _ = TARGETS[target]
+    return (
+        f"https://github.com/astral-sh/uv/releases/download/{version}/"
+        f"uv-{triple}.{ext}"
+    )
+
+
+def _extract(data: bytes, target: str, out: Path) -> Path:
+    _triple, ext, binary = TARGETS[target]
+    out.mkdir(parents=True, exist_ok=True)
+    dest = out / binary
+    if ext == "zip":
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            member = next(n for n in zf.namelist() if n.endswith(binary))
+            with zf.open(member) as src, open(dest, "wb") as fh:
+                fh.write(src.read())
+    else:
+        with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tf:
+            member = next(m for m in tf.getmembers() if m.name.endswith("/" + binary) or m.name == binary)
+            src = tf.extractfile(member)
+            assert src is not None
+            with open(dest, "wb") as fh:
+                fh.write(src.read())
+    dest.chmod(0o755)
+    return dest
+
+
+def vendor_uv(target: str, out: Path, version: str = UV_VERSION) -> Path:
+    url = release_url(target, version)
+    with urllib.request.urlopen(url, timeout=120) as resp:  # noqa: S310 (pinned github url)
+        data = resp.read()
+    return _extract(data, target, out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Vendor a pinned uv binary.")
+    ap.add_argument("--target", required=True, choices=sorted(TARGETS))
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--version", default=UV_VERSION)
+    args = ap.parse_args(argv)
+    dest = vendor_uv(args.target, Path(args.out), args.version)
+    print(f"vendored uv {args.version} ({args.target}) -> {dest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packaging/vendor_uv.py
+++ b/packaging/vendor_uv.py
@@ -14,13 +14,14 @@ Usage:  python packaging/vendor_uv.py --target windows --out dist/payload/vendor
 from __future__ import annotations
 
 import argparse
+import hashlib
 import io
 import tarfile
 import urllib.request
 import zipfile
 from pathlib import Path
 
-UV_VERSION = "0.5.29"
+UV_VERSION = "0.11.26"
 
 # target -> (release triple, archive extension, binary name inside the archive)
 TARGETS = {
@@ -60,10 +61,27 @@ def _extract(data: bytes, target: str, out: Path) -> Path:
     return dest
 
 
-def vendor_uv(target: str, out: Path, version: str = UV_VERSION) -> Path:
-    url = release_url(target, version)
+def _download(url: str) -> bytes:
     with urllib.request.urlopen(url, timeout=120) as resp:  # noqa: S310 (pinned github url)
-        data = resp.read()
+        return resp.read()
+
+
+def _verify_checksum(data: bytes, sha256_line: str) -> None:
+    """Raise if ``data``'s SHA-256 does not match the published checksum line.
+
+    uv's ``.sha256`` files are ``<hexdigest>  <filename>``; take the first token.
+    """
+    expected = sha256_line.split()[0].strip().lower()
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != expected:
+        raise ValueError(f"uv checksum mismatch: expected {expected}, got {actual}")
+
+
+def vendor_uv(target: str, out: Path, version: str = UV_VERSION, verify: bool = True) -> Path:
+    url = release_url(target, version)
+    data = _download(url)
+    if verify:
+        _verify_checksum(data, _download(url + ".sha256").decode("utf-8"))
     return _extract(data, target, out)
 
 

--- a/packaging/version.py
+++ b/packaging/version.py
@@ -1,0 +1,36 @@
+"""Single source of truth for the work-buddy version: pyproject.toml.
+
+The installer version, the git release tag, and the package version must agree.
+Everything derives the version from here instead of hardcoding it, and the release
+CI verifies the tag matches. Usage: python packaging/version.py [--root <repo>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import tomllib
+from pathlib import Path
+
+
+def read_version(root: Path | None = None) -> str:
+    """Return the version string from ``pyproject.toml`` under ``root``."""
+    root = root or Path(__file__).resolve().parent.parent
+    data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    # poetry keeps it under [tool.poetry]; PEP 621 uses [project]. Prefer poetry
+    # (this project's backend), fall back to [project] for forward-compatibility.
+    poetry_version = data.get("tool", {}).get("poetry", {}).get("version")
+    if poetry_version:
+        return poetry_version
+    return data["project"]["version"]
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Print the work-buddy version from pyproject.toml.")
+    ap.add_argument("--root", default=None, help="repo root (default: two levels up)")
+    args = ap.parse_args(argv)
+    print(read_version(Path(args.root) if args.root else None))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packaging/windows/bootstrap.ps1
+++ b/packaging/windows/bootstrap.ps1
@@ -77,7 +77,15 @@ trap {
 #    extracts fine either way. So run the install best-effort and then locate the
 #    real versioned python.exe directly, bypassing the broken link entirely.
 Write-Host "==> Installing Python 3.11 (uv)"
-& $Uv python install 3.11 2>&1 | Write-Host
+# Best-effort. uv's final version-link and shim steps can warn or fail on Windows,
+# and those surface on stderr. With ErrorActionPreference=Stop, even a uv WARNING on
+# stderr would be promoted to a terminating error and abort us. So run this step
+# with error handling relaxed, and gate real success on whether a versioned
+# python.exe actually appears (checked next), NOT on uv's exit code or stderr.
+& {
+    $ErrorActionPreference = "Continue"
+    & $Uv python install 3.11 2>&1 | ForEach-Object { Write-Host $_ }
+}
 $pyExe = Get-ChildItem (Join-Path $uvDir "python") -Recurse -Filter python.exe -Depth 2 -ErrorAction SilentlyContinue |
     Where-Object { $_.Directory.Name -like "cpython-3.11.*-windows-*" } |
     Select-Object -First 1 -ExpandProperty FullName

--- a/packaging/windows/bootstrap.ps1
+++ b/packaging/windows/bootstrap.ps1
@@ -22,11 +22,30 @@ param(
 $ErrorActionPreference = "Stop"
 $venvPy = Join-Path $AppHome ".venv\Scripts\python.exe"
 
+# The installer runs this hidden and does not surface a nonzero exit, so failure
+# handling lives here: everything is transcribed to install.log in the DATA dir,
+# and a failure raises a visible dialog instead of a silent "successful" finish.
+New-Item -ItemType Directory -Force -Path $Data | Out-Null
+$logPath = Join-Path $Data "install.log"
+Start-Transcript -Path $logPath -Append | Out-Null
+
 function Invoke-Step {
     param([string]$Desc, [scriptblock]$Body)
     Write-Host "==> $Desc"
     & $Body
     if ($LASTEXITCODE -ne 0) { throw "$Desc failed (exit $LASTEXITCODE)" }
+}
+
+trap {
+    $msg = $_.Exception.Message
+    try { Stop-Transcript | Out-Null } catch {}
+    try {
+        Add-Type -AssemblyName PresentationFramework
+        [System.Windows.MessageBox]::Show(
+            "work-buddy setup did not complete:`n`n$msg`n`nDetails: $logPath`nRe-run the installer to resume (downloads are cached).",
+            "work-buddy setup", "OK", "Error") | Out-Null
+    } catch {}
+    exit 1
 }
 
 # 1. A self-contained managed CPython 3.11 (not system python, not conda).
@@ -61,3 +80,4 @@ Invoke-Step "Provisioning work-buddy" { & $venvPy @provArgs }
 Invoke-Step "Registering login auto-start" { & $venvPy -m work_buddy.cli autostart enable }
 
 Write-Host "==> work-buddy install complete."
+Stop-Transcript | Out-Null

--- a/packaging/windows/bootstrap.ps1
+++ b/packaging/windows/bootstrap.ps1
@@ -30,10 +30,21 @@ $logPath = Join-Path $Data "install.log"
 Start-Transcript -Path $logPath -Append | Out-Null
 
 function Invoke-Step {
-    param([string]$Desc, [scriptblock]$Body)
-    Write-Host "==> $Desc"
-    & $Body
-    if ($LASTEXITCODE -ne 0) { throw "$Desc failed (exit $LASTEXITCODE)" }
+    param([string]$Desc, [scriptblock]$Body, [int]$Retries = 1)
+    for ($attempt = 1; ; $attempt++) {
+        if ($Retries -gt 1) { Write-Host "==> $Desc (attempt $attempt of $Retries)" }
+        else { Write-Host "==> $Desc" }
+        & $Body
+        if ($LASTEXITCODE -eq 0) { return }
+        if ($attempt -ge $Retries) {
+            $suffix = if ($Retries -gt 1) { " after $attempt attempts" } else { "" }
+            throw "$Desc failed (exit $LASTEXITCODE)$suffix"
+        }
+        # Transient failure: a flaky download, or antivirus briefly blocking uv's
+        # reparse-point creation (Windows "untrusted mount point", os error 448).
+        # Back off and retry; uv's cache makes retries resumable.
+        Start-Sleep -Seconds ([Math]::Pow(2, $attempt))
+    }
 }
 
 trap {
@@ -48,25 +59,28 @@ trap {
     exit 1
 }
 
+# All three uv steps are retried: each touches the network and/or creates
+# reparse points that antivirus can transiently block on a fresh path.
+
 # 1. A self-contained managed CPython 3.11 (not system python, not conda).
-Invoke-Step "Installing Python 3.11" { & $Uv python install 3.11 }
+Invoke-Step "Installing Python 3.11" -Retries 3 { & $Uv python install 3.11 }
 
 # 2. A venv inside the HOME (co-located with the code; rebuilds with the checkout).
-Invoke-Step "Creating the virtual environment" {
-    & $Uv venv --python 3.11 (Join-Path $AppHome ".venv")
+#    --clear so a re-run (the advertised "resume" path) replaces a half-built
+#    venv instead of erroring that one already exists.
+Invoke-Step "Creating the virtual environment" -Retries 3 {
+    & $Uv venv --clear --python 3.11 (Join-Path $AppHome ".venv")
 }
 
-# 3. Dependencies + editable install of work-buddy. THE slow step (CPU torch).
-#    Retry with backoff; uv's cache resumes partial downloads.
-$maxAttempts = 3
-for ($attempt = 1; ; $attempt++) {
-    Write-Host "==> Downloading dependencies (attempt $attempt of $maxAttempts; this can take several minutes)"
-    & $Uv pip install --python $venvPy --extra-index-url https://download.pytorch.org/whl/cpu -e $AppHome
-    if ($LASTEXITCODE -eq 0) { break }
-    if ($attempt -ge $maxAttempts) {
-        throw "Dependency install failed after $attempt attempts. Re-run the installer to resume (downloads are cached)."
-    }
-    Start-Sleep -Seconds ([Math]::Pow(2, $attempt))
+# 3. Dependencies + editable install of work-buddy. THE slow step (CPU torch,
+#    a few hundred MB). uv's cache resumes partial downloads between attempts.
+#    --index-strategy unsafe-best-match: the CPU-torch index also hosts stale
+#    copies of small shared packages (e.g. charset-normalizer); without this,
+#    uv's default "first index wins" rule pins those stale versions and
+#    resolution fails. Safe here: both indexes (PyPI + official PyTorch) are
+#    trusted, so there is no dependency-confusion exposure.
+Invoke-Step "Downloading dependencies (this can take several minutes)" -Retries 3 {
+    & $Uv pip install --python $venvPy --index-strategy unsafe-best-match --extra-index-url https://download.pytorch.org/whl/cpu -e $AppHome
 }
 
 # 4. Provision: config, secrets, data-dir relocation, .mcp.json, bootstrap checks,

--- a/packaging/windows/bootstrap.ps1
+++ b/packaging/windows/bootstrap.ps1
@@ -22,10 +22,20 @@ param(
 $ErrorActionPreference = "Stop"
 $venvPy = Join-Path $AppHome ".venv\Scripts\python.exe"
 
-# The installer runs this hidden and does not surface a nonzero exit, so failure
-# handling lives here: everything is transcribed to install.log in the DATA dir,
-# and a failure raises a visible dialog instead of a silent "successful" finish.
+# Install the managed Python INSIDE the HOME, not uv's shared per-user dir. A
+# fresh install-local dir has no pre-existing version-link reparse points, which
+# on Windows otherwise fail permanently (uv tries to recreate them and Windows
+# rejects re-traversing an existing reparse point: "untrusted mount point", os
+# error 448). It also keeps Python self-contained, so uninstall removes it too.
+$env:UV_PYTHON_INSTALL_DIR = Join-Path $AppHome ".uv\python"
+
+# The installer runs this hidden and Inno does not treat a nonzero exit as fatal.
+# So success is signalled by a marker file: the installer aborts if it is absent
+# after this runs. Clear any stale marker up front; everything is transcribed to
+# install.log for diagnosis.
 New-Item -ItemType Directory -Force -Path $Data | Out-Null
+$markerPath = Join-Path $Data ".install-ok"
+Remove-Item -Force -ErrorAction SilentlyContinue $markerPath
 $logPath = Join-Path $Data "install.log"
 Start-Transcript -Path $logPath -Append | Out-Null
 
@@ -48,14 +58,11 @@ function Invoke-Step {
 }
 
 trap {
-    $msg = $_.Exception.Message
+    # No dialog here: the marker is never written, so the installer detects the
+    # failure and shows a single error message pointing at the log. Just record
+    # the reason and exit nonzero.
+    Write-Host "ERROR: $($_.Exception.Message)"
     try { Stop-Transcript | Out-Null } catch {}
-    try {
-        Add-Type -AssemblyName PresentationFramework
-        [System.Windows.MessageBox]::Show(
-            "work-buddy setup did not complete:`n`n$msg`n`nDetails: $logPath`nRe-run the installer to resume (downloads are cached).",
-            "work-buddy setup", "OK", "Error") | Out-Null
-    } catch {}
     exit 1
 }
 
@@ -94,4 +101,6 @@ Invoke-Step "Provisioning work-buddy" { & $venvPy @provArgs }
 Invoke-Step "Registering login auto-start" { & $venvPy -m work_buddy.cli autostart enable }
 
 Write-Host "==> work-buddy install complete."
+# Signal success to the installer (its [Code] guard aborts if this is missing).
+New-Item -ItemType File -Force -Path $markerPath | Out-Null
 Stop-Transcript | Out-Null

--- a/packaging/windows/bootstrap.ps1
+++ b/packaging/windows/bootstrap.ps1
@@ -22,12 +22,17 @@ param(
 $ErrorActionPreference = "Stop"
 $venvPy = Join-Path $AppHome ".venv\Scripts\python.exe"
 
-# Install the managed Python INSIDE the HOME, not uv's shared per-user dir. A
-# fresh install-local dir has no pre-existing version-link reparse points, which
-# on Windows otherwise fail permanently (uv tries to recreate them and Windows
-# rejects re-traversing an existing reparse point: "untrusted mount point", os
-# error 448). It also keeps Python self-contained, so uninstall removes it too.
-$env:UV_PYTHON_INSTALL_DIR = Join-Path $AppHome ".uv\python"
+# uv creates Python's version-link inside its DATA dir, which defaults to
+# %APPDATA%\Roaming\uv. OneDrive's Files On-Demand driver intercepts reparse-point
+# creation there and fails it with "untrusted mount point" (os error 448), even
+# when nothing is inside the OneDrive folder. Point uv's DATA dir (where the link
+# is created) AND its Python dir at the per-user DATA dir under %LOCALAPPDATA%,
+# which OneDrive never touches. Setting only UV_PYTHON_INSTALL_DIR is NOT enough:
+# the link still goes to the default DATA dir. Verified in a real session.
+# See https://github.com/astral-sh/uv/issues/19616.
+$uvDir = Join-Path $Data "uv"
+$env:UV_DATA_DIR = $uvDir
+$env:UV_PYTHON_INSTALL_DIR = Join-Path $uvDir "python"
 
 # The installer runs this hidden and Inno does not treat a nonzero exit as fatal.
 # So success is signalled by a marker file: the installer aborts if it is absent

--- a/packaging/windows/bootstrap.ps1
+++ b/packaging/windows/bootstrap.ps1
@@ -22,14 +22,9 @@ param(
 $ErrorActionPreference = "Stop"
 $venvPy = Join-Path $AppHome ".venv\Scripts\python.exe"
 
-# uv creates Python's version-link inside its DATA dir, which defaults to
-# %APPDATA%\Roaming\uv. OneDrive's Files On-Demand driver intercepts reparse-point
-# creation there and fails it with "untrusted mount point" (os error 448), even
-# when nothing is inside the OneDrive folder. Point uv's DATA dir (where the link
-# is created) AND its Python dir at the per-user DATA dir under %LOCALAPPDATA%,
-# which OneDrive never touches. Setting only UV_PYTHON_INSTALL_DIR is NOT enough:
-# the link still goes to the default DATA dir. Verified in a real session.
-# See https://github.com/astral-sh/uv/issues/19616.
+# Keep uv's data dir and managed Python under the per-user DATA dir (self-contained,
+# and off the roaming profile). The Python version-link failure this used to chase
+# is handled at the install step below (we bypass the link), not by relocation.
 $uvDir = Join-Path $Data "uv"
 $env:UV_DATA_DIR = $uvDir
 $env:UV_PYTHON_INSTALL_DIR = Join-Path $uvDir "python"
@@ -71,17 +66,30 @@ trap {
     exit 1
 }
 
-# All three uv steps are retried: each touches the network and/or creates
-# reparse points that antivirus can transiently block on a fresh path.
+# 1. Install a self-contained managed CPython 3.11 (not system python, not conda).
+#    IMPORTANT: uv finishes by creating a "minor version link" (a directory junction
+#    cpython-3.11-... -> cpython-3.11.15-...) purely for transparent patch upgrades.
+#    That link step fails on common Windows setups and is NOT recoverable by retry:
+#    when the installer runs with Windows' RedirectionGuard mitigation (Inno 6.7+
+#    enables it by default and it is inherited by child processes) junction traversal
+#    is blocked with os error 448; with the guard off, uv then reports a "missing
+#    target directory" for the same link. The Python interpreter itself ALWAYS
+#    extracts fine either way. So run the install best-effort and then locate the
+#    real versioned python.exe directly, bypassing the broken link entirely.
+Write-Host "==> Installing Python 3.11 (uv)"
+& $Uv python install 3.11 2>&1 | Write-Host
+$pyExe = Get-ChildItem (Join-Path $uvDir "python") -Recurse -Filter python.exe -Depth 2 -ErrorAction SilentlyContinue |
+    Where-Object { $_.Directory.Name -like "cpython-3.11.*-windows-*" } |
+    Select-Object -First 1 -ExpandProperty FullName
+if (-not $pyExe) {
+    throw "Python 3.11 install produced no interpreter under $uvDir\python"
+}
+Write-Host "==> Using Python at $pyExe"
 
-# 1. A self-contained managed CPython 3.11 (not system python, not conda).
-Invoke-Step "Installing Python 3.11" -Retries 3 { & $Uv python install 3.11 }
-
-# 2. A venv inside the HOME (co-located with the code; rebuilds with the checkout).
-#    --clear so a re-run (the advertised "resume" path) replaces a half-built
-#    venv instead of erroring that one already exists.
+# 2. A venv inside the HOME, pointed straight at that python.exe (never the link).
+#    --clear so a re-run (the advertised "resume" path) replaces a half-built venv.
 Invoke-Step "Creating the virtual environment" -Retries 3 {
-    & $Uv venv --clear --python 3.11 (Join-Path $AppHome ".venv")
+    & $Uv venv --clear --python $pyExe (Join-Path $AppHome ".venv")
 }
 
 # 3. Dependencies + editable install of work-buddy. THE slow step (CPU torch,

--- a/packaging/windows/bootstrap.ps1
+++ b/packaging/windows/bootstrap.ps1
@@ -1,0 +1,63 @@
+# work-buddy install bootstrap, invoked by the Inno Setup installer.
+#
+# Runs the uv sequence and provisioning inside the chosen HOME:
+#   uv python install 3.11 -> uv venv -> uv pip install -e (CPU torch, retried)
+#   -> wbuddy provision -> wbuddy autostart enable.
+#
+# The dependency download is the slow, failure-prone step (a few hundred MB over
+# possibly-flaky networks), so it is retried with backoff; uv's cache makes each
+# retry resumable. The whole script is idempotent: re-running repairs.
+#
+# Note: the parameter is $AppHome, not $Home ($HOME is a PowerShell automatic
+# variable and must not be shadowed).
+
+param(
+    [Parameter(Mandatory = $true)][string]$AppHome,
+    [Parameter(Mandatory = $true)][string]$Data,
+    [Parameter(Mandatory = $true)][string]$Uv,
+    [string]$VaultRoot = "",
+    [string]$AnthropicKey = ""
+)
+
+$ErrorActionPreference = "Stop"
+$venvPy = Join-Path $AppHome ".venv\Scripts\python.exe"
+
+function Invoke-Step {
+    param([string]$Desc, [scriptblock]$Body)
+    Write-Host "==> $Desc"
+    & $Body
+    if ($LASTEXITCODE -ne 0) { throw "$Desc failed (exit $LASTEXITCODE)" }
+}
+
+# 1. A self-contained managed CPython 3.11 (not system python, not conda).
+Invoke-Step "Installing Python 3.11" { & $Uv python install 3.11 }
+
+# 2. A venv inside the HOME (co-located with the code; rebuilds with the checkout).
+Invoke-Step "Creating the virtual environment" {
+    & $Uv venv --python 3.11 (Join-Path $AppHome ".venv")
+}
+
+# 3. Dependencies + editable install of work-buddy. THE slow step (CPU torch).
+#    Retry with backoff; uv's cache resumes partial downloads.
+$maxAttempts = 3
+for ($attempt = 1; ; $attempt++) {
+    Write-Host "==> Downloading dependencies (attempt $attempt of $maxAttempts; this can take several minutes)"
+    & $Uv pip install --python $venvPy --extra-index-url https://download.pytorch.org/whl/cpu -e $AppHome
+    if ($LASTEXITCODE -eq 0) { break }
+    if ($attempt -ge $maxAttempts) {
+        throw "Dependency install failed after $attempt attempts. Re-run the installer to resume (downloads are cached)."
+    }
+    Start-Sleep -Seconds ([Math]::Pow(2, $attempt))
+}
+
+# 4. Provision: config, secrets, data-dir relocation, .mcp.json, bootstrap checks,
+#    and start the sidecar. --home makes the target explicit.
+$provArgs = @("-m", "work_buddy.cli", "provision", "--home", $AppHome, "--data-dir", $Data)
+if ($VaultRoot)    { $provArgs += @("--vault-root", $VaultRoot) }
+if ($AnthropicKey) { $provArgs += @("--anthropic-key", $AnthropicKey) }
+Invoke-Step "Provisioning work-buddy" { & $venvPy @provArgs }
+
+# 5. Register login auto-start (the WB-Sidecar scheduled task).
+Invoke-Step "Registering login auto-start" { & $venvPy -m work_buddy.cli autostart enable }
+
+Write-Host "==> work-buddy install complete."

--- a/packaging/windows/bootstrap.ps1
+++ b/packaging/windows/bootstrap.ps1
@@ -118,10 +118,24 @@ if ($VaultRoot)    { $provArgs += @("--vault-root", $VaultRoot) }
 if ($AnthropicKey) { $provArgs += @("--anthropic-key", $AnthropicKey) }
 Invoke-Step "Provisioning work-buddy" { & $venvPy @provArgs }
 
-# 5. Register login auto-start (the WB-Sidecar scheduled task).
-Invoke-Step "Registering login auto-start" { & $venvPy -m work_buddy.cli autostart enable }
+# 5. Register login auto-start (the WB-Sidecar scheduled task). BEST-EFFORT: by
+#    now work-buddy is installed and running (sidecar up, MCP wired), so failing to
+#    register the login task must NOT fail the whole install. Warn and continue; a
+#    separate marker records whether it succeeded so the finish page can mention it.
+Write-Host "==> Registering login auto-start"
+$autostartMarker = Join-Path $Data ".autostart-ok"
+Remove-Item -Force -ErrorAction SilentlyContinue $autostartMarker
+& {
+    $ErrorActionPreference = "Continue"
+    & $venvPy -m work_buddy.cli autostart enable 2>&1 | ForEach-Object { Write-Host $_ }
+}
+if ($LASTEXITCODE -eq 0) {
+    New-Item -ItemType File -Force -Path $autostartMarker | Out-Null
+} else {
+    Write-Host "WARNING: could not register login auto-start. work-buddy is installed and running; it just will not restart automatically after a reboot. You can retry later with:  wbuddy autostart enable"
+}
 
 Write-Host "==> work-buddy install complete."
-# Signal success to the installer (its [Code] guard aborts if this is missing).
+# Signal overall success to the installer (its finish page checks this marker).
 New-Item -ItemType File -Force -Path $markerPath | Out-Null
 Stop-Transcript | Out-Null

--- a/packaging/windows/work-buddy.iss
+++ b/packaging/windows/work-buddy.iss
@@ -119,19 +119,29 @@ begin
   Result := FileExists(ExpandConstant('{localappdata}\work-buddy\.install-ok'));
 end;
 
+function AutostartOk(): Boolean;
+begin
+  Result := FileExists(ExpandConstant('{localappdata}\work-buddy\.autostart-ok'));
+end;
+
 procedure CurPageChanged(CurPageID: Integer);
 var
-  Log: String;
+  Log, Msg: String;
 begin
   if CurPageID <> wpFinished then Exit;
   Log := ExpandConstant('{localappdata}\work-buddy\install.log');
   if InstallSucceeded() then
   begin
     WizardForm.FinishedHeadingLabel.Caption := 'work-buddy is installed';
-    WizardForm.FinishedLabel.Caption :=
+    Msg :=
       'work-buddy is installed at ' + ExpandConstant('{app}') + '.' + #13#10 + #13#10 +
       'To finish setup, open that folder in Claude Code and run  /wb-setup guided  ' +
       '(feature selection and the interactive integrations).';
+    if not AutostartOk() then
+      Msg := Msg + #13#10 + #13#10 +
+        'Note: automatic start at login could not be set up. work-buddy is running ' +
+        'now; after a reboot, start it with  wbuddy start  (or retry  wbuddy autostart enable).';
+    WizardForm.FinishedLabel.Caption := Msg;
   end
   else
   begin

--- a/packaging/windows/work-buddy.iss
+++ b/packaging/windows/work-buddy.iss
@@ -26,7 +26,10 @@ AppName=work-buddy
 AppVersion={#AppVersion}
 AppPublisher=Kaden McKeen
 AppSupportURL=https://github.com/KadenMc/work-buddy
-DefaultDirName={userdocs}\work-buddy
+; The user's home folder: auto-resolves to the current user, is never cloud-synced
+; (Documents often is), and is visible as a Claude Code project dir. Matches the
+; ~/work-buddy default the Linux/macOS installers already use.
+DefaultDirName={%USERPROFILE}\work-buddy
 DefaultGroupName=work-buddy
 DisableProgramGroupPage=yes
 PrivilegesRequired=lowest
@@ -56,12 +59,11 @@ Name: "{localappdata}\work-buddy"
 ; PowerShell console out of the user's face; the wizard shows StatusMsg.
 Filename: "powershell.exe"; \
   Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\vendor\bootstrap.ps1"" -AppHome ""{app}"" -Data ""{localappdata}\work-buddy"" -Uv ""{app}\vendor\uv.exe"""; \
-  StatusMsg: "Setting up Python and downloading dependencies. This can take several minutes..."; \
+  StatusMsg: "Setting up Python and downloading dependencies (about 1 GB). This can take several minutes..."; \
   Flags: runhidden
-; Offer to open the dashboard once install finishes.
-Filename: "{app}\.venv\Scripts\wbuddy.exe"; Parameters: "dashboard --open"; \
-  Description: "Open the work-buddy dashboard"; \
-  Flags: postinstall nowait skipifsilent
+; No postinstall "open dashboard" action: the finish page hands off to the real
+; setup step (/wb-setup guided in Claude Code) via [Code] below, and a failed
+; bootstrap must never leave a launch action pointing at a venv that was not built.
 
 [Icons]
 Name: "{group}\work-buddy dashboard"; Filename: "{app}\.venv\Scripts\wbuddy.exe"; Parameters: "dashboard --open"
@@ -76,8 +78,47 @@ Filename: "{app}\.venv\Scripts\wbuddy.exe"; Parameters: "autostart disable"; \
   Flags: runhidden; RunOnceId: "WbAutostart"
 
 [UninstallDelete]
-; Inno removes only what it installed, so the runtime-created venv (hundreds of
-; MB of dependencies) and the provision-written config.yaml/.env (which holds the
+; Inno removes only what it installed, so the runtime-created venv + managed
+; Python (.uv\python), and the provision-written config.yaml/.env (which holds the
 ; API key) would otherwise be left behind. Remove the whole install dir. User
 ; DATA lives under {localappdata}\work-buddy and is preserved deliberately.
 Type: filesandordirs; Name: "{app}"
+
+[Messages]
+; The installer is NOT work-buddy's "wizard" — the real setup wizard is
+; /wb-setup guided inside Claude Code. Strip "Setup Wizard" from the UI, and use
+; the welcome page to explain the one-time download up front so the size reassures
+; rather than alarms.
+WelcomeLabel1=Welcome to work-buddy Setup
+WelcomeLabel2=This will install work-buddy on your computer.%n%nwork-buddy runs a private semantic-search engine on your own machine, so Setup downloads its own Python and machine-learning libraries (about 1 GB, one time). The search models themselves download later, the first time you use search. Nothing you store is sent to a cloud service.%n%nClick Next to continue.
+FinishedHeadingLabel=work-buddy is installed
+ClickFinish=Click Finish to close Setup.
+
+[Code]
+{ Fail the install if the bootstrap did not write its success marker. Inno does
+  not treat a nonzero [Run] exit as fatal, so without this a failed setup would
+  reach the success page. ssPostInstall runs after the [Run] bootstrap. }
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  Marker, Log: String;
+begin
+  if CurStep = ssPostInstall then
+  begin
+    Marker := ExpandConstant('{localappdata}\work-buddy\.install-ok');
+    Log := ExpandConstant('{localappdata}\work-buddy\install.log');
+    if not FileExists(Marker) then
+      RaiseException(
+        'work-buddy setup could not complete. See the log at ' + Log + '.' + #13#10 +
+        'Re-run the installer to resume (downloads are cached).');
+  end;
+end;
+
+{ Point the finish page at the real next step, with the actual install path. }
+procedure CurPageChanged(CurPageID: Integer);
+begin
+  if CurPageID = wpFinished then
+    WizardForm.FinishedLabel.Caption :=
+      'work-buddy is installed at ' + ExpandConstant('{app}') + '.' + #13#10 + #13#10 +
+      'To finish setup, open that folder in Claude Code and run  /wb-setup guided  ' +
+      '(feature selection and the interactive integrations).';
+end;

--- a/packaging/windows/work-buddy.iss
+++ b/packaging/windows/work-buddy.iss
@@ -16,6 +16,9 @@
 #endif
 
 [Setup]
+; All relative Source/OutputDir paths resolve from the repo root, not this
+; script's directory (Inno defaults relative paths to the .iss location).
+SourceDir=..\..
 AppId={{8F3E2A10-9C4B-4D7E-A1F2-6B5C8D9E0A1B}
 AppName=work-buddy
 AppVersion={#AppVersion}
@@ -38,7 +41,7 @@ DiskSpaceWarning=yes
 ; The source-tree payload (build_payload.py output), including vendor\uv.exe.
 Source: "dist\payload\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs
 ; The bootstrap script is not part of the source payload; ship it into vendor\.
-Source: "bootstrap.ps1"; DestDir: "{app}\vendor"; Flags: ignoreversion
+Source: "packaging\windows\bootstrap.ps1"; DestDir: "{app}\vendor"; Flags: ignoreversion
 
 [Dirs]
 ; The hidden per-user DATA dir (DBs, caches, logs, consent). provision writes

--- a/packaging/windows/work-buddy.iss
+++ b/packaging/windows/work-buddy.iss
@@ -30,6 +30,12 @@ AppSupportURL=https://github.com/KadenMc/work-buddy
 ; (Documents often is), and is visible as a Claude Code project dir. Matches the
 ; ~/work-buddy default the Linux/macOS installers already use.
 DefaultDirName={%USERPROFILE}\work-buddy
+; Always SHOW the location picker with the current default. DisableDirPage defaults
+; to "auto", which silently skips the picker (and reuses the previous location) once
+; the app has been installed before -- surprising, and it stranded a test install at
+; a stale path. UsePreviousAppDir=no so it always offers the current default.
+DisableDirPage=no
+UsePreviousAppDir=no
 DefaultGroupName=work-buddy
 DisableProgramGroupPage=yes
 PrivilegesRequired=lowest
@@ -78,11 +84,13 @@ Filename: "{app}\.venv\Scripts\wbuddy.exe"; Parameters: "autostart disable"; \
   Flags: runhidden; RunOnceId: "WbAutostart"
 
 [UninstallDelete]
-; Inno removes only what it installed, so the runtime-created venv + managed
-; Python (.uv\python), and the provision-written config.yaml/.env (which holds the
-; API key) would otherwise be left behind. Remove the whole install dir. User
-; DATA lives under {localappdata}\work-buddy and is preserved deliberately.
+; Inno removes only what it installed, so the runtime-created venv and the
+; provision-written config.yaml/.env (which holds the API key) would otherwise be
+; left behind. Remove the whole install dir, plus the managed Python that lives
+; under the data dir (a derived artifact). The rest of the user's DATA (databases,
+; logs) under {localappdata}\work-buddy is preserved deliberately.
 Type: filesandordirs; Name: "{app}"
+Type: filesandordirs; Name: "{localappdata}\work-buddy\uv"
 
 [Messages]
 ; The installer is NOT work-buddy's "wizard" — the real setup wizard is

--- a/packaging/windows/work-buddy.iss
+++ b/packaging/windows/work-buddy.iss
@@ -110,30 +110,35 @@ FinishedHeadingLabel=work-buddy is installed
 ClickFinish=Click Finish to close Setup.
 
 [Code]
-{ Fail the install if the bootstrap did not write its success marker. Inno does
-  not treat a nonzero [Run] exit as fatal, so without this a failed setup would
-  reach the success page. ssPostInstall runs after the [Run] bootstrap. }
-procedure CurStepChanged(CurStep: TSetupStep);
-var
-  Marker, Log: String;
+{ Inno does not treat a nonzero [Run] exit as failure, so the bootstrap signals
+  success by writing a marker file only when it fully completes. Reflect the TRUE
+  outcome on the finish page (both heading and body) rather than always claiming
+  the app is installed. }
+function InstallSucceeded(): Boolean;
 begin
-  if CurStep = ssPostInstall then
-  begin
-    Marker := ExpandConstant('{localappdata}\work-buddy\.install-ok');
-    Log := ExpandConstant('{localappdata}\work-buddy\install.log');
-    if not FileExists(Marker) then
-      RaiseException(
-        'work-buddy setup could not complete. See the log at ' + Log + '.' + #13#10 +
-        'Re-run the installer to resume (downloads are cached).');
-  end;
+  Result := FileExists(ExpandConstant('{localappdata}\work-buddy\.install-ok'));
 end;
 
-{ Point the finish page at the real next step, with the actual install path. }
 procedure CurPageChanged(CurPageID: Integer);
+var
+  Log: String;
 begin
-  if CurPageID = wpFinished then
+  if CurPageID <> wpFinished then Exit;
+  Log := ExpandConstant('{localappdata}\work-buddy\install.log');
+  if InstallSucceeded() then
+  begin
+    WizardForm.FinishedHeadingLabel.Caption := 'work-buddy is installed';
     WizardForm.FinishedLabel.Caption :=
       'work-buddy is installed at ' + ExpandConstant('{app}') + '.' + #13#10 + #13#10 +
       'To finish setup, open that folder in Claude Code and run  /wb-setup guided  ' +
       '(feature selection and the interactive integrations).';
+  end
+  else
+  begin
+    WizardForm.FinishedHeadingLabel.Caption := 'Setup did not complete';
+    WizardForm.FinishedLabel.Caption :=
+      'work-buddy could not finish setting up, so it is NOT ready to use yet.' + #13#10 + #13#10 +
+      'See the log at ' + Log + #13#10 + #13#10 +
+      'Re-run the installer to try again. The downloads are cached, so it resumes.';
+  end;
 end;

--- a/packaging/windows/work-buddy.iss
+++ b/packaging/windows/work-buddy.iss
@@ -72,3 +72,10 @@ Filename: "{app}\.venv\Scripts\wbuddy.exe"; Parameters: "stop"; \
   Flags: runhidden; RunOnceId: "WbStop"
 Filename: "{app}\.venv\Scripts\wbuddy.exe"; Parameters: "autostart disable"; \
   Flags: runhidden; RunOnceId: "WbAutostart"
+
+[UninstallDelete]
+; Inno removes only what it installed, so the runtime-created venv (hundreds of
+; MB of dependencies) and the provision-written config.yaml/.env (which holds the
+; API key) would otherwise be left behind. Remove the whole install dir. User
+; DATA lives under {localappdata}\work-buddy and is preserved deliberately.
+Type: filesandordirs; Name: "{app}"

--- a/packaging/windows/work-buddy.iss
+++ b/packaging/windows/work-buddy.iss
@@ -1,0 +1,70 @@
+; work-buddy Windows installer (Inno Setup 6).
+;
+; Per-user install (no admin): lays the source-tree payload into a user-chosen
+; HOME, then runs bootstrap.ps1 (uv python + venv + editable install + provision
+; + login auto-start). Mutable state lives under {localappdata}\work-buddy.
+;
+; Build:  ISCC.exe /DAppVersion=X.Y.Z packaging\windows\work-buddy.iss
+;   expects dist\payload\  (from build_payload.py, with vendor\uv.exe from vendor_uv.py)
+;
+; NOTE: not yet compile-validated (no Inno Setup on the dev box). Compile with
+; ISCC on the clean Windows VM before the first real run. The AppId GUID below is
+; a stable placeholder; keep it fixed once published (it keys upgrade detection).
+
+#ifndef AppVersion
+  #define AppVersion "0.0.0"
+#endif
+
+[Setup]
+AppId={{8F3E2A10-9C4B-4D7E-A1F2-6B5C8D9E0A1B}
+AppName=work-buddy
+AppVersion={#AppVersion}
+AppPublisher=Kaden McKeen
+AppSupportURL=https://github.com/KadenMc/work-buddy
+DefaultDirName={userdocs}\work-buddy
+DefaultGroupName=work-buddy
+DisableProgramGroupPage=yes
+PrivilegesRequired=lowest
+OutputDir=dist
+OutputBaseFilename=work-buddy-{#AppVersion}-setup
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+UninstallDisplayName=work-buddy
+; The bootstrap downloads a few hundred MB of dependencies; warn about time/space.
+DiskSpaceWarning=yes
+
+[Files]
+; The source-tree payload (build_payload.py output), including vendor\uv.exe.
+Source: "dist\payload\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs
+; The bootstrap script is not part of the source payload; ship it into vendor\.
+Source: "bootstrap.ps1"; DestDir: "{app}\vendor"; Flags: ignoreversion
+
+[Dirs]
+; The hidden per-user DATA dir (DBs, caches, logs, consent). provision writes
+; paths.data_root here so mutable state never lands in the code tree.
+Name: "{localappdata}\work-buddy"
+
+[Run]
+; The heavy step: uv sequence + provision + autostart. runhidden keeps the
+; PowerShell console out of the user's face; the wizard shows StatusMsg.
+Filename: "powershell.exe"; \
+  Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\vendor\bootstrap.ps1"" -AppHome ""{app}"" -Data ""{localappdata}\work-buddy"" -Uv ""{app}\vendor\uv.exe"""; \
+  StatusMsg: "Setting up Python and downloading dependencies. This can take several minutes..."; \
+  Flags: runhidden
+; Offer to open the dashboard once install finishes.
+Filename: "{app}\.venv\Scripts\wbuddy.exe"; Parameters: "dashboard --open"; \
+  Description: "Open the work-buddy dashboard"; \
+  Flags: postinstall nowait skipifsilent
+
+[Icons]
+Name: "{group}\work-buddy dashboard"; Filename: "{app}\.venv\Scripts\wbuddy.exe"; Parameters: "dashboard --open"
+Name: "{group}\Uninstall work-buddy"; Filename: "{uninstallexe}"
+
+[UninstallRun]
+; Stop the sidecar and remove the login auto-start task. DATA is left in place
+; (uninstalling the app should not silently delete the user's databases).
+Filename: "{app}\.venv\Scripts\wbuddy.exe"; Parameters: "stop"; \
+  Flags: runhidden; RunOnceId: "WbStop"
+Filename: "{app}\.venv\Scripts\wbuddy.exe"; Parameters: "autostart disable"; \
+  Flags: runhidden; RunOnceId: "WbAutostart"

--- a/packaging/windows/work-buddy.iss
+++ b/packaging/windows/work-buddy.iss
@@ -39,6 +39,13 @@ UsePreviousAppDir=no
 DefaultGroupName=work-buddy
 DisableProgramGroupPage=yes
 PrivilegesRequired=lowest
+; Inno 6.7+ enables Windows' RedirectionGuard mitigation on Setup by default, and
+; it is inherited by child processes, which makes uv's junction/reparse operations
+; fail with os error 448 ("untrusted mount point"). The mitigation exists to protect
+; ELEVATED installers from junction-planting in shared paths; this installer is
+; per-user and writes only user-owned paths, so there is no privilege boundary to
+; defend. Turn it off. (Same fix Warp shipped: warpdotdev/warp#9863.)
+RedirectionGuard=no
 OutputDir=dist
 OutputBaseFilename=work-buddy-{#AppVersion}-setup
 Compression=lzma2

--- a/packaging/windows/work-buddy.iss
+++ b/packaging/windows/work-buddy.iss
@@ -36,6 +36,12 @@ DefaultDirName={%USERPROFILE}\work-buddy
 ; a stale path. UsePreviousAppDir=no so it always offers the current default.
 DisableDirPage=no
 UsePreviousAppDir=no
+; work-buddy installs into its OWN dedicated folder, never merged into a folder the
+; user picks. AppendDefaultDirName=yes (the default, set here for intent) makes a
+; Browse selection append "\work-buddy". A [Code] NextButtonClick guard additionally
+; refuses a non-empty folder that is not already a work-buddy install, so uninstall
+; (which removes the whole install dir) can never take a user's own data with it.
+AppendDefaultDirName=yes
 DefaultGroupName=work-buddy
 DisableProgramGroupPage=yes
 PrivilegesRequired=lowest
@@ -110,6 +116,56 @@ FinishedHeadingLabel=work-buddy is installed
 ClickFinish=Click Finish to close Setup.
 
 [Code]
+{ Guard the location page: work-buddy installs into its own dedicated folder, so
+  refuse a non-empty folder that is not already a work-buddy install. That keeps
+  uninstall (which removes the whole install dir) from ever deleting a user's own
+  files, while still allowing re-install/repair over an existing work-buddy. }
+function DirIsEmpty(const Dir: String): Boolean;
+var
+  FR: TFindRec;
+begin
+  Result := True;
+  if FindFirst(AddBackslash(Dir) + '*', FR) then
+  begin
+    try
+      repeat
+        if (FR.Name <> '.') and (FR.Name <> '..') then
+        begin
+          Result := False;
+          Break;
+        end;
+      until not FindNext(FR);
+    finally
+      FindClose(FR);
+    end;
+  end;
+end;
+
+function IsWorkBuddyInstall(const Dir: String): Boolean;
+begin
+  Result := FileExists(AddBackslash(Dir) + 'pyproject.toml') and
+            DirExists(AddBackslash(Dir) + 'work_buddy');
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+var
+  Dir: String;
+begin
+  Result := True;
+  if CurPageID <> wpSelectDir then Exit;
+  Dir := WizardDirValue;
+  if not DirExists(Dir) then Exit;        { new folder: fine }
+  if DirIsEmpty(Dir) then Exit;           { empty folder: fine }
+  if IsWorkBuddyInstall(Dir) then Exit;   { existing work-buddy: allow repair }
+  MsgBox('The folder' + #13#10 + #13#10 + Dir + #13#10 + #13#10 +
+    'already contains other files. work-buddy installs into its own dedicated ' +
+    'folder, and uninstalling later removes that entire folder, so it will not ' +
+    'install on top of a folder that holds your own files.' + #13#10 + #13#10 +
+    'Choose an empty folder, or a location where a new "work-buddy" folder can be ' +
+    'created.', mbError, MB_OK);
+  Result := False;
+end;
+
 { Inno does not treat a nonzero [Run] exit as failure, so the bootstrap signals
   success by writing a marker file only when it fully completes. Reflect the TRUE
   outcome on the finish page (both heading and body) rather than always claiming

--- a/packaging/windows/work-buddy.iss
+++ b/packaging/windows/work-buddy.iss
@@ -7,9 +7,9 @@
 ; Build:  ISCC.exe /DAppVersion=X.Y.Z packaging\windows\work-buddy.iss
 ;   expects dist\payload\  (from build_payload.py, with vendor\uv.exe from vendor_uv.py)
 ;
-; NOTE: not yet compile-validated (no Inno Setup on the dev box). Compile with
-; ISCC on the clean Windows VM before the first real run. The AppId GUID below is
-; a stable placeholder; keep it fixed once published (it keys upgrade detection).
+; Compile-validated with ISCC 6.7.3; runtime behavior still needs the clean-VM
+; install test before the first release. The AppId GUID below is a stable
+; placeholder; keep it fixed once published (it keys upgrade detection).
 
 #ifndef AppVersion
   #define AppVersion "0.0.0"
@@ -34,8 +34,9 @@ Compression=lzma2
 SolidCompression=yes
 WizardStyle=modern
 UninstallDisplayName=work-buddy
-; The bootstrap downloads a few hundred MB of dependencies; warn about time/space.
-DiskSpaceWarning=yes
+; The bootstrap downloads Python + dependencies after extraction (torch alone is
+; hundreds of MB); make the wizard's free-space check account for it (5 GB).
+ExtraDiskSpaceRequired=5368709120
 
 [Files]
 ; The source-tree payload (build_payload.py output), including vendor\uv.exe.

--- a/packaging/windows/work-buddy.iss
+++ b/packaging/windows/work-buddy.iss
@@ -4,8 +4,10 @@
 ; HOME, then runs bootstrap.ps1 (uv python + venv + editable install + provision
 ; + login auto-start). Mutable state lives under {localappdata}\work-buddy.
 ;
-; Build:  ISCC.exe /DAppVersion=X.Y.Z packaging\windows\work-buddy.iss
+; Build:  ISCC.exe /DAppVersion=$(python packaging/version.py) packaging\windows\work-buddy.iss
 ;   expects dist\payload\  (from build_payload.py, with vendor\uv.exe from vendor_uv.py)
+;   The version comes from pyproject.toml (single source of truth); the 0.0.0
+;   default below is only a fallback for an ad-hoc build with no version passed.
 ;
 ; Compile-validated with ISCC 6.7.3; runtime behavior still needs the clean-VM
 ; install test before the first release. The AppId GUID below is a stable

--- a/tests/unit/test_autostart.py
+++ b/tests/unit/test_autostart.py
@@ -41,10 +41,12 @@ def test_windows_register_builds_task(monkeypatch, tmp_path):
         python_exe=str(tmp_path / "python.exe"), home_dir=str(tmp_path), data_dir=str(tmp_path)
     )
     assert res["ok"] is True
-    assert "Register-ScheduledTask" in calls[0]
-    assert "WB-Sidecar" in calls[0]
-    assert "-m work_buddy.sidecar" in calls[0]
-    assert "-RunLevel Limited" in calls[0]  # per-user, no admin
+    # register() deletes any existing task first, so the Register call is the last.
+    assert "Register-ScheduledTask" in calls[-1]
+    assert "WB-Sidecar" in calls[-1]
+    assert "-m work_buddy.sidecar" in calls[-1]
+    assert "-RunLevel Limited" in calls[-1]  # per-user, no admin
+    assert "Unregister-ScheduledTask" in calls[0]  # delete-then-create
 
 
 def test_windows_is_registered(monkeypatch):
@@ -58,6 +60,19 @@ def test_windows_register_reports_failure(monkeypatch, tmp_path):
     monkeypatch.setattr(windows, "_run_ps", lambda script, timeout=60: _fake_cp(returncode=1, stderr="denied"))
     res = windows.register(python_exe="py.exe", home_dir=str(tmp_path), data_dir=str(tmp_path))
     assert res["ok"] is False and "denied" in res["detail"]
+
+
+def test_windows_register_escapes_apostrophe(monkeypatch, tmp_path):
+    # A path with an apostrophe (e.g. username O'Brien) must be escaped so it
+    # cannot terminate the single-quoted PowerShell string early.
+    calls = []
+    monkeypatch.setattr(windows, "_run_ps", lambda script, timeout=60: calls.append(script) or _fake_cp())
+    windows.register(
+        python_exe=r"C:\Users\O'Brien\.venv\Scripts\python.exe",
+        home_dir=r"C:\Users\O'Brien\work-buddy",
+        data_dir=str(tmp_path),
+    )
+    assert "O''Brien" in calls[-1]  # doubled, i.e. escaped
 
 
 # --- Linux (systemd --user) -----------------------------------------------

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -1,0 +1,88 @@
+"""Tests for the installer build scripts (build_payload, vendor_uv). No network.
+
+The scripts live in ``packaging/`` (not an importable package), so they are
+loaded by path. Network downloads are never performed: only URL construction and
+archive extraction (against synthetic archives) are exercised.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent.parent
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, _REPO / "packaging" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+build_payload = _load("build_payload")
+vendor_uv = _load("vendor_uv")
+
+
+def test_build_payload_includes_package_excludes_dev_trees(tmp_path):
+    root = tmp_path / "repo"
+    (root / "work_buddy").mkdir(parents=True)
+    (root / "work_buddy" / "__init__.py").write_text("x")
+    (root / "work_buddy" / "__pycache__").mkdir()
+    (root / "work_buddy" / "__pycache__" / "x.pyc").write_text("junk")
+    (root / "tests").mkdir()
+    (root / "tests" / "test_x.py").write_text("junk")
+    (root / "pyproject.toml").write_text("[tool]")
+
+    out = tmp_path / "payload"
+    summary = build_payload.build_payload(root, out)
+
+    assert (out / "work_buddy" / "__init__.py").exists()
+    assert (out / "pyproject.toml").exists()
+    assert not (out / "tests").exists()  # dev tree excluded by the allowlist
+    assert not (out / "work_buddy" / "__pycache__").exists()  # bytecode pruned
+    assert "work_buddy" in summary["copied"]
+
+
+def test_build_payload_recreates_out(tmp_path):
+    root = tmp_path / "repo"
+    (root / "work_buddy").mkdir(parents=True)
+    (root / "work_buddy" / "__init__.py").write_text("x")
+    out = tmp_path / "payload"
+    out.mkdir()
+    (out / "stale.txt").write_text("should be wiped")
+    build_payload.build_payload(root, out)
+    assert not (out / "stale.txt").exists()
+
+
+def test_vendor_uv_url_construction():
+    assert vendor_uv.release_url("windows", "0.5.29") == (
+        "https://github.com/astral-sh/uv/releases/download/0.5.29/"
+        "uv-x86_64-pc-windows-msvc.zip"
+    )
+    assert vendor_uv.release_url("linux").endswith("uv-x86_64-unknown-linux-gnu.tar.gz")
+    assert vendor_uv.release_url("macos").endswith("uv-aarch64-apple-darwin.tar.gz")
+
+
+def test_vendor_uv_extracts_zip(tmp_path):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("uv.exe", b"BINARY")
+    dest = vendor_uv._extract(buf.getvalue(), "windows", tmp_path)
+    assert dest.name == "uv.exe"
+    assert dest.read_bytes() == b"BINARY"
+
+
+def test_vendor_uv_extracts_tar(tmp_path):
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        data = b"BINARY"
+        info = tarfile.TarInfo("uv-x86_64-unknown-linux-gnu/uv")
+        info.size = len(data)
+        tf.addfile(info, io.BytesIO(data))
+    dest = vendor_uv._extract(buf.getvalue(), "linux", tmp_path)
+    assert dest.name == "uv"
+    assert dest.read_bytes() == b"BINARY"

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -7,11 +7,14 @@ archive extraction (against synthetic archives) are exercised.
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import io
 import tarfile
 import zipfile
 from pathlib import Path
+
+import pytest
 
 _REPO = Path(__file__).resolve().parent.parent.parent
 
@@ -86,3 +89,15 @@ def test_vendor_uv_extracts_tar(tmp_path):
     dest = vendor_uv._extract(buf.getvalue(), "linux", tmp_path)
     assert dest.name == "uv"
     assert dest.read_bytes() == b"BINARY"
+
+
+def test_vendor_uv_checksum_accepts_match():
+    data = b"BINARY"
+    digest = hashlib.sha256(data).hexdigest()
+    # uv publishes "<hexdigest>  <filename>"; the filename token is ignored.
+    vendor_uv._verify_checksum(data, f"{digest}  uv-x86_64-pc-windows-msvc.zip")
+
+
+def test_vendor_uv_checksum_rejects_mismatch():
+    with pytest.raises(ValueError):
+        vendor_uv._verify_checksum(b"BINARY", "deadbeef  uv.zip")

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -50,6 +50,15 @@ def test_build_payload_includes_package_excludes_dev_trees(tmp_path):
     assert "work_buddy" in summary["copied"]
 
 
+def test_build_payload_refuses_live_tree(tmp_path):
+    root = tmp_path / "repo"
+    (root / "work_buddy").mkdir(parents=True)
+    (root / "work_buddy" / "__init__.py").write_text("x")
+    (root / "knowledge" / "store.local").mkdir(parents=True)  # private, gitignored
+    with pytest.raises(ValueError, match="live working tree"):
+        build_payload.build_payload(root, tmp_path / "payload")
+
+
 def test_build_payload_recreates_out(tmp_path):
     root = tmp_path / "repo"
     (root / "work_buddy").mkdir(parents=True)

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -28,6 +28,20 @@ def _load(name: str):
 
 build_payload = _load("build_payload")
 vendor_uv = _load("vendor_uv")
+version = _load("version")
+
+
+def test_version_reads_pyproject(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.poetry]\nname = "x"\nversion = "1.2.3"\n', encoding="utf-8"
+    )
+    assert version.read_version(tmp_path) == "1.2.3"
+
+
+def test_version_matches_real_pyproject():
+    # The real repo's version must be readable (guards against a malformed bump).
+    v = version.read_version(_REPO)
+    assert v and v[0].isdigit()
 
 
 def test_build_payload_includes_package_excludes_dev_trees(tmp_path):

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -66,6 +66,19 @@ def test_provision_writes_config_env_mcp_and_pins_interpreter(tmp_install):
     assert "bootstrap" in res and "summary" in res["bootstrap"]
 
 
+def test_provision_ok_when_feature_config_missing(tmp_install):
+    """A fresh install with no vault and no API key still succeeds: the core work
+    (writable data, MCP wiring) is done and feature config is deferred to the
+    wizard. The unmet required checks must be surfaced in ``bootstrap`` for the
+    user, but must NOT fail provisioning (else every default install "fails")."""
+    home, data = tmp_install
+    res = prov.provision(data_dir=str(data), start=False)
+    assert res["ok"] is True
+    # the unmet feature-config requirements are still reported, just not fatal
+    failed_ids = {r["id"] for r in res["bootstrap"]["results"] if not r["ok"]}
+    assert any("vault" in i or "anthropic" in i for i in failed_ids)
+
+
 def test_provision_is_idempotent(tmp_install):
     home, data = tmp_install
     prov.provision(data_dir=str(data), start=False)

--- a/work_buddy/autostart/windows.py
+++ b/work_buddy/autostart/windows.py
@@ -37,11 +37,20 @@ def _run_ps(script: str, timeout: int = 60) -> subprocess.CompletedProcess:
 
 def register(*, python_exe: str, home_dir: str, data_dir: str) -> dict:
     pyw = _pythonw(python_exe)
-    # -Force replaces an existing task, so this is idempotent. pythonw.exe keeps
-    # the daemon windowless; a short AtLogOn delay lets the desktop settle first.
+    # Delete any existing task first, then create fresh. Register-ScheduledTask
+    # -Force *should* overwrite, but overwriting a task created in another context
+    # can fail with "Access is denied"; an explicit delete-then-create is more
+    # reliable. Deleting a task you own is permitted unelevated. -Force stays as a
+    # belt-and-suspenders. pythonw.exe keeps the daemon windowless; a short AtLogOn
+    # delay lets the desktop settle first.
+    unregister()  # best-effort; ignore result (there may be no existing task)
+    # Escape single quotes for the single-quoted PowerShell strings below, so a
+    # path like C:\Users\O'Brien\work-buddy cannot break out of the string.
+    pyw_ps = pyw.replace("'", "''")
+    home_ps = home_dir.replace("'", "''")
     script = (
-        f"$a = New-ScheduledTaskAction -Execute '{pyw}' "
-        f"-Argument '-m work_buddy.sidecar' -WorkingDirectory '{home_dir}'; "
+        f"$a = New-ScheduledTaskAction -Execute '{pyw_ps}' "
+        f"-Argument '-m work_buddy.sidecar' -WorkingDirectory '{home_ps}'; "
         f"$t = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME; "
         f"$t.Delay = 'PT15S'; "
         f"$s = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries "

--- a/work_buddy/provision.py
+++ b/work_buddy/provision.py
@@ -105,13 +105,16 @@ def provision(
     )
     steps.append("wrote .mcp.json (gateway wiring)")
 
-    # 6. Bootstrap checks.
+    # 6. Bootstrap checks. Advisory: they guide the user's next steps but do not,
+    #    by themselves, decide provisioning success. Feature config (vault_root,
+    #    the Anthropic key) is deferred to `/wb-setup guided`, so those unmet
+    #    required checks are expected on a fresh install and must NOT fail it.
     checker = RequirementChecker()
     boot_results = checker.check_bootstrap()
     summary = checker.summarize(boot_results)
 
     result = {
-        "ok": bool(summary.get("all_required_pass", False)),
+        "ok": False,  # decided after the install-critical work below
         "home": str(home),
         "data_dir": str(data),
         "steps": steps,
@@ -127,6 +130,13 @@ def provision(
         from work_buddy.cli import lifecycle
 
         result["sidecar"] = lifecycle.start_sidecar()
+
+    # Provisioning succeeds when ITS OWN work completed: the data tree is writable
+    # and (if requested) the sidecar came up. The MVP first-run state is "sidecar
+    # up + MCP wired"; feature configuration comes later via the wizard, so unmet
+    # feature-config checks are surfaced (in `bootstrap`) but never fail the install.
+    sidecar_ok = (not start) or bool((result["sidecar"] or {}).get("started"))
+    result["ok"] = bool(dw.get("ok", True)) and sidecar_ok
 
     return result
 


### PR DESCRIPTION
The packaging layer of the native-installer work: the artifacts that turn the provision and autostart core (merged in #223 and #224) into a double-click install for fresh external users. Windows is the primary target, with Linux and macOS scaffolded to fast-follow.

## What this adds

**Build scripts (unit-tested, no network)**
- `packaging/build_payload.py` assembles the installer's source-tree payload from an allowlist (work_buddy plus shipped assets, config templates, and project metadata), pruning dev trees and bytecode. It ships a plain source tree; dependencies download at install time rather than being bundled.
- `packaging/vendor_uv.py` fetches a pinned uv binary per target OS and verifies it against uv's published `.sha256` before bundling. That is supply-chain hardening for a binary that runs on end-user machines.

**Windows installer (primary)**
- `packaging/windows/work-buddy.iss` (Inno Setup, `PrivilegesRequired=lowest`, no admin): installs into a dedicated `work-buddy` folder under `%USERPROFILE%`, which is never cloud-synced and is visible as a Claude Code project directory. A location-page guard refuses a non-empty folder that is not already a work-buddy install, so uninstall (which removes the whole folder) can never take a user's own files with it. It creates the hidden DATA dir under `%LOCALAPPDATA%`, runs the bootstrap, adds a Start-menu dashboard shortcut, and wires uninstall to stop the sidecar and drop the login task while preserving user data. `RedirectionGuard=no` keeps Windows from blocking uv's reparse-point operations (the fix for os error 448).
- `packaging/windows/bootstrap.ps1`: the install-time sequence. It installs a managed CPython 3.11 via uv, creates a venv pointed straight at the real interpreter to bypass uv's Windows version-link, runs `uv pip install -e` with CPU torch and `--index-strategy unsafe-best-match` (retried with backoff), then `wbuddy provision` and a best-effort `wbuddy autostart enable`. It is idempotent, signals success through a marker file, and the finish page reflects the true outcome rather than always claiming success.

**Release CI**
- `.github/workflows/release.yml`: on a version tag it builds the payload, vendors uv, compiles the installer (choco ISCC), and attaches it to a DRAFT GitHub Release for human review. The tag must match the `pyproject.toml` version. The macOS and Linux jobs are scaffolded as commented stubs.

**Linux and macOS fast-follow**
- `packaging/linux/` and `packaging/macos/`: per-user, no-sudo tarball and installer mirroring the Windows bootstrap (systemd --user and launchd). macOS uses a Terminal-driven `install.command` rather than a `.pkg`, because a pkg postinstall would run the multi-minute dependency download inside Installer.app with no progress UI.

## uv pin

Pinned uv at 0.11.26, bumped from a 16-month-old 0.5.29. `packaging/version.py` makes `pyproject.toml` the single source of truth for the installer version, and the release job asserts the tag matches it.

## Testing

- **Unit (no network):** `test_packaging.py` covers payload allowlist and pruning, uv URL construction, archive extraction against synthetic zip and tar, and checksum match and mismatch. All four shell scripts pass `bash -n`. The full suite is green across packaging, provision, autostart, and the repointed sidecar tests.
- **Real-machine end-to-end:** the full double-click install (uv bootstrap, real dependency download, sidecar start, MCP wiring at `localhost:5126`, data under `%LOCALAPPDATA%`) was validated on a real Windows machine using controlled throwaway installs, and completed successfully. Several install-blocking bugs surfaced and were fixed along the way: the RedirectionGuard and uv version-link `448` error, a dependency-resolution deadlock (resolved with `--index-strategy unsafe-best-match`), provision's success predicate, autostart robustness, and an honest finish page. Login auto-start deferred gracefully to the machine's pre-existing WB-Sidecar task, so registration on a fresh machine (where that task is absent) is the one path best confirmed on a clean box before the first public release.
- The `.iss` is ISCC-compile-validated (6.7.3). The macOS and Linux CI jobs stay commented until run on those platforms.

## Docs

The README Getting Started guide is rewritten around the installer (download, double-click, then `/wb-setup guided`), replacing the clone/conda/Poetry flow and pointing the GPU, memory, running-services, and auto-start sections at the `wbuddy` CLI.

## Deferred (follow-ups)

- **Full uv migration:** convert `pyproject.toml` to the PEP 621 `[project]` layout, add `uv.lock` and `uv sync`, retire Poetry from CI, and rewrite the CONTRIBUTING dev workflow. This is the decided next PR, kept separate so its CI change gets its own green check.
- Update lifecycle, tray, knowledge-store seed and overlay, and code-signing and notarization.
