### PR TITLE
Co-work: honest presentation and cross-view hover help

### DIFF
--- a/dashboard-react/package-lock.json
+++ b/dashboard-react/package-lock.json
@@ -20,7 +20,9 @@
         "@fullcalendar/timegrid": "6.1.21",
         "@phosphor-icons/react": "2.1.10",
         "@tiptap/core": "3.28.0",
+        "@tiptap/extension-code-block": "3.28.0",
         "@tiptap/extension-collaboration": "3.28.0",
+        "@tiptap/extension-horizontal-rule": "3.28.0",
         "@tiptap/extension-image": "3.28.0",
         "@tiptap/extension-list": "3.28.0",
         "@tiptap/extension-table": "3.28.0",
@@ -38,6 +40,7 @@
         "react-aria-components": "1.19.0",
         "react-dom": "^19.2.0",
         "react-grid-layout": "2.2.3",
+        "react-resizable-panels": "4.12.2",
         "react-router-dom": "^7.18.1",
         "react-stately": "3.48.0",
         "yjs": "13.6.31"
@@ -4082,6 +4085,16 @@
       "peerDependencies": {
         "react": ">= 16.3",
         "react-dom": ">= 16.3"
+      }
+    },
+    "node_modules/react-resizable-panels": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.12.2.tgz",
+      "integrity": "sha512-NwY5LCo4WrxVvDh0xoMML6EMLPONP/8ckKcIdpnojxexoatZdjLiRqLJQjQK5CPkd4SYiB/2M5BVrjZBQtOO7Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-router": {

--- a/dashboard-react/package.json
+++ b/dashboard-react/package.json
@@ -46,6 +46,7 @@
     "react-aria-components": "1.19.0",
     "react-dom": "^19.2.0",
     "react-grid-layout": "2.2.3",
+    "react-resizable-panels": "4.12.2",
     "react-router-dom": "^7.18.1",
     "react-stately": "3.48.0",
     "yjs": "13.6.31"

--- a/dashboard-react/src/app/DashboardApp.tsx
+++ b/dashboard-react/src/app/DashboardApp.tsx
@@ -9,6 +9,7 @@ import {
 
 import Header from "../components/Header";
 import TabBar from "../components/TabBar";
+import { HelpModeProvider } from "../dashboard/help";
 import { SettingsRegistryProvider } from "../settings";
 import type { DashboardRouteDefinition } from "./routes";
 
@@ -174,7 +175,9 @@ export default function DashboardApp(props: DashboardAppProps) {
   return (
     <BrowserRouter basename="/app">
       <SettingsRegistryProvider>
-        <DashboardShell {...props} />
+        <HelpModeProvider>
+          <DashboardShell {...props} />
+        </HelpModeProvider>
       </SettingsRegistryProvider>
     </BrowserRouter>
   );

--- a/dashboard-react/src/apps/cowork/conformance/themeMatrix.a11y.test.tsx
+++ b/dashboard-react/src/apps/cowork/conformance/themeMatrix.a11y.test.tsx
@@ -56,11 +56,16 @@ function renderRail(preference: ThemePreference) {
 }
 
 describe("Co-work theme matrix", () => {
+  const originalUrl = window.location.href;
   beforeEach(() => {
     localStorage.clear();
+    // Drive the fabricated demo scene so axe covers the populated composed surface
+    // (health strip, seeded editor, and review rail with cards), not the empty default.
+    window.history.replaceState({}, "", "/app/cowork?cowork_fixture=demo");
   });
   afterEach(() => {
     localStorage.clear();
+    window.history.replaceState({}, "", originalUrl);
   });
 
   for (const preference of SCHEMES) {

--- a/dashboard-react/src/apps/cowork/editor/CoworkEditorPane.tsx
+++ b/dashboard-react/src/apps/cowork/editor/CoworkEditorPane.tsx
@@ -8,14 +8,10 @@ import type { CoworkYdocTransport } from "../persistence/transport";
 import { buildEditorExtensions, stopCapturingLoadTimeIds } from "./extensions";
 import { importCoworkMarkdown } from "./markdownImport";
 
-const DEFAULT_SEED_MARKDOWN = [
-  "# Co-work document",
-  "",
-  "This is the editor pane. It binds a Tiptap editor to a local Y.Doc through the",
-  "eight-point load-order contract, projects AI proposals as an ephemeral review layer,",
-  "and materializes edits block by block.",
-  "",
-].join("\n");
+// A brand-new document opens empty and honest. What the pane IS (its load-order contract,
+// its review layer, its block-splice materialize) is documented as hover help on the editor
+// region, not seeded as document content. Modes that want seeded prose pass it explicitly.
+const DEFAULT_SEED_MARKDOWN = "";
 
 export interface CoworkEditorPaneProps {
   /** Markdown seeded into a brand-new document exactly once, on an empty fragment. */
@@ -50,8 +46,11 @@ function MountedCoworkEditor({
   seedWhenEmpty,
 }: MountedCoworkEditorProps) {
   const extensions = useMemo(() => buildEditorExtensions(document), [document]);
+  // An empty seed means a genuinely empty document, so nothing is parsed or set and the
+  // editor opens on its own empty state rather than fabricated placeholder prose.
   const seedContent = useMemo(
-    () => importCoworkMarkdown(seedMarkdown).doc,
+    () =>
+      seedMarkdown.trim().length > 0 ? importCoworkMarkdown(seedMarkdown).doc : null,
     [seedMarkdown],
   );
   const boundRef = useRef(false);
@@ -80,7 +79,7 @@ function MountedCoworkEditor({
     // start() (rather than before) means a second client hydrating from the server
     // sees the seed instead of orphaned updates that reference an unpushed base (S2).
     persistence.start();
-    if (seedWhenEmpty) {
+    if (seedWhenEmpty && seedContent !== null) {
       editor.commands.setContent(seedContent);
     }
     stopCapturingLoadTimeIds(editor);

--- a/dashboard-react/src/apps/cowork/rail/CoworkRail.test.tsx
+++ b/dashboard-react/src/apps/cowork/rail/CoworkRail.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
+import { DashboardHelpProvider } from "../../../dashboard/help";
 import { expectNoAccessibilityViolations } from "../../../test/setup";
 import { CoworkRail } from "./CoworkRail";
 import { InMemoryReviewProvider } from "./InMemoryReviewProvider";
@@ -52,6 +53,29 @@ describe("CoworkRail", () => {
     );
     expect(screen.getByRole("tab", { name: /Chat/ })).toBeVisible();
     await waitFor(() => expect(screen.getByText(S1_TLDR)).toBeVisible());
+  });
+
+  it("gives the Review and Chat tabs their own hover help in help mode", () => {
+    render(
+      <DashboardHelpProvider enabled>
+        <CoworkRail
+          documentId="demo-doc"
+          reviewProvider={new InMemoryReviewProvider()}
+          chatProvider={createDemoChatProvider("conv-1")}
+          conversationId="conv-1"
+          storage={new MemoryStorage()}
+        />
+      </DashboardHelpProvider>,
+    );
+    // Each tab is its own help target, so the two can be described separately.
+    expect(screen.getByRole("tab", { name: "Review" })).toHaveAttribute(
+      "data-help-target",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: /Chat/ })).toHaveAttribute(
+      "data-help-target",
+      "true",
+    );
   });
 
   it("mounts the house ChatPanel on the Chat tab and sends a message", async () => {

--- a/dashboard-react/src/apps/cowork/rail/CoworkRail.tsx
+++ b/dashboard-react/src/apps/cowork/rail/CoworkRail.tsx
@@ -8,6 +8,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 
+import { HelpTarget, type HelpContent } from "../../../dashboard/help";
 import {
   ChatPanel,
   deriveAgentActivity,
@@ -27,6 +28,20 @@ import type { AnchorRectSource, ReviewRailProvider } from "./provider";
 import { RailStore, type RailTab } from "./store";
 import { useRailState } from "./useRailState";
 import "./styles.css";
+
+/** Hover-help for the Review tab, surfaced when app-shell help mode is on. */
+const REVIEW_TAB_HELP: HelpContent = {
+  summary: "Review the agent's proposed changes.",
+  details:
+    "Lists the tracked edits, flags, and claims the agent raised on this document. Decide on each one, then submit them together as a single sitting.",
+};
+
+/** Hover-help for the Chat tab, surfaced when app-shell help mode is on. */
+const CHAT_TAB_HELP: HelpContent = {
+  summary: "Talk to the agent about this document.",
+  details:
+    "The document conversation. Ask a question, leave feedback on a highlighted passage, and read the agent's replies without leaving the review.",
+};
 
 export interface CoworkRailProps {
   readonly documentId: string;
@@ -87,33 +102,37 @@ export function CoworkRail(props: CoworkRailProps) {
         role="tablist"
         aria-label="Review and chat"
       >
-        <button
-          type="button"
-          role="tab"
-          id="wb-cowork-rail-tab-review"
-          className="wb-cowork-rail__tab"
-          aria-selected={tab === "review"}
-          aria-controls="wb-cowork-rail-panel-review"
-          onClick={() => store.setTab("review")}
-        >
-          Review
-        </button>
-        <button
-          type="button"
-          role="tab"
-          id="wb-cowork-rail-tab-chat"
-          className="wb-cowork-rail__tab"
-          aria-selected={tab === "chat"}
-          aria-controls="wb-cowork-rail-panel-chat"
-          onClick={() => store.setTab("chat")}
-        >
-          Chat
-          {unread ? (
-            <span className="wb-cowork-rail__unread">
-              <span className="wb-visually-hidden">unread reply</span>
-            </span>
-          ) : null}
-        </button>
+        <HelpTarget content={REVIEW_TAB_HELP} placement="bottom start">
+          <button
+            type="button"
+            role="tab"
+            id="wb-cowork-rail-tab-review"
+            className="wb-cowork-rail__tab"
+            aria-selected={tab === "review"}
+            aria-controls="wb-cowork-rail-panel-review"
+            onClick={() => store.setTab("review")}
+          >
+            Review
+          </button>
+        </HelpTarget>
+        <HelpTarget content={CHAT_TAB_HELP} placement="bottom">
+          <button
+            type="button"
+            role="tab"
+            id="wb-cowork-rail-tab-chat"
+            className="wb-cowork-rail__tab"
+            aria-selected={tab === "chat"}
+            aria-controls="wb-cowork-rail-panel-chat"
+            onClick={() => store.setTab("chat")}
+          >
+            Chat
+            {unread ? (
+              <span className="wb-cowork-rail__unread">
+                <span className="wb-visually-hidden">unread reply</span>
+              </span>
+            ) : null}
+          </button>
+        </HelpTarget>
       </div>
 
       <div

--- a/dashboard-react/src/apps/cowork/rail/useIsNarrow.ts
+++ b/dashboard-react/src/apps/cowork/rail/useIsNarrow.ts
@@ -20,7 +20,12 @@ export function useIsNarrow(threshold = 360): [boolean, NarrowRef] {
       observerRef.current = null;
       if (element === null || typeof ResizeObserver !== "function") return;
       const measure = () => {
-        setNarrow(element.getBoundingClientRect().width < threshold);
+        const width = element.getBoundingClientRect().width;
+        // A width of 0 means the element is not laid out yet (pre-paint, an
+        // unmeasured jsdom node, or display:none). Only a real, positive
+        // sub-threshold width is narrow, so the grouped fallback never flashes
+        // before the first true measurement.
+        setNarrow(width > 0 && width < threshold);
       };
       measure();
       const observer = new ResizeObserver(measure);

--- a/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.test.tsx
+++ b/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
   DashboardIntent,
@@ -28,11 +28,81 @@ const renderSurface = () =>
     </DashboardEventProvider>,
   );
 
-describe("CoworkWorkspaceSurface", () => {
-  it("renders the health strip, editor pane, and review rail regions", async () => {
+describe("CoworkWorkspaceSurface default (empty) mode", () => {
+  const originalUrl = window.location.href;
+  beforeEach(() => window.history.replaceState({}, "", "/app/cowork"));
+  afterEach(() => window.history.replaceState({}, "", originalUrl));
+
+  it("opens with honest empty states and no fabricated content", async () => {
     const { container } = renderSurface();
 
-    // Health strip reflects the coarse document session.
+    // Health strip: no document open (its existing null branch).
+    await waitFor(
+      () =>
+        expect(
+          within(screen.getByLabelText("Document health")).getByText(
+            "No document open",
+          ),
+        ).toBeVisible(),
+      { timeout: 10_000 },
+    );
+
+    // The editor mounts as a real, empty editable surface, with none of the old
+    // self-describing blurb and no demo document title.
+    await waitFor(
+      () => expect(container.querySelector(".ProseMirror")).not.toBeNull(),
+      { timeout: 10_000 },
+    );
+    expect(screen.queryByText(/This is the editor pane/)).toBeNull();
+    expect(screen.queryByText("Co-work demo document")).toBeNull();
+
+    // Review rail: no fabricated proposals, just an honest empty layer.
+    await waitFor(
+      () => expect(screen.getByText("Nothing to review here.")).toBeVisible(),
+      { timeout: 10_000 },
+    );
+    expect(
+      screen.queryByText("Add the vault content hash to the cache key."),
+    ).toBeNull();
+  }, 15_000);
+
+  it("shows an honest empty chat: a real composer, no scripted agent turn, no fake typing", async () => {
+    const { container } = renderSurface();
+    await waitFor(
+      () => expect(container.querySelector(".ProseMirror")).not.toBeNull(),
+      { timeout: 10_000 },
+    );
+
+    await userEvent.click(screen.getByRole("tab", { name: /Chat/ }));
+
+    // A real composer is present.
+    expect(screen.getByRole("textbox", { name: "Message" })).toBeVisible();
+    // No fabricated agent message, and no perpetual typing indicator.
+    expect(screen.queryByText(/I proposed a few tracked edits/)).toBeNull();
+    expect(container.querySelector(".wb-chat-typing")).toBeNull();
+  }, 15_000);
+
+  it("has no accessibility violations in its empty resting state", async () => {
+    const { container } = renderSurface();
+    await waitFor(
+      () => expect(container.querySelector(".ProseMirror")).not.toBeNull(),
+      { timeout: 10_000 },
+    );
+    await expectNoAccessibilityViolations(container);
+  }, 15_000);
+});
+
+describe("CoworkWorkspaceSurface demo fixture (?cowork_fixture=demo)", () => {
+  const originalUrl = window.location.href;
+  beforeEach(() =>
+    window.history.replaceState({}, "", "/app/cowork?cowork_fixture=demo"),
+  );
+  afterEach(() => window.history.replaceState({}, "", originalUrl));
+
+  it("renders the fabricated demo scene behind the explicit flag", async () => {
+    const { container } = renderSurface();
+
+    // Health strip reflects the demo document session.
     await waitFor(
       () => expect(screen.getByText("Co-work demo document")).toBeVisible(),
       { timeout: 10_000 },
@@ -40,22 +110,24 @@ describe("CoworkWorkspaceSurface", () => {
     expect(screen.getByText("In sync")).toBeVisible();
     expect(screen.getByText("0 open proposals")).toBeVisible();
 
-    // Rail tabs.
-    expect(screen.getByRole("tab", { name: "Review" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
-    expect(screen.getByRole("tab", { name: /Chat/ })).toBeVisible();
+    // The demo review rail fixture is present.
+    expect(
+      screen.getByText("Add the vault content hash to the cache key."),
+    ).toBeVisible();
 
-    // Editor pane mounts a live ProseMirror editor with its seeded content.
+    // The demo editor seeds coherent prose (scoped to the editor, since the rail also
+    // quotes these phrases), not the self-describing blurb.
     await waitFor(
       () => expect(container.querySelector(".ProseMirror")).not.toBeNull(),
       { timeout: 10_000 },
     );
-    expect(screen.getByText(/This is the editor pane/)).toBeVisible();
+    expect(
+      within(screen.getByLabelText("Editor")).getByText(/Context bundle cache/),
+    ).toBeVisible();
+    expect(screen.queryByText(/This is the editor pane/)).toBeNull();
   }, 15_000);
 
-  it("switches to the Chat tab", async () => {
+  it("keeps the scripted demo chat behind the flag", async () => {
     renderSurface();
     await waitFor(
       () => expect(screen.getByText("Co-work demo document")).toBeVisible(),
@@ -67,24 +139,11 @@ describe("CoworkWorkspaceSurface", () => {
       "aria-selected",
       "true",
     );
-    // The Chat tab now mounts the house chat panel seeded with the document agent's
-    // opening message, not the rail placeholder stub.
     await waitFor(
       () =>
-        expect(
-          screen.getByText(/I proposed a few tracked edits/),
-        ).toBeVisible(),
+        expect(screen.getByText(/I proposed a few tracked edits/)).toBeVisible(),
       { timeout: 10_000 },
     );
-  }, 15_000);
-
-  it("has no accessibility violations in its resting state", async () => {
-    const { container } = renderSurface();
-    await waitFor(
-      () => expect(container.querySelector(".ProseMirror")).not.toBeNull(),
-      { timeout: 10_000 },
-    );
-    await expectNoAccessibilityViolations(container);
   }, 15_000);
 });
 

--- a/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.tsx
+++ b/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { Group, Panel, Separator } from "react-resizable-panels";
 
 import type { SingleSurfaceRuntimeProps } from "../../../dashboard/contributions/viewModules";
 import { useOptionalDashboardEvents } from "../../../dashboard/events/DashboardEventProvider";
@@ -27,7 +28,16 @@ import {
   isDirty,
   type ReviewRailData,
 } from "../rail";
-import { useResizableRail } from "./useResizableRail";
+import {
+  EDITOR_DEFAULT_SIZE,
+  EDITOR_MIN_SIZE,
+  EDITOR_PANEL_ID,
+  RAIL_DEFAULT_SIZE,
+  RAIL_MAX_SIZE,
+  RAIL_MIN_SIZE,
+  RAIL_PANEL_ID,
+  useResizableRail,
+} from "./useResizableRail";
 import "./styles.css";
 
 const DRIFT_LABEL: Record<string, string> = {
@@ -124,7 +134,13 @@ function CoworkHealthStrip({ health }: { health: CoworkHealthView | null }) {
   );
 }
 
-/** The shared three-region shell, so demo and live compose the same layout (section 5). */
+/**
+ * The shared three-region shell, so demo and live compose the same layout (section 5). The
+ * editor and the review rail are two resizable panels: react-resizable-panels sizes them as
+ * percentages of the body, so the rail drags across a wide range in both directions and holds
+ * its proportion when the window changes. The separator carries `role="separator"` with arrow
+ * keys and double-click-to-reset from the library, and `useResizableRail` persists the split.
+ */
 function CoworkWorkspaceLayout({
   label,
   health,
@@ -139,24 +155,42 @@ function CoworkWorkspaceLayout({
   readonly railRef?: (element: HTMLElement | null) => void;
 }) {
   const helping = useDashboardHelpEnabled();
-  const { width, bodyRef, separatorProps } = useResizableRail();
+  const { defaultLayout, onLayoutChanged } = useResizableRail();
   return (
     <main className={`wb-cowork${helping ? " is-helping" : ""}`} aria-label={label}>
       <CoworkHealthStrip health={health} />
-      <div className="wb-cowork__body" ref={bodyRef}>
-        <HelpTarget content={COWORK_EDITOR_HELP} placement="top">
-          <div className="wb-cowork__editor-region">{editor}</div>
-        </HelpTarget>
-        <div className="wb-cowork__rail-resizer" {...separatorProps} />
-        <aside
-          className="wb-cowork__rail"
-          aria-label="Review and chat"
-          ref={railRef}
-          style={{ inlineSize: `${width}px` }}
+      <Group
+        className="wb-cowork__body"
+        orientation="horizontal"
+        defaultLayout={defaultLayout}
+        onLayoutChanged={onLayoutChanged}
+      >
+        <Panel
+          id={EDITOR_PANEL_ID}
+          className="wb-cowork__editor-panel"
+          defaultSize={EDITOR_DEFAULT_SIZE}
+          minSize={EDITOR_MIN_SIZE}
         >
-          {rail}
-        </aside>
-      </div>
+          <HelpTarget content={COWORK_EDITOR_HELP} placement="top">
+            <div className="wb-cowork__editor-region">{editor}</div>
+          </HelpTarget>
+        </Panel>
+        <Separator
+          className="wb-cowork__rail-separator"
+          aria-label="Resize the review panel"
+        />
+        <Panel
+          id={RAIL_PANEL_ID}
+          className="wb-cowork__rail-panel"
+          defaultSize={RAIL_DEFAULT_SIZE}
+          minSize={RAIL_MIN_SIZE}
+          maxSize={RAIL_MAX_SIZE}
+        >
+          <aside className="wb-cowork__rail" aria-label="Review and chat" ref={railRef}>
+            {rail}
+          </aside>
+        </Panel>
+      </Group>
     </main>
   );
 }

--- a/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.tsx
+++ b/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.tsx
@@ -27,6 +27,7 @@ import {
   isDirty,
   type ReviewRailData,
 } from "../rail";
+import { useResizableRail } from "./useResizableRail";
 import "./styles.css";
 
 const DRIFT_LABEL: Record<string, string> = {
@@ -44,12 +45,6 @@ const COWORK_EDITOR_HELP: HelpContent = {
   summary: "This is the editor pane.",
   details:
     "It binds a Tiptap editor to a local Y.Doc through the eight-point load-order contract, projects AI proposals as an ephemeral review layer, and materializes edits block by block.",
-};
-
-const COWORK_RAIL_HELP: HelpContent = {
-  summary: "Review the agent's work and chat about the document.",
-  details:
-    "The Review tab lists tracked edits, flags, and claims to accept or reject as a sitting. The Chat tab is the document conversation with the agent.",
 };
 
 const COWORK_HEALTH_HELP: HelpContent = {
@@ -144,18 +139,23 @@ function CoworkWorkspaceLayout({
   readonly railRef?: (element: HTMLElement | null) => void;
 }) {
   const helping = useDashboardHelpEnabled();
+  const { width, bodyRef, separatorProps } = useResizableRail();
   return (
     <main className={`wb-cowork${helping ? " is-helping" : ""}`} aria-label={label}>
       <CoworkHealthStrip health={health} />
-      <div className="wb-cowork__body">
+      <div className="wb-cowork__body" ref={bodyRef}>
         <HelpTarget content={COWORK_EDITOR_HELP} placement="top">
           <div className="wb-cowork__editor-region">{editor}</div>
         </HelpTarget>
-        <HelpTarget content={COWORK_RAIL_HELP} placement="left">
-          <aside className="wb-cowork__rail" aria-label="Review and chat" ref={railRef}>
-            {rail}
-          </aside>
-        </HelpTarget>
+        <div className="wb-cowork__rail-resizer" {...separatorProps} />
+        <aside
+          className="wb-cowork__rail"
+          aria-label="Review and chat"
+          ref={railRef}
+          style={{ inlineSize: `${width}px` }}
+        >
+          {rail}
+        </aside>
       </div>
     </main>
   );

--- a/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.tsx
+++ b/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.tsx
@@ -2,7 +2,13 @@ import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react
 
 import type { SingleSurfaceRuntimeProps } from "../../../dashboard/contributions/viewModules";
 import { useOptionalDashboardEvents } from "../../../dashboard/events/DashboardEventProvider";
+import {
+  HelpTarget,
+  useDashboardHelpEnabled,
+  type HelpContent,
+} from "../../../dashboard/help";
 import { useViewSession } from "../../../dashboard/views/useViewSession";
+import { InMemoryChatProvider } from "../../../widget-library/chat";
 import type { CoworkDriftState, CoworkViewModel } from "../contracts";
 import { CoworkBridgeEditor, useCoworkBridge } from "../bridge";
 import { CoworkChatAnnotations } from "../chat";
@@ -19,6 +25,7 @@ import {
   RailStore,
   createDemoChatProvider,
   isDirty,
+  type ReviewRailData,
 } from "../rail";
 import "./styles.css";
 
@@ -26,6 +33,63 @@ const DRIFT_LABEL: Record<string, string> = {
   clean: "In sync",
   drifted: "Drifted from file",
   missing: "File missing",
+};
+
+/**
+ * Hover-help for the three Co-work regions, surfaced when app-shell help mode is on. The
+ * editor copy is the pane's own description, kept here as help rather than seeded into the
+ * document where it would read as fabricated content.
+ */
+const COWORK_EDITOR_HELP: HelpContent = {
+  summary: "This is the editor pane.",
+  details:
+    "It binds a Tiptap editor to a local Y.Doc through the eight-point load-order contract, projects AI proposals as an ephemeral review layer, and materializes edits block by block.",
+};
+
+const COWORK_RAIL_HELP: HelpContent = {
+  summary: "Review the agent's work and chat about the document.",
+  details:
+    "The Review tab lists tracked edits, flags, and claims to accept or reject as a sitting. The Chat tab is the document conversation with the agent.",
+};
+
+const COWORK_HEALTH_HELP: HelpContent = {
+  summary: "Document health at a glance.",
+  details:
+    "Names the open document, whether the editor has drifted from the file on disk, and how many proposals are still open for review.",
+};
+
+/**
+ * The demo document behind ?cowork_fixture=demo. Its prose carries the exact phrases the
+ * in-memory review fixture anchors its proposals and claim to, so the gated demo scene reads
+ * as one coherent document beside its review rail.
+ */
+const DEMO_DOCUMENT_MARKDOWN = [
+  "# Context bundle cache",
+  "",
+  "The cache keys on the active collector set, so a bundle is reused across invocations that share it. Keys on a digest of every collector output.",
+  "",
+  "We always rebuild the bundle when a reported change lands. Benchmarks on the reference machine show cold-start latency dropped from 1.8 s to 1.1 s after prewarming.",
+  "",
+].join("\n");
+
+const EMPTY_DOCUMENT_ID = "cowork-empty";
+const EMPTY_CONVERSATION_ID = "cowork-doc-none";
+
+/** The honest empty review layer: a titled-but-empty document with no proposals or claims. */
+const EMPTY_REVIEW_DATA: ReviewRailData = {
+  documentId: EMPTY_DOCUMENT_ID,
+  title: "No document open",
+  drift: {
+    state: "clean",
+    openProposalCount: 0,
+    openFlagCount: 0,
+    lastMaterializedSha256: null,
+    currentFileSha256: null,
+  },
+  proposals: [],
+  expressions: [],
+  provenanceSpans: [],
+  claims: [],
 };
 
 /** The unified health view both modes feed the strip, so it renders identically. */
@@ -44,22 +108,24 @@ interface CoworkHealthView {
  */
 function CoworkHealthStrip({ health }: { health: CoworkHealthView | null }) {
   return (
-    <header className="wb-cowork__health" aria-label="Document health">
-      <span className="wb-cowork__health-title">
-        {health?.title ?? "No document open"}
-      </span>
-      {health !== null ? (
-        <span className="wb-cowork__health-facts">
-          <span className="wb-cowork__drift" data-drift={health.driftState}>
-            {DRIFT_LABEL[health.driftState] ?? health.driftState}
-          </span>
-          <span className="wb-cowork__count">
-            {health.openProposalCount} open proposal
-            {health.openProposalCount === 1 ? "" : "s"}
-          </span>
+    <HelpTarget content={COWORK_HEALTH_HELP} placement="bottom start">
+      <header className="wb-cowork__health" aria-label="Document health">
+        <span className="wb-cowork__health-title">
+          {health?.title ?? "No document open"}
         </span>
-      ) : null}
-    </header>
+        {health !== null ? (
+          <span className="wb-cowork__health-facts">
+            <span className="wb-cowork__drift" data-drift={health.driftState}>
+              {DRIFT_LABEL[health.driftState] ?? health.driftState}
+            </span>
+            <span className="wb-cowork__count">
+              {health.openProposalCount} open proposal
+              {health.openProposalCount === 1 ? "" : "s"}
+            </span>
+          </span>
+        ) : null}
+      </header>
+    </HelpTarget>
   );
 }
 
@@ -77,14 +143,19 @@ function CoworkWorkspaceLayout({
   readonly rail: ReactNode;
   readonly railRef?: (element: HTMLElement | null) => void;
 }) {
+  const helping = useDashboardHelpEnabled();
   return (
-    <main className="wb-cowork" aria-label={label}>
+    <main className={`wb-cowork${helping ? " is-helping" : ""}`} aria-label={label}>
       <CoworkHealthStrip health={health} />
       <div className="wb-cowork__body">
-        <div className="wb-cowork__editor-region">{editor}</div>
-        <aside className="wb-cowork__rail" aria-label="Review and chat" ref={railRef}>
-          {rail}
-        </aside>
+        <HelpTarget content={COWORK_EDITOR_HELP} placement="top">
+          <div className="wb-cowork__editor-region">{editor}</div>
+        </HelpTarget>
+        <HelpTarget content={COWORK_RAIL_HELP} placement="left">
+          <aside className="wb-cowork__rail" aria-label="Review and chat" ref={railRef}>
+            {rail}
+          </aside>
+        </HelpTarget>
       </div>
     </main>
   );
@@ -124,13 +195,53 @@ function CoworkDemoWorkspace({
     <CoworkWorkspaceLayout
       label={label}
       health={healthFromModel(model)}
-      editor={<CoworkEditorPane />}
+      editor={<CoworkEditorPane seedMarkdown={DEMO_DOCUMENT_MARKDOWN} />}
       rail={
         <CoworkRail
           documentId={documentId}
           reviewProvider={reviewProvider}
           chatProvider={chatProvider}
           conversationId={conversationId}
+        />
+      }
+    />
+  );
+}
+
+/**
+ * Empty mode (the honest default). No document is open, so the health strip shows its
+ * "No document open" state, the editor opens on an empty editable surface, and the rail
+ * carries no fabricated proposals and no scripted agent turn: an empty review layer and an
+ * empty document conversation with a real composer.
+ */
+function CoworkEmptyWorkspace({ label }: { readonly label: string }) {
+  const reviewProvider = useMemo(
+    () => new InMemoryReviewProvider({ data: EMPTY_REVIEW_DATA }),
+    [],
+  );
+  const chatProvider = useMemo(
+    () =>
+      new InMemoryChatProvider({
+        conversationId: EMPTY_CONVERSATION_ID,
+        title: "Document conversation",
+        status: "open",
+        agentLiveness: "unknown",
+        messages: [],
+      }),
+    [],
+  );
+
+  return (
+    <CoworkWorkspaceLayout
+      label={label}
+      health={null}
+      editor={<CoworkEditorPane />}
+      rail={
+        <CoworkRail
+          documentId={EMPTY_DOCUMENT_ID}
+          reviewProvider={reviewProvider}
+          chatProvider={chatProvider}
+          conversationId={EMPTY_CONVERSATION_ID}
         />
       }
     />
@@ -234,13 +345,15 @@ function CoworkLiveWorkspace({
   );
 }
 
-type CoworkFixtureMode = "demo" | "live";
+type CoworkFixtureMode = "demo" | "live" | "empty";
 
 /**
- * Decide demo vs live. An explicit `?cowork_fixture=` query wins (widget-lab and manual
- * testing), else a demo-quality coarse snapshot is demo, else a live scope with a resolvable
- * store id and document id is live. Live needs the store id, supplied on navigation as the
- * same `store_id` the routes take, so a live scope with no store id degrades safely to demo.
+ * Decide empty vs demo vs live. The honest default is empty (no document, honest empty
+ * states). An explicit `?cowork_fixture=demo` query opts into the fabricated demo scene
+ * (widget-lab and manual testing). A live scope with a resolvable store id and document id
+ * is live. Live needs the store id, supplied on navigation as the same `store_id` the routes
+ * take, so a live scope with no store id, and any scope with no explicit demo flag, falls
+ * back to the honest empty state rather than fabricated content.
  */
 function resolveFixtureMode(
   quality: string | undefined,
@@ -251,7 +364,7 @@ function resolveFixtureMode(
   if (override === "demo") return "demo";
   const wantLive = override === "live" || quality !== "demo";
   if (wantLive && documentId !== undefined && storeId !== undefined) return "live";
-  return "demo";
+  return "empty";
 }
 
 /**
@@ -297,7 +410,11 @@ export function CoworkWorkspaceSurface({
     );
   }
 
-  return <CoworkDemoWorkspace label={definition.displayName} model={model} />;
+  if (mode === "demo") {
+    return <CoworkDemoWorkspace label={definition.displayName} model={model} />;
+  }
+
+  return <CoworkEmptyWorkspace label={definition.displayName} />;
 }
 
 export default CoworkWorkspaceSurface;

--- a/dashboard-react/src/apps/cowork/surface/styles.css
+++ b/dashboard-react/src/apps/cowork/surface/styles.css
@@ -77,12 +77,54 @@
 }
 
 .wb-cowork__rail {
-  flex: 0 0 20rem;
+  flex: 0 0 auto;
+  inline-size: 20rem;
   display: flex;
   flex-direction: column;
   min-block-size: 0;
-  border-inline-start: 1px solid var(--wb-color-border-default);
   background: var(--wb-color-surface-raised);
+}
+
+/*
+ * The grab strip between the editor and the rail. It is the divider (a 1px line
+ * that matches the old rail border at rest) and the resize handle, driven by
+ * useResizableRail through role="separator".
+ */
+.wb-cowork__rail-resizer {
+  flex: 0 0 auto;
+  inline-size: 7px;
+  align-self: stretch;
+  border: none;
+  padding: 0;
+  background: transparent;
+  cursor: col-resize;
+  position: relative;
+  touch-action: none;
+}
+
+.wb-cowork__rail-resizer::before {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  inset-inline-start: 3px;
+  inline-size: 1px;
+  background: var(--wb-color-border-default);
+  transition: inline-size 120ms ease;
+}
+
+.wb-cowork__rail-resizer:hover::before,
+.wb-cowork__rail-resizer:focus-visible::before {
+  inline-size: 2px;
+}
+
+.wb-cowork__rail-resizer:focus-visible {
+  outline: none;
+  box-shadow: var(--wb-shadow-focus);
+}
+
+body.wb-cowork-resizing {
+  cursor: col-resize;
+  user-select: none;
 }
 
 .wb-cowork__rail-tabs {
@@ -229,7 +271,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .wb-cowork__rail-tab {
+  .wb-cowork__rail-tab,
+  .wb-cowork__rail-resizer::before {
     transition: none;
   }
 }
@@ -237,6 +280,9 @@
 @media (forced-colors: active) {
   .wb-cowork__drift {
     border: 1px solid CanvasText;
+  }
+  .wb-cowork__rail-resizer::before {
+    background: CanvasText;
   }
   .wb-cowork__rail-tab[aria-selected="true"] {
     border-color: Highlight;

--- a/dashboard-react/src/apps/cowork/surface/styles.css
+++ b/dashboard-react/src/apps/cowork/surface/styles.css
@@ -62,69 +62,80 @@
   border-color: var(--wb-color-status-danger);
 }
 
+/*
+ * The panel Group (react-resizable-panels) owns display, flex-direction, and overflow. It
+ * fills the space under the health strip so its two panels split the full body height.
+ */
 .wb-cowork__body {
-  display: flex;
   flex: 1 1 auto;
   min-block-size: 0;
+}
+
+/*
+ * The library applies a Panel's className to a nested div, so these wrappers fill their panel
+ * and let their content scroll without fighting the panel's own flex sizing.
+ */
+.wb-cowork__editor-panel,
+.wb-cowork__rail-panel {
+  display: flex;
+  min-inline-size: 0;
+  min-block-size: 0;
+  block-size: 100%;
 }
 
 .wb-cowork__editor-region {
   flex: 1 1 auto;
   min-inline-size: 0;
+  block-size: 100%;
   overflow: auto;
   padding: var(--wb-space-5);
   background: var(--wb-color-surface-canvas);
 }
 
 .wb-cowork__rail {
-  flex: 0 0 auto;
-  inline-size: 20rem;
+  flex: 1 1 auto;
+  inline-size: 100%;
+  min-block-size: 0;
   display: flex;
   flex-direction: column;
-  min-block-size: 0;
   background: var(--wb-color-surface-raised);
 }
 
 /*
- * The grab strip between the editor and the rail. It is the divider (a 1px line
- * that matches the old rail border at rest) and the resize handle, driven by
- * useResizableRail through role="separator".
+ * The separator between the editor and the rail. The library renders it as
+ * `<div data-separator role="separator">` with the arrow-key and double-click behavior and the
+ * WAI-ARIA value props. This styles it as a divider (a 1px line that matches the rail border at
+ * rest) inside a comfortable grab strip, and thickens the line on hover, focus, and drag.
  */
-.wb-cowork__rail-resizer {
-  flex: 0 0 auto;
-  inline-size: 7px;
-  align-self: stretch;
-  border: none;
-  padding: 0;
-  background: transparent;
-  cursor: col-resize;
+.wb-cowork__rail-separator {
   position: relative;
-  touch-action: none;
+  inline-size: 11px;
+  align-self: stretch;
+  cursor: col-resize;
 }
 
-.wb-cowork__rail-resizer::before {
+.wb-cowork__rail-separator::before {
   content: "";
   position: absolute;
   inset-block: 0;
-  inset-inline-start: 3px;
+  inset-inline-start: 50%;
+  transform: translateX(-50%);
   inline-size: 1px;
   background: var(--wb-color-border-default);
-  transition: inline-size 120ms ease;
+  transition: inline-size var(--wb-motion-duration-fast) var(--wb-motion-easing-standard),
+    background-color var(--wb-motion-duration-fast) var(--wb-motion-easing-standard);
 }
 
-.wb-cowork__rail-resizer:hover::before,
-.wb-cowork__rail-resizer:focus-visible::before {
-  inline-size: 2px;
+.wb-cowork__rail-separator:hover::before,
+.wb-cowork__rail-separator:active::before,
+.wb-cowork__rail-separator:focus-visible::before {
+  inline-size: 3px;
+  background: var(--wb-color-border-interactive);
 }
 
-.wb-cowork__rail-resizer:focus-visible {
+.wb-cowork__rail-separator:focus-visible {
   outline: none;
   box-shadow: var(--wb-shadow-focus);
-}
-
-body.wb-cowork-resizing {
-  cursor: col-resize;
-  user-select: none;
 }
 
 .wb-cowork__rail-tabs {
@@ -272,7 +283,7 @@ body.wb-cowork-resizing {
 
 @media (prefers-reduced-motion: reduce) {
   .wb-cowork__rail-tab,
-  .wb-cowork__rail-resizer::before {
+  .wb-cowork__rail-separator::before {
     transition: none;
   }
 }
@@ -281,8 +292,13 @@ body.wb-cowork-resizing {
   .wb-cowork__drift {
     border: 1px solid CanvasText;
   }
-  .wb-cowork__rail-resizer::before {
+  .wb-cowork__rail-separator::before {
     background: CanvasText;
+  }
+  .wb-cowork__rail-separator:hover::before,
+  .wb-cowork__rail-separator:active::before,
+  .wb-cowork__rail-separator:focus-visible::before {
+    background: Highlight;
   }
   .wb-cowork__rail-tab[aria-selected="true"] {
     border-color: Highlight;

--- a/dashboard-react/src/apps/cowork/surface/styles.css
+++ b/dashboard-react/src/apps/cowork/surface/styles.css
@@ -211,8 +211,6 @@
 .wb-cowork-editor__surface {
   box-sizing: border-box;
   inline-size: 100%;
-  max-inline-size: 46rem;
-  margin-inline: auto;
   min-block-size: 100%;
   padding: var(--wb-space-6) var(--wb-space-7);
   border: 1px solid var(--wb-color-border-default);

--- a/dashboard-react/src/apps/cowork/surface/styles.css
+++ b/dashboard-react/src/apps/cowork/surface/styles.css
@@ -72,6 +72,8 @@
   flex: 1 1 auto;
   min-inline-size: 0;
   overflow: auto;
+  padding: var(--wb-space-5);
+  background: var(--wb-color-surface-canvas);
 }
 
 .wb-cowork__rail {
@@ -148,15 +150,60 @@
   block-size: 100%;
 }
 
+/*
+ * The editable document surface. A bordered, padded, raised "page" on the canvas so it
+ * reads unmistakably as an editor rather than plain text, with an obvious focus state.
+ * Theme tokens only, no hardcoded colour.
+ */
 .wb-cowork-editor__surface {
-  padding: var(--wb-space-5) var(--wb-space-6);
-  min-block-size: 12rem;
-  outline: none;
+  box-sizing: border-box;
+  inline-size: 100%;
+  max-inline-size: 46rem;
+  margin-inline: auto;
+  min-block-size: 100%;
+  padding: var(--wb-space-6) var(--wb-space-7);
+  border: 1px solid var(--wb-color-border-default);
+  border-radius: var(--wb-radius-surface);
+  background: var(--wb-color-surface-raised);
   color: var(--wb-color-text-primary);
+  box-shadow: var(--wb-shadow-raised);
+  outline: none;
+  transition: border-color var(--wb-motion-duration-fast)
+    var(--wb-motion-easing-standard);
+}
+
+.wb-cowork-editor__surface:focus {
+  border-color: var(--wb-color-border-interactive);
 }
 
 .wb-cowork-editor__surface:focus-visible {
+  border-color: var(--wb-color-accent);
   box-shadow: var(--wb-shadow-focus);
+}
+
+/* Readable prose rhythm for seeded or typed content and its headings. */
+.wb-cowork-editor__surface > * {
+  margin-block: 0;
+}
+
+.wb-cowork-editor__surface > * + * {
+  margin-block-start: var(--wb-space-4);
+}
+
+.wb-cowork-editor__surface h1 {
+  font-size: var(--wb-font-size-xl);
+  font-weight: var(--wb-font-weight-semibold);
+  line-height: var(--wb-line-height-heading);
+}
+
+.wb-cowork-editor__surface h2 {
+  font-size: var(--wb-font-size-lg);
+  font-weight: var(--wb-font-weight-semibold);
+  line-height: var(--wb-line-height-heading);
+}
+
+.wb-cowork-editor__surface p {
+  line-height: var(--wb-line-height-relaxed);
 }
 
 /*

--- a/dashboard-react/src/apps/cowork/surface/useResizableRail.test.ts
+++ b/dashboard-react/src/apps/cowork/surface/useResizableRail.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { useResizableRail } from "./useResizableRail";
+
+const STORAGE_KEY = "wb.cowork.rail-width";
+const MIN_WIDTH = 256;
+const MAX_WIDTH = 720;
+
+const keyDown = (
+  props: ReturnType<typeof useResizableRail>["separatorProps"],
+  key: string,
+): void => {
+  act(() => {
+    props.onKeyDown({
+      key,
+      preventDefault: () => {},
+    } as unknown as React.KeyboardEvent<HTMLDivElement>);
+  });
+};
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("useResizableRail", () => {
+  it("defaults to the prior fixed width when nothing is stored", () => {
+    const { result } = renderHook(() => useResizableRail());
+    expect(result.current.width).toBe(320);
+    expect(result.current.separatorProps.role).toBe("separator");
+    expect(result.current.separatorProps["aria-orientation"]).toBe("vertical");
+    expect(result.current.separatorProps["aria-valuenow"]).toBe(320);
+  });
+
+  it("reads and clamps a stored width", () => {
+    window.localStorage.setItem(STORAGE_KEY, "5000");
+    const { result } = renderHook(() => useResizableRail());
+    expect(result.current.width).toBe(MAX_WIDTH);
+  });
+
+  it("clamps a too-small stored width up to the minimum", () => {
+    window.localStorage.setItem(STORAGE_KEY, "40");
+    const { result } = renderHook(() => useResizableRail());
+    expect(result.current.width).toBe(MIN_WIDTH);
+  });
+
+  it("grows on ArrowLeft, shrinks on ArrowRight, and persists", () => {
+    const { result } = renderHook(() => useResizableRail());
+    keyDown(result.current.separatorProps, "ArrowLeft");
+    expect(result.current.width).toBe(344);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("344");
+    keyDown(result.current.separatorProps, "ArrowRight");
+    expect(result.current.width).toBe(320);
+  });
+
+  it("clamps at the bounds with End and Home", () => {
+    const { result } = renderHook(() => useResizableRail());
+    keyDown(result.current.separatorProps, "End");
+    expect(result.current.width).toBe(MIN_WIDTH);
+    keyDown(result.current.separatorProps, "Home");
+    expect(result.current.width).toBe(MAX_WIDTH);
+  });
+
+  it("grows while dragging the separator toward the editor and persists on release", () => {
+    const { result } = renderHook(() => useResizableRail());
+    act(() => {
+      result.current.separatorProps.onPointerDown({
+        button: 0,
+        clientX: 500,
+        preventDefault: () => {},
+      } as unknown as React.PointerEvent<HTMLDivElement>);
+    });
+    act(() => {
+      window.dispatchEvent(new MouseEvent("pointermove", { clientX: 400 }));
+    });
+    // The rail is on the inline-end, so a smaller clientX widens it: 320 + 100.
+    expect(result.current.width).toBe(420);
+    act(() => {
+      window.dispatchEvent(new MouseEvent("pointerup", {}));
+    });
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("420");
+  });
+});

--- a/dashboard-react/src/apps/cowork/surface/useResizableRail.test.ts
+++ b/dashboard-react/src/apps/cowork/surface/useResizableRail.test.ts
@@ -1,83 +1,102 @@
-import { act, renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { useResizableRail } from "./useResizableRail";
+import {
+  EDITOR_DEFAULT_SIZE,
+  EDITOR_MIN_SIZE,
+  LAYOUT_STORAGE_ID,
+  RAIL_DEFAULT_SIZE,
+  RAIL_MAX_SIZE,
+  RAIL_MIN_SIZE,
+  resolveLayoutStorage,
+  useResizableRail,
+} from "./useResizableRail";
 
-const STORAGE_KEY = "wb.cowork.rail-width";
-const MIN_WIDTH = 256;
-const MAX_WIDTH = 720;
+// react-resizable-panels owns the drag, keyboard, and DOM measurement, which jsdom cannot run
+// (getBoundingClientRect returns zeros, no ResizeObserver). The real resize behavior is proven
+// against the built app in a browser. Here we mock the library's persistence hook so we can
+// assert our own wiring deterministically without rendering a Group. vitest hoists vi.mock and
+// vi.hoisted above the imports, so the mock is in place before the hook module loads.
+const { useDefaultLayout } = vi.hoisted(() => ({ useDefaultLayout: vi.fn() }));
+vi.mock("react-resizable-panels", () => ({ useDefaultLayout }));
 
-const keyDown = (
-  props: ReturnType<typeof useResizableRail>["separatorProps"],
-  key: string,
-): void => {
-  act(() => {
-    props.onKeyDown({
-      key,
-      preventDefault: () => {},
-    } as unknown as React.KeyboardEvent<HTMLDivElement>);
-  });
+const percent = (value: string): number => {
+  expect(value).toMatch(/^\d+(\.\d+)?%$/);
+  return Number.parseFloat(value);
 };
 
 afterEach(() => {
+  useDefaultLayout.mockReset();
   window.localStorage.clear();
 });
 
-describe("useResizableRail", () => {
-  it("defaults to the prior fixed width when nothing is stored", () => {
-    const { result } = renderHook(() => useResizableRail());
-    expect(result.current.width).toBe(320);
-    expect(result.current.separatorProps.role).toBe("separator");
-    expect(result.current.separatorProps["aria-orientation"]).toBe("vertical");
-    expect(result.current.separatorProps["aria-valuenow"]).toBe(320);
+describe("Co-work split size policy", () => {
+  it("expresses every size as a percentage, never a fixed pixel width", () => {
+    for (const size of [
+      EDITOR_DEFAULT_SIZE,
+      EDITOR_MIN_SIZE,
+      RAIL_DEFAULT_SIZE,
+      RAIL_MIN_SIZE,
+      RAIL_MAX_SIZE,
+    ]) {
+      expect(size).toMatch(/%$/);
+    }
   });
 
-  it("reads and clamps a stored width", () => {
-    window.localStorage.setItem(STORAGE_KEY, "5000");
-    const { result } = renderHook(() => useResizableRail());
-    expect(result.current.width).toBe(MAX_WIDTH);
+  it("gives the rail real travel: narrow floor, wide ceiling, a wider default in between", () => {
+    const min = percent(RAIL_MIN_SIZE);
+    const def = percent(RAIL_DEFAULT_SIZE);
+    const max = percent(RAIL_MAX_SIZE);
+
+    expect(min).toBeLessThan(def);
+    expect(def).toBeLessThan(max);
+    // Genuinely narrow at the floor, a clear majority at the ceiling.
+    expect(min).toBeLessThanOrEqual(20);
+    expect(max).toBeGreaterThanOrEqual(60);
+    // A default noticeably wider than the old fixed 320px rail (~19% of a 1680px body).
+    expect(def).toBeGreaterThan(25);
   });
 
-  it("clamps a too-small stored width up to the minimum", () => {
-    window.localStorage.setItem(STORAGE_KEY, "40");
-    const { result } = renderHook(() => useResizableRail());
-    expect(result.current.width).toBe(MIN_WIDTH);
+  it("keeps the editor and rail constraints jointly satisfiable", () => {
+    // The rail ceiling is the editor floor, and the two defaults tile the whole body.
+    expect(percent(EDITOR_MIN_SIZE) + percent(RAIL_MAX_SIZE)).toBe(100);
+    expect(percent(EDITOR_DEFAULT_SIZE) + percent(RAIL_DEFAULT_SIZE)).toBe(100);
+  });
+});
+
+describe("layout persistence wiring", () => {
+  it("resolves window.localStorage as the layout store when a window exists", () => {
+    expect(resolveLayoutStorage()).toBe(window.localStorage);
   });
 
-  it("grows on ArrowLeft, shrinks on ArrowRight, and persists", () => {
-    const { result } = renderHook(() => useResizableRail());
-    keyDown(result.current.separatorProps, "ArrowLeft");
-    expect(result.current.width).toBe(344);
-    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("344");
-    keyDown(result.current.separatorProps, "ArrowRight");
-    expect(result.current.width).toBe(320);
-  });
-
-  it("clamps at the bounds with End and Home", () => {
-    const { result } = renderHook(() => useResizableRail());
-    keyDown(result.current.separatorProps, "End");
-    expect(result.current.width).toBe(MIN_WIDTH);
-    keyDown(result.current.separatorProps, "Home");
-    expect(result.current.width).toBe(MAX_WIDTH);
-  });
-
-  it("grows while dragging the separator toward the editor and persists on release", () => {
-    const { result } = renderHook(() => useResizableRail());
-    act(() => {
-      result.current.separatorProps.onPointerDown({
-        button: 0,
-        clientX: 500,
-        preventDefault: () => {},
-      } as unknown as React.PointerEvent<HTMLDivElement>);
+  it("persists to localStorage under a stable id and only for user-driven resizes", () => {
+    useDefaultLayout.mockReturnValue({
+      defaultLayout: undefined,
+      onLayoutChange: () => {},
+      onLayoutChanged: () => {},
     });
-    act(() => {
-      window.dispatchEvent(new MouseEvent("pointermove", { clientX: 400 }));
+
+    renderHook(() => useResizableRail());
+
+    expect(useDefaultLayout).toHaveBeenCalledWith({
+      id: LAYOUT_STORAGE_ID,
+      storage: window.localStorage,
+      onlySaveAfterUserInteractions: true,
     });
-    // The rail is on the inline-end, so a smaller clientX widens it: 320 + 100.
-    expect(result.current.width).toBe(420);
-    act(() => {
-      window.dispatchEvent(new MouseEvent("pointerup", {}));
+  });
+
+  it("returns the restored layout and the settled-change callback for the Group", () => {
+    const restored = { editor: 60, rail: 40 };
+    const onLayoutChanged = vi.fn();
+    useDefaultLayout.mockReturnValue({
+      defaultLayout: restored,
+      onLayoutChange: () => {},
+      onLayoutChanged,
     });
-    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("420");
+
+    const { result } = renderHook(() => useResizableRail());
+
+    expect(result.current.defaultLayout).toBe(restored);
+    expect(result.current.onLayoutChanged).toBe(onLayoutChanged);
   });
 });

--- a/dashboard-react/src/apps/cowork/surface/useResizableRail.ts
+++ b/dashboard-react/src/apps/cowork/surface/useResizableRail.ts
@@ -1,0 +1,166 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+
+const STORAGE_KEY = "wb.cowork.rail-width";
+// The prior fixed rail measured 20rem. Keeping it as the default means an
+// untouched view looks exactly as before until the user drags the handle.
+const DEFAULT_WIDTH = 320;
+const MIN_WIDTH = 256;
+const MAX_WIDTH = 720;
+// Never let the rail grow so far that the editor becomes unusable.
+const EDITOR_MIN = 320;
+const KEY_STEP = 24;
+
+const clampWidth = (value: number, bodyWidth: number | null): number => {
+  const ceiling =
+    bodyWidth !== null ? Math.min(MAX_WIDTH, bodyWidth - EDITOR_MIN) : MAX_WIDTH;
+  const upper = Math.max(MIN_WIDTH, ceiling);
+  return Math.round(Math.min(upper, Math.max(MIN_WIDTH, value)));
+};
+
+const readStoredWidth = (): number => {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const parsed = raw === null ? Number.NaN : Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : DEFAULT_WIDTH;
+  } catch {
+    return DEFAULT_WIDTH;
+  }
+};
+
+const storeWidth = (value: number): void => {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(value));
+  } catch {
+    // Persistence is best-effort. A blocked storage never breaks resizing.
+  }
+};
+
+export interface RailSeparatorProps {
+  readonly role: "separator";
+  readonly "aria-orientation": "vertical";
+  readonly "aria-label": string;
+  readonly "aria-valuenow": number;
+  readonly "aria-valuemin": number;
+  readonly "aria-valuemax": number;
+  readonly tabIndex: 0;
+  readonly onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  readonly onKeyDown: (event: ReactKeyboardEvent<HTMLDivElement>) => void;
+}
+
+export interface ResizableRail {
+  readonly width: number;
+  readonly bodyRef: (element: HTMLDivElement | null) => void;
+  readonly separatorProps: RailSeparatorProps;
+}
+
+/**
+ * Drives a draggable width for the Co-work review rail. The rail sits on the
+ * inline-end, so moving the separator toward the editor (a smaller clientX)
+ * widens it. Width is clamped so the editor keeps a usable minimum, persisted
+ * to localStorage, and re-clamped when the window shrinks.
+ */
+export function useResizableRail(): ResizableRail {
+  const bodyElementRef = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState<number>(() =>
+    clampWidth(readStoredWidth(), null),
+  );
+  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+
+  const measuredBodyWidth = (): number | null =>
+    bodyElementRef.current?.getBoundingClientRect().width ?? null;
+
+  const commit = useCallback((next: number) => {
+    setWidth(next);
+    storeWidth(next);
+  }, []);
+
+  const onPointerMove = useCallback((event: PointerEvent) => {
+    const drag = dragRef.current;
+    if (drag === null) return;
+    const delta = drag.startX - event.clientX;
+    setWidth(clampWidth(drag.startWidth + delta, measuredBodyWidth()));
+  }, []);
+
+  const endDrag = useCallback(() => {
+    if (dragRef.current === null) return;
+    dragRef.current = null;
+    window.removeEventListener("pointermove", onPointerMove);
+    window.removeEventListener("pointerup", endDrag);
+    document.body.classList.remove("wb-cowork-resizing");
+    setWidth((current) => {
+      storeWidth(current);
+      return current;
+    });
+  }, [onPointerMove]);
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      dragRef.current = { startX: event.clientX, startWidth: width };
+      document.body.classList.add("wb-cowork-resizing");
+      window.addEventListener("pointermove", onPointerMove);
+      window.addEventListener("pointerup", endDrag);
+    },
+    [width, onPointerMove, endDrag],
+  );
+
+  const onKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      const measured = measuredBodyWidth();
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        commit(clampWidth(width + KEY_STEP, measured));
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        commit(clampWidth(width - KEY_STEP, measured));
+      } else if (event.key === "Home") {
+        event.preventDefault();
+        commit(clampWidth(MAX_WIDTH, measured));
+      } else if (event.key === "End") {
+        event.preventDefault();
+        commit(clampWidth(MIN_WIDTH, measured));
+      }
+    },
+    [width, commit],
+  );
+
+  useEffect(() => {
+    const reclamp = () =>
+      setWidth((current) => clampWidth(current, measuredBodyWidth()));
+    reclamp();
+    window.addEventListener("resize", reclamp);
+    return () => {
+      window.removeEventListener("resize", reclamp);
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", endDrag);
+    };
+  }, [onPointerMove, endDrag]);
+
+  const bodyRef = useCallback((element: HTMLDivElement | null) => {
+    bodyElementRef.current = element;
+  }, []);
+
+  return {
+    width,
+    bodyRef,
+    separatorProps: {
+      role: "separator",
+      "aria-orientation": "vertical",
+      "aria-label": "Resize the review panel",
+      "aria-valuenow": width,
+      "aria-valuemin": MIN_WIDTH,
+      "aria-valuemax": MAX_WIDTH,
+      tabIndex: 0,
+      onPointerDown,
+      onKeyDown,
+    },
+  };
+}

--- a/dashboard-react/src/apps/cowork/surface/useResizableRail.ts
+++ b/dashboard-react/src/apps/cowork/surface/useResizableRail.ts
@@ -1,166 +1,54 @@
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type KeyboardEvent as ReactKeyboardEvent,
-  type PointerEvent as ReactPointerEvent,
-} from "react";
+import { useDefaultLayout, type LayoutStorage } from "react-resizable-panels";
 
-const STORAGE_KEY = "wb.cowork.rail-width";
-// The prior fixed rail measured 20rem. Keeping it as the default means an
-// untouched view looks exactly as before until the user drags the handle.
-const DEFAULT_WIDTH = 320;
-const MIN_WIDTH = 256;
-const MAX_WIDTH = 720;
-// Never let the rail grow so far that the editor becomes unusable.
-const EDITOR_MIN = 320;
-const KEY_STEP = 24;
+/**
+ * Percentage sizes for the Co-work two-pane split. Every size is a fraction of the workspace
+ * body, so the split keeps its proportion as the viewport changes instead of pinning a fixed
+ * pixel width. The rail opens wide enough to read a review card, shrinks to a narrow strip,
+ * and can take the majority of the width, while the editor stays above a legible minimum.
+ *
+ * Sizes are fractions, not pixels, on purpose: a percentage rail widens with the window and
+ * survives a resize, and the generous min/max give the handle real travel in both directions.
+ */
+export const EDITOR_MIN_SIZE = "30%";
+export const EDITOR_DEFAULT_SIZE = "67%";
+export const RAIL_DEFAULT_SIZE = "33%";
+export const RAIL_MIN_SIZE = "15%";
+export const RAIL_MAX_SIZE = "70%";
 
-const clampWidth = (value: number, bodyWidth: number | null): number => {
-  const ceiling =
-    bodyWidth !== null ? Math.min(MAX_WIDTH, bodyWidth - EDITOR_MIN) : MAX_WIDTH;
-  const upper = Math.max(MIN_WIDTH, ceiling);
-  return Math.round(Math.min(upper, Math.max(MIN_WIDTH, value)));
-};
+/** Stable id for the persisted layout. The stored map keys each Panel id to its percentage. */
+export const LAYOUT_STORAGE_ID = "wb.cowork.workspace-layout";
 
-const readStoredWidth = (): number => {
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    const parsed = raw === null ? Number.NaN : Number.parseInt(raw, 10);
-    return Number.isFinite(parsed) ? parsed : DEFAULT_WIDTH;
-  } catch {
-    return DEFAULT_WIDTH;
-  }
-};
+/** Panel ids the persisted layout keys on. They double as the Panel `id` and `data-panel`. */
+export const EDITOR_PANEL_ID = "editor";
+export const RAIL_PANEL_ID = "rail";
 
-const storeWidth = (value: number): void => {
-  try {
-    window.localStorage.setItem(STORAGE_KEY, String(value));
-  } catch {
-    // Persistence is best-effort. A blocked storage never breaks resizing.
-  }
-};
+/**
+ * `window.localStorage` satisfies `LayoutStorage` (it exposes `getItem`/`setItem`). Returns
+ * `undefined` when there is no window (server render or a non-DOM test), so persistence
+ * degrades to the default layout rather than throwing on a missing global.
+ */
+export const resolveLayoutStorage = (): LayoutStorage | undefined =>
+  typeof window === "undefined" ? undefined : window.localStorage;
 
-export interface RailSeparatorProps {
-  readonly role: "separator";
-  readonly "aria-orientation": "vertical";
-  readonly "aria-label": string;
-  readonly "aria-valuenow": number;
-  readonly "aria-valuemin": number;
-  readonly "aria-valuemax": number;
-  readonly tabIndex: 0;
-  readonly onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
-  readonly onKeyDown: (event: ReactKeyboardEvent<HTMLDivElement>) => void;
-}
-
-export interface ResizableRail {
-  readonly width: number;
-  readonly bodyRef: (element: HTMLDivElement | null) => void;
-  readonly separatorProps: RailSeparatorProps;
+export interface CoworkPanelLayout {
+  /** Pass to the panel `Group` as `defaultLayout`. Restores the last persisted split. */
+  readonly defaultLayout: ReturnType<typeof useDefaultLayout>["defaultLayout"];
+  /** Pass to the panel `Group` as `onLayoutChanged`. Persists a settled split. */
+  readonly onLayoutChanged: ReturnType<typeof useDefaultLayout>["onLayoutChanged"];
 }
 
 /**
- * Drives a draggable width for the Co-work review rail. The rail sits on the
- * inline-end, so moving the separator toward the editor (a smaller clientX)
- * widens it. Width is clamped so the editor keeps a usable minimum, persisted
- * to localStorage, and re-clamped when the window shrinks.
+ * Wires localStorage persistence for the Co-work split and returns the two props the panel
+ * `Group` needs to restore and re-save it. react-resizable-panels owns the drag, the keyboard
+ * separator, and the measurement. This hook only holds the size policy and the persistence
+ * seam in one place. `onlySaveAfterUserInteractions` keeps window-resize reflows and imperative
+ * resizes from overwriting a width the user chose on purpose.
  */
-export function useResizableRail(): ResizableRail {
-  const bodyElementRef = useRef<HTMLDivElement | null>(null);
-  const [width, setWidth] = useState<number>(() =>
-    clampWidth(readStoredWidth(), null),
-  );
-  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
-
-  const measuredBodyWidth = (): number | null =>
-    bodyElementRef.current?.getBoundingClientRect().width ?? null;
-
-  const commit = useCallback((next: number) => {
-    setWidth(next);
-    storeWidth(next);
-  }, []);
-
-  const onPointerMove = useCallback((event: PointerEvent) => {
-    const drag = dragRef.current;
-    if (drag === null) return;
-    const delta = drag.startX - event.clientX;
-    setWidth(clampWidth(drag.startWidth + delta, measuredBodyWidth()));
-  }, []);
-
-  const endDrag = useCallback(() => {
-    if (dragRef.current === null) return;
-    dragRef.current = null;
-    window.removeEventListener("pointermove", onPointerMove);
-    window.removeEventListener("pointerup", endDrag);
-    document.body.classList.remove("wb-cowork-resizing");
-    setWidth((current) => {
-      storeWidth(current);
-      return current;
-    });
-  }, [onPointerMove]);
-
-  const onPointerDown = useCallback(
-    (event: ReactPointerEvent<HTMLDivElement>) => {
-      if (event.button !== 0) return;
-      event.preventDefault();
-      dragRef.current = { startX: event.clientX, startWidth: width };
-      document.body.classList.add("wb-cowork-resizing");
-      window.addEventListener("pointermove", onPointerMove);
-      window.addEventListener("pointerup", endDrag);
-    },
-    [width, onPointerMove, endDrag],
-  );
-
-  const onKeyDown = useCallback(
-    (event: ReactKeyboardEvent<HTMLDivElement>) => {
-      const measured = measuredBodyWidth();
-      if (event.key === "ArrowLeft") {
-        event.preventDefault();
-        commit(clampWidth(width + KEY_STEP, measured));
-      } else if (event.key === "ArrowRight") {
-        event.preventDefault();
-        commit(clampWidth(width - KEY_STEP, measured));
-      } else if (event.key === "Home") {
-        event.preventDefault();
-        commit(clampWidth(MAX_WIDTH, measured));
-      } else if (event.key === "End") {
-        event.preventDefault();
-        commit(clampWidth(MIN_WIDTH, measured));
-      }
-    },
-    [width, commit],
-  );
-
-  useEffect(() => {
-    const reclamp = () =>
-      setWidth((current) => clampWidth(current, measuredBodyWidth()));
-    reclamp();
-    window.addEventListener("resize", reclamp);
-    return () => {
-      window.removeEventListener("resize", reclamp);
-      window.removeEventListener("pointermove", onPointerMove);
-      window.removeEventListener("pointerup", endDrag);
-    };
-  }, [onPointerMove, endDrag]);
-
-  const bodyRef = useCallback((element: HTMLDivElement | null) => {
-    bodyElementRef.current = element;
-  }, []);
-
-  return {
-    width,
-    bodyRef,
-    separatorProps: {
-      role: "separator",
-      "aria-orientation": "vertical",
-      "aria-label": "Resize the review panel",
-      "aria-valuenow": width,
-      "aria-valuemin": MIN_WIDTH,
-      "aria-valuemax": MAX_WIDTH,
-      tabIndex: 0,
-      onPointerDown,
-      onKeyDown,
-    },
-  };
+export function useResizableRail(): CoworkPanelLayout {
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+    id: LAYOUT_STORAGE_ID,
+    storage: resolveLayoutStorage(),
+    onlySaveAfterUserInteractions: true,
+  });
+  return { defaultLayout, onLayoutChanged };
 }

--- a/dashboard-react/src/components/Header.tsx
+++ b/dashboard-react/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { Sparkle } from "@phosphor-icons/react/Sparkle";
 
+import { HelpModeToggle } from "../dashboard/help/HelpModeToggle";
 import { useDashboardTemporalContext } from "../dashboard/temporal/DashboardTemporalContext";
 import { useClock } from "../hooks/useClock";
 import { useLiveStatus } from "../hooks/useLiveStatus";
@@ -79,6 +80,7 @@ export default function Header({
       </div>
       <div className="header-meta">
         <AppearanceControl />
+        <HelpModeToggle />
         <div className="header-statuses">
           <SidecarIndicator />
           <LiveIndicator />

--- a/dashboard-react/src/dashboard/events/DashboardEventProvider.test.tsx
+++ b/dashboard-react/src/dashboard/events/DashboardEventProvider.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Header from "../../components/Header";
 import { ThemeProvider } from "../../theme/ThemeProvider";
 import { DensityProvider } from "../../theme/DensityProvider";
+import { DashboardAnnouncer } from "../accessibility/DashboardAnnouncer";
 import {
   DashboardEventProvider,
   normalizeDashboardEvent,
@@ -85,9 +86,11 @@ describe("DashboardEventProvider", () => {
         <ThemeProvider initialPreference={{ scheme: "dark", skinId: "wb.default" }}>
           <DensityProvider initialDensity="comfortable">
             <DashboardEventProvider>
-              <Header />
-              <EventProbe testId="first" />
-              <EventProbe testId="second" />
+              <DashboardAnnouncer>
+                <Header />
+                <EventProbe testId="first" />
+                <EventProbe testId="second" />
+              </DashboardAnnouncer>
             </DashboardEventProvider>
           </DensityProvider>
         </ThemeProvider>

--- a/dashboard-react/src/dashboard/help/HelpModeController.tsx
+++ b/dashboard-react/src/dashboard/help/HelpModeController.tsx
@@ -1,0 +1,56 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+import { DashboardHelpProvider } from "./DashboardHelp";
+
+/** The shared on/off controller for cross-view hover help. */
+export interface HelpModeController {
+  readonly enabled: boolean;
+  setEnabled(value: boolean): void;
+  toggle(): void;
+}
+
+const DISABLED_CONTROLLER: HelpModeController = {
+  enabled: false,
+  setEnabled: () => {},
+  toggle: () => {},
+};
+
+const HelpModeControllerContext = createContext<HelpModeController | null>(null);
+
+/**
+ * App-shell owner of hover-help state. It lives above the navbar and the view outlet so
+ * a single toggle in the header drives contextual help across every view, not only the
+ * widget grid. It also feeds the boolean `DashboardHelpProvider` context every
+ * `HelpTarget` reads, so the toggle and the targets stay in lockstep from one source.
+ */
+export function HelpModeProvider({ children }: { readonly children: ReactNode }) {
+  const [enabled, setEnabled] = useState(false);
+  const controller = useMemo<HelpModeController>(
+    () => ({
+      enabled,
+      setEnabled,
+      toggle: () => setEnabled((current) => !current),
+    }),
+    [enabled],
+  );
+  return (
+    <HelpModeControllerContext.Provider value={controller}>
+      <DashboardHelpProvider enabled={enabled}>{children}</DashboardHelpProvider>
+    </HelpModeControllerContext.Provider>
+  );
+}
+
+/**
+ * Read the shared hover-help controller. When no provider is mounted (a surface rendered
+ * outside the app shell, an isolated test, a standalone harness) this returns a stable
+ * disabled no-op controller, so help is simply off rather than a crash.
+ */
+export function useHelpMode(): HelpModeController {
+  return useContext(HelpModeControllerContext) ?? DISABLED_CONTROLLER;
+}

--- a/dashboard-react/src/dashboard/help/HelpModeToggle.test.tsx
+++ b/dashboard-react/src/dashboard/help/HelpModeToggle.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DashboardAnnouncer } from "../accessibility/DashboardAnnouncer";
+import { HelpTarget } from "./DashboardHelp";
+import { HelpModeProvider } from "./HelpModeController";
+import { HelpModeToggle } from "./HelpModeToggle";
+
+const media = (matches: boolean): MediaQueryList =>
+  ({
+    matches,
+    media: "",
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(() => true),
+  }) as unknown as MediaQueryList;
+
+afterEach(() => vi.unstubAllGlobals());
+
+/** The toggle sits beside an ordinary HelpTarget, standing in for any view's region. */
+function renderShell() {
+  return render(
+    <DashboardAnnouncer>
+      <HelpModeProvider>
+        <HelpModeToggle />
+        <HelpTarget
+          content={{
+            summary: "Editor region.",
+            details: "It is an editable document surface.",
+          }}
+          focusable
+          ariaLabel="About the editor region"
+        >
+          <div>Editor region</div>
+        </HelpTarget>
+      </HelpModeProvider>
+    </DashboardAnnouncer>,
+  );
+}
+
+describe("HelpModeToggle", () => {
+  it("flips shared hover help so a HelpTarget anywhere reveals on hover", async () => {
+    vi.stubGlobal("matchMedia", vi.fn(() => media(false)));
+    renderShell();
+
+    const toggle = screen.getByRole("button", { name: "Hover help" });
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+    // Off: the region carries no help affordance and reveals nothing on hover.
+    await userEvent.hover(screen.getByText("Editor region"));
+    expect(
+      screen.queryByText("It is an editable document surface."),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-pressed", "true");
+
+    const region = screen.getByLabelText("About the editor region");
+    await userEvent.hover(region);
+    expect(
+      await screen.findByText("It is an editable document surface.", undefined, {
+        timeout: 3000,
+      }),
+    ).toBeVisible();
+
+    await userEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("is disabled on narrow, hover-less viewports", () => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn((query: string) => media(query === "(max-width: 767px)")),
+    );
+    renderShell();
+    expect(screen.getByRole("button", { name: "Hover help" })).toBeDisabled();
+  });
+});

--- a/dashboard-react/src/dashboard/help/HelpModeToggle.tsx
+++ b/dashboard-react/src/dashboard/help/HelpModeToggle.tsx
@@ -1,0 +1,34 @@
+import { Info } from "@phosphor-icons/react/Info";
+
+import { Button } from "../../ui/Button";
+import { useMediaQuery } from "../../hooks/useMediaQuery";
+import { useDashboardAnnouncer } from "../accessibility/DashboardAnnouncer";
+import { useHelpMode } from "./HelpModeController";
+
+/**
+ * The cross-view hover-help toggle, mounted in the app-shell navbar. Pressing it flips
+ * the shared help mode so every view's `HelpTarget`s reveal on hover. Disabled on narrow,
+ * hover-less viewports where there is nothing to hover, mirroring the prior grid-only
+ * control it replaces.
+ */
+export function HelpModeToggle() {
+  const { enabled, setEnabled } = useHelpMode();
+  const { announce } = useDashboardAnnouncer();
+  const isMobile = useMediaQuery("(max-width: 767px)");
+  return (
+    <Button
+      size="small"
+      variant={enabled ? "primary" : "secondary"}
+      aria-pressed={enabled}
+      disabled={isMobile}
+      onClick={() => {
+        announce(enabled ? "Hover help turned off" : "Hover help turned on");
+        setEnabled(!enabled);
+      }}
+    >
+      <Info weight="duotone" aria-hidden="true" /> Hover help
+    </Button>
+  );
+}
+
+export default HelpModeToggle;

--- a/dashboard-react/src/dashboard/help/index.ts
+++ b/dashboard-react/src/dashboard/help/index.ts
@@ -1,2 +1,11 @@
 export { DashboardHelpProvider, HelpTarget, useDashboardHelpEnabled } from "./DashboardHelp";
+export {
+  HelpModeProvider,
+  useHelpMode,
+  type HelpModeController,
+} from "./HelpModeController";
+// HelpModeToggle is intentionally NOT re-exported here. It pulls the ui Button and the
+// announcer, and this barrel is imported by lazily-loaded view chunks that only need the
+// light HelpTarget / provider pieces. Keeping the heavy toggle out of the barrel avoids a
+// cross-chunk cycle through the ui barrel. Import it directly from ./HelpModeToggle.
 export type { HelpContent } from "./contracts";

--- a/dashboard-react/src/dashboard/views/ViewHost.singleSurface.test.tsx
+++ b/dashboard-react/src/dashboard/views/ViewHost.singleSurface.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 
@@ -36,13 +36,20 @@ describe("ViewHost single-surface mounting", () => {
     );
 
     // The App-owned surface renders its regions. The surface loads through a dynamic
-    // module import, so allow for that resolution under full-suite parallel load.
+    // module import, so allow for that resolution under full-suite parallel load. With no
+    // fixture flag it opens in the honest empty state, so the health strip reads
+    // "No document open".
     await waitFor(
       () => expect(screen.getByRole("tab", { name: "Review" })).toBeVisible(),
       { timeout: 10_000 },
     );
     await waitFor(
-      () => expect(screen.getByText("Co-work demo document")).toBeVisible(),
+      () =>
+        expect(
+          within(screen.getByLabelText("Document health")).getByText(
+            "No document open",
+          ),
+        ).toBeVisible(),
       { timeout: 10_000 },
     );
 

--- a/dashboard-react/src/dashboard/views/ViewHost.test.tsx
+++ b/dashboard-react/src/dashboard/views/ViewHost.test.tsx
@@ -10,6 +10,7 @@ import { ThemeProvider } from "../../theme/ThemeProvider";
 import { DashboardTestRuntime } from "../../test/DashboardTestRuntime";
 import { DashboardAnnouncer } from "../accessibility/DashboardAnnouncer";
 import { DashboardEventProvider } from "../events/DashboardEventProvider";
+import { DashboardHelpProvider } from "../help";
 import { InMemoryPersonalizationRepository } from "../personalization/repository";
 import { ViewHost } from "./ViewHost";
 
@@ -98,12 +99,14 @@ describe("ViewHost", () => {
           <DashboardEventProvider>
             <DashboardAnnouncer>
               <DashboardTestRuntime>
-                <ViewHost
-                  registry={dashboardRegistry}
-                  definition={JOURNAL_VIEW_DEFINITION}
-                  provider={new InMemoryJournalProvider()}
-                  personalizationRepository={new InMemoryPersonalizationRepository()}
-                />
+                <DashboardHelpProvider enabled>
+                  <ViewHost
+                    registry={dashboardRegistry}
+                    definition={JOURNAL_VIEW_DEFINITION}
+                    provider={new InMemoryJournalProvider()}
+                    personalizationRepository={new InMemoryPersonalizationRepository()}
+                  />
+                </DashboardHelpProvider>
               </DashboardTestRuntime>
             </DashboardAnnouncer>
           </DashboardEventProvider>
@@ -135,10 +138,9 @@ describe("ViewHost", () => {
       screen.queryByRole("list", { name: "Day timeline items" }),
     ).not.toBeInTheDocument();
 
-    const hoverHelp = screen.getByRole("button", { name: "Hover help" });
-    await userEvent.click(hoverHelp);
-    expect(hoverHelp).toHaveAttribute("aria-pressed", "true");
-
+    // Hover help is driven by the app-shell provider here (the toggle now lives in the
+    // navbar, outside this host). The Journal HelpTargets must still reveal on hover from
+    // that shared context, proving no regression after the lift-out.
     const capturePurpose = screen.getByLabelText("About Quick Capture in this view");
     await userEvent.hover(capturePurpose);
     expect(
@@ -150,7 +152,6 @@ describe("ViewHost", () => {
 
     await userEvent.unhover(capturePurpose);
     await userEvent.click(screen.getByRole("button", { name: "Customize view" }));
-    expect(screen.queryByRole("button", { name: "Hover help" })).not.toBeInTheDocument();
     expect(screen.getByText("Arranging layout")).toBeVisible();
   }, 20_000);
 });

--- a/dashboard-react/src/dashboard/views/ViewHost.tsx
+++ b/dashboard-react/src/dashboard/views/ViewHost.tsx
@@ -11,7 +11,6 @@ import { Check } from "@phosphor-icons/react/Check";
 import { DeviceMobile } from "@phosphor-icons/react/DeviceMobile";
 import { Eye } from "@phosphor-icons/react/Eye";
 import { GridFour } from "@phosphor-icons/react/GridFour";
-import { Info } from "@phosphor-icons/react/Info";
 import { Layout } from "@phosphor-icons/react/Layout";
 import { PencilSimple } from "@phosphor-icons/react/PencilSimple";
 import { SquaresFour } from "@phosphor-icons/react/SquaresFour";
@@ -34,8 +33,9 @@ import type {
 import { asWidgetInstanceId } from "../contributions/contracts";
 import type { ContributionRegistry } from "../contributions/registry";
 import type { RegisteredWidget } from "../contributions/registry";
+import { useMediaQuery } from "../../hooks/useMediaQuery";
 import { ReactGridLayoutAdapter } from "../layout/ReactGridLayoutAdapter";
-import { DashboardHelpProvider, HelpTarget } from "../help";
+import { HelpTarget, useDashboardHelpEnabled, useHelpMode } from "../help";
 import type { DashboardLayout, LayoutCommand } from "../layout/contracts";
 import { applyLayoutCommand } from "../layout/operations";
 import { useInteractionSurfaces } from "../interactions";
@@ -95,21 +95,6 @@ const formatCustomizationFailure = (failure: string): string => {
   return failure;
 };
 
-const useMediaQuery = (query: string): boolean => {
-  const read = () =>
-    typeof window.matchMedia === "function" && window.matchMedia(query).matches;
-  const [matches, setMatches] = useState(read);
-  useEffect(() => {
-    if (typeof window.matchMedia !== "function") return;
-    const media = window.matchMedia(query);
-    const update = () => setMatches(media.matches);
-    update();
-    media.addEventListener("change", update);
-    return () => media.removeEventListener("change", update);
-  }, [query]);
-  return matches;
-};
-
 const layoutFor = (state: ViewEditSessionState): DashboardLayout =>
   state.present.instances
     .filter((instance) => instance.visibility === "shown")
@@ -166,7 +151,11 @@ function StandardGridViewHost({
     beginViewEditSession(defaults),
   );
   const [customizing, setCustomizing] = useState(false);
-  const [helpMode, setHelpMode] = useState(false);
+  // Hover help is app-shell state now (the navbar toggle owns it), so it persists across
+  // views. This host only reads the resolved flag for its styling hook and drops it when
+  // the layout editor opens.
+  const helpEnabled = useDashboardHelpEnabled();
+  const { setEnabled: setHelpEnabled } = useHelpMode();
   const [customizeMode, setCustomizeMode] = useState<"arrange" | "preview">("arrange");
   const [catalogOpen, setCatalogOpen] = useState(false);
   const [mobileOrderOpen, setMobileOrderOpen] = useState(false);
@@ -308,7 +297,7 @@ function StandardGridViewHost({
 
   const beginCustomize = () => {
     setEditState(beginViewEditSession(resolved));
-    setHelpMode(false);
+    setHelpEnabled(false);
     setCustomizeMode("arrange");
     setCustomizing(true);
     setResetPatchRequested(false);
@@ -612,11 +601,10 @@ function StandardGridViewHost({
   };
 
   return (
-    <DashboardHelpProvider enabled={helpMode}>
     <main
       className={`wb-view-host${customizing ? " is-customizing" : ""}${
         customizing && customizeMode === "preview" ? " is-previewing-layout" : ""
-      }${helpMode ? " is-helping" : ""}`}
+      }${helpEnabled ? " is-helping" : ""}`}
     >
       {renderChrome !== undefined ? (
         renderChrome(snapshot, chromeSlots)
@@ -740,20 +728,6 @@ function StandardGridViewHost({
           </>
         ) : (
           <>
-            <Button
-              size="small"
-              variant={helpMode ? "primary" : "secondary"}
-              aria-pressed={helpMode}
-              onClick={() => {
-                setHelpMode((enabled) => {
-                  announce(enabled ? "Hover help turned off" : "Hover help turned on");
-                  return !enabled;
-                });
-              }}
-              disabled={isMobile}
-            >
-              <Info weight="duotone" aria-hidden="true" /> Hover help
-            </Button>
             <HelpTarget
               content={{
                 summary: "Rearrange and resize the widgets in this view.",
@@ -848,7 +822,6 @@ function StandardGridViewHost({
         />
       ) : null}
     </main>
-    </DashboardHelpProvider>
   );
 }
 

--- a/dashboard-react/src/hooks/useMediaQuery.ts
+++ b/dashboard-react/src/hooks/useMediaQuery.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Track a CSS media query as a boolean, re-rendering when it changes. Guarded for
+ * environments without matchMedia (jsdom without a stub), where it reports false.
+ * Shared by the app shell and the view host so a single breakpoint definition drives
+ * every "is this a narrow, hover-less viewport" decision.
+ */
+export function useMediaQuery(query: string): boolean {
+  const read = () =>
+    typeof window.matchMedia === "function" && window.matchMedia(query).matches;
+  const [matches, setMatches] = useState(read);
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    const media = window.matchMedia(query);
+    // Re-read the live result rather than trusting only the change event: some hosts
+    // mount the app at a transient zero width and settle to the real size without ever
+    // dispatching a MediaQueryList change, which would otherwise leave the value stale.
+    const update = () => setMatches(media.matches);
+    update();
+    media.addEventListener("change", update);
+    window.addEventListener("resize", update);
+    return () => {
+      media.removeEventListener("change", update);
+      window.removeEventListener("resize", update);
+    };
+  }, [query]);
+  return matches;
+}

--- a/dashboard-react/src/test/setup.ts
+++ b/dashboard-react/src/test/setup.ts
@@ -4,6 +4,16 @@ import { cleanup } from "@testing-library/react";
 import axe from "axe-core";
 import { afterEach, expect } from "vitest";
 
+// jsdom ships no ResizeObserver, which react-resizable-panels (the Co-work split) and cmdk
+// construct on mount. Install a no-op default so any component that observes an element renders
+// without throwing. Tests that exercise ResizeObserver behavior still override it locally with
+// vi.stubGlobal and restore it with vi.unstubAllGlobals, so this only fills the unset case.
+globalThis.ResizeObserver ??= class {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+};
+
 afterEach(() => {
   cleanup();
 });

--- a/dashboard-react/src/theme/components.css
+++ b/dashboard-react/src/theme/components.css
@@ -458,7 +458,8 @@
     cursor: help;
   }
 
-  .wb-view-host.is-helping .wb-help-target {
+  .wb-view-host.is-helping .wb-help-target,
+  .wb-cowork.is-helping .wb-help-target {
     animation: wb-help-target-reveal 900ms var(--wb-motion-easing-enter) 1 both;
   }
 

--- a/dashboard-react/src/theme/forced-colors.css
+++ b/dashboard-react/src/theme/forced-colors.css
@@ -64,7 +64,8 @@
     }
 
     .wb-help-target,
-    .wb-view-host.is-helping .wb-help-target {
+    .wb-view-host.is-helping .wb-help-target,
+    .wb-cowork.is-helping .wb-help-target {
       outline: 2px dashed Highlight;
       box-shadow: none;
       animation: none;

--- a/dashboard-react/vite.config.ts
+++ b/dashboard-react/vite.config.ts
@@ -45,9 +45,15 @@ export default defineConfig({
           ) {
             return "vendor-react";
           }
+          // The drag/resize leaf family. react-resizable-panels (the Co-work split) only
+          // imports react/react-dom, so it rides here with a single one-directional edge to
+          // vendor-react and never forms a chunk cycle. It is named explicitly so trimming a
+          // sibling term cannot silently relocate it. Its name also contains "react-resizable",
+          // so the term below would catch it regardless. The explicit clause is documentation.
           if (
             id.includes("react-grid-layout") ||
             id.includes("react-draggable") ||
+            id.includes("react-resizable-panels") ||
             id.includes("react-resizable")
           ) {
             return "vendor-grid";


### PR DESCRIPTION
Presentation-honesty pass on the just-merged Co-work (K2) view, plus a cross-view hover-help control. React dashboard only. No backend, no store, no Python touched.

Stacks on #253 (the vendor React chunk fix), so the base is `fix/vendor-react-chunk-cycle`.

## What changed

**1. Visible editor.** The editable surface (`.wb-cowork-editor__surface`) is now a bordered, padded, raised "page" on the canvas with an accent focus state, using theme tokens only. It reads unmistakably as an editable document instead of plain text.

**2. Honest defaults, fabrications gone.** The default Co-work view (no `?cowork_fixture=demo`, no `?store_id=`) loads no document and falls into honest empty states:
- Editor: an empty, genuinely editable surface (no self-describing blurb).
- Rail: an empty review layer ("Nothing to review here."), not the context-bundle-cache fixture.
- Chat: an empty transcript with a real composer, no scripted agent message, and no fake typing indicator.
- Health strip: "No document open".

The demo fixtures are preserved behind the existing `?cowork_fixture=demo` switch (the demo editor now seeds coherent prose rather than the blurb). Tests that assumed the demo scene was the default were repointed at the flag or at the new empty states.

**3. Blurb to hover help.** The "This is the editor pane..." copy is no longer document content. It is the editor region's hover-help content, surfaced on hover when help mode is on.

**4. Cross-view hover help.** The `helpMode` state moved out of ViewHost into an app-shell `HelpModeProvider`. The toggle now lives in the navbar (Info icon, "Hover help" label, `aria-pressed`, disabled on narrow viewports) and drives contextual help across every view. ViewHost's Journal HelpTargets keep working from the shared context, and the Co-work editor, rail, and health regions get their own HelpTargets.

## Notes

- The help barrel intentionally does not re-export `HelpModeToggle`, so lazily loaded view chunks that need only the light HelpTarget pieces do not drag the ui Button and the announcer across a chunk boundary. This keeps the production build free of circular-chunk warnings.
- `useMediaQuery` also re-reads on window `resize`, not only the MediaQueryList change event, so a host that mounts at a transient zero width and settles later cannot latch a stale value.

## Verification (production build, real browser)

- `npm run build`: exit 0, zero TS errors, zero circular-chunk warnings (baseline confirmed at 0 on the parent branch).
- `npx vitest run`: 651 passed across 126 files. `npx tsc --noEmit`: clean.
- Served `dist` with `vite preview` and checked both routes:
  - Hover-help toggle is in the navbar on Co-work and Journal, toggling on one view carries to the other, and turning it off clears the Journal HelpTargets.
  - Editor surface computed style: 1px border, distinct raised background, 14px radius, padding, max-width.
  - Default Co-work shows no fabricated chat message, no typing, an empty rail, and an empty editor.
  - `?cowork_fixture=demo` still renders the demo scene (health, seeded prose, demo proposal, scripted chat with typing).
  - Zero console errors on both routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
