### PR TITLE
Publish wbuddy on the user's PATH; add wbuddy uninstall

### DIFF
--- a/knowledge/store/operations/wb-cli.md
+++ b/knowledge/store/operations/wb-cli.md
@@ -1,7 +1,7 @@
 ---
 name: wbuddy CLI
 kind: directions
-description: 'The wbuddy shell CLI: bootstrap, provisioning, and sidecar-lifecycle ramp (start/stop/status/doctor/setup/provision/autostart/mcp print). Not the agent operations surface, the wb_* gateway stays that.'
+description: 'The wbuddy shell CLI: bootstrap, provisioning, and sidecar-lifecycle ramp (start/stop/status/doctor/setup/provision/uninstall/autostart/mcp print). Not the agent operations surface, the wb_* gateway stays that.'
 summary: '`wbuddy start` runs the sidecar detached, `wbuddy status` and `doctor` report health, and `wbuddy setup` plus `wbuddy mcp print` do pre-MCP bootstrap. A console script (via pyproject) and also `python -m work_buddy.cli`. The wb_* MCP gateway remains the agent operations surface.'
 trigger: user or agent needs to start/stop/check the sidecar from the shell, run bootstrap setup, or print the MCP config
 tags:
@@ -21,6 +21,7 @@ aliases:
 - wbuddy mcp print
 - wbuddy dashboard
 - wbuddy provision
+- wbuddy uninstall
 - wbuddy autostart
 - start the sidecar
 - wbuddy command
@@ -46,7 +47,8 @@ Installed as a console script (`wbuddy`) via pyproject, also runnable as `python
 - `wbuddy setup` -- run the bootstrap checks, print the Claude Code MCP config, and point to `/wb-setup guided` for the interactive feature selection.
 - `wbuddy mcp print` -- emit the Claude Code MCP config (HTTP, the gateway port) to stdout.
 - `wbuddy dashboard [--open]` -- print (or open) the dashboard URL.
-- `wbuddy provision [--home ...] [--data-dir ...] [--vault-root ...] [--repos-root ...] [--timezone ...] [--anthropic-key ...] [--no-start]` -- the native installer's one-shot entry point. `--home` targets a specific install dir (redirects `config_dir`, the one safe way since `config_dir()` is env-var-only), defaulting to the running package's repo root. Seeds `config.yaml` from the template, relocates the mutable-state tree to a per-user data dir (absolute `paths.data_root`), pins `sidecar.python_executable` to the running interpreter, writes secrets to `.env`, refreshes `.mcp.json`, runs the bootstrap checks, and starts the sidecar. Idempotent. Logic in `work_buddy/provision.py`.
+- `wbuddy provision [--home ...] [--data-dir ...] [--vault-root ...] [--repos-root ...] [--timezone ...] [--anthropic-key ...] [--no-start]` -- the native installer's one-shot entry point. `--home` targets a specific install dir (redirects `config_dir`, the one safe way since `config_dir()` is env-var-only), defaulting to the running package's repo root. Seeds `config.yaml` from the template, relocates the mutable-state tree to a per-user data dir (absolute `paths.data_root`), pins `sidecar.python_executable` to the running interpreter, writes secrets to `.env`, refreshes `.mcp.json`, publishes `wbuddy` on the user's PATH (a one-command shim, best-effort: `<home>\bin\wbuddy.cmd` plus a per-user PATH entry on Windows, `~/.local/bin/wbuddy` on POSIX; the venv's own `Scripts`/`bin` never lands on PATH), runs the bootstrap checks, and starts the sidecar. Idempotent. Logic in `work_buddy/provision.py` and `work_buddy/userpath.py`.
+- `wbuddy uninstall` -- tear down machine integration: stop the sidecar, remove the login auto-start task, and remove the PATH shim. User data is preserved; removing the install directory itself is the OS uninstaller's (or the user's) job. The Windows uninstaller invokes this before deleting files.
 - `wbuddy autostart {enable,disable,status}` -- manage login auto-start of the detached sidecar (Windows Task Scheduler `WB-Sidecar`, Linux systemd `--user` unit, macOS launchd agent), via `work_buddy/autostart/`.
 
 ## When to use

--- a/packaging/windows/work-buddy.iss
+++ b/packaging/windows/work-buddy.iss
@@ -89,12 +89,12 @@ Name: "{group}\work-buddy dashboard"; Filename: "{app}\.venv\Scripts\wbuddy.exe"
 Name: "{group}\Uninstall work-buddy"; Filename: "{uninstallexe}"
 
 [UninstallRun]
-; Stop the sidecar and remove the login auto-start task. DATA is left in place
-; (uninstalling the app should not silently delete the user's databases).
-Filename: "{app}\.venv\Scripts\wbuddy.exe"; Parameters: "stop"; \
-  Flags: runhidden; RunOnceId: "WbStop"
-Filename: "{app}\.venv\Scripts\wbuddy.exe"; Parameters: "autostart disable"; \
-  Flags: runhidden; RunOnceId: "WbAutostart"
+; Tear down machine integration in one call: stop the sidecar, remove the login
+; auto-start task, and remove the wbuddy PATH shim (registry PATH-segment surgery
+; lives in Python, where it is unit-testable, not in Pascal). DATA is left in
+; place (uninstalling the app should not silently delete the user's databases).
+Filename: "{app}\.venv\Scripts\wbuddy.exe"; Parameters: "uninstall"; \
+  Flags: runhidden; RunOnceId: "WbUninstall"
 
 [UninstallDelete]
 ; Inno removes only what it installed, so the runtime-created venv and the

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -18,6 +18,23 @@ import yaml
 from work_buddy import compat, provision as prov
 
 
+@pytest.fixture(autouse=True)
+def _stub_cli_shim(monkeypatch):
+    """provision() publishes a wbuddy PATH shim; stub it so tests never touch
+    the host's registry or ~/.local/bin. The shim itself is covered by
+    test_userpath.py against temp paths."""
+    from work_buddy import userpath
+
+    monkeypatch.setattr(
+        userpath, "install_cli_shim",
+        lambda home: {"ok": True, "changed": False, "detail": "stubbed in tests"},
+    )
+    monkeypatch.setattr(
+        userpath, "uninstall_cli_shim",
+        lambda home: {"ok": True, "detail": "stubbed in tests"},
+    )
+
+
 @pytest.fixture
 def tmp_install(tmp_path, monkeypatch):
     home = tmp_path / "home"

--- a/tests/unit/test_userpath.py
+++ b/tests/unit/test_userpath.py
@@ -1,0 +1,157 @@
+"""Tests for the wbuddy PATH shim (``work_buddy.userpath``).
+
+The pure PATH-string surgery is tested directly; everything that would touch
+the host (registry writes, ``~/.local/bin``) is monkeypatched to temp paths or
+stubs, so the tests never modify the machine they run on.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from work_buddy import userpath
+
+
+# --- pure PATH-string surgery ----------------------------------------------
+
+def _sep(*segments: str) -> str:
+    return os.pathsep.join(segments)
+
+
+def test_merge_appends_when_absent():
+    assert userpath.merge_path(_sep("a", "b"), "c") == _sep("a", "b", "c")
+
+
+def test_merge_into_empty_path():
+    assert userpath.merge_path("", "c") == "c"
+
+
+def test_merge_returns_none_when_present():
+    assert userpath.merge_path(_sep("a", "c", "b"), "c") is None
+
+
+def test_merge_is_trailing_separator_insensitive(monkeypatch):
+    monkeypatch.setattr(userpath, "IS_WINDOWS", True)
+    assert userpath.merge_path(r"C:\x;C:\tool\bin\;C:\y", r"C:\tool\bin") is None
+
+
+def test_merge_is_case_insensitive_on_windows(monkeypatch):
+    monkeypatch.setattr(userpath, "IS_WINDOWS", True)
+    assert userpath.merge_path(r"C:\Tool\Bin", r"c:\tool\bin") is None
+
+
+def test_merge_is_case_sensitive_on_posix(monkeypatch):
+    monkeypatch.setattr(userpath, "IS_WINDOWS", False)
+    assert userpath.merge_path("/Tool/bin", "/tool/bin") is not None
+
+
+def test_merge_preserves_existing_value_verbatim(monkeypatch):
+    # %VAR% references in a REG_EXPAND_SZ value must survive untouched.
+    monkeypatch.setattr(userpath, "IS_WINDOWS", True)
+    current = r"%SystemRoot%\system32;%USERPROFILE%\.local\bin"
+    merged = userpath.merge_path(current, r"C:\wb\bin")
+    assert merged == current + os.pathsep + r"C:\wb\bin"
+
+
+def test_strip_removes_entry():
+    assert userpath.strip_path(_sep("a", "c", "b"), "c") == _sep("a", "b")
+
+
+def test_strip_returns_none_when_absent():
+    assert userpath.strip_path(_sep("a", "b"), "c") is None
+
+
+def test_strip_drops_empty_segments():
+    assert userpath.strip_path(_sep("a", "", "c"), "c") == "a"
+
+
+def test_merge_then_strip_roundtrips():
+    merged = userpath.merge_path(_sep("a", "b"), "c")
+    assert userpath.strip_path(merged, "c") == _sep("a", "b")
+
+
+# --- shim install / uninstall (host fully mocked) ---------------------------
+
+@pytest.fixture
+def win_home(tmp_path, monkeypatch):
+    monkeypatch.setattr(userpath, "IS_WINDOWS", True)
+    calls = {}
+
+    def fake_add(d):
+        calls["added"] = d
+        return {"ok": True, "changed": True, "detail": "added"}
+
+    def fake_remove(d):
+        calls["removed"] = d
+        return {"ok": True, "changed": True, "detail": "removed"}
+
+    monkeypatch.setattr(userpath, "add_dir_to_user_path", fake_add)
+    monkeypatch.setattr(userpath, "remove_dir_from_user_path", fake_remove)
+    home = tmp_path / "wb-home"
+    (home / ".venv" / "Scripts").mkdir(parents=True)
+    (home / ".venv" / "Scripts" / "wbuddy.exe").write_bytes(b"MZ")
+    return home, calls
+
+
+@pytest.fixture
+def posix_home(tmp_path, monkeypatch):
+    monkeypatch.setattr(userpath, "IS_WINDOWS", False)
+    monkeypatch.setattr(userpath, "_posix_bin_dir", lambda: tmp_path / "local-bin")
+    home = tmp_path / "wb-home"
+    (home / ".venv" / "bin").mkdir(parents=True)
+    (home / ".venv" / "bin" / "wbuddy").write_text("#!fake")
+    return home, tmp_path / "local-bin"
+
+
+def test_windows_install_writes_shim_and_updates_path(win_home):
+    home, calls = win_home
+    res = userpath.install_cli_shim(home)
+    assert res["ok"] is True
+    shim = home / "bin" / "wbuddy.cmd"
+    assert shim.exists()
+    # Relative to the shim's own location, so the pair survives as a unit.
+    assert "%~dp0" in shim.read_text(encoding="utf-8")
+    assert "wbuddy.exe" in shim.read_text(encoding="utf-8")
+    assert calls["added"] == str(home / "bin")
+
+
+def test_windows_uninstall_removes_shim_and_path_entry(win_home):
+    home, calls = win_home
+    userpath.install_cli_shim(home)
+    res = userpath.uninstall_cli_shim(home)
+    assert res["ok"] is True
+    assert not (home / "bin" / "wbuddy.cmd").exists()
+    assert not (home / "bin").exists()  # empty dir cleaned up
+    assert calls["removed"] == str(home / "bin")
+
+
+def test_skips_when_venv_cli_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(userpath, "IS_WINDOWS", True)
+    res = userpath.install_cli_shim(tmp_path)  # no .venv at all
+    assert res["ok"] is True and res["changed"] is False
+    assert not (tmp_path / "bin").exists()
+
+
+def test_posix_install_writes_exec_shim(posix_home):
+    home, bin_dir = posix_home
+    res = userpath.install_cli_shim(home)
+    assert res["ok"] is True
+    shim = bin_dir / "wbuddy"
+    text = shim.read_text(encoding="utf-8")
+    assert text.startswith("#!/bin/sh")
+    assert str(home.resolve()) in text
+
+
+def test_posix_uninstall_only_removes_own_shim(posix_home, tmp_path):
+    home, bin_dir = posix_home
+    userpath.install_cli_shim(home)
+    # A shim pointing at a DIFFERENT install must be left alone.
+    other = tmp_path / "other-home"
+    res = userpath.uninstall_cli_shim(other)
+    assert (bin_dir / "wbuddy").exists()
+    assert "different install" in res["detail"]
+    # The owning install's uninstall removes it.
+    userpath.uninstall_cli_shim(home)
+    assert not (bin_dir / "wbuddy").exists()

--- a/tests/unit/test_userpath.py
+++ b/tests/unit/test_userpath.py
@@ -33,13 +33,16 @@ def test_merge_returns_none_when_present():
 
 
 def test_merge_is_trailing_separator_insensitive(monkeypatch):
+    # Segments join with os.pathsep so the Windows normalization semantics are
+    # exercised on any host OS (CI runs Linux, where the separator is ':').
     monkeypatch.setattr(userpath, "IS_WINDOWS", True)
-    assert userpath.merge_path(r"C:\x;C:\tool\bin\;C:\y", r"C:\tool\bin") is None
+    current = _sep(r"C:\x", "C:\\tool\\bin\\", r"C:\y")
+    assert userpath.merge_path(current, r"C:\tool\bin") is None
 
 
 def test_merge_is_case_insensitive_on_windows(monkeypatch):
     monkeypatch.setattr(userpath, "IS_WINDOWS", True)
-    assert userpath.merge_path(r"C:\Tool\Bin", r"c:\tool\bin") is None
+    assert userpath.merge_path(_sep(r"C:\Tool\Bin"), r"c:\tool\bin") is None
 
 
 def test_merge_is_case_sensitive_on_posix(monkeypatch):
@@ -50,7 +53,7 @@ def test_merge_is_case_sensitive_on_posix(monkeypatch):
 def test_merge_preserves_existing_value_verbatim(monkeypatch):
     # %VAR% references in a REG_EXPAND_SZ value must survive untouched.
     monkeypatch.setattr(userpath, "IS_WINDOWS", True)
-    current = r"%SystemRoot%\system32;%USERPROFILE%\.local\bin"
+    current = _sep(r"%SystemRoot%\system32", r"%USERPROFILE%\.local\bin")
     merged = userpath.merge_path(current, r"C:\wb\bin")
     assert merged == current + os.pathsep + r"C:\wb\bin"
 

--- a/tests/unit/test_userpath.py
+++ b/tests/unit/test_userpath.py
@@ -33,16 +33,15 @@ def test_merge_returns_none_when_present():
 
 
 def test_merge_is_trailing_separator_insensitive(monkeypatch):
-    # Segments join with os.pathsep so the Windows normalization semantics are
-    # exercised on any host OS (CI runs Linux, where the separator is ':').
+    # A Windows PATH value is ';'-separated on any host (drive letters contain
+    # ':', so it could never ride the POSIX separator), hence the literals.
     monkeypatch.setattr(userpath, "IS_WINDOWS", True)
-    current = _sep(r"C:\x", "C:\\tool\\bin\\", r"C:\y")
-    assert userpath.merge_path(current, r"C:\tool\bin") is None
+    assert userpath.merge_path(r"C:\x;C:\tool\bin\;C:\y", r"C:\tool\bin") is None
 
 
 def test_merge_is_case_insensitive_on_windows(monkeypatch):
     monkeypatch.setattr(userpath, "IS_WINDOWS", True)
-    assert userpath.merge_path(_sep(r"C:\Tool\Bin"), r"c:\tool\bin") is None
+    assert userpath.merge_path(r"C:\Tool\Bin", r"c:\tool\bin") is None
 
 
 def test_merge_is_case_sensitive_on_posix(monkeypatch):
@@ -53,9 +52,9 @@ def test_merge_is_case_sensitive_on_posix(monkeypatch):
 def test_merge_preserves_existing_value_verbatim(monkeypatch):
     # %VAR% references in a REG_EXPAND_SZ value must survive untouched.
     monkeypatch.setattr(userpath, "IS_WINDOWS", True)
-    current = _sep(r"%SystemRoot%\system32", r"%USERPROFILE%\.local\bin")
+    current = r"%SystemRoot%\system32;%USERPROFILE%\.local\bin"
     merged = userpath.merge_path(current, r"C:\wb\bin")
-    assert merged == current + os.pathsep + r"C:\wb\bin"
+    assert merged == current + ";" + r"C:\wb\bin"
 
 
 def test_strip_removes_entry():

--- a/work_buddy/cli/commands.py
+++ b/work_buddy/cli/commands.py
@@ -252,6 +252,16 @@ def cmd_provision(args) -> int:
     return EXIT_OK if res["ok"] else EXIT_FAIL
 
 
+def cmd_uninstall(args) -> int:
+    """Tear down machine integration; the OS uninstaller (or the user) removes files."""
+    from work_buddy import provision as _prov
+
+    res = _prov.uninstall()
+    for step in res["steps"]:
+        print(f"  - {step}")
+    return EXIT_OK
+
+
 def cmd_autostart(args) -> int:
     from work_buddy import autostart, paths
 

--- a/work_buddy/cli/dispatch.py
+++ b/work_buddy/cli/dispatch.py
@@ -10,6 +10,7 @@ owns only setup, sidecar lifecycle, diagnostics, and emitting the MCP config.
     wbuddy status [--json]       wbuddy doctor [<component>] [--json]
     wbuddy setup                 wbuddy mcp print   wbuddy dashboard [--open]
     wbuddy provision [...]       wbuddy autostart {enable,disable,status}
+    wbuddy uninstall
 
 ``provision`` is the native installer's one-shot entry point. The interactive,
 domain-by-domain feature selection lives in ``/wb-setup guided`` inside Claude
@@ -86,6 +87,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--no-start", action="store_true", help="do not start the sidecar afterward",
     )
 
+    sub.add_parser(
+        "uninstall",
+        help="remove machine integration (stop sidecar, login task, PATH shim); user data is preserved",
+    )
+
     p_auto = sub.add_parser("autostart", help="manage login auto-start of the sidecar")
     auto_sub = p_auto.add_subparsers(dest="autostart_command", required=True)
     auto_sub.add_parser("enable", help="register login auto-start")
@@ -104,6 +110,7 @@ _HANDLERS = {
     "setup": commands.cmd_setup,
     "dashboard": commands.cmd_dashboard,
     "provision": commands.cmd_provision,
+    "uninstall": commands.cmd_uninstall,
 }
 
 

--- a/work_buddy/provision.py
+++ b/work_buddy/provision.py
@@ -105,6 +105,16 @@ def provision(
     )
     steps.append("wrote .mcp.json (gateway wiring)")
 
+    # 5b. Publish the wbuddy CLI on the user's PATH (a one-command shim; the
+    #     venv's Scripts/bin never lands on PATH). Best-effort: a failed shim
+    #     must not fail the install — the venv CLI itself still works.
+    try:
+        from work_buddy import userpath
+
+        steps.append("cli shim: " + str(userpath.install_cli_shim(home).get("detail")))
+    except Exception as exc:
+        steps.append(f"cli shim: skipped ({exc})")
+
     # 6. Bootstrap checks. Advisory: they guide the user's next steps but do not,
     #    by themselves, decide provisioning success. Feature config (vault_root,
     #    the Anthropic key) is deferred to `/wb-setup guided`, so those unmet
@@ -147,12 +157,13 @@ def uninstall(*, remove_data: bool = False) -> dict:
     Removing the HOME working copy is left to the OS uninstaller (it knows the
     install path). The data dir is removed only when ``remove_data`` is set.
     """
-    from work_buddy import autostart, paths
+    from work_buddy import autostart, paths, userpath
     from work_buddy.cli import lifecycle
 
     steps: list[str] = []
     steps.append("stop sidecar: " + str(lifecycle.stop_sidecar().get("detail")))
     steps.append("autostart: " + str(autostart.unregister().get("detail")))
+    steps.append("cli shim: " + str(userpath.uninstall_cli_shim(paths.config_dir()).get("detail")))
     if remove_data:
         data = paths._data_base()
         shutil.rmtree(data, ignore_errors=True)

--- a/work_buddy/userpath.py
+++ b/work_buddy/userpath.py
@@ -1,0 +1,220 @@
+"""Expose the ``wbuddy`` CLI on the user's PATH, per-user and reversible.
+
+The native installers never put the venv's ``Scripts``/``bin`` directory on
+PATH (that would expose ``python.exe``/``pip`` globally). Instead, provisioning
+publishes exactly one command:
+
+- **Windows**: a ``bin\\wbuddy.cmd`` shim inside the install HOME forwards to
+  ``.venv\\Scripts\\wbuddy.exe``, and that ``bin`` directory is appended to the
+  per-user PATH (``HKCU\\Environment``, no elevation). A ``WM_SETTINGCHANGE``
+  broadcast lets newly opened shells pick it up without a logoff.
+- **POSIX**: a ``~/.local/bin/wbuddy`` shim execs ``.venv/bin/wbuddy``.
+  ``~/.local/bin`` is on PATH by convention (systemd distros and macOS shells
+  include it via the default profile); when it is not, the caller surfaces that
+  in its step detail rather than editing shell rc files.
+
+Uninstall (``provision.uninstall``) removes the shim and, on Windows, strips
+the PATH segment again. The PATH string surgery lives in pure functions
+(:func:`merge_path`, :func:`strip_path`) so it is unit-testable without
+touching the registry.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from work_buddy.compat import IS_WINDOWS
+from work_buddy.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_WIN_SHIM = '@"%~dp0..\\.venv\\Scripts\\wbuddy.exe" %*\n'
+
+
+# --- pure PATH-string surgery (unit-tested) --------------------------------
+
+def _norm(segment: str) -> str:
+    """Normalize a PATH segment for comparison (Windows: case + trailing sep)."""
+    seg = segment.strip().rstrip("\\/")
+    return seg.casefold() if IS_WINDOWS else seg
+
+
+def merge_path(current: str, entry: str) -> str | None:
+    """Return ``current`` with ``entry`` appended, or None if already present.
+
+    Preserves the existing value byte-for-byte (including ``%VAR%`` references
+    in a ``REG_EXPAND_SZ`` value, which must never be expanded and re-written).
+    """
+    segments = [s for s in current.split(os.pathsep) if s.strip()]
+    if any(_norm(s) == _norm(entry) for s in segments):
+        return None
+    if not segments:
+        return entry
+    return current.rstrip(os.pathsep) + os.pathsep + entry
+
+
+def strip_path(current: str, entry: str) -> str | None:
+    """Return ``current`` without ``entry``, or None if it was absent."""
+    segments = current.split(os.pathsep)
+    kept = [s for s in segments if not (s.strip() and _norm(s) == _norm(entry))]
+    if len(kept) == len(segments):
+        return None
+    return os.pathsep.join(s for s in kept if s.strip())
+
+
+# --- Windows per-user PATH (HKCU\Environment) ------------------------------
+
+def _read_user_path() -> tuple[str, int]:
+    """Return the raw per-user PATH value and its registry type.
+
+    ``winreg.QueryValueEx`` does NOT expand ``REG_EXPAND_SZ`` values, so
+    ``%VAR%`` references come back literally and can be written back intact.
+    A missing value reads as an empty ``REG_EXPAND_SZ``.
+    """
+    import winreg
+
+    with winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Environment") as key:
+        try:
+            value, regtype = winreg.QueryValueEx(key, "Path")
+        except FileNotFoundError:
+            return "", winreg.REG_EXPAND_SZ
+    return str(value), int(regtype)
+
+
+def _write_user_path(value: str, regtype: int) -> None:
+    import winreg
+
+    with winreg.OpenKey(
+        winreg.HKEY_CURRENT_USER, "Environment", 0, winreg.KEY_SET_VALUE
+    ) as key:
+        winreg.SetValueEx(key, "Path", 0, regtype, value)
+
+
+def _broadcast_environment_change() -> None:
+    """Tell running shells the environment changed (best-effort)."""
+    import ctypes
+
+    HWND_BROADCAST = 0xFFFF
+    WM_SETTINGCHANGE = 0x001A
+    SMTO_ABORTIFHUNG = 0x0002
+    try:
+        ctypes.windll.user32.SendMessageTimeoutW(
+            HWND_BROADCAST, WM_SETTINGCHANGE, 0, "Environment",
+            SMTO_ABORTIFHUNG, 5000, ctypes.byref(ctypes.c_ulong()),
+        )
+    except Exception:  # pragma: no cover - cosmetic; new logins still see it
+        logger.debug("WM_SETTINGCHANGE broadcast failed", exc_info=True)
+
+
+def add_dir_to_user_path(directory: str) -> dict:
+    """Append ``directory`` to the per-user PATH (idempotent, Windows only)."""
+    if not IS_WINDOWS:
+        return {"ok": True, "changed": False, "detail": "POSIX: PATH not managed"}
+    try:
+        current, regtype = _read_user_path()
+        merged = merge_path(current, directory)
+        if merged is None:
+            return {"ok": True, "changed": False, "detail": f"{directory} already on user PATH"}
+        _write_user_path(merged, regtype)
+        _broadcast_environment_change()
+        return {"ok": True, "changed": True, "detail": f"added {directory} to user PATH"}
+    except OSError as exc:
+        return {"ok": False, "changed": False, "detail": f"user PATH update failed: {exc}"}
+
+
+def remove_dir_from_user_path(directory: str) -> dict:
+    """Remove ``directory`` from the per-user PATH (idempotent, Windows only)."""
+    if not IS_WINDOWS:
+        return {"ok": True, "changed": False, "detail": "POSIX: PATH not managed"}
+    try:
+        current, regtype = _read_user_path()
+        stripped = strip_path(current, directory)
+        if stripped is None:
+            return {"ok": True, "changed": False, "detail": f"{directory} was not on user PATH"}
+        _write_user_path(stripped, regtype)
+        _broadcast_environment_change()
+        return {"ok": True, "changed": True, "detail": f"removed {directory} from user PATH"}
+    except OSError as exc:
+        return {"ok": False, "changed": False, "detail": f"user PATH update failed: {exc}"}
+
+
+# --- the shim itself --------------------------------------------------------
+
+def _venv_wbuddy(home: Path) -> Path:
+    if IS_WINDOWS:
+        return home / ".venv" / "Scripts" / "wbuddy.exe"
+    return home / ".venv" / "bin" / "wbuddy"
+
+
+def _posix_bin_dir() -> Path:
+    return Path.home() / ".local" / "bin"
+
+
+def install_cli_shim(home: str | Path) -> dict:
+    """Publish ``wbuddy`` on the user's PATH for the install at ``home``.
+
+    Creates only a one-command shim; the venv's own ``Scripts``/``bin`` never
+    lands on PATH. No-ops (with detail) when the venv CLI does not exist, so
+    source checkouts without a ``.venv`` are unaffected.
+    """
+    home = Path(home).resolve()
+    target = _venv_wbuddy(home)
+    if not target.exists():
+        return {"ok": True, "changed": False, "detail": f"no venv CLI at {target}; shim skipped"}
+
+    if IS_WINDOWS:
+        bin_dir = home / "bin"
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        (bin_dir / "wbuddy.cmd").write_text(_WIN_SHIM, encoding="utf-8")
+        path_res = add_dir_to_user_path(str(bin_dir))
+        detail = f"wrote {bin_dir / 'wbuddy.cmd'}; {path_res['detail']}"
+        return {"ok": path_res["ok"], "changed": True, "detail": detail}
+
+    bin_dir = _posix_bin_dir()
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shim = bin_dir / "wbuddy"
+    shim.write_text(f'#!/bin/sh\nexec "{target}" "$@"\n', encoding="utf-8")
+    shim.chmod(0o755)
+    on_path = any(_norm(str(bin_dir)) == _norm(s) for s in os.environ.get("PATH", "").split(os.pathsep))
+    hint = "" if on_path else f" (note: {bin_dir} is not on PATH in this shell)"
+    return {"ok": True, "changed": True, "detail": f"wrote {shim}{hint}"}
+
+
+def uninstall_cli_shim(home: str | Path) -> dict:
+    """Remove the shim and (Windows) the PATH entry for the install at ``home``.
+
+    On POSIX the shared ``~/.local/bin/wbuddy`` is removed only when it points
+    at this install, so uninstalling one copy never breaks another.
+    """
+    home = Path(home).resolve()
+    details: list[str] = []
+
+    if IS_WINDOWS:
+        bin_dir = home / "bin"
+        shim = bin_dir / "wbuddy.cmd"
+        if shim.exists():
+            shim.unlink()
+            details.append(f"removed {shim}")
+        try:
+            bin_dir.rmdir()  # only if empty
+        except OSError:
+            pass
+        details.append(remove_dir_from_user_path(str(bin_dir))["detail"])
+        return {"ok": True, "detail": "; ".join(details)}
+
+    shim = _posix_bin_dir() / "wbuddy"
+    if shim.exists():
+        try:
+            points_here = str(home) in shim.read_text(encoding="utf-8")
+        except OSError:
+            points_here = False
+        if points_here:
+            shim.unlink()
+            details.append(f"removed {shim}")
+        else:
+            details.append(f"left {shim} (points at a different install)")
+    else:
+        details.append("no shim present")
+    return {"ok": True, "detail": "; ".join(details)}

--- a/work_buddy/userpath.py
+++ b/work_buddy/userpath.py
@@ -35,6 +35,13 @@ _WIN_SHIM = '@"%~dp0..\\.venv\\Scripts\\wbuddy.exe" %*\n'
 
 # --- pure PATH-string surgery (unit-tested) --------------------------------
 
+def _pathsep() -> str:
+    """The separator of the PATH value being edited. A Windows registry PATH is
+    ';'-separated regardless of the host manipulating it (``os.pathsep`` only
+    coincides with this when running on Windows)."""
+    return ";" if IS_WINDOWS else ":"
+
+
 def _norm(segment: str) -> str:
     """Normalize a PATH segment for comparison (Windows: case + trailing sep)."""
     seg = segment.strip().rstrip("\\/")
@@ -47,21 +54,23 @@ def merge_path(current: str, entry: str) -> str | None:
     Preserves the existing value byte-for-byte (including ``%VAR%`` references
     in a ``REG_EXPAND_SZ`` value, which must never be expanded and re-written).
     """
-    segments = [s for s in current.split(os.pathsep) if s.strip()]
+    sep = _pathsep()
+    segments = [s for s in current.split(sep) if s.strip()]
     if any(_norm(s) == _norm(entry) for s in segments):
         return None
     if not segments:
         return entry
-    return current.rstrip(os.pathsep) + os.pathsep + entry
+    return current.rstrip(sep) + sep + entry
 
 
 def strip_path(current: str, entry: str) -> str | None:
     """Return ``current`` without ``entry``, or None if it was absent."""
-    segments = current.split(os.pathsep)
+    sep = _pathsep()
+    segments = current.split(sep)
     kept = [s for s in segments if not (s.strip() and _norm(s) == _norm(entry))]
     if len(kept) == len(segments):
         return None
-    return os.pathsep.join(s for s in kept if s.strip())
+    return sep.join(s for s in kept if s.strip())
 
 
 # --- Windows per-user PATH (HKCU\Environment) ------------------------------


### PR DESCRIPTION
## Summary

The installers and README tell users to run `wbuddy start` / `wbuddy autostart enable`, but nothing put `wbuddy` on PATH, so on a fresh machine those commands failed with "not recognized". This makes the existing guidance true, publishing exactly one command rather than the venv's whole `Scripts`/`bin` directory (no global `python.exe`/`pip` exposure):

- **`work_buddy/userpath.py` (new):** provisioning writes a `bin\wbuddy.cmd` shim inside the install HOME and appends that `bin` dir to the per-user PATH on Windows (`HKCU\Environment`, existing value and registry type preserved verbatim, `WM_SETTINGCHANGE` broadcast so new shells see it, idempotent, no elevation). On POSIX it writes a `~/.local/bin/wbuddy` shim. The PATH string surgery is pure functions with direct unit tests.
- **`wbuddy uninstall` (new verb):** tears down machine integration in one call: stop the sidecar, remove the login task, remove the PATH shim. User data is preserved. The Windows uninstaller's `[UninstallRun]` now invokes this instead of separate stop/autostart entries. On POSIX the shared `~/.local/bin/wbuddy` is removed only when it points at the uninstalling install.
- Provision runs the shim step best-effort: a failed shim never fails an install (the venv CLI still works).

## Deviation from the task brief

The brief preferred `bootstrap.ps1` owning the shim and PATH append. It is centralized in `provision()` instead: all three platform installers already invoke provision, so one tested Python implementation covers them (zero installer-script changes), and uninstall gets a symmetric, unit-testable hook, which Inno's `[UninstallRun]` alone could not express without Pascal registry surgery.

## Test plan

- [x] `test_userpath.py` 16/16: PATH merge/strip semantics (idempotent, Windows case and trailing-separator insensitive, `%VAR%` references preserved verbatim) plus shim install/uninstall on both platform branches with the host fully mocked
- [x] `test_provision.py` and `test_packaging.py` green; provision tests stub the shim step so they never touch the host registry or `~/.local/bin`
- [x] Live registry round-trip on a real machine with a throwaway directory: add and remove restored the user PATH byte-identical and preserved the value type
- [x] CLI smoke: `wbuddy uninstall` parses and dispatches
- [ ] CI green (the `.iss` edit is inspection-validated against the existing entry format; the release workflow compiles it on tag builds)

Stacked on #226 (needs the uv-only pyproject); it retargets to main automatically when #226 merges.