### PR TITLE
Recover automatic conversation summarization

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -575,16 +575,12 @@ amplifier_policy:
 # .data/designs/conversation-summarize/PRD.md for the design rationale.
 conversation_observability:
   summaries:
-    # v1 master switch — generates the legacy 8-topic single-call summary
-    # via the 2h cron. Set to true to start collecting summaries at all.
-    enabled: false
-    # v2 master switch — when true:
-    # - the queue worker (sidecar_jobs/summarization-worker.md) drains the
-    #   summarization_queue on the 5min cadence
-    # - refresh_observed_sessions enqueues changed sessions
-    # - refresh_session_summaries (v1 legacy entry) no-ops to avoid race
-    # Bump only after the §8 eval pass clears (PRD OQ19).
-    use_incremental: false
+    # Automatic v2 summaries are active by default. The user-facing switch is
+    # features.conversation_summaries.wanted in config.local.yaml (false opts
+    # out; true opts in; absent/undecided stays active). Existing installs with
+    # an explicit use_incremental value keep that legacy choice until a
+    # preference is set. New installs should omit this compatibility key.
+    # use_incremental: true
     # Model chain for v2's LLM calls (PRD F5). First entry is the primary
     # tier; remaining are tried in order on transient errors (TIMEOUT,
     # CONTEXT_EXCEEDED, RATE_LIMITED, MALFORMED_RESPONSE, BACKEND_UNAVAILABLE,
@@ -606,9 +602,9 @@ conversation_observability:
     # next day. Default $1.00 is generous given the ~$0.07/day baseline
     # at v2 Haiku rates.
     daily_budget_usd: 1.00
-    # Per-call input token budget for the LLM (PRD OQ9). Default 32k —
-    # tracks frontier_fast (Haiku) per the resolved default chain.
-    per_call_budget_tokens: 32000
+    # Optional per-call input-token override. When omitted, the primary tier
+    # determines the budget (local tiers 8k, frontier_fast 32k).
+    # per_call_budget_tokens: 32000
     # Pathway selection threshold (PRD OQ17). Route to chunked when
     # predicted input > pathway_threshold_ratio × per_call_budget.
     pathway_threshold_ratio: 0.85
@@ -616,3 +612,6 @@ conversation_observability:
     # one tick's work; backlogs catch up across many ticks under the
     # daily budget. Default 20.
     worker_tick_limit: 20
+    # Item-intrinsic failures dead-letter after this many attempts. Backend,
+    # model, timeout, rate-limit, and auth failures do not consume attempts.
+    max_attempts: 3

--- a/knowledge/store/architecture/conversation-observability.md
+++ b/knowledge/store/architecture/conversation-observability.md
@@ -90,8 +90,8 @@ Foreign-key cascades use `SqliteRowsStorage.post_delete_sql` rather than SQLite'
 
 Two sidecar crons keep the DB fresh independent of caller demand:
 
-- `conversation-observability-refresh.md` — every 5 minutes (offset from `ir-index-rebuild` by 2 minutes), `max_sessions=5`, `stale_only=true`. Runs all five non-LLM refreshers (observed-sessions, commits, writes, PRs, note-reads) AND auto-enqueues changed sessions into the summarization queue when `summaries.use_incremental` is on. Because the cron uses a 7-day window, PR / commit / write / note-read attribution for *older* sessions requires a one-off wide-window backfill (e.g. `refresh_session_note_reads(days=…)`) after the table first lands.
-- `summarization-worker.md` — every 5 minutes (offset 3 minutes from observability-refresh). Drains the summarization queue FIFO over the cooldown-passed subset, bounded by the daily cost budget. Feature-gated on `summaries.use_incremental`.
+- `conversation-observability-refresh.md` — every 5 minutes (offset from `ir-index-rebuild` by 2 minutes), `max_sessions=5`, `stale_only=true`. Runs all five non-LLM refreshers (observed-sessions, commits, writes, PRs, note-reads) and auto-enqueues changed sessions while Session Summaries is active. Automatic summaries are on by default; `features.conversation_summaries.wanted: false` opts out. Because the cron uses a 7-day window, older history enters the pipeline through `summarization_backfill`.
+- `summarization-worker.md` — every 5 minutes (offset 3 minutes from observability-refresh). Drains cooldown-eligible active rows under the daily cost budget. It remains dormant without a plausible backend, rotates failures behind waiting work, and excludes dead letters while preserving them for status and revival. See `summarization/failure-handling`.
 
 The `claude_session_summary` context source also triggers a stale-only refresh inline before rendering so bundle collections never read a cold DB. The `/ir/index` endpoint is deliberately NOT hooked — stale-only DB-backed scans are cheap enough that an independent cron is cleaner than embedding-service coupling.
 

--- a/knowledge/store/architecture/summarization-framework.md
+++ b/knowledge/store/architecture/summarization-framework.md
@@ -34,7 +34,7 @@ dev_notes: |-
 
   ### Pathway selection
 
-  `_resolve_per_call_budget()` reads `conversation_observability.summaries.per_call_budget_tokens` (default 32k tracking frontier_fast). Pathway selector routes to chunked when the predicted fresh-tail input exceeds `pathway_threshold_ratio × budget` (default 0.85). The chunked path estimates tokens-per-turn from a 10-turn probe, picks a turn-count per chunk that fits the remaining budget after compressed-prior-topic context, and accumulates topics across chunks (each chunk sees the previous chunk's emissions as compressed context).
+  `_resolve_per_call_budget()` honors `conversation_observability.summaries.per_call_budget_tokens` when explicitly set; otherwise it derives the budget from the primary model tier (local 8k, frontier_fast 32k). Pathway selector routes to chunked when the predicted fresh-tail input exceeds `pathway_threshold_ratio × budget` (default 0.85). The chunked path estimates tokens-per-turn from a 10-turn probe, picks a turn-count per chunk that fits the remaining budget after compressed-prior-topic context, and accumulates topics across chunks (each chunk sees the previous chunk's emissions as compressed context).
 
   ### Model chain wiring
 
@@ -42,7 +42,7 @@ dev_notes: |-
 
   ### Queue worker — cadence and bounds
 
-  The worker (`summarization/worker.py`) is invoked by the `summarization-worker.md` sidecar job every 5 minutes (offset 3 minutes from `conversation-observability-refresh`). One tick drains up to `worker_tick_limit` (default 20) entries FIFO over the eligible (cooldown-passed) subset. Eligibility is enforced at dequeue time, not enqueue time, so an actively-changing session that re-enqueues during cooldown stays in the queue but doesn't pre-empt other work. The daily-budget circuit-breaker computes today's spend by summing `agents/*/llm_costs.jsonl` entries with `trace_id` prefix `summarization.`; when it trips, the worker returns `budget_paused: true` until the next day. `bypass_cooldown=True` and `bypass_budget=True` flags exist for explicit user-triggered refresh via the `summarization_worker_tick` MCP op.
+  The worker (`summarization/worker.py`) is invoked by the `summarization-worker.md` sidecar job every 5 minutes. Automatic summaries are active by default and use the component preference as their switch. Before dequeue, the worker goes dormant when no configured backend is plausible. Failures rotate to the queue tail; environmental kinds do not consume attempts, while item-intrinsic kinds dead-letter at `max_attempts` (default 3). Re-enqueue resets failure state. The daily-budget circuit-breaker still bounds spend. See `summarization/failure-handling`.
 
   ### Provenance is core, not an axis
 

--- a/knowledge/store/summarization/failure-handling.md
+++ b/knowledge/store/summarization/failure-handling.md
@@ -1,0 +1,38 @@
+---
+name: Summarization Failure Handling
+kind: concept
+description: Classified retry, queue fairness, dormancy, dead-letter, and revival semantics for automatic conversation summaries.
+tags:
+- summarization
+- retries
+- dead-letter
+- dormancy
+- queue
+aliases:
+- summary retries
+- summarization dead letters
+parents:
+- summarization
+---
+
+Conversation summaries are active unless the `conversation_summaries`
+preference is explicitly unwanted. An explicit legacy
+`conversation_observability.summaries.use_incremental` value is honored only
+while that preference is undecided.
+
+Before dequeueing, the worker performs a no-network plausibility check over the
+configured model chain. With no resolvable local profile and no Anthropic key,
+it returns `dormant: true, dormancy_reason: no_backend`; the queue is untouched.
+
+Failures use the shared LLM `ErrorKind` taxonomy. `backend_unavailable`,
+`model_not_available`, `timeout`, `rate_limited`, and `auth` are environmental:
+they rotate behind waiting work but do not consume attempts. All other kinds
+are item-intrinsic by default and consume the attempt budget. At `max_attempts`
+(default 3), the row becomes a dead letter: excluded from dequeue, retained in
+queue snapshots and health/UI status.
+
+Every failure updates `enqueued_at`, preventing one poison item from pinning
+the FIFO head. Re-enqueueing after source change or `summarization_backfill`
+resets attempts and error fields, reviving a dead letter after its cause is
+fixed. `None` from incremental refresh means clean no-content only; typed
+failures are recorded in the summary store and raised to the worker.

--- a/knowledge/store/summarization/summarization_backfill.md
+++ b/knowledge/store/summarization/summarization_backfill.md
@@ -1,0 +1,40 @@
+---
+name: Summarization Backfill
+kind: capability
+description: Observe historical conversation sessions and enqueue every missing or stale summary without making LLM calls.
+capability_name: summarization_backfill
+category: summarization
+op: op.wb.summarization_backfill
+schema_version: wb-capability/v1
+parameters:
+  days:
+    type: int
+    description: Historical discovery window in days. Defaults to 3650.
+    required: false
+  observe:
+    type: bool
+    description: Refresh the observed-session ledger before reconciliation. Defaults to true.
+    required: false
+  max_sessions:
+    type: int
+    description: Optional bound for the observation pass.
+    required: false
+mutates_state: true
+retry_policy: safe
+tags:
+- summarization
+- backfill
+- queue
+- conversation_observability
+aliases:
+- backfill conversation summaries
+- revive summary dead letters
+parents:
+- summarization
+---
+
+Widens local session observation, then reconciles missing or stale v2 summaries
+into the durable queue. Re-enqueueing resets the attempt/error state, so running
+this after correcting an item-intrinsic failure also revives dead letters. The
+operation is enqueue-only; the background worker still enforces cooldown and
+daily budget limits.

--- a/knowledge/store/summarization/summarization_worker_tick.md
+++ b/knowledge/store/summarization/summarization_worker_tick.md
@@ -1,7 +1,7 @@
 ---
 name: Summarization Worker Tick
 kind: capability
-description: 'Drain the summarization queue once (PRD §6 O2). Picks eligible (cooldown-passed) entries FIFO, bounded by `worker_tick_limit` and the daily cost budget. Used by the sidecar cron and inline-trigger from `/wb-journal-update` and `/wb-morning`. Pass `bypass_cooldown=true` for explicit user-triggered refresh; `bypass_budget=true` to override the daily ceiling.'
+description: 'Drain the active summarization queue once. Runs by default, respects the Session Summaries preference, remains dormant without a plausible backend, rotates failures for fairness, and excludes visible dead letters.'
 capability_name: summarization_worker_tick
 category: summarization
 op: op.wb.summarization_worker_tick
@@ -34,3 +34,9 @@ aliases:
 parents:
 - summarization
 ---
+
+One tick first evaluates activation and backend plausibility without making a
+network call. It then drains cooldown-eligible, non-dead-letter rows under the
+tick and daily-cost bounds. Environmental failures rotate to the queue tail
+without consuming attempts; item-intrinsic failures consume the configured
+attempt budget and remain visible after dead-lettering.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,5 +109,6 @@ markers = [
     "real_obsidian_bridge: opt out of the autouse Obsidian-bridge neutralization (see _isolate_task_store_and_vault)",
     "real_notification_delivery: opt out of the autouse notification-delivery stub (see _isolate_notification_delivery)",
     "real_sidecar_runtime_files: opt out of the autouse sidecar pid/state file redirection (see _isolate_sidecar_runtime_files)",
+    "real_conversation_databases: opt out of conversation-observability and summarization temp-DB isolation",
 ]
 addopts = "-q --tb=short"

--- a/sidecar_jobs/summarization-worker.md
+++ b/sidecar_jobs/summarization-worker.md
@@ -5,9 +5,6 @@ jitter_seconds: 60
 type: capability
 capability: summarization_worker_tick
 params: {}
-feature_gated:
-  config_path: conversation_observability.summaries.use_incremental
-  default: false
 ---
 v2 summarization queue worker (PRD §6 O2). Drains the
 `summarization_queue` SQLite table FIFO over the cooldown-passed
@@ -24,6 +21,6 @@ Per-session cooldown (default 30 min, configurable
 actively-churning session from re-summarizing every 5 minutes —
 the worker SKIPS in-cooldown sessions and tries the next eligible entry.
 
-Feature-gated on `conversation_observability.summaries.use_incremental`
-so v1's 2h cron path still works until the operator flips the flag and
-the eval pass clears (PRD OQ19).
+Runs by default. The worker itself honors the Session Summaries preference,
+goes dormant without a plausible configured backend, and excludes dead letters
+from drainage while keeping them visible for diagnosis and backfill revival.

--- a/tests/component/test_agent_session.py
+++ b/tests/component/test_agent_session.py
@@ -16,7 +16,8 @@ from work_buddy.agent_session import (
 class TestGetSessionId:
     def test_missing_env_raises(self, monkeypatch):
         monkeypatch.delenv("WORK_BUDDY_SESSION_ID", raising=False)
-        with pytest.raises(RuntimeError, match="WORK_BUDDY_SESSION_ID"):
+        monkeypatch.delenv("CODEX_THREAD_ID", raising=False)
+        with pytest.raises(RuntimeError, match="session identity"):
             _get_session_id()
 
     def test_reads_env(self, monkeypatch):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,6 +138,33 @@ def _isolate_sidecar_runtime_files(tmp_path, monkeypatch, request):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_conversation_summary_databases(tmp_path, monkeypatch, request):
+    """Keep transcript observation and summarization writes out of live DBs.
+
+    Observing a fixture session can enqueue it as a side effect now that
+    summaries are on by default. Both databases therefore need a suite-wide
+    boundary; isolating only the observability DB still leaks queue rows into
+    the user's real summarization store.
+    """
+    if request.node.get_closest_marker("real_conversation_databases") is not None:
+        return
+
+    import work_buddy.conversation_observability.db as observation_db
+    import work_buddy.summarization.db as summarization_db
+
+    observation_path = tmp_path / "conversation_observability.db"
+    summarization_path = tmp_path / "summarization.db"
+    monkeypatch.setattr(observation_db, "_default_db_path", lambda: observation_path)
+    monkeypatch.setattr(
+        observation_db, "db_path", lambda cfg=None: observation_db._default_db_path(),
+    )
+    monkeypatch.setattr(summarization_db, "_default_db_path", lambda: summarization_path)
+    monkeypatch.setattr(
+        summarization_db, "db_path", lambda cfg=None: summarization_db._default_db_path(),
+    )
+
+
+@pytest.fixture(autouse=True)
 def _isolate_notification_delivery(monkeypatch, request):
     """Neutralize outbound notification delivery for every test.
 

--- a/tests/unit/test_dashboard_chat_topics_endpoint.py
+++ b/tests/unit/test_dashboard_chat_topics_endpoint.py
@@ -51,6 +51,21 @@ def client():
         yield c
 
 
+@pytest.fixture(autouse=True)
+def active_summary_backend(monkeypatch):
+    monkeypatch.setattr(
+        "work_buddy.summarization.policy.summaries_active", lambda: True,
+    )
+    monkeypatch.setattr(
+        "work_buddy.summarization.orchestrator.chain_has_plausible_backend",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "work_buddy.summarization.worker._resolve_config",
+        lambda: {"max_attempts": 3},
+    )
+
+
 def _prov(prompt_version: int = 1) -> Provenance:
     return Provenance(
         model="claude-haiku-4-5",
@@ -112,8 +127,12 @@ def test_chat_topics_endpoint_returns_full_legacy_shape(
     assert resp.status_code == 200
     data = resp.get_json()
 
-    assert set(data.keys()) == {"topics", "tldr"}
+    assert set(data.keys()) == {
+        "topics", "tldr", "status", "error", "error_kind",
+        "attempts", "max_attempts",
+    }
     assert data["tldr"] == "Overall TLDR for the snapshot test."
+    assert data["status"] == "ready"
 
     topics = data["topics"]
     assert len(topics) == 2
@@ -157,7 +176,11 @@ def test_chat_topics_endpoint_returns_empty_for_unknown_session(
     resp = client.get("/api/chats/sess-does-not-exist/topics")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert data == {"topics": [], "tldr": None}
+    assert data == {
+        "topics": [], "tldr": None, "status": "unsummarized",
+        "error": None, "error_kind": None, "attempts": 0,
+        "max_attempts": 3,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -192,6 +215,8 @@ def test_chat_topics_endpoint_returns_no_tldr_when_status_error(
     assert len(data["topics"]) == 1
     # But tldr is None because status != 'ok'
     assert data["tldr"] is None
+    assert data["status"] == "error"
+    assert data["error"] == "LLM call failed"
 
 
 # ---------------------------------------------------------------------------
@@ -213,3 +238,36 @@ def test_chat_topics_endpoint_returns_zero_topics_for_topicless_session(
     data = resp.get_json()
     assert data["topics"] == []
     assert data["tldr"] == "TLDR but no topics."
+    assert data["status"] == "ready"
+
+
+def test_chat_topics_endpoint_surfaces_queue_and_dead_letter_state(
+    tmp_summarization_db, client,
+):
+    from work_buddy.summarization import queue as queue_mod
+
+    queue_mod.enqueue("conversation_session", "sess-queued")
+    queued = client.get("/api/chats/sess-queued/topics").get_json()
+    assert queued["status"] == "queued"
+    assert queued["attempts"] == 0
+
+    for _ in range(3):
+        queue_mod.record_failure(
+            "conversation_session", "sess-queued", "invalid response",
+            error_kind="malformed_response", count_attempt=True,
+        )
+    dead = client.get("/api/chats/sess-queued/topics").get_json()
+    assert dead["status"] == "dead_lettered"
+    assert dead["attempts"] == 3
+    assert dead["error_kind"] == "malformed_response"
+
+
+def test_chat_topics_endpoint_surfaces_dormancy(
+    tmp_summarization_db, client, monkeypatch,
+):
+    monkeypatch.setattr(
+        "work_buddy.summarization.orchestrator.chain_has_plausible_backend",
+        lambda: False,
+    )
+    data = client.get("/api/chats/sess-dormant/topics").get_json()
+    assert data["status"] == "dormant"

--- a/tests/unit/test_incremental_strategy.py
+++ b/tests/unit/test_incremental_strategy.py
@@ -431,6 +431,57 @@ def test_refresh_one_incremental_initial(tmp_db):
     assert meta["activity_kind"] == "planning"
 
 
+def test_incremental_llm_failure_is_recorded_and_raised(tmp_db):
+    from work_buddy.llm.response import ErrorKind
+    from work_buddy.summarization.protocol import LLMCallResult, SummarizationError
+    from work_buddy.summarization.summarizer import Summarizer
+
+    source = _StubSource(total=15)
+    store = DurableSummaryStore("ns_test")
+    summarizer = Summarizer(
+        name="t", source=source,
+        strategy=IncrementalLayeredStrategy(), store=store,
+    )
+
+    class _FailingCaller:
+        def call(self, **_kwargs):
+            return LLMCallResult(
+                error="backend timed out", error_kind=ErrorKind.TIMEOUT,
+            )
+
+    with pytest.raises(SummarizationError) as raised:
+        refresh_one_incremental(
+            summarizer, "item-1", freshness_token="tok-1",
+            llm_caller=_FailingCaller(),
+        )
+
+    assert raised.value.error_kind is ErrorKind.TIMEOUT
+    assert raised.value.recorded is True
+    assert store.load_item_meta("item-1")["status"] == "error"
+
+
+def test_incremental_parse_failure_is_intrinsic(tmp_db):
+    from work_buddy.llm.response import ErrorKind
+    from work_buddy.summarization.protocol import SummarizationError
+    from work_buddy.summarization.summarizer import Summarizer
+
+    source = _StubSource(total=15)
+    store = DurableSummaryStore("ns_test")
+    summarizer = Summarizer(
+        name="t", source=source,
+        strategy=IncrementalLayeredStrategy(), store=store,
+    )
+
+    with pytest.raises(SummarizationError) as raised:
+        refresh_one_incremental(
+            summarizer, "item-1", freshness_token="tok-1",
+            llm_caller=_stub_llm_returning({"not": "the schema"}),
+        )
+
+    assert raised.value.error_kind is ErrorKind.MALFORMED_RESPONSE
+    assert raised.value.recorded is True
+
+
 def test_refresh_one_incremental_with_prior_finalized(tmp_db):
     """Prior 3 topics, 2 are finalized (distance 10). Refresh emits trailing+new."""
     from work_buddy.summarization.summarizer import Summarizer
@@ -658,7 +709,7 @@ def test_pathway_selection_single_call_short_session(tmp_db):
     assert meta["chunks_used"] == 1
 
 
-def test_pathway_selection_chunked_long_session(tmp_db):
+def test_pathway_selection_chunked_long_session(tmp_db, monkeypatch):
     """Long fresh tail exceeding budget → chunked pathway → multiple chunks_used.
 
     We force the chunked path by setting a tiny budget via monkeypatching the
@@ -683,6 +734,7 @@ def test_pathway_selection_chunked_long_session(tmp_db):
     # Override the default budget constant in the module to force chunking.
     original_budget = incr_mod._DEFAULT_PER_CALL_BUDGET_TOKENS
     incr_mod._DEFAULT_PER_CALL_BUDGET_TOKENS = 500
+    monkeypatch.setattr(incr_mod, "_resolve_per_call_budget", lambda: 500)
     try:
         # Stub LLM returns one new topic per chunk so accumulator advances.
         call_count = {"n": 0}
@@ -723,7 +775,7 @@ def test_pathway_selection_chunked_long_session(tmp_db):
         incr_mod._DEFAULT_PER_CALL_BUDGET_TOKENS = original_budget
 
 
-def test_chunked_pathway_records_model_used(tmp_db):
+def test_chunked_pathway_records_model_used(tmp_db, monkeypatch):
     """Chunked pathway records the model that ran each chunk."""
     from work_buddy.summarization.summarizer import Summarizer
     from work_buddy.summarization import incremental as incr_mod
@@ -735,6 +787,7 @@ def test_chunked_pathway_records_model_used(tmp_db):
 
     original = incr_mod._DEFAULT_PER_CALL_BUDGET_TOKENS
     incr_mod._DEFAULT_PER_CALL_BUDGET_TOKENS = 500
+    monkeypatch.setattr(incr_mod, "_resolve_per_call_budget", lambda: 500)
     try:
         out = {
             "tldr": "x",

--- a/tests/unit/test_llm_runner_v2.py
+++ b/tests/unit/test_llm_runner_v2.py
@@ -47,6 +47,13 @@ class TestClassifyError:
         assert _classify_error("Timed out waiting", None) is ErrorKind.TIMEOUT
         assert _classify_error("Rate limit hit (429)", None) is ErrorKind.RATE_LIMITED
         assert _classify_error("invalid api key", None) is ErrorKind.AUTH
+        assert _classify_error(
+            "Your credit balance is too low to access the Anthropic API.",
+            None,
+        ) is ErrorKind.AUTH
+        assert _classify_error(
+            "Request denied due to insufficient credit", None,
+        ) is ErrorKind.AUTH
         # Unknown text → UNKNOWN
         assert _classify_error("something weird", None) is ErrorKind.UNKNOWN
 

--- a/tests/unit/test_session_summaries_recovery.py
+++ b/tests/unit/test_session_summaries_recovery.py
@@ -1,0 +1,161 @@
+"""Activation, health, and backfill coverage for session summaries."""
+
+from __future__ import annotations
+
+
+def test_activation_is_on_by_default(monkeypatch):
+    from work_buddy.summarization import policy
+
+    monkeypatch.setattr(
+        "work_buddy.health.preferences.is_wanted", lambda _component: None,
+    )
+    monkeypatch.setattr("work_buddy.config.load_config", lambda: {})
+    assert policy.summaries_active() is True
+
+
+def test_activation_preference_is_authoritative(monkeypatch):
+    from work_buddy.summarization import policy
+
+    monkeypatch.setattr(
+        "work_buddy.health.preferences.is_wanted", lambda _component: False,
+    )
+    monkeypatch.setattr(
+        "work_buddy.config.load_config",
+        lambda: {"conversation_observability": {"summaries": {
+            "use_incremental": True,
+        }}},
+    )
+    assert policy.summaries_active() is False
+
+    monkeypatch.setattr(
+        "work_buddy.health.preferences.is_wanted", lambda _component: True,
+    )
+    monkeypatch.setattr(
+        "work_buddy.config.load_config",
+        lambda: {"conversation_observability": {"summaries": {
+            "use_incremental": False,
+        }}},
+    )
+    assert policy.summaries_active() is True
+
+
+def test_activation_honors_explicit_legacy_flag_when_undecided(monkeypatch):
+    from work_buddy.summarization import policy
+
+    monkeypatch.setattr(
+        "work_buddy.health.preferences.is_wanted", lambda _component: None,
+    )
+    monkeypatch.setattr(
+        "work_buddy.config.load_config",
+        lambda: {"conversation_observability": {"summaries": {
+            "use_incremental": False,
+        }}},
+    )
+    assert policy.summaries_active() is False
+
+
+def test_component_and_topology_are_registered():
+    from work_buddy.control.graph_static import SUBSYSTEMS
+    from work_buddy.health.components import COMPONENT_CATALOG
+    from work_buddy.health.requirements import REQUIREMENT_REGISTRY
+
+    component = COMPONENT_CATALOG["conversation_summaries"]
+    assert component.is_core is False
+    assert component.health_source == "custom"
+    assert component.requirements == [
+        "services/conversation-summaries/llm-backend",
+    ]
+    node = next(
+        item for item in SUBSYSTEMS
+        if item["id"] == "subsystem:session-summaries"
+    )
+    assert node["component_deps"] == ["conversation_summaries"]
+    assert all(req in REQUIREMENT_REGISTRY for req in node["requirement_ids"])
+
+
+def test_backfill_observes_then_reconciles(monkeypatch):
+    from work_buddy.mcp_server.ops import conversation_observability_ops as ops
+
+    calls = {}
+    monkeypatch.setattr(
+        "work_buddy.summarization.policy.summaries_active", lambda: True,
+    )
+
+    def _refresh(**kwargs):
+        calls["refresh"] = kwargs
+        return {"observed": 12}
+
+    monkeypatch.setattr(
+        "work_buddy.conversation_observability.sessions.refresh_observed_sessions",
+        _refresh,
+    )
+    monkeypatch.setattr(
+        "work_buddy.summarization.worker.enqueue_missing",
+        lambda **_kwargs: {
+            "candidates": 12, "enqueued": 9, "queue_depth": 9,
+        },
+    )
+
+    result = ops.summarization_backfill(days=365, max_sessions=50)
+    assert calls["refresh"] == {
+        "days": 365, "stale_only": True, "max_sessions": 50,
+    }
+    assert result["active"] is True
+    assert result["enqueued"] == 9
+
+
+def test_backfill_respects_opt_out(monkeypatch):
+    from work_buddy.mcp_server.ops import conversation_observability_ops as ops
+
+    monkeypatch.setattr(
+        "work_buddy.summarization.policy.summaries_active", lambda: False,
+    )
+    result = ops.summarization_backfill()
+    assert result["active"] is False
+    assert result["enqueued"] == 0
+
+
+def test_primary_model_tier_sets_default_budget(monkeypatch):
+    from work_buddy.llm.tiers import ModelTier
+    from work_buddy.summarization import incremental
+
+    monkeypatch.setattr("work_buddy.config.load_config", lambda: {})
+    monkeypatch.setattr(
+        "work_buddy.summarization.orchestrator._resolve_model_chain",
+        lambda: [ModelTier.LOCAL_FAST, ModelTier.FRONTIER_FAST],
+    )
+    assert incremental._resolve_per_call_budget() == 8_000
+
+    monkeypatch.setattr(
+        "work_buddy.summarization.orchestrator._resolve_model_chain",
+        lambda: [ModelTier.FRONTIER_FAST],
+    )
+    assert incremental._resolve_per_call_budget() == 32_000
+
+
+def test_local_backend_plausibility_requires_model_and_url(monkeypatch):
+    from types import SimpleNamespace
+
+    from work_buddy.llm.tiers import ModelTier
+    from work_buddy.summarization import orchestrator
+
+    monkeypatch.setattr(
+        orchestrator, "_resolve_model_chain", lambda: [ModelTier.LOCAL_FAST],
+    )
+    monkeypatch.setattr(
+        "work_buddy.llm.tiers.resolve_tier",
+        lambda _tier: SimpleNamespace(
+            backend="openai_compat", profile="local_general",
+        ),
+    )
+    monkeypatch.setattr(
+        "work_buddy.llm.profiles.resolve_profile",
+        lambda _name: {"base_url": "", "model": "qwen"},
+    )
+    assert orchestrator.chain_has_plausible_backend() is False
+
+    monkeypatch.setattr(
+        "work_buddy.llm.profiles.resolve_profile",
+        lambda _name: {"base_url": "http://localhost:1234/v1", "model": "qwen"},
+    )
+    assert orchestrator.chain_has_plausible_backend() is True

--- a/tests/unit/test_summarization_queue.py
+++ b/tests/unit/test_summarization_queue.py
@@ -90,6 +90,48 @@ def test_queue_record_attempt(tmp_db):
     assert snap[0]["last_error"] == "stub failure"
 
 
+def test_queue_dead_letters_are_visible_but_not_dequeued(tmp_db):
+    queue_mod.enqueue("ns_a", "poison")
+    for _ in range(3):
+        queue_mod.record_failure(
+            "ns_a", "poison", "bad transcript",
+            error_kind="malformed_response", count_attempt=True,
+        )
+
+    assert queue_mod.dequeue_eligible(cooldown_minutes=0, max_attempts=3) == []
+    snapshot = queue_mod.queue_snapshot(max_attempts=3)
+    assert snapshot[0]["dead_lettered"] is True
+    assert queue_mod.queue_stats(max_attempts=3) == {
+        "active": 0, "dead_lettered": 1, "total": 1,
+    }
+
+
+def test_queue_reenqueue_revives_dead_letter(tmp_db):
+    queue_mod.enqueue("ns_a", "poison")
+    for _ in range(3):
+        queue_mod.record_attempt("ns_a", "poison", "bad transcript")
+
+    queue_mod.enqueue("ns_a", "poison")
+    revived = queue_mod.queue_snapshot(max_attempts=3)[0]
+    assert revived["attempts"] == 0
+    assert revived["last_error"] is None
+    assert revived["last_error_kind"] is None
+    assert revived["dead_lettered"] is False
+
+
+def test_failed_head_rotates_behind_waiting_work(tmp_db):
+    queue_mod.enqueue("ns_a", "poison")
+    queue_mod.enqueue("ns_a", "healthy")
+    queue_mod.record_failure(
+        "ns_a", "poison", "timeout",
+        error_kind="timeout", count_attempt=False,
+    )
+
+    eligible = queue_mod.dequeue_eligible(cooldown_minutes=0)
+    assert [entry["item_id"] for entry in eligible] == ["healthy", "poison"]
+    assert eligible[1]["attempts"] == 0
+
+
 def test_queue_re_enqueue_updates_enqueued_at(tmp_db):
     """Re-enqueueing an already-queued session updates timestamp; doesn't
     pre-empt items queued before it."""
@@ -120,7 +162,13 @@ def test_worker_budget_circuit_breaker(tmp_db, monkeypatch):
     # And force the config to a tight budget.
     monkeypatch.setattr(
         worker_mod, "_resolve_config",
-        lambda: {"cooldown_minutes": 30, "daily_budget_usd": 1.0, "tick_limit": 20},
+        lambda: {"active": True, "cooldown_minutes": 30,
+                 "daily_budget_usd": 1.0, "tick_limit": 20,
+                 "max_attempts": 3},
+    )
+    monkeypatch.setattr(
+        "work_buddy.summarization.orchestrator.chain_has_plausible_backend",
+        lambda: True,
     )
 
     result = worker_mod.run_worker_tick()
@@ -140,7 +188,13 @@ def test_worker_no_summarizer_for_namespace(tmp_db, monkeypatch):
     )
     monkeypatch.setattr(
         worker_mod, "_resolve_config",
-        lambda: {"cooldown_minutes": 0, "daily_budget_usd": 1.0, "tick_limit": 20},
+        lambda: {"active": True, "cooldown_minutes": 0,
+                 "daily_budget_usd": 1.0, "tick_limit": 20,
+                 "max_attempts": 3},
+    )
+    monkeypatch.setattr(
+        "work_buddy.summarization.orchestrator.chain_has_plausible_backend",
+        lambda: True,
     )
 
     result = worker_mod.run_worker_tick()
@@ -166,7 +220,13 @@ def test_worker_bypass_cooldown(tmp_db, monkeypatch):
     )
     monkeypatch.setattr(
         worker_mod, "_resolve_config",
-        lambda: {"cooldown_minutes": 30, "daily_budget_usd": 1.0, "tick_limit": 20},
+        lambda: {"active": True, "cooldown_minutes": 30,
+                 "daily_budget_usd": 1.0, "tick_limit": 20,
+                 "max_attempts": 3},
+    )
+    monkeypatch.setattr(
+        "work_buddy.summarization.orchestrator.chain_has_plausible_backend",
+        lambda: True,
     )
     # Force the summarizer resolver to return a stub that "succeeds".
     fake_summ_calls = {"n": 0}
@@ -191,6 +251,66 @@ def test_worker_bypass_cooldown(tmp_db, monkeypatch):
     assert fake_summ_calls["n"] == 1
     # And the queue entry is removed.
     assert queue_mod.queue_depth() == 0
+
+
+def test_worker_dormant_without_backend_preserves_queue(tmp_db, monkeypatch):
+    from work_buddy.summarization import worker as worker_mod
+
+    queue_mod.enqueue("conversation_session", "item-1")
+    monkeypatch.setattr(
+        worker_mod, "_resolve_config",
+        lambda: {"active": True, "cooldown_minutes": 0,
+                 "daily_budget_usd": 1.0, "tick_limit": 20,
+                 "max_attempts": 3},
+    )
+    monkeypatch.setattr(
+        "work_buddy.summarization.orchestrator.chain_has_plausible_backend",
+        lambda: False,
+    )
+
+    result = worker_mod.run_worker_tick()
+    assert result["dormant"] is True
+    assert result["dormancy_reason"] == "no_backend"
+    assert queue_mod.queue_depth() == 1
+
+
+def test_worker_classifies_environmental_and_intrinsic_failures(tmp_db, monkeypatch):
+    from work_buddy.llm.response import ErrorKind
+    from work_buddy.summarization import worker as worker_mod
+    from work_buddy.summarization.protocol import SummarizationError
+
+    queue_mod.enqueue("conversation_session", "environmental")
+    queue_mod.enqueue("conversation_session", "intrinsic")
+    monkeypatch.setattr(
+        worker_mod, "_resolve_config",
+        lambda: {"active": True, "cooldown_minutes": 0,
+                 "daily_budget_usd": 1.0, "tick_limit": 20,
+                 "max_attempts": 3},
+    )
+    monkeypatch.setattr(worker_mod, "today_summarization_spend_usd", lambda: 0.0)
+    monkeypatch.setattr(
+        "work_buddy.summarization.orchestrator.chain_has_plausible_backend",
+        lambda: True,
+    )
+
+    class _FailingSummarizer:
+        def refresh_one(self, item_id, **_kwargs):
+            kind = (
+                ErrorKind.TIMEOUT
+                if item_id == "environmental"
+                else ErrorKind.MALFORMED_RESPONSE
+            )
+            raise SummarizationError("failed", error_kind=kind, recorded=True)
+
+    monkeypatch.setattr(worker_mod, "_resolve_summarizer", lambda _ns: _FailingSummarizer())
+    result = worker_mod.run_worker_tick()
+
+    by_id = {item["item_id"]: item for item in queue_mod.queue_snapshot()}
+    assert by_id["environmental"]["attempts"] == 0
+    assert by_id["environmental"]["last_error_kind"] == "timeout"
+    assert by_id["intrinsic"]["attempts"] == 1
+    assert by_id["intrinsic"]["last_error_kind"] == "malformed_response"
+    assert result["errored"] == 2
 
 
 def test_v2_feature_flag_default_false():

--- a/work_buddy/control/graph_static.py
+++ b/work_buddy/control/graph_static.py
@@ -215,6 +215,20 @@ SUBSYSTEMS: list[_DomainDef] = [
         "component_deps": ["embedding"],
     },
     {
+        "id": "subsystem:session-summaries",
+        "label": "Session Summaries",
+        "description": (
+            "On-by-default per-session recaps and topic timelines. Users can "
+            "opt out with the component preference; without a plausible LLM "
+            "backend the queue stays dormant rather than burning retries."
+        ),
+        "grouping_parents": ["domain:knowledge"],
+        "component_deps": ["conversation_summaries"],
+        "requirement_ids": [
+            "services/conversation-summaries/llm-backend",
+        ],
+    },
+    {
         "id": "subsystem:obsidian-knowledge",
         "label": "Obsidian Knowledge Plugins",
         "description": (

--- a/work_buddy/conversation_observability/sessions.py
+++ b/work_buddy/conversation_observability/sessions.py
@@ -25,22 +25,10 @@ from work_buddy.conversation_observability.db import get_connection
 
 
 def _v2_summarization_enabled() -> bool:
-    """Read the feature flag for v2 incremental summarization.
+    """Compatibility wrapper for the on-by-default summary policy."""
+    from work_buddy.summarization.policy import summaries_active
 
-    `conversation_observability.summaries.use_incremental` (default False).
-    Determines whether `refresh_observed_sessions` enqueues into the
-    summarization queue. When False, the enqueue is skipped and the
-    deprecated v1 batch path remains the only LLM producer (callable
-    via `conversation_observability_summarize`).
-    """
-    try:
-        from work_buddy.config import load_config
-
-        cfg = load_config()
-        summ = (cfg.get("conversation_observability") or {}).get("summaries", {}) or {}
-        return bool(summ.get("use_incremental", False))
-    except Exception:
-        return False
+    return summaries_active()
 
 
 # ---------------------------------------------------------------------------
@@ -215,11 +203,9 @@ def refresh_observed_sessions(
             conn.close()
         observed += 1
 
-        # Enqueue for summarization on mtime change. Gated by the
-        # use_incremental feature flag so we only push onto the queue
-        # when there's a v2 worker draining it; with the flag off the
-        # deprecated v1 batch path is the only producer. Failure here
-        # doesn't break observation.
+        # Enqueue on mtime change while the on-by-default summary policy is
+        # active. An explicit user opt-out stops both enqueue and drainage.
+        # Failure here doesn't break observation.
         try:
             if _v2_summarization_enabled():
                 from work_buddy.summarization.queue import enqueue as _sum_enqueue

--- a/work_buddy/conversation_observability/summaries.py
+++ b/work_buddy/conversation_observability/summaries.py
@@ -69,8 +69,8 @@ def refresh_session_summaries(
     Refreshes `observed_sessions` first (legacy behavior — the source of
     candidate ids), then delegates to `Summarizer.refresh`.
 
-    v2: if `conversation_observability.summaries.use_incremental` is True,
-    this entry no-ops — the queue worker handles refresh on its own cadence.
+    When the on-by-default v2 policy is active, this legacy entry no-ops; the
+    queue worker handles refresh on its own cadence.
     """
     from work_buddy.conversation_observability.sessions import (
         _v2_summarization_enabled,
@@ -81,7 +81,7 @@ def refresh_session_summaries(
     # queue worker (sidecar job `summarization-worker`) handles refresh.
     # Don't double-summarize. Tests passing `llm_call=stub_llm` are
     # explicitly invoking the v1 path with a controlled response and
-    # should not be short-circuited regardless of the config flag.
+    # should not be short-circuited regardless of activation policy.
     if llm_call is None and _v2_summarization_enabled():
         # Still refresh observed_sessions so the queue gets new entries.
         refresh_observed_sessions(days=days, stale_only=True)

--- a/work_buddy/conversation_observability/summarizer_binding.py
+++ b/work_buddy/conversation_observability/summarizer_binding.py
@@ -295,11 +295,9 @@ def build_session_summarizer(use_incremental: bool = False) -> Summarizer:
       schema_v=1) + `DurableSummaryStore(selection=1, cache=1)`. v1-shape
       legacy callers (tests, query helpers, the v1 cron) always get this.
 
-    The feature flag `conversation_observability.summaries.use_incremental`
-    is consulted by the WORKER directly (see `summarization/worker.py`) and
-    by `refresh_observed_sessions` for the auto-enqueue gate — NOT by this
-    function. This separation prevents the lazy singleton from flipping
-    legacy callers to v2 strategy when the worker flag is enabled.
+    The activation policy is consulted by the worker and observed-session
+    enqueue path, not by this factory. This separation prevents the lazy v1
+    singleton from flipping legacy callers to v2 strategy.
     """
     if use_incremental:
         from work_buddy.summarization.strategies import IncrementalLayeredStrategy

--- a/work_buddy/dashboard/frontend/scripts/tabs/chats.py
+++ b/work_buddy/dashboard/frontend/scripts/tabs/chats.py
@@ -769,7 +769,26 @@ function renderChatTldr(topicData) {
 
 function _railTopicsHtml(topicData) {
     if (!topicData || !topicData.topics || topicData.topics.length === 0) {
-        return '<div class="chats-rail-empty">No topic summary for this session.</div>';
+        var status = topicData && topicData.status;
+        var messages = {
+            ready: 'Summary ready; no topic segments were emitted.',
+            queued: 'Summary queued.',
+            retrying: 'Summary retry scheduled (attempt '
+                + (topicData && topicData.attempts || 0) + ' of '
+                + (topicData && topicData.max_attempts || 3) + ').',
+            dead_lettered: 'Summary paused after repeated item-specific failures.',
+            dormant: 'Summary waiting for a configured LLM backend.',
+            opted_out: 'Session summaries are turned off in Settings.',
+            error: 'Summary failed and is not currently queued.',
+            unsummarized: 'This session has not been queued for summarization yet.',
+            unavailable: 'Summary status is unavailable.'
+        };
+        var detail = (topicData && topicData.error)
+            ? '<div class="chats-rail-empty">' + escapeHtml(topicData.error) + '</div>'
+            : '';
+        return '<div class="chats-rail-empty">'
+            + escapeHtml(messages[status] || 'No topic summary for this session.')
+            + '</div>' + detail;
     }
     return topicData.topics.map(function(t, i) {
         var range = (t.turn_start != null && t.turn_end != null)
@@ -969,7 +988,7 @@ function renderActivityRail() {
     // both the intended UX and what keeps the rail from vanishing when you
     // page through chats that happen to have, say, no topics.
     var enabled = {
-        topics: !!(topicData && topicData.topics && topicData.topics.length),
+        topics: !!topicData,
         git: commits.length > 0 || prs.length > 0,
         // Tasks is lazy: enable on any cheap "might be non-empty" signal —
         // an assigned-task hint, commits (which may reference tasks →

--- a/work_buddy/dashboard/service.py
+++ b/work_buddy/dashboard/service.py
@@ -1230,26 +1230,77 @@ def api_chat_commits(session_id: str):
 def api_chat_topics(session_id: str):
     """Cached LLM topic summaries for a session.
 
-    Returns ``{topics: [...], tldr: str | None}``. Empty topics list +
-    ``tldr=None`` when the session hasn't been summarized (the LLM
-    summary feature is gated off by default). The dashboard hides its
-    topic-timeline rail entirely when topics is empty.
+    The status field distinguishes a genuinely absent summary from queued,
+    retrying, dead-lettered, dormant, and opted-out states.
     """
+    empty = {
+        "topics": [],
+        "tldr": None,
+        "status": "unavailable",
+        "error": None,
+        "error_kind": None,
+        "attempts": 0,
+        "max_attempts": 3,
+    }
     try:
         from work_buddy.conversation_observability.session_summary_row import (
             session_summary_row,
         )
     except ImportError:
-        return jsonify({"topics": [], "tldr": None})
+        return jsonify(empty)
 
     try:
+        from work_buddy.summarization import queue as summary_queue
+        from work_buddy.summarization.orchestrator import (
+            chain_has_plausible_backend,
+        )
+        from work_buddy.summarization.policy import summaries_active
+        from work_buddy.summarization.worker import _resolve_config
+
+        max_attempts = int(_resolve_config().get("max_attempts", 3))
+        queued = next(
+            (
+                item
+                for item in summary_queue.queue_snapshot(
+                    "conversation_session", max_attempts=max_attempts,
+                )
+                if item["item_id"] == session_id
+            ),
+            None,
+        )
         row = session_summary_row(session_id)
-        if row is None:
-            return jsonify({"topics": [], "tldr": None})
-        tldr = None
-        if row.get("status") == "ok":
-            tldr = row.get("tldr") or None
-        return jsonify({"topics": row["topics"], "tldr": tldr})
+        response = dict(empty)
+        response["max_attempts"] = max_attempts
+        if row is not None:
+            response["topics"] = row["topics"]
+            response["error"] = row.get("error")
+            if row.get("status") == "ok":
+                response["tldr"] = row.get("tldr") or None
+
+        if queued is not None:
+            response.update({
+                "attempts": int(queued.get("attempts") or 0),
+                "error": queued.get("last_error") or response["error"],
+                "error_kind": queued.get("last_error_kind"),
+            })
+
+        if not summaries_active():
+            response["status"] = "opted_out"
+        elif queued is not None and queued.get("dead_lettered"):
+            response["status"] = "dead_lettered"
+        elif not chain_has_plausible_backend():
+            response["status"] = "dormant"
+        elif queued is not None:
+            response["status"] = (
+                "retrying" if queued.get("last_error") else "queued"
+            )
+        elif row is not None and row.get("status") == "ok":
+            response["status"] = "ready"
+        elif row is not None and row.get("status") == "error":
+            response["status"] = "error"
+        else:
+            response["status"] = "unsummarized"
+        return jsonify(response)
     except Exception as exc:
         logger.exception("chat topics error")
         return jsonify({"error": str(exc)}), 500

--- a/work_buddy/health/checks.py
+++ b/work_buddy/health/checks.py
@@ -513,6 +513,61 @@ def check_github_backup_freshness() -> dict[str, Any]:
     }
 
 
+def check_conversation_summaries() -> dict[str, Any]:
+    """Report opted-out, dormant, or active queue/coverage state."""
+    from work_buddy.summarization.policy import summaries_active
+
+    if not summaries_active():
+        return {
+            "ok": True,
+            "state": "opted_out",
+            "detail": "Session summaries are explicitly opted out.",
+        }
+
+    from work_buddy.summarization.orchestrator import chain_has_plausible_backend
+    from work_buddy.summarization.queue import queue_stats
+    from work_buddy.summarization.worker import _resolve_config
+
+    max_attempts = int(_resolve_config().get("max_attempts", 3))
+    stats = queue_stats(
+        "conversation_session", max_attempts=max_attempts,
+    )
+    state = "active" if chain_has_plausible_backend() else "dormant"
+    parts = [
+        f"{stats['active']} queued",
+        f"{stats['dead_lettered']} dead-lettered",
+    ]
+
+    try:
+        from work_buddy.conversation_observability.db import (
+            get_connection as observed_connection,
+        )
+        from work_buddy.summarization.db import get_connection as summary_connection
+
+        conn = observed_connection()
+        try:
+            observed = int(conn.execute(
+                "SELECT COUNT(*) AS n FROM observed_sessions"
+            ).fetchone()["n"])
+        finally:
+            conn.close()
+        conn = summary_connection()
+        try:
+            summarized = int(conn.execute(
+                "SELECT COUNT(*) AS n FROM summary_items "
+                "WHERE namespace = 'conversation_session' AND status = 'ok'"
+            ).fetchone()["n"])
+        finally:
+            conn.close()
+        parts.append(f"{summarized} of {observed} observed sessions summarized")
+    except Exception as exc:  # pragma: no cover - defensive visibility
+        parts.append(f"coverage unavailable: {exc}")
+
+    if state == "dormant":
+        parts.insert(0, "no plausible configured LLM backend")
+    return {"ok": True, "state": state, "detail": "; ".join(parts)}
+
+
 def check_google_calendar_native_api() -> dict[str, Any]:
     """Runtime probe: the Google Calendar API answers with the stored native
     OAuth token. Resolves only on diagnose (the component is ``health_source``

--- a/work_buddy/health/components.py
+++ b/work_buddy/health/components.py
@@ -590,6 +590,27 @@ _register(ComponentDef(
 ))
 
 _register(ComponentDef(
+    id="conversation_summaries",
+    display_name="Session Summaries",
+    category="service",
+    is_core=False,
+    depends_on=["sidecar"],
+    health_source="custom",
+    requirements=["services/conversation-summaries/llm-backend"],
+    check_sequence=[
+        CheckStep(
+            description="Summarization pipeline state and coverage",
+            check_fn="work_buddy.health.checks.check_conversation_summaries",
+            on_fail=(
+                "Inspect the queue and configured model chain. Dead letters "
+                "remain visible and can be revived with "
+                "summarization_backfill after the underlying issue is fixed."
+            ),
+        ),
+    ],
+))
+
+_register(ComponentDef(
     id="google_calendar_native",
     display_name="Google Calendar (native OAuth)",
     category="integration",

--- a/work_buddy/health/requirement_checks.py
+++ b/work_buddy/health/requirement_checks.py
@@ -706,6 +706,29 @@ def check_jina_api_key() -> dict[str, Any]:
     return {"ok": False, "detail": f"${env_name} not set — the keyless ddgs fallback is used instead"}
 
 
+def check_summaries_llm_backend() -> dict[str, Any]:
+    """No-network preflight for the configured summarization model chain."""
+    from work_buddy.summarization.orchestrator import (
+        _resolve_model_chain,
+        chain_has_plausible_backend,
+    )
+
+    chain = [tier.value for tier in _resolve_model_chain()]
+    if chain_has_plausible_backend():
+        return {
+            "ok": True,
+            "detail": f"Model chain {chain} has a plausible configured backend.",
+        }
+    return {
+        "ok": False,
+        "detail": (
+            f"Model chain {chain} has no plausible backend. Configure its "
+            "local profile or provide an Anthropic API key; the worker will "
+            "remain dormant until then."
+        ),
+    }
+
+
 def check_thunderbird_bridge() -> dict[str, Any]:
     """Check the thunderbird-work-buddy companion bridge is reachable.
 

--- a/work_buddy/health/requirements.py
+++ b/work_buddy/health/requirements.py
@@ -771,6 +771,21 @@ _register(RequirementDef(
 ))
 
 _register(RequirementDef(
+    id="services/conversation-summaries/llm-backend",
+    component="conversation_summaries",
+    description="A plausible LLM backend exists for session summaries",
+    check_fn="work_buddy.health.requirement_checks.check_summaries_llm_backend",
+    severity="recommended",
+    fix_hint=(
+        "Configure at least one tier in the summarization model chain: a "
+        "resolvable local profile, or an Anthropic tier with "
+        "SUBAGENT_ANTHROPIC_API_KEY/ANTHROPIC_API_KEY. Without one, the "
+        "on-by-default worker remains dormant and preserves its queue."
+    ),
+    setup_group="summaries",
+))
+
+_register(RequirementDef(
     id="integrations/thunderbird/bridge",
     component="thunderbird",
     description=(

--- a/work_buddy/llm/runner_v2.py
+++ b/work_buddy/llm/runner_v2.py
@@ -107,7 +107,13 @@ def _classify_error(error: str | None, kind_str: str | None) -> ErrorKind | None
         return ErrorKind.TIMEOUT
     if "rate limit" in lower or "429" in lower:
         return ErrorKind.RATE_LIMITED
-    if "authentication" in lower or "api key" in lower or "401" in lower:
+    if (
+        "authentication" in lower
+        or "api key" in lower
+        or "401" in lower
+        or "credit balance is too low" in lower
+        or "insufficient credit" in lower
+    ):
         return ErrorKind.AUTH
     # SCHEMA_VIOLATION last — narrowed to require schema/JSON context AND
     # an actual violation/invalid signal. Was: ``"schema" in lower or

--- a/work_buddy/mcp_server/ops/conversation_observability_ops.py
+++ b/work_buddy/mcp_server/ops/conversation_observability_ops.py
@@ -119,6 +119,53 @@ def summarization_worker_tick(
     )
 
 
+def summarization_backfill(
+    days: int = 3650,
+    observe: bool = True,
+    max_sessions: int | None = None,
+) -> dict[str, Any]:
+    """Observe historical sessions and enqueue every missing/stale summary.
+
+    This operation does no LLM work. The normal worker drains the reconciled
+    queue under its cooldown, retry, and daily-budget policies.
+    """
+    from work_buddy.summarization.policy import summaries_active
+    from work_buddy.summarization.worker import enqueue_missing
+
+    if not summaries_active():
+        return {
+            "active": False,
+            "observed": None,
+            "enqueued": 0,
+            "hint": (
+                "Session summaries are opted out. Set the Session Summaries "
+                "preference to Want, then run summarization_backfill again."
+            ),
+        }
+
+    observed: dict[str, Any] | None = None
+    if observe:
+        from work_buddy.conversation_observability.sessions import (
+            refresh_observed_sessions,
+        )
+
+        observed = refresh_observed_sessions(
+            days=days,
+            stale_only=True,
+            max_sessions=max_sessions,
+        )
+
+    reconciled = enqueue_missing(days=days)
+    return {
+        "active": True,
+        "observed": observed,
+        "candidates": reconciled["candidates"],
+        "enqueued": reconciled["enqueued"],
+        "queue_depth": reconciled["queue_depth"],
+        "note": "Enqueue-only; the background worker drains the backlog.",
+    }
+
+
 def session_prs_get(session_id: str) -> dict[str, Any]:
     """Return the GitHub PR-activity events attributed to one session.
 
@@ -154,6 +201,8 @@ def _register() -> None:
                 refresh_session_summaries)
     register_op("op.wb.summarization_worker_tick",
                 summarization_worker_tick, replace=True)
+    register_op("op.wb.summarization_backfill",
+                summarization_backfill, replace=True)
     # Both op IDs bind the same callable so existing
     # `conversation_observability_summary_get` callers keep working;
     # the capability declaration for the long-namespace name is marked

--- a/work_buddy/summarization/incremental.py
+++ b/work_buddy/summarization/incremental.py
@@ -34,6 +34,8 @@ import json
 import logging
 from typing import Any
 
+from work_buddy.llm.response import ErrorKind
+
 from work_buddy.summarization.protocol import (
     LLMCaller,
     Provenance,
@@ -79,7 +81,8 @@ def refresh_one_incremental(
     """Run one incremental refresh against the given item.
 
     Returns the merged `SummaryNode` tree after save, or `None` if there was
-    nothing to do (empty session, no fresh turns) or the LLM/parse failed.
+    nothing to do (empty session or no fresh turns). LLM and parse failures
+    are recorded and then raised with a stable ``ErrorKind`` for the worker.
 
     The caller is expected to have already verified that the item is stale —
     this function does not consult `store.is_fresh`.
@@ -170,7 +173,8 @@ def refresh_one_incremental(
         raise SummarizationError(
             f"Prior-topic context (~{context_token_estimate} tokens) exceeds "
             f"per-call budget (~{budget_tokens} × {_PATHWAY_THRESHOLD_RATIO}); "
-            f"finalization heuristic may need re-tuning"
+            f"finalization heuristic may need re-tuning",
+            error_kind=ErrorKind.CONTEXT_EXCEEDED,
         )
 
     # Quick fresh-tail size probe via render_from (which respects the 40k
@@ -255,22 +259,35 @@ def _refresh_single_call(
     )
 
     if result.is_error():
+        message = result.error or "llm error"
         store.record_error(
             item_id,
-            result.error or "llm error",
+            message,
             build_error_provenance(summarizer, profile),
         )
-        return None
+        raise SummarizationError(
+            message,
+            error_kind=result.error_kind or ErrorKind.UNKNOWN,
+            recorded=True,
+        )
 
     try:
         new_root = strategy.parse(result.structured_output, result.content)
     except Exception as exc:
+        message = f"parse error: {exc}"
         store.record_error(
             item_id,
-            f"parse error: {exc}",
+            message,
             build_provenance(summarizer, result, profile),
         )
-        return None
+        raise SummarizationError(
+            message,
+            error_kind=(
+                getattr(exc, "error_kind", None)
+                or ErrorKind.MALFORMED_RESPONSE
+            ),
+            recorded=True,
+        ) from exc
 
     prov = build_provenance(summarizer, result, profile)
     activity_kind = new_root.extra.get("activity_kind", "unknown")
@@ -392,12 +409,20 @@ def _refresh_chunked(
         if result.is_error():
             # Per PRD: on chunked failure mid-way, record an error and
             # bail. Don't half-update the store with partial state.
+            message = (
+                f"chunked refresh failed at chunk {chunks_used}: "
+                f"{result.error or 'llm error'}"
+            )
             store.record_error(
                 item_id,
-                f"chunked refresh failed at chunk {chunks_used}: {result.error}",
+                message,
                 build_error_provenance(summarizer, profile),
             )
-            return None
+            raise SummarizationError(
+                message,
+                error_kind=result.error_kind or ErrorKind.UNKNOWN,
+                recorded=True,
+            )
 
         if result.model:
             models_used.append(result.model)
@@ -405,12 +430,22 @@ def _refresh_chunked(
         try:
             chunk_root = strategy.parse(result.structured_output, result.content)
         except Exception as exc:
+            message = (
+                f"chunked refresh parse error at chunk {chunks_used}: {exc}"
+            )
             store.record_error(
                 item_id,
-                f"chunked refresh parse error at chunk {chunks_used}: {exc}",
+                message,
                 build_provenance(summarizer, result, profile),
             )
-            return None
+            raise SummarizationError(
+                message,
+                error_kind=(
+                    getattr(exc, "error_kind", None)
+                    or ErrorKind.MALFORMED_RESPONSE
+                ),
+                recorded=True,
+            ) from exc
 
         # Merge chunk_root.children into accumulator.
         if accumulated_root is None:
@@ -545,8 +580,9 @@ def _estimate_topic_context_tokens(
 
 
 def _resolve_per_call_budget() -> int:
-    """Resolve the per-call input token budget from config, falling back to
-    the frontier_fast default. PRD §6 config block:
+    """Resolve the input budget from an override or the primary model tier.
+
+    PRD §6 config block:
 
         conversation_observability:
           summaries:
@@ -565,7 +601,15 @@ def _resolve_per_call_budget() -> int:
             return explicit
     except Exception:
         pass
-    return _DEFAULT_PER_CALL_BUDGET_TOKENS
+    try:
+        from work_buddy.summarization.orchestrator import _resolve_model_chain
+
+        primary = _resolve_model_chain()[0]
+        return _TIER_BUDGETS_TOKENS.get(
+            primary.value, _DEFAULT_PER_CALL_BUDGET_TOKENS,
+        )
+    except Exception:
+        return _DEFAULT_PER_CALL_BUDGET_TOKENS
 
 
 # ---------------------------------------------------------------------------

--- a/work_buddy/summarization/orchestrator.py
+++ b/work_buddy/summarization/orchestrator.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from typing import Any, Callable
 
 from work_buddy.summarization.protocol import (
@@ -356,7 +357,10 @@ def as_caller(fn: Callable[..., Any] | None) -> LLMCaller | None:
                     profile=profile,
                 )
             except Exception as exc:
-                return LLMCallResult(error=str(exc))
+                return LLMCallResult(
+                    error=str(exc),
+                    error_kind=getattr(exc, "error_kind", None),
+                )
             return _normalize_stub_response(resp)
 
     return _Adapter()
@@ -406,6 +410,7 @@ def _normalize_stub_response(resp: Any) -> LLMCallResult:
     model = getattr(resp, "model", None)
     backend = getattr(resp, "backend", None)
     error = getattr(resp, "error", None)
+    error_kind = getattr(resp, "error_kind", None)
     is_err_method = getattr(resp, "is_error", None)
     if callable(is_err_method):
         try:
@@ -420,6 +425,7 @@ def _normalize_stub_response(resp: Any) -> LLMCallResult:
         model=model,
         backend=backend,
         error=error,
+        error_kind=error_kind,
     )
 
 
@@ -487,7 +493,11 @@ def default_llm_caller() -> LLMCaller:
                     trace_id=trace_id,
                 )
             except Exception as exc:
-                return LLMCallResult(error=str(exc))
+                from work_buddy.llm.response import ErrorKind
+
+                return LLMCallResult(
+                    error=str(exc), error_kind=ErrorKind.UNKNOWN,
+                )
 
             return LLMCallResult(
                 structured_output=resp.structured_output,
@@ -495,9 +505,63 @@ def default_llm_caller() -> LLMCaller:
                 model=resp.model or None,
                 backend=resp.backend or None,
                 error=resp.error if resp.is_error() else None,
+                error_kind=resp.error_kind if resp.is_error() else None,
             )
 
     return _Default()
+
+
+def anthropic_key_available() -> bool:
+    """Cheap local check matching the key sources used by the LLM runner."""
+    if os.environ.get("SUBAGENT_ANTHROPIC_API_KEY") or os.environ.get(
+        "ANTHROPIC_API_KEY"
+    ):
+        return True
+
+    try:
+        from work_buddy.paths import config_dir
+
+        env_file = config_dir() / ".env"
+        for line in env_file.read_text(encoding="utf-8").splitlines():
+            key, sep, value = line.partition("=")
+            if (
+                sep
+                and key.strip() in {
+                    "SUBAGENT_ANTHROPIC_API_KEY",
+                    "ANTHROPIC_API_KEY",
+                }
+                and value.strip()
+            ):
+                return True
+    except OSError:
+        pass
+    return False
+
+
+def chain_has_plausible_backend() -> bool:
+    """Check whether any configured summarization tier could run.
+
+    This is deliberately a no-network preflight.  Local tiers are plausible
+    when their tier and profile resolve; Anthropic tiers are plausible when a
+    key is available.  Runtime failures remain the worker's responsibility.
+    """
+    from work_buddy.llm.profiles import resolve_profile
+    from work_buddy.llm.tiers import resolve_tier
+
+    for tier in _resolve_model_chain():
+        try:
+            binding = resolve_tier(tier)
+            if binding.backend == "anthropic":
+                if anthropic_key_available():
+                    return True
+            elif binding.backend in {"lmstudio_native", "openai_compat"}:
+                if binding.profile:
+                    resolved = resolve_profile(binding.profile)
+                    if resolved.get("base_url") and resolved.get("model"):
+                        return True
+        except (KeyError, TypeError, ValueError):
+            continue
+    return False
 
 
 def _resolve_model_chain() -> list[Any]:

--- a/work_buddy/summarization/policy.py
+++ b/work_buddy/summarization/policy.py
@@ -1,0 +1,39 @@
+"""Activation policy for automatic conversation summaries."""
+
+from __future__ import annotations
+
+
+COMPONENT_ID = "conversation_summaries"
+
+
+def summaries_active() -> bool:
+    """Return whether automatic conversation summaries should run.
+
+    The user preference is authoritative when explicitly set.  For users
+    upgrading from the pre-preference implementation, an explicit legacy
+    ``use_incremental`` value is still honored.  A completely undecided
+    installation is active by default.
+    """
+    try:
+        from work_buddy.health.preferences import is_wanted
+
+        wanted = is_wanted(COMPONENT_ID)
+        if wanted is not None:
+            return bool(wanted)
+    except Exception:
+        pass
+
+    try:
+        from work_buddy.config import load_config
+
+        summaries = (
+            (load_config().get("conversation_observability") or {})
+            .get("summaries", {})
+            or {}
+        )
+        if "use_incremental" in summaries:
+            return bool(summaries["use_incremental"])
+    except Exception:
+        pass
+
+    return True

--- a/work_buddy/summarization/protocol.py
+++ b/work_buddy/summarization/protocol.py
@@ -24,7 +24,6 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Iterable, Protocol, runtime_checkable
 
-
 # ---------------------------------------------------------------------------
 # Datatypes
 # ---------------------------------------------------------------------------
@@ -137,6 +136,17 @@ class SummarizationError(RuntimeError):
     flips to `status='error'`, prior good results are preserved, and other
     items in the same refresh pass continue.
     """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_kind: Any | None = None,
+        recorded: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.error_kind = error_kind
+        self.recorded = recorded
 
 
 # ---------------------------------------------------------------------------
@@ -289,9 +299,10 @@ class LLMCallResult:
     model: str | None = None
     backend: str | None = None
     error: str | None = None
+    error_kind: Any | None = None
 
     def is_error(self) -> bool:
-        return self.error is not None
+        return self.error is not None or self.error_kind is not None
 
 
 class LLMCaller(Protocol):

--- a/work_buddy/summarization/queue.py
+++ b/work_buddy/summarization/queue.py
@@ -21,6 +21,7 @@ CREATE TABLE summarization_queue (
     enqueued_at TEXT NOT NULL,
     attempts    INTEGER NOT NULL DEFAULT 0,
     last_error  TEXT,
+    last_error_kind TEXT,
     PRIMARY KEY (namespace, item_id)
 );
 ```
@@ -44,6 +45,7 @@ CREATE TABLE IF NOT EXISTS summarization_queue (
     enqueued_at TEXT NOT NULL,
     attempts    INTEGER NOT NULL DEFAULT 0,
     last_error  TEXT,
+    last_error_kind TEXT,
     PRIMARY KEY (namespace, item_id)
 );
 CREATE INDEX IF NOT EXISTS idx_summarization_queue_enqueued_at
@@ -60,6 +62,14 @@ def ensure_queue_table(conn=None) -> None:
         owned = False
     try:
         conn.executescript(_QUEUE_SCHEMA)
+        columns = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(summarization_queue)")
+        }
+        if "last_error_kind" not in columns:
+            conn.execute(
+                "ALTER TABLE summarization_queue ADD COLUMN last_error_kind TEXT"
+            )
         conn.commit()
     finally:
         if owned:
@@ -83,7 +93,8 @@ def enqueue(namespace: str, item_id: str) -> None:
             "(namespace, item_id, enqueued_at) "
             "VALUES (?, ?, ?) "
             "ON CONFLICT(namespace, item_id) DO UPDATE SET "
-            "  enqueued_at=excluded.enqueued_at",
+            "  enqueued_at=excluded.enqueued_at, "
+            "  attempts=0, last_error=NULL, last_error_kind=NULL",
             (namespace, item_id, now),
         )
         conn.commit()
@@ -95,6 +106,7 @@ def dequeue_eligible(
     namespace: str | None = None,
     cooldown_minutes: int = 30,
     limit: int | None = None,
+    max_attempts: int = 3,
 ) -> list[dict[str, Any]]:
     """Return queue entries eligible for processing — strictly FIFO over the
     eligible subset (cooldown-passed).
@@ -104,7 +116,7 @@ def dequeue_eligible(
     - OR no row in `summary_items` (never summarized)
 
     Doesn't remove rows from the queue — the worker calls `remove(...)`
-    after successful processing, or `record_attempt(...)` on failure.
+    after successful processing, or `record_failure(...)` on failure.
 
     Returns dicts with `namespace`, `item_id`, `enqueued_at`, `attempts`,
     `last_error`, `last_summarized_at` (None if never).
@@ -118,14 +130,18 @@ def dequeue_eligible(
         params: list[Any] = []
         sql = (
             "SELECT q.namespace, q.item_id, q.enqueued_at, q.attempts, "
-            "       q.last_error, s.generated_at AS last_summarized_at "
+            "       q.last_error, q.last_error_kind, "
+            "       s.generated_at AS last_summarized_at "
             "FROM summarization_queue q "
             "LEFT JOIN summary_items s "
             "  ON q.namespace = s.namespace AND q.item_id = s.item_id "
         )
+        where = ["q.attempts < ?"]
+        params.append(max_attempts)
         if namespace:
-            sql += "WHERE q.namespace = ? "
+            where.append("q.namespace = ?")
             params.append(namespace)
+        sql += "WHERE " + " AND ".join(where) + " "
         sql += "ORDER BY q.enqueued_at ASC"
         rows = list(conn.execute(sql, params))
     finally:
@@ -164,43 +180,85 @@ def remove(namespace: str, item_id: str) -> None:
         conn.close()
 
 
-def record_attempt(namespace: str, item_id: str, error: str | None) -> None:
-    """Record an attempt — increment attempts; stash last_error if any."""
+def record_failure(
+    namespace: str,
+    item_id: str,
+    error: str | None,
+    *,
+    error_kind: str | None,
+    count_attempt: bool,
+) -> None:
+    """Record and rotate a failure so the next queue item gets a turn.
+
+    Environmental failures remain retryable without consuming the intrinsic
+    attempt budget.  Intrinsic failures increment ``attempts`` and become a
+    visible dead letter once they reach the worker's configured cap.
+    """
+    now = datetime.now(timezone.utc).isoformat()
     conn = get_connection()
     try:
         conn.execute(
             "UPDATE summarization_queue SET "
-            "  attempts = attempts + 1, "
-            "  last_error = ? "
+            "  attempts = attempts + ?, "
+            "  last_error = ?, last_error_kind = ?, enqueued_at = ? "
             "WHERE namespace = ? AND item_id = ?",
-            (error, namespace, item_id),
+            (
+                1 if count_attempt else 0,
+                error,
+                error_kind,
+                now,
+                namespace,
+                item_id,
+            ),
         )
         conn.commit()
     finally:
         conn.close()
 
 
-def queue_depth(namespace: str | None = None) -> int:
+def record_attempt(namespace: str, item_id: str, error: str | None) -> None:
+    """Backward-compatible intrinsic/unknown failure recorder."""
+    record_failure(
+        namespace,
+        item_id,
+        error,
+        error_kind="unknown",
+        count_attempt=True,
+    )
+
+
+def queue_depth(
+    namespace: str | None = None,
+    *,
+    include_dead_letters: bool = True,
+    max_attempts: int = 3,
+) -> int:
     """Return the count of queued items. Cheap; for dashboard/observability."""
     conn = get_connection()
     try:
         ensure_queue_table(conn)
+        where: list[str] = []
+        params: list[Any] = []
         if namespace:
-            row = conn.execute(
-                "SELECT COUNT(*) AS n FROM summarization_queue "
-                "WHERE namespace = ?",
-                (namespace,),
-            ).fetchone()
-        else:
-            row = conn.execute(
-                "SELECT COUNT(*) AS n FROM summarization_queue"
-            ).fetchone()
+            where.append("namespace = ?")
+            params.append(namespace)
+        if not include_dead_letters:
+            where.append("attempts < ?")
+            params.append(max_attempts)
+        sql = "SELECT COUNT(*) AS n FROM summarization_queue"
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        row = conn.execute(sql, params).fetchone()
         return int(row["n"])
     finally:
         conn.close()
 
 
-def queue_snapshot(namespace: str | None = None) -> list[dict[str, Any]]:
+def queue_snapshot(
+    namespace: str | None = None,
+    *,
+    max_attempts: int = 3,
+) -> list[dict[str, Any]]:
     """Return a snapshot of all queued items for dashboard rendering."""
     conn = get_connection()
     try:
@@ -208,7 +266,8 @@ def queue_snapshot(namespace: str | None = None) -> list[dict[str, Any]]:
         params: list[Any] = []
         sql = (
             "SELECT q.namespace, q.item_id, q.enqueued_at, q.attempts, "
-            "       q.last_error, s.generated_at AS last_summarized_at "
+            "       q.last_error, q.last_error_kind, "
+            "       s.generated_at AS last_summarized_at "
             "FROM summarization_queue q "
             "LEFT JOIN summary_items s "
             "  ON q.namespace = s.namespace AND q.item_id = s.item_id "
@@ -217,6 +276,20 @@ def queue_snapshot(namespace: str | None = None) -> list[dict[str, Any]]:
             sql += "WHERE q.namespace = ? "
             params.append(namespace)
         sql += "ORDER BY q.enqueued_at ASC"
-        return [dict(row) for row in conn.execute(sql, params)]
+        result = [dict(row) for row in conn.execute(sql, params)]
+        for item in result:
+            item["dead_lettered"] = item["attempts"] >= max_attempts
+        return result
     finally:
         conn.close()
+
+
+def queue_stats(
+    namespace: str | None = None,
+    *,
+    max_attempts: int = 3,
+) -> dict[str, int]:
+    """Return active/dead-letter counts without hiding either population."""
+    snapshot = queue_snapshot(namespace, max_attempts=max_attempts)
+    dead = sum(1 for item in snapshot if item["dead_lettered"])
+    return {"active": len(snapshot) - dead, "dead_lettered": dead, "total": len(snapshot)}

--- a/work_buddy/summarization/worker.py
+++ b/work_buddy/summarization/worker.py
@@ -5,13 +5,13 @@ cadence (piggybacked, no separate cron). One worker tick:
 
 1. Read `cooldown_minutes` and `daily_budget_usd` from config.
 2. Check today's spend against the budget; if exceeded, log + return.
-3. Fetch eligible queue entries (cooldown-passed, FIFO).
+3. Fetch cooldown-eligible, non-dead-letter queue entries.
 4. For each entry (bounded per tick):
    - Resolve a `Summarizer` instance for the namespace.
    - Call `summarizer.refresh_one(item_id, force=True, ...)`.
    - On success: remove from queue.
-   - On error: record_attempt (which `refresh_one_incremental` already
-     does internally via `store.record_error`).
+   - On error: classify, rotate, and consume an attempt only for
+     item-intrinsic failures.
 
 A single worker tick is bounded; if the queue is long, subsequent ticks
 drain the rest. This is intentional — the global daily budget naturally
@@ -28,12 +28,29 @@ from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Any
 
+from work_buddy.summarization.policy import summaries_active
+
 logger = logging.getLogger(__name__)
 
 
 _DEFAULT_COOLDOWN_MINUTES = 30
 _DEFAULT_DAILY_BUDGET_USD = 1.00
 _DEFAULT_TICK_LIMIT = 20  # max items per tick (safety bound; queue catches up over many ticks)
+_DEFAULT_MAX_ATTEMPTS = 3
+
+
+def _error_kind_value(value: Any) -> str:
+    raw = getattr(value, "value", value)
+    return raw if isinstance(raw, str) and raw else "unknown"
+
+
+_ENVIRONMENTAL_ERROR_KINDS = frozenset({
+    "backend_unavailable",
+    "model_not_available",
+    "timeout",
+    "rate_limited",
+    "auth",
+})
 
 
 # ---------------------------------------------------------------------------
@@ -100,6 +117,7 @@ def _resolve_config() -> dict[str, Any]:
     except Exception:
         summ = {}
     return {
+        "active": summaries_active(),
         "cooldown_minutes": int(
             summ.get("cooldown_minutes", _DEFAULT_COOLDOWN_MINUTES)
         ),
@@ -107,7 +125,13 @@ def _resolve_config() -> dict[str, Any]:
             summ.get("daily_budget_usd", _DEFAULT_DAILY_BUDGET_USD)
         ),
         "tick_limit": int(summ.get("worker_tick_limit", _DEFAULT_TICK_LIMIT)),
+        "max_attempts": int(summ.get("max_attempts", _DEFAULT_MAX_ATTEMPTS)),
     }
+
+
+def summaries_enabled() -> bool:
+    """Compatibility name for callers that need the activation policy."""
+    return summaries_active()
 
 
 # ---------------------------------------------------------------------------
@@ -164,10 +188,43 @@ def run_worker_tick(
         - `queue_depth_after`: remaining queue depth
     """
     from work_buddy.summarization import queue as queue_mod
+    from work_buddy.summarization.orchestrator import chain_has_plausible_backend
+    from work_buddy.summarization.protocol import SummarizationError
 
     cfg = _resolve_config()
     cooldown = 0 if bypass_cooldown else cfg["cooldown_minutes"]
     tick_limit = limit if limit is not None else cfg["tick_limit"]
+    max_attempts = int(cfg.get("max_attempts", _DEFAULT_MAX_ATTEMPTS))
+
+    if not cfg.get("active", True):
+        stats = queue_mod.queue_stats(namespace, max_attempts=max_attempts)
+        return {
+            "processed": 0,
+            "skipped_cooldown": 0,
+            "errored": 0,
+            "dead_lettered": stats["dead_lettered"],
+            "budget_paused": False,
+            "opted_out": True,
+            "dormant": False,
+            "dormancy_reason": None,
+            "today_spend_usd": 0.0,
+            "queue_depth_after": stats["active"],
+        }
+
+    if not chain_has_plausible_backend():
+        stats = queue_mod.queue_stats(namespace, max_attempts=max_attempts)
+        return {
+            "processed": 0,
+            "skipped_cooldown": 0,
+            "errored": 0,
+            "dead_lettered": stats["dead_lettered"],
+            "budget_paused": False,
+            "opted_out": False,
+            "dormant": True,
+            "dormancy_reason": "no_backend",
+            "today_spend_usd": 0.0,
+            "queue_depth_after": stats["active"],
+        }
 
     # Daily-budget gate.
     spend = today_summarization_spend_usd()
@@ -180,7 +237,13 @@ def run_worker_tick(
             "processed": 0,
             "skipped_cooldown": 0,
             "errored": 0,
+            "dead_lettered": queue_mod.queue_stats(
+                namespace, max_attempts=max_attempts,
+            )["dead_lettered"],
             "budget_paused": True,
+            "opted_out": False,
+            "dormant": False,
+            "dormancy_reason": None,
             "today_spend_usd": spend,
             "queue_depth_after": queue_mod.queue_depth(namespace),
         }
@@ -190,11 +253,14 @@ def run_worker_tick(
         namespace=namespace,
         cooldown_minutes=cooldown,
         limit=tick_limit,
+        max_attempts=max_attempts,
     )
 
     # Count cooldown-skipped (for visibility): how many ENTRIES exist for
     # the namespace minus how many we just picked up.
-    total_queued = queue_mod.queue_depth(namespace)
+    total_queued = queue_mod.queue_depth(
+        namespace, include_dead_letters=False, max_attempts=max_attempts,
+    )
     skipped_cooldown = max(0, total_queued - len(eligible))
 
     processed = 0
@@ -217,13 +283,9 @@ def run_worker_tick(
             # item is stale, so we don't want refresh_one to short-circuit
             # on its own staleness check.
             node = summarizer.refresh_one(item_id, force=True)
-            if node is None:
-                # Likely an error or no content. record_attempt to track.
-                queue_mod.record_attempt(ns, item_id, "refresh returned None")
-                errored += 1
-            else:
-                queue_mod.remove(ns, item_id)
-                processed += 1
+            # ``None`` is a clean no-content result.  Typed failures raise.
+            queue_mod.remove(ns, item_id)
+            processed += 1
 
             # Re-check budget after each call — bail mid-tick if exceeded.
             if not bypass_budget:
@@ -235,19 +297,75 @@ def run_worker_tick(
                         spend,
                     )
                     break
+        except SummarizationError as exc:
+            kind = _error_kind_value(exc.error_kind)
+            queue_mod.record_failure(
+                ns,
+                item_id,
+                str(exc),
+                error_kind=kind,
+                count_attempt=kind not in _ENVIRONMENTAL_ERROR_KINDS,
+            )
+            errored += 1
+            logger.warning(
+                "summarization worker: %s failure on %s/%s: %s",
+                kind, ns, item_id, exc,
+            )
         except Exception as exc:
-            queue_mod.record_attempt(ns, item_id, f"{type(exc).__name__}: {exc}")
+            queue_mod.record_failure(
+                ns,
+                item_id,
+                f"{type(exc).__name__}: {exc}",
+                error_kind="unknown",
+                count_attempt=True,
+            )
             errored += 1
             logger.exception(
                 "summarization worker: unexpected exception on %s/%s",
                 ns, item_id,
             )
 
+    stats = queue_mod.queue_stats(namespace, max_attempts=max_attempts)
     return {
         "processed": processed,
         "skipped_cooldown": skipped_cooldown,
         "errored": errored,
+        "dead_lettered": stats["dead_lettered"],
         "budget_paused": False,
+        "opted_out": False,
+        "dormant": False,
+        "dormancy_reason": None,
         "today_spend_usd": spend,
-        "queue_depth_after": queue_mod.queue_depth(namespace),
+        "queue_depth_after": stats["active"],
+    }
+
+
+def enqueue_missing(
+    *,
+    namespace: str = "conversation_session",
+    days: int = 3650,
+) -> dict[str, Any]:
+    """Reconcile missing/stale summaries into the queue without LLM calls."""
+    from work_buddy.summarization import queue as queue_mod
+    from work_buddy.summarization.protocol import DiscoveryWindow
+
+    summarizer = _resolve_summarizer(namespace)
+    if summarizer is None:
+        return {
+            "namespace": namespace,
+            "candidates": 0,
+            "enqueued": 0,
+            "queue_depth": queue_mod.queue_depth(namespace),
+        }
+
+    candidates = summarizer.source.discover(DiscoveryWindow(days=days))
+    stale = summarizer.store.select_stale(candidates)
+    for item_id, _token in stale:
+        queue_mod.enqueue(namespace, item_id)
+
+    return {
+        "namespace": namespace,
+        "candidates": len(candidates),
+        "enqueued": len(stale),
+        "queue_depth": queue_mod.queue_depth(namespace),
     }


### PR DESCRIPTION
## Summary
- Restore preference-aware automatic conversation summarization and dormant startup behavior.
- Add fair classified retries, dead letters, backfill, and observable Dashboard status.
- Enforce tier-aware context budgets and isolate the test suite from host credentials.

## Test plan
- [x] `uv run --no-sync pytest --cache-clear -q` (`5782` passed, `4` skipped)
- [x] Run targeted recovery, queue, incremental, Dashboard, and LLM runner suites.
- [x] Exercise live backfill and worker execution against real session data.
- [x] Verify the current Codex session reports an environmental auth retry without consuming retry attempts.

## Known limitation
A long atomic chunk refresh can continue in the sidecar after the five-minute MCP transport timeout. The operation remains recoverable, and this follow-up is documented in the ignored design progress notes.
