### PR TITLE
fix(security): harden local trust boundaries

### DIFF
--- a/tests/unit/email/test_thunderbird_provider.py
+++ b/tests/unit/email/test_thunderbird_provider.py
@@ -225,6 +225,21 @@ def test_health_round_trip(tmp_path, monkeypatch):
     assert state.requests[0]["path"] == "/health"
 
 
+def test_local_bridge_bypasses_environment_proxy(tmp_path, monkeypatch):
+    """Authenticated localhost IPC must not send its bearer token to a proxy."""
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:1")
+    monkeypatch.setenv("http_proxy", "http://127.0.0.1:1")
+    monkeypatch.setenv("NO_PROXY", "")
+    monkeypatch.setenv("no_proxy", "")
+    state = _BridgeState()
+
+    with _running_bridge(state, tmp_path, monkeypatch):
+        provider = tb_mod.ThunderbirdEmailProvider()
+        assert provider.health()["ok"] is True
+
+    assert state.requests == [{"method": "GET", "path": "/health"}]
+
+
 def test_recent_messages_maps_to_summary_with_stable_key(tmp_path, monkeypatch):
     state = _BridgeState()
     with _running_bridge(state, tmp_path, monkeypatch):

--- a/tests/unit/test_backup_restore_security.py
+++ b/tests/unit/test_backup_restore_security.py
@@ -1,0 +1,63 @@
+"""Security regression tests for backup archive extraction."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+import pytest
+
+from work_buddy.backups.restore import RestoreFailed, _safe_extract_tar
+
+
+def _archive(tmp_path, members):
+    path = tmp_path / "snapshot.tar.gz"
+    with tarfile.open(path, "w:gz") as tf:
+        for name, payload, kind in members:
+            info = tarfile.TarInfo(name)
+            if kind == "file":
+                data = payload.encode()
+                info.size = len(data)
+                tf.addfile(info, io.BytesIO(data))
+            elif kind == "symlink":
+                info.type = tarfile.SYMTYPE
+                info.linkname = payload
+                tf.addfile(info)
+    return path
+
+
+def test_safe_extract_accepts_regular_files(tmp_path):
+    archive = _archive(tmp_path, [("db/tasks.db", "sqlite", "file")])
+    destination = tmp_path / "staging"
+    destination.mkdir()
+
+    with tarfile.open(archive, "r:gz") as tf:
+        _safe_extract_tar(tf, destination)
+
+    assert (destination / "db" / "tasks.db").read_text() == "sqlite"
+
+
+@pytest.mark.parametrize("name", ["../escaped.db", "/tmp/escaped.db"])
+def test_safe_extract_rejects_paths_outside_destination(tmp_path, name):
+    archive = _archive(tmp_path, [(name, "payload", "file")])
+    destination = tmp_path / "staging"
+    destination.mkdir()
+
+    with tarfile.open(archive, "r:gz") as tf:
+        with pytest.raises(RestoreFailed, match="Unsafe backup member path"):
+            _safe_extract_tar(tf, destination)
+
+    assert not (tmp_path / "escaped.db").exists()
+
+
+def test_safe_extract_rejects_links(tmp_path):
+    archive = _archive(
+        tmp_path,
+        [("db/link", "../../outside", "symlink")],
+    )
+    destination = tmp_path / "staging"
+    destination.mkdir()
+
+    with tarfile.open(archive, "r:gz") as tf:
+        with pytest.raises(RestoreFailed, match="Unsupported backup member"):
+            _safe_extract_tar(tf, destination)

--- a/tests/unit/test_google_native_adapter.py
+++ b/tests/unit/test_google_native_adapter.py
@@ -342,6 +342,26 @@ def test_auth_token_status(monkeypatch, tmp_path):
     assert ga.token_status({})["token_present"] is True
 
 
+def test_auth_persist_is_atomic_and_owner_only(tmp_path):
+    import os
+    import stat
+
+    from work_buddy.calendar import google_auth as ga
+
+    class _Creds:
+        @staticmethod
+        def to_json():
+            return '{"refresh_token":"secret"}'
+
+    token = tmp_path / "credentials" / "token.json"
+    ga._persist(_Creds(), token)
+
+    assert token.read_text(encoding="utf-8") == '{"refresh_token":"secret"}'
+    if os.name != "nt":
+        assert stat.S_IMODE(token.stat().st_mode) == 0o600
+    assert list(token.parent.glob(f".{token.name}.*.tmp")) == []
+
+
 def test_client_secret_convention_discovery(monkeypatch, tmp_path):
     from work_buddy import paths
     from work_buddy.calendar import google_auth as ga

--- a/tests/unit/test_session_launcher.py
+++ b/tests/unit/test_session_launcher.py
@@ -1,6 +1,7 @@
 """Unit tests for session_launcher — command construction and remote_control flag."""
 
-from unittest.mock import patch, MagicMock
+import shlex
+from unittest.mock import patch
 
 import pytest
 
@@ -158,6 +159,31 @@ class TestDoResumeCommandConstruction:
 
         assert mock_launch.call_args[0][0] == ["codex", "resume", "codex-thread"]
         assert result["status"] == "ok"
+
+
+@pytest.mark.unit
+class TestMacOSLauncher:
+    """The generated AppleScript must never contain command input."""
+
+    @patch("work_buddy.session_launcher.subprocess.Popen")
+    def test_passes_command_as_data_via_environment(self, mock_popen):
+        from work_buddy.session_launcher import _launch_macos
+
+        mock_popen.return_value.pid = 123
+        prompt = 'hello" & do shell script "touch /tmp/injected" & "'
+
+        result = _launch_macos(["claude", prompt], "/tmp/quoted path")
+
+        assert result == 123
+        popen_argv = mock_popen.call_args.args[0]
+        script = popen_argv[2]
+        env = mock_popen.call_args.kwargs["env"]
+        assert prompt not in script
+        assert "WORK_BUDDY_LAUNCH_COMMAND" in script
+        assert env["WORK_BUDDY_LAUNCH_COMMAND"] == (
+            f"cd {shlex.quote('/tmp/quoted path')} && "
+            f"claude {shlex.quote(prompt)}"
+        )
 
 
 @pytest.mark.unit

--- a/tests/unit/threads/test_execution_runner.py
+++ b/tests/unit/threads/test_execution_runner.py
@@ -14,12 +14,52 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from work_buddy.threads import execution_runner, models
+from work_buddy.threads.enums import FSMState
+from work_buddy.threads.events import KIND_EXECUTION_FINISHED
 
 
 def _entry(*, is_action: bool, params: dict):
     """Minimal stand-in for a registry ``Capability`` entry — only the
     attributes ``_bind_runtime_parameters`` reads."""
     return SimpleNamespace(is_action=is_action, parameters=params)
+
+
+def test_missing_action_proposal_records_failure_and_advances(monkeypatch):
+    thread = models.Thread(fsm_state=FSMState.EXECUTING)
+    recorded = []
+    transitions = []
+
+    monkeypatch.setattr(
+        execution_runner.store, "get_thread", lambda _thread_id: thread,
+    )
+    monkeypatch.setattr(
+        execution_runner, "_latest_action_proposal", lambda _thread_id: None,
+    )
+    monkeypatch.setattr(
+        execution_runner.store, "latest_event_id", lambda _thread_id: "event-1",
+    )
+    monkeypatch.setattr(
+        execution_runner.store, "append_event", recorded.append,
+    )
+    monkeypatch.setattr(
+        execution_runner.store, "update_thread_state", lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        execution_runner.engine,
+        "transition",
+        lambda *args, **kwargs: transitions.append((args, kwargs)),
+    )
+
+    execution_runner.execution_state_entry_handler(SimpleNamespace(
+        next_state=FSMState.EXECUTING,
+        thread_id=thread.thread_id,
+    ))
+
+    assert len(recorded) == 1
+    assert recorded[0].kind == KIND_EXECUTION_FINISHED
+    assert recorded[0].data["success"] is False
+    assert recorded[0].data["error"] == "no action_inferred event found"
+    assert transitions[0][0][1] == execution_runner.TRIG_EXECUTION_FAILED
 
 
 class TestBindRuntimeThreadId:

--- a/work_buddy/backups/restore.py
+++ b/work_buddy/backups/restore.py
@@ -76,6 +76,34 @@ class RestoreFailed(Exception):
     """
 
 
+# ─── Safe archive extraction ───────────────────────────────────────
+
+
+def _safe_extract_tar(tf: tarfile.TarFile, destination: Path) -> None:
+    """Extract a backup tarball without allowing it to escape ``destination``.
+
+    Backup snapshots contain only regular files and directories.  Reject links
+    and special files as well as absolute/parent-traversal paths before writing
+    any member, so an untrusted local or downloaded snapshot cannot overwrite
+    files elsewhere on the host.
+    """
+    root = destination.resolve()
+    members = tf.getmembers()
+
+    for member in members:
+        target = (root / member.name).resolve()
+        if not target.is_relative_to(root):
+            raise RestoreFailed(
+                f"Unsafe backup member path: {member.name!r}"
+            )
+        if not (member.isfile() or member.isdir()):
+            raise RestoreFailed(
+                f"Unsupported backup member type: {member.name!r}"
+            )
+
+    tf.extractall(root, members=members, filter="data")
+
+
 # ─── Source resolution ─────────────────────────────────────────────
 
 
@@ -316,7 +344,7 @@ def restore(
         shutil.rmtree(staging_dir)
     staging_dir.mkdir(parents=True)
     with tarfile.open(tarball, "r:gz") as tf:
-        tf.extractall(staging_dir)
+        _safe_extract_tar(tf, staging_dir)
     # Scoped truth payloads require an explicit Truth import/recovery flow.
     # Keep them in the snapshot tarball and out of the host database swap.
     truth_payloads = staging_dir / "truth_stores"

--- a/work_buddy/calendar/google_auth.py
+++ b/work_buddy/calendar/google_auth.py
@@ -21,6 +21,7 @@ expire (Testing mode expires sensitive-scope refresh tokens after 7 days).
 from __future__ import annotations
 
 import os
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -71,8 +72,29 @@ def _client_secret_path(cfg: dict[str, Any] | None) -> Path | None:
 
 
 def _persist(creds, token_path: Path) -> None:
+    """Atomically persist OAuth credentials with owner-only permissions."""
     token_path.parent.mkdir(parents=True, exist_ok=True)
-    token_path.write_text(creds.to_json(), encoding="utf-8")
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{token_path.name}.",
+        suffix=".tmp",
+        dir=token_path.parent,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        if os.name != "nt":
+            os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = -1
+            handle.write(creds.to_json())
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, token_path)
+        if os.name != "nt":
+            os.chmod(token_path, 0o600)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        tmp_path.unlink(missing_ok=True)
 
 
 def load_credentials(cfg: dict[str, Any] | None = None):

--- a/work_buddy/email/providers/thunderbird.py
+++ b/work_buddy/email/providers/thunderbird.py
@@ -21,7 +21,7 @@ import time
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from urllib.request import ProxyHandler, Request, build_opener
 
 from work_buddy.email.errors import (
     EmailBridgeUnauthorized,
@@ -44,6 +44,10 @@ CONNECTION_DIR_NAME = "thunderbird-work-buddy"
 CONNECTION_FILE = "connection.json"
 DEFAULT_TIMEOUT_SECONDS = 10
 PROTOCOL_VERSION_MIN = "0.1.0"
+
+# The Thunderbird bridge is authenticated local IPC.  The process or system
+# proxy configuration must never receive its requests (or bearer token).
+_DIRECT_OPENER = build_opener(ProxyHandler({}))
 
 
 def connection_file_path() -> Path:
@@ -117,7 +121,7 @@ class ThunderbirdEmailProvider:
         req = Request(url, data=data, method=method, headers=headers)
 
         try:
-            with urlopen(req, timeout=self._timeout) as resp:
+            with _DIRECT_OPENER.open(req, timeout=self._timeout) as resp:
                 raw = resp.read()
         except HTTPError as exc:
             # Read body for diagnostics.
@@ -400,7 +404,7 @@ def probe_thunderbird_bridge() -> tuple[bool, str]:
             f"http://127.0.0.1:{port}/health",
             headers={"Authorization": f"Bearer {token}"},
         )
-        with urlopen(req, timeout=2) as resp:
+        with _DIRECT_OPENER.open(req, timeout=2) as resp:
             body = resp.read()
             ok = resp.status == 200
     except HTTPError as exc:

--- a/work_buddy/session_launcher.py
+++ b/work_buddy/session_launcher.py
@@ -165,13 +165,23 @@ def _launch_macos(argv: list[str], cwd: str) -> int:
     # Build a shell command that cd's and runs the command
     escaped_argv = " ".join(_shell_quote(a) for a in argv)
     escaped_cwd = _shell_quote(cwd)
+    command = f"cd {escaped_cwd} && {escaped_argv}"
+
+    # Keep untrusted argv/cwd data out of the AppleScript source.  Shell
+    # quoting protects the command that Terminal eventually runs, but it does
+    # not escape an AppleScript string literal; embedding the command directly
+    # allowed a quote in a prompt to inject additional AppleScript statements.
+    # ``system attribute`` returns the value as data, so quotes, backslashes,
+    # and newlines cannot alter the script's structure.
+    env = _clean_env()
+    env["WORK_BUDDY_LAUNCH_COMMAND"] = command
     script = (
-        f'tell application "Terminal" to do script '
-        f'"cd {escaped_cwd} && {escaped_argv}"'
+        'set launchCommand to system attribute "WORK_BUDDY_LAUNCH_COMMAND"\n'
+        'tell application "Terminal" to do script launchCommand'
     )
     proc = subprocess.Popen(
         ["osascript", "-e", script],
-        env=_clean_env(),
+        env=env,
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/work_buddy/threads/execution_runner.py
+++ b/work_buddy/threads/execution_runner.py
@@ -177,6 +177,47 @@ def _latest_action_proposal(thread_id: str) -> dict[str, Any] | None:
     return None
 
 
+def _record_failure(
+    thread_id: str,
+    *,
+    error: str,
+    capability: str | None,
+) -> None:
+    """Record a pre-dispatch failure and move the Thread out of EXECUTING."""
+    store.append_event(ThreadEvent(
+        thread_id=thread_id,
+        kind=KIND_EXECUTION_FINISHED,
+        actor=ACTOR_AGENT,
+        data={
+            "capability_name": capability,
+            "success": False,
+            "result": None,
+            "error": error,
+        },
+        parent_event_id=store.latest_event_id(thread_id),
+    ))
+    store.update_thread_state(
+        thread_id,
+        parent_event_id=store.latest_event_id(thread_id),
+    )
+    try:
+        engine.transition(
+            thread_id,
+            TRIG_EXECUTION_FAILED,
+            data={
+                "success": False,
+                "error": error,
+                "capability_name": capability,
+            },
+            parent_event_id=store.latest_event_id(thread_id),
+            fire_side_effects=True,
+        )
+    except engine.InvalidTransition:
+        logger.warning(
+            "execution_runner: failure trigger rejected for %s", thread_id,
+        )
+
+
 def _bind_runtime_parameters(
     *,
     capability_name: str,


### PR DESCRIPTION
## Summary

- keep macOS terminal commands out of generated AppleScript source
- validate every backup archive member before extraction and apply the stdlib data filter
- bypass process and system proxies for authenticated Thunderbird localhost IPC
- persist Google OAuth credentials atomically with owner-only POSIX permissions
- record and transition the existing pre-dispatch Thread failure path instead of raising `NameError`

## Why

These are small, independent trust-boundary fixes found during a security review. Each issue has a focused regression test, and the changes preserve the existing public APIs and normal workflows.

The macOS launcher previously shell-quoted argv but embedded the resulting command inside an AppleScript string literal. Shell quoting does not protect the AppleScript parser. The command now travels through an environment variable and is read as data by `system attribute`.

Backup restore previously called `extractall` directly. It now rejects paths outside the staging root, links, and special members before extracting regular files/directories with `filter="data"`.

Thunderbird bridge requests carry a per-startup bearer token to `127.0.0.1`. A dedicated no-proxy opener ensures proxy configuration cannot receive that token or break local IPC.

## Compatibility notes

- snapshot archives produced by work-buddy contain regular files/directories and continue to restore normally
- the OAuth permission assertion is POSIX-only; Windows retains its inherited ACL behavior
- no endpoint, capability, config, or persisted schema changes

## Validation

- full Python test suite: passed (`NO_PROXY=127.0.0.1,localhost uv run pytest -q`)
- focused regression suites for launcher, restore, Google auth, Thunderbird, and Thread execution: passed
- Python bytecode compilation: passed
- AppleScript source compiled successfully with `osacompile`
- Bandit on modified production modules: no high-severity findings
- Ruff fatal-error selection (`E9,F63,F7,F82`): passed
- `git diff --check`: passed
