### PR TITLE
Fix Chats topic range alignment

### DIFF
--- a/tests/unit/test_dashboard_chats_merge_invariants.py
+++ b/tests/unit/test_dashboard_chats_merge_invariants.py
@@ -48,6 +48,37 @@ def styles_text() -> str:
 
 
 # ---------------------------------------------------------------------------
+# Topic rail: title and turn range occupy stable, non-overlapping columns
+# ---------------------------------------------------------------------------
+
+
+def test_topic_rail_reserves_space_for_centered_turn_range(
+    chats_js: str, styles_text: str,
+) -> None:
+    assert '<span class="topic-title">' in chats_js
+
+    item_rule = re.search(r"\.chats-topic-item\s*\{([^}]+)\}", styles_text)
+    assert item_rule is not None
+    assert "display: grid" in item_rule.group(1)
+    assert "grid-template-columns: auto minmax(0, 1fr) auto" in item_rule.group(1)
+    assert "align-items: center" in item_rule.group(1)
+
+    title_rule = re.search(
+        r"\.chats-topic-item \.topic-title\s*\{([^}]+)\}", styles_text,
+    )
+    assert title_rule is not None
+    assert "min-width: 0" in title_rule.group(1)
+    assert "overflow-wrap: anywhere" in title_rule.group(1)
+
+    range_rule = re.search(
+        r"\.chats-topic-item \.topic-range\s*\{([^}]+)\}", styles_text,
+    )
+    assert range_rule is not None
+    assert "white-space: nowrap" in range_rule.group(1)
+    assert "float:" not in range_rule.group(1)
+
+
+# ---------------------------------------------------------------------------
 # Search-merge: there is exactly one renderer; no separate results pane
 # ---------------------------------------------------------------------------
 

--- a/work_buddy/dashboard/frontend/scripts/tabs/chats.py
+++ b/work_buddy/dashboard/frontend/scripts/tabs/chats.py
@@ -792,13 +792,13 @@ function _railTopicsHtml(topicData) {
     }
     return topicData.topics.map(function(t, i) {
         var range = (t.turn_start != null && t.turn_end != null)
-            ? ' <span class="topic-range">' + t.turn_start + '–' + t.turn_end + '</span>'
+            ? '<span class="topic-range">' + t.turn_start + '–' + t.turn_end + '</span>'
             : '';
         return '<div class="chats-topic-item"'
             + ' ' + wbActAttrs('chatsJumpToTopicAction', { turn: t.turn_start != null ? t.turn_start : '' })
             + ' title="' + escapeHtml(t.summary || '') + '">'
-            + '<span class="topic-index">' + (i + 1) + '.</span> '
-            + escapeHtml(t.title || '(untitled)')
+            + '<span class="topic-index">' + (i + 1) + '.</span>'
+            + '<span class="topic-title">' + escapeHtml(t.title || '(untitled)') + '</span>'
             + range
             + '</div>';
     }).join('');

--- a/work_buddy/dashboard/frontend/styles.py
+++ b/work_buddy/dashboard/frontend/styles.py
@@ -2406,6 +2406,10 @@ a.chat-card-badge.prs:hover { text-decoration: underline; }
     border-bottom: 1px solid var(--border);
 }
 .chats-topic-item {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    column-gap: 4px;
     padding: 6px 8px;
     border-radius: 4px;
     cursor: pointer;
@@ -2423,11 +2427,15 @@ a.chat-card-badge.prs:hover { text-decoration: underline; }
     font-family: var(--font-mono);
     font-size: 11px;
 }
+.chats-topic-item .topic-title {
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
 .chats-topic-item .topic-range {
     color: var(--text-muted);
     font-family: var(--font-mono);
     font-size: 10px;
-    float: right;
+    white-space: nowrap;
 }
 /* Activity-rail selector (Topics | Git | Tasks) + switchable panels. The
    selector is the shared wb-filter rail; the scoped overrides below keep its


### PR DESCRIPTION
## Summary
- Place each topic index, title, and turn range in dedicated grid columns.
- Allow long titles to wrap without overlapping or displacing the range.
- Add a regression test for the non-overlapping, centered layout.

## Test plan
- [x] Run 74 relevant Chats/frontend tests.
- [x] Re-run the focused topic-layout regression after final formatting.
- [x] Verify the live Dashboard at `532x827`.
- [x] Confirm all sampled title/range boxes have zero overlap and centered ranges.

## Notes
The project environment does not install `ruff`, so no `ruff` result is claimed.
