### PR TITLE
feat(dashboard): reusable chat primitives for the Co-work Chat tab

### DIFF
--- a/dashboard-react/COMPONENTS.md
+++ b/dashboard-react/COMPONENTS.md
@@ -1,0 +1,29 @@
+# Component inventory
+
+Reusable components and component families in the React dashboard, one entry per public surface. Registered widget types live in the contribution registry (`src/app/dashboardRegistry.ts`) and are additionally listed in [ARCHITECTURE.md](ARCHITECTURE.md). This file inventories the reusable component layer beneath and beside them: what exists, where it lives, and what contract it exposes, so new views compose before they invent.
+
+## Widget library (registered publishers)
+
+| Component | Location | Contract |
+|---|---|---|
+| Quick Capture | `src/widget-library/capture/` | `wb.capture.quick-text` widget type, `wb.widget-role.capture@1` |
+| Day Timeline | `src/widget-library/timeline/` | `wb.timeline.day` widget type, `wb.widget-role.day-timeline@1` |
+| Running Notes | `src/widget-library/notes/` | `wb.notes.running` widget type, `wb.widget-role.running-notes@1` |
+| Shared widget primitives | `src/widget-library/shared/` | Cross-publisher presentation helpers consumed by the library widgets |
+
+## Chat primitives (library components, not registered widget types)
+
+Reusable conversational surface for any view that mounts a house conversation. Knowledge unit: `services/dashboard/react/chat-primitives`.
+
+| Component | Location | Contract |
+|---|---|---|
+| ChatPanel | `src/widget-library/chat/ChatPanel.tsx` | Message log plus composer with header slot and the standard host states (ready, loading, empty, error, read-only). Composer self-disables while the agent is stopped |
+| ChatMessageList | `src/widget-library/chat/ChatMessageList.tsx` | Author-attributed transcript with unread boundary, scroll lock, jump-to-latest, inline choice and boolean answers, typing and agent-stopped indicators |
+| ChatComposer | `src/widget-library/chat/ChatComposer.tsx` | Enter submits, Shift plus Enter newline, IME-safe, draft retained on send failure |
+| useChatConversation | `src/widget-library/chat/useChatConversation.ts` | Binds a ChatConversationProvider to load, silent-refresh, and send lifecycles. Provider must be referentially stable |
+| ChatConversationProvider | `src/widget-library/chat/contracts.ts` | The transport seam: loadConversation, sendMessage, subscribe. `InMemoryChatProvider` is the test and development fixture |
+| normalizeConversationPayload, deriveAgentActivity | `src/widget-library/chat/mapping.ts` | Raw `GET /api/conversations/<id>` payload to canonical types, message identity via `message_id`, legacy typing and stopped derivation |
+
+## Adding an entry
+
+New reusable components add a row (or a new family section) in the same landing that creates them, with the knowledge unit cross-referenced when one exists. Entries describe the current contract, never the change history.

--- a/dashboard-react/src/widget-library/chat/ChatComposer.test.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatComposer.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { expectNoAccessibilityViolations } from "../../test/setup";
+import { ChatComposer } from "./ChatComposer";
+
+describe("ChatComposer", () => {
+  it("enables Send only with content and submits the trimmed value", async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(<ChatComposer onSend={onSend} />);
+
+    const input = screen.getByRole("textbox", { name: "Message" });
+    const send = screen.getByRole("button", { name: "Send" });
+    expect(send).toBeDisabled();
+
+    await userEvent.type(input, "  hello world  ");
+    expect(send).toBeEnabled();
+    await userEvent.click(send);
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith("hello world"));
+    await waitFor(() => expect(input).toHaveValue(""));
+  });
+
+  it("submits on Enter and inserts a newline on Shift+Enter", async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(<ChatComposer onSend={onSend} />);
+    const input = screen.getByRole("textbox", { name: "Message" });
+
+    await userEvent.type(input, "first{Shift>}{Enter}{/Shift}second");
+    expect(onSend).not.toHaveBeenCalled();
+    expect(input).toHaveValue("first\nsecond");
+
+    await userEvent.type(input, "{Enter}");
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith("first\nsecond"));
+  });
+
+  it("retains the draft when the send fails", async () => {
+    const onSend = vi.fn().mockRejectedValue(new Error("offline"));
+    render(<ChatComposer onSend={onSend} />);
+    const input = screen.getByRole("textbox", { name: "Message" });
+
+    await userEvent.type(input, "keep me");
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    expect(input).toHaveValue("keep me");
+  });
+
+  it("disables input and Send when the composer is disabled", () => {
+    render(<ChatComposer onSend={vi.fn()} disabled />);
+    expect(screen.getByRole("textbox", { name: "Message" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+  });
+
+  it("shows a pending state while a send is in flight", () => {
+    render(<ChatComposer onSend={vi.fn()} sending />);
+    expect(screen.getByText("Sending message")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Sending message/ })).toBeDisabled();
+  });
+
+  it("surfaces the inline send error and stays accessible", async () => {
+    const { container } = render(
+      <ChatComposer onSend={vi.fn()} errorMessage="Message could not be delivered" />,
+    );
+    expect(
+      screen.getByText("Message could not be delivered"),
+    ).toBeInTheDocument();
+    await expectNoAccessibilityViolations(container);
+  });
+});

--- a/dashboard-react/src/widget-library/chat/ChatComposer.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatComposer.tsx
@@ -1,0 +1,124 @@
+import {
+  useRef,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+} from "react";
+import { TextArea, TextField } from "react-aria-components";
+
+import { Button, InlineAlert, Spinner } from "../../ui";
+import "./styles.css";
+
+/** Cap the auto-grown textarea height so a long draft scrolls within itself. */
+const MAX_INPUT_HEIGHT = 160;
+
+export interface ChatComposerProps {
+  /**
+   * Send intent. May return a promise. A resolved promise clears the draft, a
+   * rejected one retains it so the human never loses typed text.
+   */
+  onSend(value: string): void | Promise<void>;
+  /** Fully disable input, e.g. a stopped agent or a closed conversation. */
+  readonly disabled?: boolean;
+  /** Externally-driven pending state (the provider send is in flight). */
+  readonly sending?: boolean;
+  readonly placeholder?: string;
+  /** Accessible label for the input. Visually hidden by default. */
+  readonly label?: string;
+  /** Inline error from the most recent failed send. */
+  readonly errorMessage?: string;
+}
+
+export function ChatComposer({
+  onSend,
+  disabled = false,
+  sending = false,
+  placeholder = "Type a message…",
+  label = "Message",
+  errorMessage,
+}: ChatComposerProps) {
+  const [draft, setDraft] = useState("");
+  const [busy, setBusy] = useState(false);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const isSending = sending || busy;
+  const canSend = !disabled && !isSending && draft.trim().length > 0;
+
+  const grow = (element: HTMLTextAreaElement | null) => {
+    if (element === null) return;
+    element.style.height = "auto";
+    const next = Math.min(element.scrollHeight, MAX_INPUT_HEIGHT);
+    if (next > 0) element.style.height = `${next}px`;
+  };
+
+  const submit = async () => {
+    const value = draft.trim();
+    if (value.length === 0 || disabled || isSending) return;
+    setBusy(true);
+    try {
+      await onSend(value);
+      setDraft("");
+      if (inputRef.current !== null) {
+        inputRef.current.style.height = "";
+        inputRef.current.focus();
+      }
+    } catch {
+      // Retain the draft. The panel surfaces the failure through errorMessage.
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    void submit();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (
+      event.key === "Enter" &&
+      !event.shiftKey &&
+      !event.nativeEvent.isComposing
+    ) {
+      event.preventDefault();
+      event.currentTarget.form?.requestSubmit();
+    }
+  };
+
+  return (
+    <form className="wb-chat-composer" onSubmit={handleSubmit}>
+      {errorMessage !== undefined ? (
+        <InlineAlert tone="danger" role="status" className="wb-chat-composer__error">
+          {errorMessage}
+        </InlineAlert>
+      ) : null}
+      <div className="wb-chat-composer__row">
+        <TextField
+          className="wb-chat-composer__field"
+          aria-label={label}
+          value={draft}
+          isDisabled={disabled}
+          onChange={(value) => {
+            setDraft(value);
+            grow(inputRef.current);
+          }}
+        >
+          <TextArea
+            ref={inputRef}
+            className="wb-chat-composer__input"
+            rows={1}
+            placeholder={placeholder}
+            onKeyDown={handleKeyDown}
+          />
+        </TextField>
+        <Button
+          type="submit"
+          variant="primary"
+          className="wb-chat-composer__send"
+          disabled={!canSend}
+        >
+          {isSending ? <Spinner label="Sending message" /> : "Send"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/dashboard-react/src/widget-library/chat/ChatMessageList.test.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatMessageList.test.tsx
@@ -125,6 +125,35 @@ describe("ChatMessageList", () => {
     ).toBeInTheDocument();
   });
 
+  it("opens at the top with the separator above the first message when the whole transcript is unread", () => {
+    const scrollIntoView = vi.fn();
+    const original = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = scrollIntoView;
+    try {
+      render(
+        <ChatMessageList
+          messages={[
+            msg("m1", "unread one", "assistant"),
+            msg("m2", "unread two", "assistant"),
+          ]}
+          initialUnreadFromMessageId="m1"
+        />,
+      );
+      const separator = screen.getByRole("separator", { name: /unread/i });
+      const log = screen.getByRole("log");
+      // Boundary at index 0 renders above the first message.
+      expect(log.firstElementChild).toBe(separator);
+      // The mount position is the boundary, which sits at the top.
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+      expect(scrollIntoView.mock.contexts[0]).toBe(separator);
+      expect(
+        screen.getByRole("button", { name: /2 new messages/ }),
+      ).toBeInTheDocument();
+    } finally {
+      Element.prototype.scrollIntoView = original;
+    }
+  });
+
   it("answers a pending choice question inline", async () => {
     const onRespond = vi.fn();
     render(

--- a/dashboard-react/src/widget-library/chat/ChatMessageList.test.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatMessageList.test.tsx
@@ -1,0 +1,205 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { expectNoAccessibilityViolations } from "../../test/setup";
+import { ChatMessageList } from "./ChatMessageList";
+import type { ChatMessage } from "./contracts";
+
+// jsdom performs no layout, so scroll geometry is installed explicitly. scrollTop
+// is backed by a real variable so the component's writes are observable.
+function installScroll(
+  element: HTMLElement,
+  geometry: { scrollHeight: number; clientHeight: number; scrollTop?: number },
+) {
+  let top = geometry.scrollTop ?? 0;
+  Object.defineProperty(element, "scrollTop", {
+    configurable: true,
+    get: () => top,
+    set: (value: number) => {
+      top = value;
+    },
+  });
+  Object.defineProperty(element, "scrollHeight", {
+    configurable: true,
+    get: () => geometry.scrollHeight,
+  });
+  Object.defineProperty(element, "clientHeight", {
+    configurable: true,
+    get: () => geometry.clientHeight,
+  });
+}
+
+const msg = (id: string, content: string, author: ChatMessage["author"]): ChatMessage => ({
+  id,
+  author,
+  content,
+});
+
+describe("ChatMessageList", () => {
+  it("renders author-attributed messages with a timestamp", () => {
+    render(
+      <ChatMessageList
+        messages={[
+          { id: "m1", author: "user", content: "Hi", createdAt: "2026-07-17T12:00:00-04:00" },
+          { id: "m2", author: "assistant", content: "Hello" },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Hi")).toBeInTheDocument();
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+    expect(screen.getByText("You:")).toBeInTheDocument();
+    expect(screen.getByText("Assistant:")).toBeInTheDocument();
+  });
+
+  it("shows the empty label when there are no messages", () => {
+    render(<ChatMessageList messages={[]} emptyLabel="Nothing yet." />);
+    expect(screen.getByText("Nothing yet.")).toBeInTheDocument();
+  });
+
+  it("autoscrolls to the newest message while pinned to the bottom", () => {
+    const initial = [msg("m1", "one", "assistant")];
+    const { rerender } = render(<ChatMessageList messages={initial} />);
+    const log = screen.getByRole("log");
+    installScroll(log, { scrollHeight: 500, clientHeight: 100, scrollTop: 0 });
+
+    rerender(
+      <ChatMessageList messages={[...initial, msg("m2", "two", "assistant")]} />,
+    );
+
+    expect(log.scrollTop).toBe(500);
+    expect(
+      screen.queryByRole("button", { name: /Jump to latest/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("locks scroll and shows an unread boundary when the reader has scrolled up", async () => {
+    const onReachLatest = vi.fn();
+    const initial = [msg("m1", "one", "assistant")];
+    const { rerender } = render(
+      <ChatMessageList messages={initial} onReachLatest={onReachLatest} />,
+    );
+    const log = screen.getByRole("log");
+    installScroll(log, { scrollHeight: 500, clientHeight: 100, scrollTop: 0 });
+    fireEvent.scroll(log);
+
+    rerender(
+      <ChatMessageList
+        messages={[
+          ...initial,
+          msg("m2", "two", "assistant"),
+          msg("m3", "three", "assistant"),
+        ]}
+        onReachLatest={onReachLatest}
+      />,
+    );
+
+    // Scroll lock holds position and surfaces the unread affordances.
+    expect(log.scrollTop).toBe(0);
+    expect(screen.getByRole("separator", { name: /unread/i })).toBeInTheDocument();
+    const jump = screen.getByRole("button", { name: /2 new messages/ });
+
+    await userEvent.click(jump);
+
+    expect(log.scrollTop).toBe(500);
+    expect(
+      screen.queryByRole("button", { name: /Jump to latest/ }),
+    ).not.toBeInTheDocument();
+    expect(onReachLatest).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens locked at the seeded unread boundary rather than the bottom", () => {
+    render(
+      <ChatMessageList
+        messages={[
+          msg("m1", "read one", "assistant"),
+          msg("m2", "unread one", "assistant"),
+          msg("m3", "unread two", "assistant"),
+        ]}
+        initialUnreadFromMessageId="m2"
+      />,
+    );
+    expect(screen.getByRole("separator", { name: /unread/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /2 new messages/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("answers a pending choice question inline", async () => {
+    const onRespond = vi.fn();
+    render(
+      <ChatMessageList
+        messages={[
+          {
+            id: "q1",
+            author: "assistant",
+            content: "Which one?",
+            pending: true,
+            question: {
+              responseType: "choice",
+              choices: [
+                { key: "a", label: "Option A" },
+                { key: "b", label: "Option B" },
+              ],
+            },
+          },
+        ]}
+        onRespond={onRespond}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Option B" }));
+    expect(onRespond).toHaveBeenCalledWith("b", "q1");
+  });
+
+  it("answers a pending boolean question inline", async () => {
+    const onRespond = vi.fn();
+    render(
+      <ChatMessageList
+        messages={[
+          {
+            id: "q1",
+            author: "assistant",
+            content: "Proceed?",
+            pending: true,
+            question: { responseType: "boolean" },
+          },
+        ]}
+        onRespond={onRespond}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Yes" }));
+    expect(onRespond).toHaveBeenCalledWith("true", "q1");
+  });
+
+  it("shows the typing indicator and the agent-stopped notice", () => {
+    const { rerender } = render(
+      <ChatMessageList
+        messages={[msg("m1", "working", "assistant")]}
+        agentActivity="thinking"
+      />,
+    );
+    expect(screen.getByText("Assistant is typing")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Assistant is typing");
+
+    rerender(
+      <ChatMessageList
+        messages={[msg("m1", "working", "assistant")]}
+        agentActivity="stopped"
+      />,
+    );
+    expect(screen.getByText(/Agent stopped responding/)).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ChatMessageList
+        messages={[
+          msg("m1", "one", "user"),
+          msg("m2", "two", "assistant"),
+        ]}
+        agentActivity="thinking"
+      />,
+    );
+    await expectNoAccessibilityViolations(container);
+  });
+});

--- a/dashboard-react/src/widget-library/chat/ChatMessageList.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatMessageList.tsx
@@ -1,0 +1,262 @@
+import {
+  Fragment,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+import { Button, InlineAlert } from "../../ui";
+import { formatTime } from "../shared";
+import type { ChatAgentActivity, ChatMessage } from "./contracts";
+import "./styles.css";
+
+/** Distance in px from the bottom within which the view counts as pinned. */
+const PIN_THRESHOLD = 24;
+
+export interface ChatMessageListProps {
+  readonly messages: readonly ChatMessage[];
+  /** Accessible name for the transcript log region. */
+  readonly label?: string;
+  /** Drives the typing indicator and agent-stopped notice. */
+  readonly agentActivity?: ChatAgentActivity;
+  /** Inline answer handler for pending boolean and choice questions. */
+  readonly onRespond?: (value: string, inReplyTo?: string) => void;
+  /**
+   * Seed the unread boundary on mount. Messages from this id onward start
+   * unread and the view opens locked at that boundary rather than the bottom.
+   */
+  readonly initialUnreadFromMessageId?: string | null;
+  /** Fired when the reader reaches the latest message and unread clears. */
+  readonly onReachLatest?: () => void;
+  /** Shown when the conversation has no messages yet. */
+  readonly emptyLabel?: string;
+}
+
+function authorName(message: ChatMessage): string {
+  if (message.author === "user") return "You";
+  if (message.author === "system") return message.authorLabel ?? "System";
+  return message.authorLabel ?? "Assistant";
+}
+
+function seedReadCount(
+  messages: readonly ChatMessage[],
+  initialUnreadFromMessageId: string | null | undefined,
+): number {
+  if (initialUnreadFromMessageId != null) {
+    const index = messages.findIndex(
+      (message) => message.id === initialUnreadFromMessageId,
+    );
+    if (index >= 0) return index;
+  }
+  return messages.length;
+}
+
+export function ChatMessageList({
+  messages,
+  label,
+  agentActivity = "idle",
+  onRespond,
+  initialUnreadFromMessageId,
+  onReachLatest,
+  emptyLabel = "No messages yet.",
+}: ChatMessageListProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const boundaryRef = useRef<HTMLDivElement>(null);
+  const [pinned, setPinned] = useState<boolean>(
+    () => initialUnreadFromMessageId == null,
+  );
+  const pinnedRef = useRef(pinned);
+  const [readCount, setReadCount] = useState<number>(() =>
+    seedReadCount(messages, initialUnreadFromMessageId),
+  );
+
+  useEffect(() => {
+    pinnedRef.current = pinned;
+  }, [pinned]);
+
+  const messageCount = messages.length;
+  const unreadCount = Math.max(0, messageCount - readCount);
+  const boundaryIndex =
+    unreadCount > 0 && readCount > 0 && readCount < messageCount
+      ? readCount
+      : -1;
+
+  // Autoscroll while pinned. When the reader has scrolled up (scroll lock) the
+  // view holds position and the arriving messages accumulate as unread.
+  useLayoutEffect(() => {
+    if (!pinnedRef.current) return;
+    const element = scrollRef.current;
+    if (element !== null) element.scrollTop = element.scrollHeight;
+    setReadCount(messageCount);
+  }, [messageCount]);
+
+  // On a seeded-unread mount, open at the boundary rather than the bottom.
+  useLayoutEffect(() => {
+    if (pinnedRef.current) return;
+    const boundary = boundaryRef.current;
+    if (boundary !== null && typeof boundary.scrollIntoView === "function") {
+      boundary.scrollIntoView({ block: "start" });
+    } else if (scrollRef.current !== null) {
+      scrollRef.current.scrollTop = 0;
+    }
+    // Intentionally mount-only, later positioning is scroll and pin driven.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const prevUnreadRef = useRef(unreadCount);
+  useEffect(() => {
+    if (prevUnreadRef.current > 0 && unreadCount === 0) onReachLatest?.();
+    prevUnreadRef.current = unreadCount;
+  }, [unreadCount, onReachLatest]);
+
+  const handleScroll = () => {
+    const element = scrollRef.current;
+    if (element === null) return;
+    const distance =
+      element.scrollHeight - element.scrollTop - element.clientHeight;
+    const nowPinned = distance <= PIN_THRESHOLD;
+    setPinned(nowPinned);
+    pinnedRef.current = nowPinned;
+    if (nowPinned) setReadCount(messageCount);
+  };
+
+  const jumpToLatest = () => {
+    const element = scrollRef.current;
+    if (element !== null) element.scrollTop = element.scrollHeight;
+    setPinned(true);
+    pinnedRef.current = true;
+    setReadCount(messageCount);
+  };
+
+  const renderAffordances = (message: ChatMessage): ReactNode => {
+    if (onRespond === undefined) return null;
+    if (message.pending !== true || message.question === undefined) return null;
+    const { question } = message;
+    if (question.responseType === "boolean") {
+      return (
+        <div className="wb-chat-msg__choices">
+          <Button
+            variant="secondary"
+            size="small"
+            className="wb-chat-choice"
+            onClick={() => onRespond("true", message.id)}
+          >
+            Yes
+          </Button>
+          <Button
+            variant="secondary"
+            size="small"
+            className="wb-chat-choice"
+            onClick={() => onRespond("false", message.id)}
+          >
+            No
+          </Button>
+        </div>
+      );
+    }
+    if (question.responseType === "choice" && question.choices !== undefined) {
+      return (
+        <div className="wb-chat-msg__choices">
+          {question.choices.map((choice) => (
+            <Button
+              key={choice.key}
+              variant="secondary"
+              size="small"
+              className="wb-chat-choice"
+              onClick={() => onRespond(choice.key, message.id)}
+            >
+              {choice.label}
+            </Button>
+          ))}
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <div className="wb-chat-list">
+      <div
+        ref={scrollRef}
+        className="wb-chat-list__scroll"
+        role="log"
+        aria-label={label ?? "Conversation"}
+        aria-live="polite"
+        aria-relevant="additions"
+        tabIndex={0}
+        onScroll={handleScroll}
+      >
+        {messageCount === 0 ? (
+          <p className="wb-chat-list__empty">{emptyLabel}</p>
+        ) : (
+          messages.map((message, index) => (
+            <Fragment key={message.id}>
+              {index === boundaryIndex ? (
+                <div
+                  ref={boundaryRef}
+                  className="wb-chat-list__unread"
+                  role="separator"
+                  aria-label="Start of unread messages"
+                >
+                  <span aria-hidden="true">New messages</span>
+                </div>
+              ) : null}
+              <div
+                className={`wb-chat-msg wb-chat-msg--${message.author}`}
+                data-author={message.author}
+              >
+                <div className="wb-chat-msg__bubble">
+                  <span className="wb-visually-hidden">
+                    {authorName(message)}:
+                  </span>
+                  <span className="wb-chat-msg__content">{message.content}</span>
+                  {renderAffordances(message)}
+                </div>
+                {message.createdAt !== undefined ? (
+                  <span className="wb-chat-msg__time">
+                    {formatTime(message.createdAt)}
+                  </span>
+                ) : null}
+              </div>
+            </Fragment>
+          ))
+        )}
+      </div>
+
+      {agentActivity === "thinking" ? (
+        <div className="wb-chat-typing" role="status">
+          <span className="wb-chat-typing__dots" aria-hidden="true">
+            <span className="wb-chat-typing__dot" />
+            <span className="wb-chat-typing__dot" />
+            <span className="wb-chat-typing__dot" />
+          </span>
+          <span className="wb-visually-hidden">Assistant is typing</span>
+        </div>
+      ) : null}
+
+      {agentActivity === "stopped" ? (
+        <InlineAlert tone="danger" role="status" className="wb-chat-stopped">
+          <span aria-hidden="true">■ </span>
+          Agent stopped responding. Close this chat and start a new one to
+          continue.
+        </InlineAlert>
+      ) : null}
+
+      {unreadCount > 0 ? (
+        <div className="wb-chat-list__jump">
+          <Button
+            variant="primary"
+            size="small"
+            className="wb-chat-list__jump-button"
+            onClick={jumpToLatest}
+          >
+            {unreadCount} new {unreadCount === 1 ? "message" : "messages"} ·
+            Jump to latest
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/dashboard-react/src/widget-library/chat/ChatMessageList.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatMessageList.tsx
@@ -78,13 +78,16 @@ export function ChatMessageList({
 
   const messageCount = messages.length;
   const unreadCount = Math.max(0, messageCount - readCount);
+  // A boundary at index 0 is legitimate: a seeded id matching the first
+  // message means the whole transcript is unread, and the separator renders
+  // above it.
   const boundaryIndex =
-    unreadCount > 0 && readCount > 0 && readCount < messageCount
-      ? readCount
-      : -1;
+    unreadCount > 0 && readCount < messageCount ? readCount : -1;
 
   // Autoscroll while pinned. When the reader has scrolled up (scroll lock) the
-  // view holds position and the arriving messages accumulate as unread.
+  // view holds position and the arriving messages accumulate as unread. Keyed
+  // on the message COUNT: the house store appends discrete messages, so a
+  // last message whose content grows in place will not re-stick the view.
   useLayoutEffect(() => {
     if (!pinnedRef.current) return;
     const element = scrollRef.current;

--- a/dashboard-react/src/widget-library/chat/ChatPanel.test.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatPanel.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { expectNoAccessibilityViolations } from "../../test/setup";
+import { ChatPanel } from "./ChatPanel";
+import type { ChatMessage } from "./contracts";
+
+const messages: ChatMessage[] = [
+  { id: "m1", author: "user", content: "Hi" },
+  { id: "m2", author: "assistant", content: "Hello" },
+];
+
+describe("ChatPanel", () => {
+  it("renders the title header, transcript, and composer when ready", () => {
+    render(<ChatPanel title="Doc chat" messages={messages} onSend={vi.fn()} />);
+    expect(screen.getByRole("heading", { name: "Doc chat" })).toBeInTheDocument();
+    expect(screen.getByRole("log", { name: "Doc chat" })).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Message" })).toBeInTheDocument();
+  });
+
+  it("renders a custom header slot in place of the default title", () => {
+    render(
+      <ChatPanel
+        title="Doc chat"
+        header={<div>Custom header content</div>}
+        messages={messages}
+        onSend={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Custom header content")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Doc chat" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the loading host state", () => {
+    render(<ChatPanel status="loading" messages={[]} />);
+    expect(screen.getByRole("status")).toHaveTextContent("Loading conversation");
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("shows the empty host state with custom copy", () => {
+    render(
+      <ChatPanel status="empty" messages={[]} emptyMessage="No document chat yet." />,
+    );
+    expect(screen.getByText("No document chat yet.")).toBeInTheDocument();
+  });
+
+  it("shows the error host state and retries", async () => {
+    const onRetry = vi.fn();
+    render(
+      <ChatPanel
+        status="error"
+        messages={[]}
+        errorMessage="Could not reach the conversation."
+        onRetry={onRetry}
+      />,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Could not reach the conversation.",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the transcript readable but replaces the composer when read-only", () => {
+    render(
+      <ChatPanel
+        status="read-only"
+        title="Archived"
+        messages={messages}
+        onSend={vi.fn()}
+        readOnlyReason="This conversation is closed."
+      />,
+    );
+    expect(screen.getByRole("log", { name: "Archived" })).toBeInTheDocument();
+    expect(screen.getByText("This conversation is closed.")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("wires the composer send intent", async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(<ChatPanel title="Doc chat" messages={messages} onSend={onSend} />);
+    await userEvent.type(
+      screen.getByRole("textbox", { name: "Message" }),
+      "a reply",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith("a reply"));
+  });
+
+  it("has no accessibility violations when ready", async () => {
+    const { container } = render(
+      <ChatPanel title="Doc chat" messages={messages} onSend={vi.fn()} />,
+    );
+    await expectNoAccessibilityViolations(container);
+  });
+});

--- a/dashboard-react/src/widget-library/chat/ChatPanel.test.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatPanel.test.tsx
@@ -96,4 +96,85 @@ describe("ChatPanel", () => {
     );
     await expectNoAccessibilityViolations(container);
   });
+
+  it("disables the composer while the agent is stopped even without composerDisabled", () => {
+    render(
+      <ChatPanel
+        title="Doc chat"
+        messages={messages}
+        onSend={vi.fn()}
+        agentActivity="stopped"
+      />,
+    );
+    expect(screen.getByText(/Agent stopped responding/)).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Message" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+  });
+
+  it("passes the question message id as the inline answer's second argument", async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ChatPanel
+        title="Doc chat"
+        messages={[
+          {
+            id: "q1",
+            author: "assistant",
+            content: "Proceed?",
+            pending: true,
+            question: { responseType: "boolean" },
+          },
+        ]}
+        onSend={onSend}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Yes" }));
+    expect(onSend).toHaveBeenCalledWith("true", "q1");
+  });
+
+  it("handles a rejected inline answer without an unhandled rejection", async () => {
+    // No @types/node in this package, so the process listener is reached
+    // through a narrow structural cast.
+    const proc = (
+      globalThis as {
+        process?: {
+          on(
+            event: "unhandledRejection",
+            listener: (reason: unknown) => void,
+          ): void;
+          off(
+            event: "unhandledRejection",
+            listener: (reason: unknown) => void,
+          ): void;
+        };
+      }
+    ).process;
+    expect(proc).toBeDefined();
+    const onUnhandled = vi.fn();
+    proc?.on("unhandledRejection", onUnhandled);
+    try {
+      const onSend = vi.fn().mockRejectedValue(new Error("send failed"));
+      render(
+        <ChatPanel
+          title="Doc chat"
+          messages={[
+            {
+              id: "q1",
+              author: "assistant",
+              content: "Proceed?",
+              pending: true,
+              question: { responseType: "boolean" },
+            },
+          ]}
+          onSend={onSend}
+        />,
+      );
+      await userEvent.click(screen.getByRole("button", { name: "No" }));
+      expect(onSend).toHaveBeenCalledWith("false", "q1");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(onUnhandled).not.toHaveBeenCalled();
+    } finally {
+      proc?.off("unhandledRejection", onUnhandled);
+    }
+  });
 });

--- a/dashboard-react/src/widget-library/chat/ChatPanel.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatPanel.tsx
@@ -1,0 +1,181 @@
+import type { ReactNode } from "react";
+
+import { Button, InlineAlert } from "../../ui";
+import { ChatComposer } from "./ChatComposer";
+import { ChatMessageList } from "./ChatMessageList";
+import type {
+  ChatAgentActivity,
+  ChatMessage,
+  ChatPanelStatus,
+} from "./contracts";
+import "./styles.css";
+
+export interface ChatPanelProps {
+  /** Host presentation state, mirroring the dashboard host-state contract. */
+  readonly status?: ChatPanelStatus;
+  readonly messages: readonly ChatMessage[];
+  /** Accessible name for the panel and the default header text. */
+  readonly title?: string;
+  /** Header slot. Overrides the default title bar when provided. */
+  readonly header?: ReactNode;
+  readonly agentActivity?: ChatAgentActivity;
+  /** Send intent for freeform messages and inline question answers. */
+  onSend?(value: string): void | Promise<void>;
+  readonly sending?: boolean;
+  readonly sendErrorMessage?: string;
+  readonly composerDisabled?: boolean;
+  readonly composerPlaceholder?: string;
+  /** Reason shown in place of the composer when status is "read-only". */
+  readonly readOnlyReason?: string;
+  /** Full-panel copy for the "empty" host state. */
+  readonly emptyMessage?: string;
+  /** Full-panel copy for the "error" host state. */
+  readonly errorMessage?: string;
+  readonly onRetry?: () => void;
+  readonly initialUnreadFromMessageId?: string | null;
+  readonly onReachLatest?: () => void;
+  /** Empty-transcript copy inside a ready conversation. */
+  readonly noMessagesLabel?: string;
+}
+
+interface StateCopy {
+  readonly title: string;
+  readonly message: string;
+}
+
+const LOADING_COPY: StateCopy = {
+  title: "Loading conversation",
+  message: "Work Buddy is preparing this conversation.",
+};
+const EMPTY_COPY: StateCopy = {
+  title: "No conversation",
+  message: "There is no conversation to show yet.",
+};
+const ERROR_COPY: StateCopy = {
+  title: "Conversation could not load",
+  message: "Try again to reload this conversation.",
+};
+
+export function ChatPanel({
+  status = "ready",
+  messages,
+  title,
+  header,
+  agentActivity = "idle",
+  onSend,
+  sending = false,
+  sendErrorMessage,
+  composerDisabled = false,
+  composerPlaceholder,
+  readOnlyReason,
+  emptyMessage,
+  errorMessage,
+  onRetry,
+  initialUnreadFromMessageId,
+  onReachLatest,
+  noMessagesLabel,
+}: ChatPanelProps) {
+  const label = title ?? "Conversation";
+
+  const renderHeader = () => {
+    if (header !== undefined) {
+      return <header className="wb-chat-panel__header">{header}</header>;
+    }
+    if (title !== undefined) {
+      return (
+        <header className="wb-chat-panel__header">
+          <h2 className="wb-chat-panel__title">{title}</h2>
+        </header>
+      );
+    }
+    return null;
+  };
+
+  const renderTranscript = () => (
+    <ChatMessageList
+      messages={messages}
+      label={label}
+      agentActivity={agentActivity}
+      onRespond={
+        onSend === undefined
+          ? undefined
+          : (value) => {
+              void onSend(value);
+            }
+      }
+      initialUnreadFromMessageId={initialUnreadFromMessageId}
+      onReachLatest={onReachLatest}
+      emptyLabel={noMessagesLabel}
+    />
+  );
+
+  const renderBody = () => {
+    if (status === "loading") {
+      return (
+        <div className="wb-chat-state" role="status">
+          <span className="wb-spinner" aria-hidden="true" />
+          <h3 className="wb-chat-state__title">{LOADING_COPY.title}</h3>
+          <p>{LOADING_COPY.message}</p>
+        </div>
+      );
+    }
+    if (status === "empty") {
+      return (
+        <div className="wb-chat-state" role="status">
+          <h3 className="wb-chat-state__title">{EMPTY_COPY.title}</h3>
+          <p>{emptyMessage ?? EMPTY_COPY.message}</p>
+        </div>
+      );
+    }
+    if (status === "error") {
+      return (
+        <div className="wb-chat-state" role="alert">
+          <h3 className="wb-chat-state__title">{ERROR_COPY.title}</h3>
+          <p>{errorMessage ?? ERROR_COPY.message}</p>
+          {onRetry !== undefined ? (
+            <Button
+              variant="secondary"
+              className="wb-chat-state__action"
+              onClick={onRetry}
+            >
+              Retry
+            </Button>
+          ) : null}
+        </div>
+      );
+    }
+
+    // "ready" and "read-only" both render the transcript.
+    const readOnly = status === "read-only";
+    return (
+      <>
+        {renderTranscript()}
+        {readOnly ? (
+          <InlineAlert
+            tone="info"
+            role="status"
+            className="wb-chat-panel__read-only"
+          >
+            <strong>Read-only:</strong>{" "}
+            {readOnlyReason ?? "Replies are currently disabled."}
+          </InlineAlert>
+        ) : onSend !== undefined ? (
+          <ChatComposer
+            onSend={onSend}
+            sending={sending}
+            disabled={composerDisabled}
+            placeholder={composerPlaceholder}
+            errorMessage={sendErrorMessage}
+          />
+        ) : null}
+      </>
+    );
+  };
+
+  return (
+    <section className="wb-chat-panel" aria-label={label}>
+      {renderHeader()}
+      {renderBody()}
+    </section>
+  );
+}

--- a/dashboard-react/src/widget-library/chat/ChatPanel.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatPanel.tsx
@@ -19,8 +19,11 @@ export interface ChatPanelProps {
   /** Header slot. Overrides the default title bar when provided. */
   readonly header?: ReactNode;
   readonly agentActivity?: ChatAgentActivity;
-  /** Send intent for freeform messages and inline question answers. */
-  onSend?(value: string): void | Promise<void>;
+  /**
+   * Send intent for freeform messages and inline question answers. Inline
+   * answers pass the answered question's message id as inReplyTo.
+   */
+  onSend?(value: string, inReplyTo?: string): void | Promise<void>;
   readonly sending?: boolean;
   readonly sendErrorMessage?: string;
   readonly composerDisabled?: boolean;
@@ -99,8 +102,11 @@ export function ChatPanel({
       onRespond={
         onSend === undefined
           ? undefined
-          : (value) => {
-              void onSend(value);
+          : (value, inReplyTo) => {
+              // A failed inline answer surfaces through sendErrorMessage from
+              // the container (the hook records it before rethrowing). The
+              // catch prevents an unhandled rejection on this path.
+              void Promise.resolve(onSend(value, inReplyTo)).catch(() => {});
             }
       }
       initialUnreadFromMessageId={initialUnreadFromMessageId}
@@ -163,7 +169,7 @@ export function ChatPanel({
           <ChatComposer
             onSend={onSend}
             sending={sending}
-            disabled={composerDisabled}
+            disabled={composerDisabled === true || agentActivity === "stopped"}
             placeholder={composerPlaceholder}
             errorMessage={sendErrorMessage}
           />

--- a/dashboard-react/src/widget-library/chat/InMemoryChatProvider.test.ts
+++ b/dashboard-react/src/widget-library/chat/InMemoryChatProvider.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { InMemoryChatProvider } from "./InMemoryChatProvider";
+
+describe("InMemoryChatProvider", () => {
+  it("loads the seeded snapshot", async () => {
+    const provider = new InMemoryChatProvider({
+      conversationId: "c1",
+      title: "Seed",
+      messages: [{ id: "m1", author: "assistant", content: "Hello" }],
+    });
+    const snapshot = await provider.loadConversation("c1");
+    expect(snapshot.conversationId).toBe("c1");
+    expect(snapshot.messages).toHaveLength(1);
+  });
+
+  it("rejects a load for an unknown conversation", async () => {
+    const provider = new InMemoryChatProvider({ conversationId: "c1" });
+    await expect(provider.loadConversation("other")).rejects.toThrow(
+      /Unknown conversation/,
+    );
+  });
+
+  it("appends the human turn and any scripted reply, notifying subscribers", async () => {
+    const provider = new InMemoryChatProvider({
+      conversationId: "c1",
+      autoReply: () => [{ id: "a1", author: "assistant", content: "Got it" }],
+    });
+    const listener = vi.fn();
+    provider.subscribe("c1", listener);
+
+    const snapshot = await provider.sendMessage("c1", { value: "hi there" });
+
+    expect(snapshot.messages.map((message) => message.content)).toEqual([
+      "hi there",
+      "Got it",
+    ]);
+    expect(snapshot.messages[0]?.author).toBe("user");
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a send when failSend is set and recovers when cleared", async () => {
+    const provider = new InMemoryChatProvider({
+      conversationId: "c1",
+      failSend: true,
+    });
+    await expect(provider.sendMessage("c1", { value: "x" })).rejects.toThrow(
+      /could not be delivered/,
+    );
+    provider.setFailSend(false);
+    const snapshot = await provider.sendMessage("c1", { value: "x" });
+    expect(snapshot.messages).toHaveLength(1);
+  });
+
+  it("stops delivering to a listener after unsubscribe", () => {
+    const provider = new InMemoryChatProvider({ conversationId: "c1" });
+    const listener = vi.fn();
+    const unsubscribe = provider.subscribe("c1", listener);
+
+    provider.pushMessage({ id: "a1", author: "assistant", content: "one" });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    provider.pushMessage({ id: "a2", author: "assistant", content: "two" });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies on liveness and status changes", () => {
+    const provider = new InMemoryChatProvider({ conversationId: "c1" });
+    const listener = vi.fn();
+    provider.subscribe("c1", listener);
+
+    provider.setAgentLiveness("stopped");
+    provider.setStatus("closed");
+
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/dashboard-react/src/widget-library/chat/InMemoryChatProvider.ts
+++ b/dashboard-react/src/widget-library/chat/InMemoryChatProvider.ts
@@ -1,0 +1,159 @@
+// In-memory fixture implementation of the ChatConversationProvider seam. Used by
+// component and hook tests and available to a development harness. It performs
+// no I/O and holds one conversation of scripted state. It is deliberately NOT a
+// live transport, the join or wave-2 work supplies that behind the same seam.
+
+import type {
+  ChatAgentLiveness,
+  ChatConversationProvider,
+  ChatConversationSnapshot,
+  ChatConversationStatus,
+  ChatInvalidationListener,
+  ChatMessage,
+  ChatSendInput,
+  ChatUnsubscribe,
+} from "./contracts";
+
+export interface InMemoryChatSeed {
+  readonly conversationId: string;
+  readonly title?: string;
+  readonly status?: ChatConversationStatus;
+  readonly agentLiveness?: ChatAgentLiveness;
+  readonly messages?: readonly ChatMessage[];
+  /**
+   * Optional scripted agent reply. Given the human input and the snapshot after
+   * the human turn was appended, returns agent or system messages to append.
+   */
+  readonly autoReply?: (
+    input: ChatSendInput,
+    snapshot: ChatConversationSnapshot,
+  ) => readonly ChatMessage[] | undefined;
+  /** Artificial resolve delay in milliseconds for load and send. Default 0. */
+  readonly latencyMs?: number;
+  /** When true, sendMessage rejects so failure handling can be exercised. */
+  readonly failSend?: boolean;
+}
+
+function delay(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class InMemoryChatProvider implements ChatConversationProvider {
+  private readonly conversationId: string;
+  private title: string | undefined;
+  private status: ChatConversationStatus;
+  private agentLiveness: ChatAgentLiveness;
+  private messages: ChatMessage[];
+  private readonly autoReply: InMemoryChatSeed["autoReply"];
+  private readonly latencyMs: number;
+  private failSend: boolean;
+  private readonly listeners = new Map<string, Set<ChatInvalidationListener>>();
+  private sequence = 0;
+
+  constructor(seed: InMemoryChatSeed) {
+    this.conversationId = seed.conversationId;
+    this.title = seed.title;
+    this.status = seed.status ?? "open";
+    this.agentLiveness = seed.agentLiveness ?? "unknown";
+    this.messages = seed.messages !== undefined ? [...seed.messages] : [];
+    this.autoReply = seed.autoReply;
+    this.latencyMs = seed.latencyMs ?? 0;
+    this.failSend = seed.failSend ?? false;
+  }
+
+  /** Stable id generator for fixture-authored messages. */
+  nextId(prefix = "msg"): string {
+    this.sequence += 1;
+    return `${prefix}-${this.sequence}`;
+  }
+
+  private snapshot(): ChatConversationSnapshot {
+    return {
+      conversationId: this.conversationId,
+      title: this.title,
+      status: this.status,
+      agentLiveness: this.agentLiveness,
+      messages: [...this.messages],
+    };
+  }
+
+  private notify(conversationId: string): void {
+    const set = this.listeners.get(conversationId);
+    if (set === undefined) return;
+    for (const listener of set) listener();
+  }
+
+  async loadConversation(
+    conversationId: string,
+  ): Promise<ChatConversationSnapshot> {
+    await delay(this.latencyMs);
+    if (conversationId !== this.conversationId) {
+      throw new Error(`Unknown conversation ${conversationId}`);
+    }
+    return this.snapshot();
+  }
+
+  async sendMessage(
+    conversationId: string,
+    input: ChatSendInput,
+  ): Promise<ChatConversationSnapshot> {
+    await delay(this.latencyMs);
+    if (conversationId !== this.conversationId) {
+      throw new Error(`Unknown conversation ${conversationId}`);
+    }
+    if (this.failSend) {
+      throw new Error("Message could not be delivered");
+    }
+    this.messages.push({
+      id: this.nextId("user"),
+      author: "user",
+      content: input.value,
+      createdAt: new Date().toISOString(),
+    });
+    const replies = this.autoReply?.(input, this.snapshot());
+    if (replies !== undefined) this.messages.push(...replies);
+    this.notify(conversationId);
+    return this.snapshot();
+  }
+
+  subscribe(
+    conversationId: string,
+    onInvalidate: ChatInvalidationListener,
+  ): ChatUnsubscribe {
+    let set = this.listeners.get(conversationId);
+    if (set === undefined) {
+      set = new Set();
+      this.listeners.set(conversationId, set);
+    }
+    set.add(onInvalidate);
+    return () => {
+      set?.delete(onInvalidate);
+    };
+  }
+
+  // --- Fixture controls (test and harness only) ---------------------------
+
+  /** Append a message from any author and notify subscribers. */
+  pushMessage(message: ChatMessage): void {
+    this.messages.push(message);
+    this.notify(this.conversationId);
+  }
+
+  /** Flip the driving-agent liveness and notify subscribers. */
+  setAgentLiveness(liveness: ChatAgentLiveness): void {
+    this.agentLiveness = liveness;
+    this.notify(this.conversationId);
+  }
+
+  /** Flip the conversation status and notify subscribers. */
+  setStatus(status: ChatConversationStatus): void {
+    this.status = status;
+    this.notify(this.conversationId);
+  }
+
+  /** Toggle the send-failure switch at runtime. */
+  setFailSend(failSend: boolean): void {
+    this.failSend = failSend;
+  }
+}

--- a/dashboard-react/src/widget-library/chat/InMemoryChatProvider.ts
+++ b/dashboard-react/src/widget-library/chat/InMemoryChatProvider.ts
@@ -1,7 +1,7 @@
 // In-memory fixture implementation of the ChatConversationProvider seam. Used by
 // component and hook tests and available to a development harness. It performs
 // no I/O and holds one conversation of scripted state. It is deliberately NOT a
-// live transport, the join or wave-2 work supplies that behind the same seam.
+// live transport, which is supplied separately behind the same seam.
 
 import type {
   ChatAgentLiveness,

--- a/dashboard-react/src/widget-library/chat/contracts.ts
+++ b/dashboard-react/src/widget-library/chat/contracts.ts
@@ -1,0 +1,155 @@
+// Typed chat primitives for the Co-work Chat tab and future conversational
+// surfaces. These types mirror the house conversation_* semantics (the legacy
+// dashboard chat-sidebar seam) in a JSON-compatible, transport-agnostic shape.
+// No HTTP wiring lives here. The provider seam is the contract a live transport
+// (join or wave-2 work) implements later.
+
+/**
+ * Canonical author of a rendered message. The house backend labels an agent
+ * turn "agent" and a human turn "user". This surface maps "agent" onto
+ * "assistant" and reserves "system" for non-attributed notices.
+ */
+export type ChatAuthorRole = "user" | "assistant" | "system";
+
+/** How the human is expected to answer a pending question. */
+export type ChatResponseType = "freeform" | "boolean" | "choice";
+
+/** One labelled option for a choice question. */
+export interface ChatChoice {
+  readonly key: string;
+  readonly label: string;
+}
+
+/**
+ * The answerable shape attached to a pending question message. Boolean and
+ * choice questions render inline affordances, freeform falls back to the
+ * ordinary composer.
+ */
+export interface ChatQuestion {
+  readonly responseType: ChatResponseType;
+  readonly choices?: readonly ChatChoice[];
+}
+
+/** One conversation message as displayed in the transcript. */
+export interface ChatMessage {
+  readonly id: string;
+  readonly author: ChatAuthorRole;
+  /** Optional display name override, e.g. a named assistant persona. */
+  readonly authorLabel?: string;
+  readonly content: string;
+  /** ISO-8601 timestamp. Absent messages render without a time stamp. */
+  readonly createdAt?: string;
+  /** True when this message is a question still awaiting the human answer. */
+  readonly pending?: boolean;
+  /** Present when the message is a structured question, drives inline answers. */
+  readonly question?: ChatQuestion;
+}
+
+/** Whether the conversation still accepts input. */
+export type ChatConversationStatus = "open" | "closed";
+
+/**
+ * Liveness of the driving agent process, mirroring conversation.agent_alive.
+ * "alive" == true, "stopped" == false, "unknown" == null (no registered driver).
+ */
+export type ChatAgentLiveness = "alive" | "stopped" | "unknown";
+
+/** A full point-in-time view of one conversation. */
+export interface ChatConversationSnapshot {
+  readonly conversationId: string;
+  readonly title?: string;
+  readonly status: ChatConversationStatus;
+  readonly agentLiveness: ChatAgentLiveness;
+  readonly messages: readonly ChatMessage[];
+}
+
+/**
+ * A human-authored outbound value. For a freeform reply this is the typed text,
+ * for a boolean question "true" or "false", for a choice question the choice
+ * key. inReplyTo optionally names the pending question being answered.
+ */
+export interface ChatSendInput {
+  readonly value: string;
+  readonly inReplyTo?: string;
+}
+
+/** Called by a provider when its view of a conversation may have changed. */
+export type ChatInvalidationListener = () => void;
+
+/** Tear down a subscription registered through the provider. */
+export type ChatUnsubscribe = () => void;
+
+/**
+ * The provider seam. A live implementation maps loadConversation onto
+ * GET /api/conversations/<id>, sendMessage onto POST .../respond, and subscribe
+ * onto the 3s poll loop or an SSE-driven invalidation. This module ships only
+ * the interface plus an in-memory fixture. It never performs I/O itself.
+ */
+export interface ChatConversationProvider {
+  /** Load the current snapshot for a conversation. */
+  loadConversation(conversationId: string): Promise<ChatConversationSnapshot>;
+  /** Submit one human message or answer, resolving with the next snapshot. */
+  sendMessage(
+    conversationId: string,
+    input: ChatSendInput,
+  ): Promise<ChatConversationSnapshot>;
+  /**
+   * Register an invalidation listener. The returned unsubscribe stops delivery.
+   * This is the poll or subscribe hook shape, the consumer reloads on notify.
+   */
+  subscribe(
+    conversationId: string,
+    onInvalidate: ChatInvalidationListener,
+  ): ChatUnsubscribe;
+}
+
+/**
+ * Derived activity signal for the transcript. "thinking" shows the typing
+ * indicator, "stopped" shows the agent-stopped notice, "idle" shows neither.
+ */
+export type ChatAgentActivity = "thinking" | "stopped" | "idle";
+
+/**
+ * Host presentation state for the whole panel, mirroring the dashboard
+ * host-state contract (SnapshotStatus plus loading/empty). "ready" and
+ * "read-only" render the transcript, the rest are full-panel placeholders.
+ */
+export type ChatPanelStatus =
+  | "ready"
+  | "loading"
+  | "empty"
+  | "error"
+  | "read-only";
+
+// --- Raw house-conversation payload shapes (the mirroring source) ---------
+// These describe the JSON that GET /api/conversations/<id> returns today, so a
+// live transport can normalize into the canonical types above with the pure
+// helper in mapping.ts. They are documentation of the seam, not a fetch layer.
+
+export interface RawChatChoice {
+  readonly key: string;
+  readonly label: string;
+}
+
+export interface RawChatMessage {
+  readonly id?: string | number;
+  readonly role?: string;
+  readonly content?: string;
+  readonly created_at?: string;
+  readonly message_type?: string;
+  readonly status?: string;
+  readonly response_type?: string;
+  readonly choices?: readonly RawChatChoice[];
+}
+
+export interface RawChatConversation {
+  readonly conversation_id: string;
+  readonly title?: string;
+  readonly status?: string;
+  readonly agent_alive?: boolean | null;
+}
+
+export interface RawChatConversationPayload {
+  readonly conversation: RawChatConversation;
+  readonly messages?: readonly RawChatMessage[];
+}

--- a/dashboard-react/src/widget-library/chat/contracts.ts
+++ b/dashboard-react/src/widget-library/chat/contracts.ts
@@ -1,8 +1,8 @@
 // Typed chat primitives for the Co-work Chat tab and future conversational
 // surfaces. These types mirror the house conversation_* semantics (the legacy
 // dashboard chat-sidebar seam) in a JSON-compatible, transport-agnostic shape.
-// No HTTP wiring lives here. The provider seam is the contract a live transport
-// (join or wave-2 work) implements later.
+// No HTTP wiring lives here. The provider seam is the contract a live
+// transport implements.
 
 /**
  * Canonical author of a rendered message. The house backend labels an agent
@@ -132,6 +132,9 @@ export interface RawChatChoice {
 }
 
 export interface RawChatMessage {
+  /** The endpoint's message identity field (ConversationMessage.to_dict). */
+  readonly message_id?: string;
+  /** Fixture-side fallback identity. The live endpoint never emits this. */
   readonly id?: string | number;
   readonly role?: string;
   readonly content?: string;

--- a/dashboard-react/src/widget-library/chat/index.ts
+++ b/dashboard-react/src/widget-library/chat/index.ts
@@ -1,0 +1,37 @@
+export type {
+  ChatAgentActivity,
+  ChatAgentLiveness,
+  ChatAuthorRole,
+  ChatChoice,
+  ChatConversationProvider,
+  ChatConversationSnapshot,
+  ChatConversationStatus,
+  ChatInvalidationListener,
+  ChatMessage,
+  ChatPanelStatus,
+  ChatQuestion,
+  ChatResponseType,
+  ChatSendInput,
+  ChatUnsubscribe,
+  RawChatConversation,
+  RawChatConversationPayload,
+  RawChatMessage,
+} from "./contracts";
+export {
+  deriveAgentActivity,
+  normalizeConversationPayload,
+  toAgentLiveness,
+  toAuthorRole,
+} from "./mapping";
+export {
+  InMemoryChatProvider,
+  type InMemoryChatSeed,
+} from "./InMemoryChatProvider";
+export {
+  useChatConversation,
+  type ChatLoadStatus,
+  type UseChatConversationResult,
+} from "./useChatConversation";
+export { ChatMessageList, type ChatMessageListProps } from "./ChatMessageList";
+export { ChatComposer, type ChatComposerProps } from "./ChatComposer";
+export { ChatPanel, type ChatPanelProps } from "./ChatPanel";

--- a/dashboard-react/src/widget-library/chat/mapping.test.ts
+++ b/dashboard-react/src/widget-library/chat/mapping.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ChatConversationSnapshot,
+  RawChatConversationPayload,
+} from "./contracts";
+import {
+  deriveAgentActivity,
+  normalizeConversationPayload,
+  toAgentLiveness,
+  toAuthorRole,
+} from "./mapping";
+
+describe("toAuthorRole", () => {
+  it("maps the backend agent role onto assistant and preserves user and system", () => {
+    expect(toAuthorRole("agent")).toBe("assistant");
+    expect(toAuthorRole("assistant")).toBe("assistant");
+    expect(toAuthorRole("user")).toBe("user");
+    expect(toAuthorRole("system")).toBe("system");
+    expect(toAuthorRole(undefined)).toBe("assistant");
+  });
+});
+
+describe("toAgentLiveness", () => {
+  it("maps agent_alive true/false/null onto the liveness enum", () => {
+    expect(toAgentLiveness(true)).toBe("alive");
+    expect(toAgentLiveness(false)).toBe("stopped");
+    expect(toAgentLiveness(null)).toBe("unknown");
+    expect(toAgentLiveness(undefined)).toBe("unknown");
+  });
+});
+
+describe("normalizeConversationPayload", () => {
+  it("normalizes the raw conversation payload into canonical types", () => {
+    const payload: RawChatConversationPayload = {
+      conversation: {
+        conversation_id: "c1",
+        title: "Doc chat",
+        status: "open",
+        agent_alive: true,
+      },
+      messages: [
+        {
+          id: 1,
+          role: "user",
+          content: "Hi",
+          created_at: "2026-07-17T12:00:00-04:00",
+        },
+        {
+          id: 2,
+          role: "agent",
+          content: "Pick one",
+          message_type: "question",
+          status: "pending",
+          response_type: "choice",
+          choices: [
+            { key: "a", label: "Option A" },
+            { key: "b", label: "Option B" },
+          ],
+        },
+      ],
+    };
+
+    const snapshot = normalizeConversationPayload(payload);
+
+    expect(snapshot).toMatchObject({
+      conversationId: "c1",
+      title: "Doc chat",
+      status: "open",
+      agentLiveness: "alive",
+    });
+    expect(snapshot.messages).toHaveLength(2);
+    expect(snapshot.messages[0]).toMatchObject({
+      id: "1",
+      author: "user",
+      content: "Hi",
+    });
+    expect(snapshot.messages[1]).toMatchObject({
+      id: "2",
+      author: "assistant",
+      pending: true,
+      question: {
+        responseType: "choice",
+        choices: [
+          { key: "a", label: "Option A" },
+          { key: "b", label: "Option B" },
+        ],
+      },
+    });
+  });
+
+  it("defaults missing fields and treats a closed status honestly", () => {
+    const snapshot = normalizeConversationPayload({
+      conversation: { conversation_id: "c2", status: "closed" },
+    });
+    expect(snapshot.status).toBe("closed");
+    expect(snapshot.agentLiveness).toBe("unknown");
+    expect(snapshot.messages).toEqual([]);
+  });
+
+  it("synthesizes a stable id when the backend omits one", () => {
+    const snapshot = normalizeConversationPayload({
+      conversation: { conversation_id: "c3" },
+      messages: [{ role: "agent", content: "no id here" }],
+    });
+    expect(snapshot.messages[0]?.id).toBe("msg-0");
+  });
+});
+
+const base = (
+  overrides: Partial<ChatConversationSnapshot>,
+): ChatConversationSnapshot => ({
+  conversationId: "c",
+  status: "open",
+  agentLiveness: "alive",
+  messages: [],
+  ...overrides,
+});
+
+describe("deriveAgentActivity", () => {
+  it("reports stopped when the driver process exited", () => {
+    expect(
+      deriveAgentActivity(base({ agentLiveness: "stopped" })),
+    ).toBe("stopped");
+  });
+
+  it("is idle for a closed conversation regardless of liveness", () => {
+    expect(
+      deriveAgentActivity(base({ status: "closed", agentLiveness: "stopped" })),
+    ).toBe("idle");
+  });
+
+  it("is idle while a question is pending", () => {
+    expect(
+      deriveAgentActivity(
+        base({
+          messages: [
+            {
+              id: "m1",
+              author: "assistant",
+              content: "?",
+              pending: true,
+              question: { responseType: "freeform" },
+            },
+          ],
+        }),
+      ),
+    ).toBe("idle");
+  });
+
+  it("shows thinking while a live agent holds the last turn as text", () => {
+    expect(
+      deriveAgentActivity(
+        base({
+          messages: [{ id: "m1", author: "assistant", content: "Looking..." }],
+        }),
+      ),
+    ).toBe("thinking");
+  });
+
+  it("shows thinking after the human replies even with no registered driver", () => {
+    expect(
+      deriveAgentActivity(
+        base({
+          agentLiveness: "unknown",
+          messages: [{ id: "m1", author: "user", content: "and this?" }],
+        }),
+      ),
+    ).toBe("thinking");
+  });
+
+  it("is idle when no driver is registered and the agent holds the turn", () => {
+    expect(
+      deriveAgentActivity(
+        base({
+          agentLiveness: "unknown",
+          messages: [{ id: "m1", author: "assistant", content: "done" }],
+        }),
+      ),
+    ).toBe("idle");
+  });
+});

--- a/dashboard-react/src/widget-library/chat/mapping.test.ts
+++ b/dashboard-react/src/widget-library/chat/mapping.test.ts
@@ -41,13 +41,13 @@ describe("normalizeConversationPayload", () => {
       },
       messages: [
         {
-          id: 1,
+          message_id: "m-1",
           role: "user",
           content: "Hi",
           created_at: "2026-07-17T12:00:00-04:00",
         },
         {
-          id: 2,
+          message_id: "m-2",
           role: "agent",
           content: "Pick one",
           message_type: "question",
@@ -71,12 +71,12 @@ describe("normalizeConversationPayload", () => {
     });
     expect(snapshot.messages).toHaveLength(2);
     expect(snapshot.messages[0]).toMatchObject({
-      id: "1",
+      id: "m-1",
       author: "user",
       content: "Hi",
     });
     expect(snapshot.messages[1]).toMatchObject({
-      id: "2",
+      id: "m-2",
       author: "assistant",
       pending: true,
       question: {
@@ -98,7 +98,25 @@ describe("normalizeConversationPayload", () => {
     expect(snapshot.messages).toEqual([]);
   });
 
-  it("synthesizes a stable id when the backend omits one", () => {
+  it("falls back to a bare id when only a fixture-shaped id is present", () => {
+    const snapshot = normalizeConversationPayload({
+      conversation: { conversation_id: "c3" },
+      messages: [{ id: 7, role: "user", content: "fixture shape" }],
+    });
+    expect(snapshot.messages[0]?.id).toBe("7");
+  });
+
+  it("prefers message_id over a bare id when both are present", () => {
+    const snapshot = normalizeConversationPayload({
+      conversation: { conversation_id: "c3" },
+      messages: [
+        { message_id: "m-9", id: 9, role: "user", content: "both fields" },
+      ],
+    });
+    expect(snapshot.messages[0]?.id).toBe("m-9");
+  });
+
+  it("synthesizes a positional id when no identity field is present", () => {
     const snapshot = normalizeConversationPayload({
       conversation: { conversation_id: "c3" },
       messages: [{ role: "agent", content: "no id here" }],

--- a/dashboard-react/src/widget-library/chat/mapping.ts
+++ b/dashboard-react/src/widget-library/chat/mapping.ts
@@ -1,0 +1,121 @@
+// Pure, transport-free helpers that translate the raw house-conversation
+// payload into the canonical chat types and derive display signals. A live
+// transport (join or wave-2 work) reuses normalizeConversationPayload so the
+// mirroring of conversation_* semantics lives in one tested place.
+
+import type {
+  ChatAgentActivity,
+  ChatAgentLiveness,
+  ChatAuthorRole,
+  ChatConversationSnapshot,
+  ChatConversationStatus,
+  ChatMessage,
+  ChatQuestion,
+  ChatResponseType,
+  RawChatConversationPayload,
+  RawChatMessage,
+} from "./contracts";
+
+const RESPONSE_TYPES: ReadonlySet<string> = new Set([
+  "freeform",
+  "boolean",
+  "choice",
+]);
+
+/** Map the backend role token onto a canonical author. "agent" becomes assistant. */
+export function toAuthorRole(role: string | undefined): ChatAuthorRole {
+  if (role === "user") return "user";
+  if (role === "system") return "system";
+  return "assistant";
+}
+
+/** Map conversation.agent_alive (true/false/null) onto the liveness enum. */
+export function toAgentLiveness(
+  agentAlive: boolean | null | undefined,
+): ChatAgentLiveness {
+  if (agentAlive === true) return "alive";
+  if (agentAlive === false) return "stopped";
+  return "unknown";
+}
+
+function toResponseType(raw: string | undefined): ChatResponseType {
+  if (raw !== undefined && RESPONSE_TYPES.has(raw)) {
+    return raw as ChatResponseType;
+  }
+  return "freeform";
+}
+
+function toMessage(raw: RawChatMessage, index: number): ChatMessage {
+  const pending = raw.status === "pending" && raw.message_type === "question";
+  let question: ChatQuestion | undefined;
+  if (raw.message_type === "question") {
+    const responseType = toResponseType(raw.response_type);
+    question = {
+      responseType,
+      choices:
+        responseType === "choice" && raw.choices !== undefined
+          ? raw.choices.map((choice) => ({
+              key: choice.key,
+              label: choice.label,
+            }))
+          : undefined,
+    };
+  }
+  return {
+    id: raw.id !== undefined ? String(raw.id) : `msg-${index}`,
+    author: toAuthorRole(raw.role),
+    content: raw.content ?? "",
+    createdAt: raw.created_at,
+    pending,
+    question,
+  };
+}
+
+/**
+ * Normalize the raw GET /api/conversations/<id> payload into a snapshot. Pure,
+ * total, and defensive against missing optional fields.
+ */
+export function normalizeConversationPayload(
+  payload: RawChatConversationPayload,
+): ChatConversationSnapshot {
+  const status: ChatConversationStatus =
+    payload.conversation.status === "closed" ? "closed" : "open";
+  return {
+    conversationId: payload.conversation.conversation_id,
+    title: payload.conversation.title,
+    status,
+    agentLiveness: toAgentLiveness(payload.conversation.agent_alive),
+    messages: (payload.messages ?? []).map(toMessage),
+  };
+}
+
+/**
+ * Derive the transcript activity signal from a snapshot, mirroring the legacy
+ * _computeAgentTyping and agent-dead logic:
+ *  - stopped: conversation open and the driver process exited
+ *  - thinking: open, no pending question, and the agent still appears to be
+ *    working (last turn is the human, or the agent is mid-stream sending
+ *    text rather than a question)
+ *  - idle: everything else
+ */
+export function deriveAgentActivity(
+  snapshot: ChatConversationSnapshot,
+): ChatAgentActivity {
+  if (snapshot.status !== "open") return "idle";
+  if (snapshot.agentLiveness === "stopped") return "stopped";
+
+  const messages = snapshot.messages;
+  const hasPending = messages.some((message) => message.pending === true);
+  if (hasPending) return "idle";
+
+  const last = messages.length > 0 ? messages[messages.length - 1] : undefined;
+  if (last === undefined) return "idle";
+
+  // The agent has explicitly handed control back with a question.
+  if (last.author !== "user" && last.question !== undefined) return "idle";
+
+  // A live driver is mid-flow. With no registered driver (unknown) fall back to
+  // showing activity only while the human holds the last turn.
+  if (snapshot.agentLiveness === "alive") return "thinking";
+  return last.author === "user" ? "thinking" : "idle";
+}

--- a/dashboard-react/src/widget-library/chat/mapping.ts
+++ b/dashboard-react/src/widget-library/chat/mapping.ts
@@ -1,7 +1,7 @@
 // Pure, transport-free helpers that translate the raw house-conversation
 // payload into the canonical chat types and derive display signals. A live
-// transport (join or wave-2 work) reuses normalizeConversationPayload so the
-// mirroring of conversation_* semantics lives in one tested place.
+// transport reuses normalizeConversationPayload so the mirroring of
+// conversation_* semantics lives in one tested place.
 
 import type {
   ChatAgentActivity,
@@ -61,8 +61,12 @@ function toMessage(raw: RawChatMessage, index: number): ChatMessage {
           : undefined,
     };
   }
+  // The live endpoint serializes the identity field as message_id
+  // (ConversationMessage.to_dict). A bare id is accepted as a fixture-side
+  // fallback only, and the positional id is the last resort.
+  const rawId = raw.message_id ?? raw.id;
   return {
-    id: raw.id !== undefined ? String(raw.id) : `msg-${index}`,
+    id: rawId !== undefined ? String(rawId) : `msg-${index}`,
     author: toAuthorRole(raw.role),
     content: raw.content ?? "",
     createdAt: raw.created_at,

--- a/dashboard-react/src/widget-library/chat/styles.css
+++ b/dashboard-react/src/widget-library/chat/styles.css
@@ -1,0 +1,290 @@
+@layer wb.widgets {
+  .wb-chat-panel {
+    display: flex;
+    min-height: 0;
+    height: 100%;
+    flex-direction: column;
+    gap: var(--wb-widget-gap);
+  }
+
+  .wb-chat-panel__header {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--wb-space-4);
+  }
+
+  .wb-chat-panel__title {
+    color: var(--wb-color-text-strong);
+    font-size: var(--wb-font-size-sm);
+    font-weight: var(--wb-font-weight-semibold);
+  }
+
+  .wb-chat-panel__read-only {
+    flex: 0 0 auto;
+  }
+
+  /* --- Transcript list ---------------------------------------------------- */
+
+  .wb-chat-list {
+    position: relative;
+    display: flex;
+    min-height: 0;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: var(--wb-space-3);
+  }
+
+  .wb-chat-list__scroll {
+    display: flex;
+    min-height: 0;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: var(--wb-space-4);
+    padding: var(--wb-space-3);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    border: var(--wb-border-width) solid var(--wb-color-border-subtle);
+    border-radius: var(--wb-radius-surface);
+    background: var(--wb-color-surface-canvas);
+  }
+
+  .wb-chat-list__scroll:focus-visible {
+    outline: var(--wb-focus-width) solid var(--wb-color-focus-ring);
+    outline-offset: -1px;
+  }
+
+  .wb-chat-list__empty {
+    margin: auto;
+    padding: var(--wb-space-6);
+    color: var(--wb-color-text-muted);
+    font-size: var(--wb-font-size-xs);
+    text-align: center;
+  }
+
+  .wb-chat-msg {
+    display: flex;
+    max-width: 85%;
+    flex-direction: column;
+    gap: var(--wb-space-2);
+  }
+
+  .wb-chat-msg--user {
+    align-self: flex-end;
+    align-items: flex-end;
+  }
+
+  .wb-chat-msg--assistant,
+  .wb-chat-msg--system {
+    align-self: flex-start;
+    align-items: flex-start;
+  }
+
+  .wb-chat-msg__bubble {
+    padding: var(--wb-space-4) var(--wb-space-5);
+    border: var(--wb-border-width) solid var(--wb-color-border-subtle);
+    border-radius: var(--wb-radius-surface);
+    background: var(--wb-color-surface-raised);
+    color: var(--wb-color-text-primary);
+    font-size: var(--wb-font-size-sm);
+    line-height: var(--wb-line-height-body);
+  }
+
+  .wb-chat-msg--user .wb-chat-msg__bubble {
+    border-color: var(--wb-color-border-interactive);
+    background: var(--wb-color-surface-selected);
+    color: var(--wb-color-text-strong);
+  }
+
+  .wb-chat-msg--system .wb-chat-msg__bubble {
+    background: var(--wb-color-surface-inset);
+    color: var(--wb-color-text-secondary);
+    font-style: italic;
+  }
+
+  .wb-chat-msg__content {
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+  }
+
+  .wb-chat-msg__time {
+    color: var(--wb-color-text-muted);
+    font-family: var(--wb-font-mono);
+    font-size: var(--wb-font-size-2xs);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .wb-chat-msg__choices {
+    display: flex;
+    margin-top: var(--wb-space-4);
+    flex-wrap: wrap;
+    gap: var(--wb-space-3);
+  }
+
+  .wb-chat-choice.wb-button {
+    min-width: 0;
+  }
+
+  /* --- Unread boundary ---------------------------------------------------- */
+
+  .wb-chat-list__unread {
+    display: flex;
+    align-items: center;
+    gap: var(--wb-space-4);
+    color: var(--wb-color-status-info);
+    font-size: var(--wb-font-size-2xs);
+    font-weight: var(--wb-font-weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .wb-chat-list__unread::before,
+  .wb-chat-list__unread::after {
+    height: 0;
+    flex: 1 1 auto;
+    border-top: var(--wb-border-width) solid var(--wb-color-status-info);
+    content: "";
+  }
+
+  /* --- Jump to latest ----------------------------------------------------- */
+
+  .wb-chat-list__jump {
+    position: absolute;
+    right: 0;
+    bottom: var(--wb-space-4);
+    left: 0;
+    display: flex;
+    justify-content: center;
+    pointer-events: none;
+  }
+
+  .wb-chat-list__jump-button.wb-button {
+    box-shadow: var(--wb-shadow-overlay);
+    pointer-events: auto;
+  }
+
+  /* --- Typing indicator --------------------------------------------------- */
+
+  .wb-chat-typing {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    min-height: 1.25rem;
+    padding-inline: var(--wb-space-4);
+  }
+
+  .wb-chat-typing__dots {
+    display: inline-flex;
+    gap: var(--wb-space-2);
+  }
+
+  .wb-chat-typing__dot {
+    width: 0.4rem;
+    height: 0.4rem;
+    border-radius: var(--wb-radius-round);
+    background: var(--wb-color-text-muted);
+    animation: wb-chat-typing-pulse 1.2s var(--wb-motion-easing-standard) infinite;
+  }
+
+  .wb-chat-typing__dot:nth-child(2) {
+    animation-delay: 0.2s;
+  }
+
+  .wb-chat-typing__dot:nth-child(3) {
+    animation-delay: 0.4s;
+  }
+
+  @keyframes wb-chat-typing-pulse {
+    0%,
+    60%,
+    100% {
+      opacity: 0.35;
+    }
+    30% {
+      opacity: 1;
+    }
+  }
+
+  .wb-chat-stopped {
+    flex: 0 0 auto;
+  }
+
+  /* --- Composer ----------------------------------------------------------- */
+
+  .wb-chat-composer {
+    display: flex;
+    flex: 0 0 auto;
+    flex-direction: column;
+    gap: var(--wb-space-3);
+  }
+
+  .wb-chat-composer__row {
+    display: flex;
+    align-items: flex-end;
+    gap: var(--wb-space-4);
+  }
+
+  .wb-chat-composer__field {
+    display: flex;
+    min-width: 0;
+    flex: 1 1 auto;
+    flex-direction: column;
+  }
+
+  .wb-chat-composer__input {
+    width: 100%;
+    max-height: 10rem;
+    padding: var(--wb-space-4) var(--wb-space-5);
+    border: var(--wb-border-width) solid var(--wb-color-border-default);
+    border-radius: var(--wb-radius-control);
+    background: var(--wb-color-surface-raised);
+    color: var(--wb-color-text-primary);
+    font-family: inherit;
+    font-size: var(--wb-font-size-sm);
+    line-height: var(--wb-line-height-body);
+    resize: none;
+  }
+
+  .wb-chat-composer__input:focus-visible {
+    outline: var(--wb-focus-width) solid var(--wb-color-focus-ring);
+    outline-offset: 1px;
+  }
+
+  .wb-chat-composer__input[data-disabled] {
+    background: var(--wb-color-surface-inset);
+    color: var(--wb-color-text-disabled);
+    cursor: not-allowed;
+  }
+
+  .wb-chat-composer__send.wb-button {
+    flex: 0 0 auto;
+  }
+
+  .wb-chat-composer__error {
+    flex: 0 0 auto;
+  }
+
+  /* --- Full-panel host states --------------------------------------------- */
+
+  .wb-chat-state {
+    display: grid;
+    min-height: 8rem;
+    flex: 1 1 auto;
+    gap: var(--wb-space-4);
+    place-content: center;
+    padding: var(--wb-space-6);
+    color: var(--wb-color-text-secondary);
+    text-align: center;
+  }
+
+  .wb-chat-state__title {
+    color: var(--wb-color-text-strong);
+    font-size: var(--wb-font-size-sm);
+    font-weight: var(--wb-font-weight-semibold);
+  }
+
+  .wb-chat-state__action {
+    justify-self: center;
+  }
+}

--- a/dashboard-react/src/widget-library/chat/useChatConversation.test.tsx
+++ b/dashboard-react/src/widget-library/chat/useChatConversation.test.tsx
@@ -8,6 +8,23 @@ import type {
 import { InMemoryChatProvider } from "./InMemoryChatProvider";
 import { useChatConversation } from "./useChatConversation";
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (cause: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const emptySnapshot = (conversationId: string): ChatConversationSnapshot => ({
+  conversationId,
+  status: "open",
+  agentLiveness: "unknown",
+  messages: [],
+});
+
 describe("useChatConversation", () => {
   it("loads the initial snapshot and reaches the ready state", async () => {
     const provider = new InMemoryChatProvider({
@@ -101,5 +118,75 @@ describe("useChatConversation", () => {
 
     await waitFor(() => expect(result.current.status).toBe("ready"));
     expect(result.current.error).toBeNull();
+  });
+
+  it("drops a stale send result that resolves after a rebind to another conversation", async () => {
+    const pendingSend = deferred<ChatConversationSnapshot>();
+    const provider: ChatConversationProvider = {
+      loadConversation: async (conversationId) => emptySnapshot(conversationId),
+      sendMessage: () => pendingSend.promise,
+      subscribe: () => () => {},
+    };
+    const { result, rerender } = renderHook(
+      ({ conversationId }) => useChatConversation(provider, conversationId),
+      { initialProps: { conversationId: "conv-a" } },
+    );
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    let sendPromise!: Promise<void>;
+    act(() => {
+      sendPromise = result.current.send("late reply");
+    });
+
+    rerender({ conversationId: "conv-b" });
+    await waitFor(() =>
+      expect(result.current.snapshot?.conversationId).toBe("conv-b"),
+    );
+
+    await act(async () => {
+      pendingSend.resolve({
+        ...emptySnapshot("conv-a"),
+        messages: [{ id: "stale-1", author: "user", content: "late reply" }],
+      });
+      await sendPromise;
+    });
+
+    // The stale result is dropped, conv-b's transcript is untouched.
+    expect(result.current.snapshot?.conversationId).toBe("conv-b");
+    expect(result.current.snapshot?.messages).toHaveLength(0);
+  });
+
+  it("does not surface a stale send failure under the new binding", async () => {
+    const pendingSend = deferred<ChatConversationSnapshot>();
+    const provider: ChatConversationProvider = {
+      loadConversation: async (conversationId) => emptySnapshot(conversationId),
+      sendMessage: () => pendingSend.promise,
+      subscribe: () => () => {},
+    };
+    const { result, rerender } = renderHook(
+      ({ conversationId }) => useChatConversation(provider, conversationId),
+      { initialProps: { conversationId: "conv-a" } },
+    );
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    let sendPromise!: Promise<void>;
+    act(() => {
+      sendPromise = result.current.send("doomed reply");
+    });
+
+    rerender({ conversationId: "conv-b" });
+    await waitFor(() =>
+      expect(result.current.snapshot?.conversationId).toBe("conv-b"),
+    );
+
+    await act(async () => {
+      pendingSend.reject(new Error("network blip"));
+      await expect(sendPromise).rejects.toThrow(/network blip/);
+    });
+
+    // The stale failure belongs to conv-a's binding and must not paint an
+    // error over conv-b.
+    expect(result.current.sendError).toBeNull();
+    expect(result.current.snapshot?.conversationId).toBe("conv-b");
   });
 });

--- a/dashboard-react/src/widget-library/chat/useChatConversation.test.tsx
+++ b/dashboard-react/src/widget-library/chat/useChatConversation.test.tsx
@@ -1,0 +1,105 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  ChatConversationProvider,
+  ChatConversationSnapshot,
+} from "./contracts";
+import { InMemoryChatProvider } from "./InMemoryChatProvider";
+import { useChatConversation } from "./useChatConversation";
+
+describe("useChatConversation", () => {
+  it("loads the initial snapshot and reaches the ready state", async () => {
+    const provider = new InMemoryChatProvider({
+      conversationId: "c1",
+      messages: [{ id: "m1", author: "assistant", content: "Hello" }],
+    });
+    const { result } = renderHook(() => useChatConversation(provider, "c1"));
+
+    expect(result.current.status).toBe("loading");
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.snapshot?.messages).toHaveLength(1);
+  });
+
+  it("appends a sent message and clears the sending flag", async () => {
+    const provider = new InMemoryChatProvider({
+      conversationId: "c1",
+      autoReply: () => [{ id: "a1", author: "assistant", content: "Got it" }],
+    });
+    const { result } = renderHook(() => useChatConversation(provider, "c1"));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    await act(async () => {
+      await result.current.send("hi");
+    });
+
+    expect(result.current.sending).toBe(false);
+    expect(result.current.snapshot?.messages.map((m) => m.content)).toEqual([
+      "hi",
+      "Got it",
+    ]);
+  });
+
+  it("reloads on a provider invalidation", async () => {
+    const provider = new InMemoryChatProvider({ conversationId: "c1" });
+    const { result } = renderHook(() => useChatConversation(provider, "c1"));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.snapshot?.messages).toHaveLength(0);
+
+    act(() => {
+      provider.pushMessage({ id: "a1", author: "assistant", content: "ping" });
+    });
+
+    await waitFor(() =>
+      expect(result.current.snapshot?.messages).toHaveLength(1),
+    );
+  });
+
+  it("records a send error and rethrows so a draft can be retained", async () => {
+    const provider = new InMemoryChatProvider({
+      conversationId: "c1",
+      failSend: true,
+    });
+    const { result } = renderHook(() => useChatConversation(provider, "c1"));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    await act(async () => {
+      await expect(result.current.send("x")).rejects.toThrow(
+        /could not be delivered/,
+      );
+    });
+
+    expect(result.current.sendError).toMatch(/could not be delivered/);
+    expect(result.current.sending).toBe(false);
+  });
+
+  it("recovers from a load error on retry", async () => {
+    const snapshot: ChatConversationSnapshot = {
+      conversationId: "c1",
+      status: "open",
+      agentLiveness: "unknown",
+      messages: [],
+    };
+    let failLoad = true;
+    const provider: ChatConversationProvider = {
+      loadConversation: vi.fn(async () => {
+        if (failLoad) throw new Error("network down");
+        return snapshot;
+      }),
+      sendMessage: vi.fn(),
+      subscribe: () => () => {},
+    };
+
+    const { result } = renderHook(() => useChatConversation(provider, "c1"));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toMatch(/network down/);
+
+    failLoad = false;
+    act(() => {
+      result.current.retry();
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/dashboard-react/src/widget-library/chat/useChatConversation.ts
+++ b/dashboard-react/src/widget-library/chat/useChatConversation.ts
@@ -2,6 +2,10 @@
 // React state: an initial load, a silent refresh on every provider
 // invalidation, and a send path that surfaces failures without discarding the
 // human draft. It holds no transport knowledge, only the seam.
+//
+// The provider argument must be referentially stable (module constant, memo,
+// or context value). A consumer that constructs a fresh provider each render
+// re-subscribes and reloads on every render.
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -91,16 +95,22 @@ export function useChatConversation(
 
   const send = useCallback(
     async (value: string, inReplyTo?: string) => {
+      // Capture the binding this send belongs to. A send resolving after the
+      // hook has rebound to another provider or conversation must not write
+      // its snapshot or error over the current binding's state.
+      const boundTo = activeRef.current;
       setSending(true);
       setSendError(null);
       const input: ChatSendInput = { value, inReplyTo };
       try {
         const next = await provider.sendMessage(conversationId, input);
-        if (activeRef.current !== null) {
+        if (activeRef.current === boundTo) {
           setSnapshot(next);
         }
       } catch (cause) {
-        setSendError(messageOf(cause));
+        if (activeRef.current === boundTo) {
+          setSendError(messageOf(cause));
+        }
         throw cause;
       } finally {
         setSending(false);

--- a/dashboard-react/src/widget-library/chat/useChatConversation.ts
+++ b/dashboard-react/src/widget-library/chat/useChatConversation.ts
@@ -1,0 +1,117 @@
+// The poll or subscribe hook shape. It binds a ChatConversationProvider to
+// React state: an initial load, a silent refresh on every provider
+// invalidation, and a send path that surfaces failures without discarding the
+// human draft. It holds no transport knowledge, only the seam.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type {
+  ChatConversationProvider,
+  ChatConversationSnapshot,
+  ChatSendInput,
+} from "./contracts";
+
+/** Load lifecycle for the whole transcript. Send failures are separate. */
+export type ChatLoadStatus = "loading" | "ready" | "error";
+
+export interface UseChatConversationResult {
+  readonly snapshot: ChatConversationSnapshot | null;
+  readonly status: ChatLoadStatus;
+  /** Set when status is "error", a human-readable load failure reason. */
+  readonly error: string | null;
+  readonly sending: boolean;
+  /** Set when the most recent send failed, cleared on the next attempt. */
+  readonly sendError: string | null;
+  /** Submit a human message or answer. Rejects on failure so a composer can retain its draft. */
+  send(value: string, inReplyTo?: string): Promise<void>;
+  /** Re-run the initial load after an error. */
+  retry(): void;
+}
+
+function messageOf(error: unknown): string {
+  if (error instanceof Error && error.message.length > 0) return error.message;
+  return "Something went wrong.";
+}
+
+export function useChatConversation(
+  provider: ChatConversationProvider,
+  conversationId: string,
+): UseChatConversationResult {
+  const [snapshot, setSnapshot] = useState<ChatConversationSnapshot | null>(
+    null,
+  );
+  const [status, setStatus] = useState<ChatLoadStatus>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+
+  // Identity of the active binding. Async results from a superseded provider or
+  // conversation (or after unmount) are dropped rather than applied.
+  const activeRef = useRef<object>({});
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    const active = {};
+    activeRef.current = active;
+    let cancelled = false;
+    const isCurrent = () => !cancelled && activeRef.current === active;
+
+    const load = (showLoading: boolean) => {
+      if (showLoading) {
+        setStatus("loading");
+        setError(null);
+      }
+      provider
+        .loadConversation(conversationId)
+        .then((next) => {
+          if (!isCurrent()) return;
+          setSnapshot(next);
+          setStatus("ready");
+          setError(null);
+        })
+        .catch((cause) => {
+          if (!isCurrent()) return;
+          // A silent refresh must not blow away a good transcript. Only the
+          // initial load (or an explicit retry) escalates to the error state.
+          if (showLoading) {
+            setStatus("error");
+            setError(messageOf(cause));
+          }
+        });
+    };
+
+    load(true);
+    const unsubscribe = provider.subscribe(conversationId, () => load(false));
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [provider, conversationId, reloadToken]);
+
+  const send = useCallback(
+    async (value: string, inReplyTo?: string) => {
+      setSending(true);
+      setSendError(null);
+      const input: ChatSendInput = { value, inReplyTo };
+      try {
+        const next = await provider.sendMessage(conversationId, input);
+        if (activeRef.current !== null) {
+          setSnapshot(next);
+        }
+      } catch (cause) {
+        setSendError(messageOf(cause));
+        throw cause;
+      } finally {
+        setSending(false);
+      }
+    },
+    [provider, conversationId],
+  );
+
+  const retry = useCallback(() => {
+    setReloadToken((token) => token + 1);
+  }, []);
+
+  return { snapshot, status, error, sending, sendError, send, retry };
+}

--- a/knowledge/store/services/dashboard/react/chat-primitives.md
+++ b/knowledge/store/services/dashboard/react/chat-primitives.md
@@ -1,0 +1,42 @@
+---
+name: React Dashboard Chat Primitives
+kind: concept
+description: Reusable React chat components and a typed provider seam mirroring house conversation semantics for the /app dashboard.
+tags:
+- dashboard
+- react
+- chat
+- conversations
+- widget-library
+aliases:
+- ChatPanel
+- chat primitives
+- useChatConversation
+- React chat
+parents:
+- services/dashboard/react
+dev_notes: |-
+  The provider argument to useChatConversation must be referentially stable, a fresh instance each render re-subscribes and reloads. Send results and errors that resolve after the hook rebinds to another provider or conversation are dropped by a captured-identity guard, keep that guard when extending the send path.
+
+  The autoscroll effect keys on message COUNT, so a last message whose content grows in place will not re-stick a pinned view (the house store appends discrete messages). An unread boundary seeded at the first message is legitimate, the separator renders above index 0.
+
+  The composer disables itself while agentActivity is stopped, callers do not need to derive that. Inline question answers thread the question's message id as onSend's second argument and catch rejection, failures surface through sendErrorMessage from the container.
+---
+
+Reusable React chat components for conversational surfaces in the React dashboard, at `dashboard-react/src/widget-library/chat/`. They render the same backend conversations the root dashboard's chat sidebar shows, behind a typed, transport-agnostic provider seam. The root dashboard's own surface remains `services/dashboard/chat-sidebar` and is unchanged by these primitives.
+
+## Components
+
+- **ChatPanel**: message log plus composer with a header slot and the standard host states, including a read-only banner.
+- **ChatMessageList**: author attribution, timestamps, unread boundary with scroll lock and jump-to-latest, inline choice and boolean answers, typing indicator and agent-stopped notice.
+- **ChatComposer**: Enter submits, Shift plus Enter inserts a newline, the draft is retained on send failure.
+
+## State and mapping
+
+`useChatConversation(provider, conversationId)` binds a `ChatConversationProvider` (loadConversation, sendMessage, subscribe) to React state with load, silent-refresh, and send lifecycles. `normalizeConversationPayload` converts the raw `GET /api/conversations/<id>` payload into canonical types, and `deriveAgentActivity` mirrors the legacy typing and stopped logic from `conversation.agent_alive`.
+
+Message identity: the endpoint serializes message ids as `message_id`, which the mapping prefers. A bare `id` is accepted as a fixture-side fallback and a positional id is the last resort.
+
+## Transport posture
+
+No HTTP wiring lives in the package. A live transport implements the provider seam. `InMemoryChatProvider` is the test and development fixture. The components consume the appearance system's semantic tokens only, honor forced-colors and reduced-motion with non-color encodings, and are keyboard complete.


### PR DESCRIPTION
Rebuilds the legacy dashboard's conversation chat surface as reusable React primitives in the widget library, behavior-matched against the chat-sidebar contract and the conversation_* capability semantics, fully inside the new dashboard architecture (Theme Contract v1 semantic tokens only, react-aria interaction primitives, host-state contract, axe-clean).

## Summary
- ChatPanel / ChatMessageList / ChatComposer: full conversational surface with unread boundary, scroll lock, inline question answers, typing and agent-stopped indicators, IME-safe composer with draft retention.
- ChatConversationProvider seam + InMemoryChatProvider fixture + useChatConversation hook. No live HTTP wiring: the seam is the contract, the live transport arrives with the Co-work view.
- normalizeConversationPayload + deriveAgentActivity mirror the live endpoint (message identity via message_id, agent_alive tri-state).
- High-effort review applied: two criticals fixed (endpoint message-identity field, stale-send rebind guard) with mutation-verified regression tests.
- Durable docs: new knowledge unit services/dashboard/react/chat-primitives (confirmed) and the COMPONENTS.md component inventory.

Zero new dependencies. Full dashboard-react suite 292 passed, typecheck clean, production build clean. Both house scanners (PII, transient identifiers) clean across the branch diff.

## Test plan
- [ ] CI: DCO check green (all four commits signed off)
- [ ] npx vitest run in dashboard-react (292 passing, 53 in the chat suite)
- [ ] Reviewer spot-check: the chat primitives render correctly in the widget test states (InMemoryChatProvider fixtures)

Part of the Co-work K2 build (Wave 1, WP-B1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
