### PR TITLE
fix(dashboard): keep the React ecosystem in one vendor chunk

### DIFF
--- a/dashboard-react/vite.config.ts
+++ b/dashboard-react/vite.config.ts
@@ -25,18 +25,23 @@ export default defineConfig({
       output: {
         manualChunks(id) {
           if (!id.includes("node_modules")) return undefined;
-          if (
-            id.includes("react-aria-components") ||
-            id.includes("@react-aria") ||
-            id.includes("@react-stately") ||
-            id.includes("@internationalized")
-          ) {
-            return "vendor-react-aria";
-          }
+          // The whole React ecosystem lives in ONE chunk. react-aria and
+          // react-aria-components import react/react-dom and cross-reference
+          // @react-aria / @react-stately, so isolating them in a separate
+          // chunk makes Rollup emit two chunks that import each other at module
+          // top level. ES module init order then trips a temporal dead zone at
+          // runtime ("Cannot access '$' before initialization"). A single chunk
+          // is larger but correct, which is the right trade for a same-origin
+          // local dashboard. Keep leaf packages (grid, icons) split for caching.
           if (
             id.includes("/react/") ||
             id.includes("/react-dom/") ||
-            id.includes("/react-router")
+            id.includes("/react-router") ||
+            id.includes("react-aria") ||
+            id.includes("@react-aria") ||
+            id.includes("react-stately") ||
+            id.includes("@react-stately") ||
+            id.includes("@internationalized")
           ) {
             return "vendor-react";
           }


### PR DESCRIPTION
## What

The production dashboard bundle crashed on load with `Uncaught ReferenceError: Cannot access '$' before initialization` (from `vendor-react-aria`), blanking the whole app when served by Flask at `/app`.

## Cause

`manualChunks` in `vite.config.ts` isolated `react-aria` / `react-aria-components` into a `vendor-react-aria` chunk separate from `react`. Those packages import react/react-dom and cross-reference `@react-aria` / `@react-stately`, so Rollup emitted two chunks that import each other at module top level:

```
Circular chunk: vendor-react-aria -> vendor-react -> vendor-react-aria
```

ES module init order then hit a temporal dead zone at runtime. The Vite **dev server** does not apply `manualChunks`, so the crash only appears in the production build, which is why it was invisible during `npm run dev`. K2 did not introduce the config (it dates to the reskin commit) but pulled react-aria onto the critical path heavily enough to turn the latent cycle into a hard crash.

## Fix

Merge the whole React ecosystem into one `vendor-react` chunk. Leaf packages (grid, icons) stay split for caching. One larger chunk is the right trade for a same-origin local app.

## Verification (against the built output, not the dev server)

- `npm run build` (tsc + vite build): exit 0, **zero** `Circular chunk` warnings, zero TS errors.
- Served the built `dist` with `vite preview` and loaded it in a browser: `/app/journal` and `/app/cowork` both render fully with **zero console errors**. The `$` init error is gone.

The only remaining build line is the benign "chunk larger than 500 kB" size advisory, expected from the deliberate merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)