### PR TITLE
feat(cowork): add account-backed provider and model picker

### DIFF
--- a/dashboard-react/src/apps/cowork/bridge/sittingSubmit.test.ts
+++ b/dashboard-react/src/apps/cowork/bridge/sittingSubmit.test.ts
@@ -285,6 +285,61 @@ describe("routingDeliveriesFrom", () => {
     ]);
   });
 
+  it("carries the authoritative conversation execution returned by the sitting", () => {
+    expect(
+      routingDeliveriesFrom(
+        [],
+        routingReceipt({
+          ...baseDelivery,
+          delivered: true,
+          conversation_id: "conversation-1",
+          message_id: "message-1",
+          agent: {
+            status: "running",
+            alive: true,
+            started: true,
+            error: null,
+          },
+          execution: {
+            selection: {
+              provider_id: "codex",
+              model_id: "gpt-5.6-sol",
+              provider_label: "Codex",
+              model_label: "GPT-5.6 Sol",
+              revision: "execution:sitting",
+            },
+            providers: [
+              {
+                id: "codex",
+                label: "Codex",
+                available: true,
+                models: [
+                  {
+                    id: "gpt-5.6-sol",
+                    label: "GPT-5.6 Sol",
+                    available: true,
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        conversationId: "conversation-1",
+        agent: expect.objectContaining({ status: "running" }),
+        execution: expect.objectContaining({
+          selection: expect.objectContaining({
+            providerId: "codex",
+            modelId: "gpt-5.6-sol",
+            revision: "execution:sitting",
+          }),
+        }),
+      }),
+    ]);
+  });
+
   it("reports failed when the routing note was not saved", () => {
     expect(
       routingDeliveriesFrom(

--- a/dashboard-react/src/apps/cowork/bridge/sittingSubmit.ts
+++ b/dashboard-react/src/apps/cowork/bridge/sittingSubmit.ts
@@ -1,4 +1,5 @@
 import type { RoutingDeliveryInput } from "../chat";
+import { normalizeChatExecutionSnapshot } from "../../../dashboard/conversations";
 import type {
   SittingItemResult as RailSittingItemResult,
   SittingResult as RailSittingResult,
@@ -56,6 +57,14 @@ export const routingDeliveriesFrom = (
           : delivery.delivered === true && delivery.agent?.status === "running"
             ? "delivered"
             : "queued";
+      let execution: RoutingDeliveryInput["execution"];
+      if (delivery.execution !== undefined) {
+        try {
+          execution = normalizeChatExecutionSnapshot(delivery.execution);
+        } catch {
+          execution = undefined;
+        }
+      }
       return {
         verb: delivery.verb,
         proposalId: delivery.proposal_id,
@@ -66,6 +75,18 @@ export const routingDeliveriesFrom = (
         ...(delivery.reason === undefined || delivery.reason === null
           ? {}
           : { reason: delivery.reason }),
+        ...(execution === undefined
+          ? {}
+          : {
+              execution,
+              ...(delivery.conversation_id === undefined ||
+              delivery.conversation_id === null
+                ? {}
+                : { conversationId: delivery.conversation_id }),
+              ...(delivery.agent === undefined
+                ? {}
+                : { agent: delivery.agent }),
+            }),
       };
     });
   }

--- a/dashboard-react/src/apps/cowork/chat/CoworkChatPanel.tsx
+++ b/dashboard-react/src/apps/cowork/chat/CoworkChatPanel.tsx
@@ -12,6 +12,7 @@ import {
 import {
   ConversationChat,
   type ChatConversationProvider,
+  type ChatExecutionControl,
   type ChatInputRecovery,
   type ChatMessage,
   type ConversationChatState,
@@ -56,6 +57,8 @@ export interface CoworkChatPanelProps {
   readonly onEnsureAgent?: () => void;
   /** Let the owning rail derive unread state without mounting another hook. */
   readonly onMessagesChange?: (messages: readonly ChatMessage[]) => void;
+  /** Generic provider/model selection owned by the shared Chat surface. */
+  readonly execution?: ChatExecutionControl;
 }
 
 export function CoworkChatPanel({
@@ -73,6 +76,7 @@ export function CoworkChatPanel({
   ensureError,
   onEnsureAgent,
   onMessagesChange,
+  execution,
 }: CoworkChatPanelProps) {
   const store = useMemo(
     () => annotations ?? new CoworkChatAnnotations(),
@@ -152,6 +156,7 @@ export function CoworkChatPanel({
                 label: actionLabel,
                 onAction: onEnsureAgent,
                 pending: ensuringAgent,
+                requiresExecution: true,
               },
             }),
       };
@@ -184,6 +189,7 @@ export function CoworkChatPanel({
       }
       inputRecovery={resolveInputRecovery}
       readOnlyReason="This chat is closed."
+      execution={execution}
     />
   );
 }

--- a/dashboard-react/src/apps/cowork/chat/contracts.ts
+++ b/dashboard-react/src/apps/cowork/chat/contracts.ts
@@ -7,6 +7,7 @@
 // of the shared ChatMessage.
 
 import type { CoworkDocumentAgent } from "./documentConversationBinding";
+import type { ChatExecutionSnapshot } from "../../../widget-library/chat";
 
 /**
  * A quote anchor as the R9 feedback route and kernel anchors.py address it. The
@@ -38,6 +39,12 @@ export interface FeedbackCapture {
   readonly messageId: string;
   /** Agent state returned by R9 after its user-authorized ensure attempt. */
   readonly agent?: CoworkDocumentAgent;
+  /**
+   * The exact execution selection/revision returned by the same R9
+   * transaction. Present on live captures so a first feedback turn cannot
+   * leave the picker holding the earlier unpinned revision.
+   */
+  readonly execution?: ChatExecutionSnapshot;
   /** The verbatim feedback text, exactly as R9 posted it as the user message. */
   readonly text: string;
   /** The document span the feedback was anchored to, for the scroll-to seam. */
@@ -73,6 +80,12 @@ export interface RoutingDeliveryInput {
   readonly note?: string;
   /** A short, user-safe reason when persistence or agent startup was incomplete. */
   readonly reason?: string;
+  /** Server-issued document conversation that received the routing note. */
+  readonly conversationId?: string;
+  /** Agent state returned by the same sitting transaction. */
+  readonly agent?: CoworkDocumentAgent;
+  /** Exact execution choice/revision returned by the same transaction. */
+  readonly execution?: ChatExecutionSnapshot;
 }
 
 /** A stored routing delivery: an input plus the store-assigned notice id. */

--- a/dashboard-react/src/apps/cowork/chat/documentConversationBinding.test.ts
+++ b/dashboard-react/src/apps/cowork/chat/documentConversationBinding.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  CoworkDocumentConversationBindingError,
   HttpCoworkDocumentConversationBindingClient,
   normalizeCoworkDocumentAgent,
 } from "./documentConversationBinding";
@@ -126,6 +127,102 @@ describe("HttpCoworkDocumentConversationBindingClient", () => {
     expect(binding.conversationId).toBe("server-issued-a4e9");
     expect(binding.created).toBe(true);
     expect(binding.agent.started).toBe(true);
+  });
+
+  it("starts with the selected provider/model pair in the same POST", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        ok: true,
+        conversation_id: "server-issued-codex",
+        created: true,
+        agent: { ...RUNNING_AGENT, started: true },
+      }),
+    );
+    const client = new HttpCoworkDocumentConversationBindingClient(
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    await client.ensure("doc-1", "store-1", {
+      providerId: "codex",
+      modelId: "gpt-5.6",
+      expectedRevision: "",
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "/api/truth/doc/doc-1/conversation?store_id=store-1",
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          provider_id: "codex",
+          model_id: "gpt-5.6",
+          expected_revision: "",
+        }),
+      },
+    );
+  });
+
+  it("preserves authoritative execution from a start conflict", async () => {
+    const client = new HttpCoworkDocumentConversationBindingClient(
+      vi.fn(async () =>
+        jsonResponse(
+          {
+            ok: false,
+            error: {
+              code: "execution_selection_changed",
+              message: "The model choice changed elsewhere.",
+            },
+            execution: {
+              selection: {
+                provider_id: "codex",
+                model_id: "gpt-5.6",
+                provider_label: "Codex",
+                model_label: "GPT-5.6",
+                revision: "revision:new",
+              },
+              providers: [
+                {
+                  id: "codex",
+                  label: "Codex",
+                  available: true,
+                  models: [
+                    {
+                      id: "gpt-5.6",
+                      label: "GPT-5.6",
+                      available: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          409,
+        ),
+      ) as unknown as typeof fetch,
+    );
+
+    const caught = await client
+      .ensure("doc-1", "store-1", {
+        providerId: "claude-code",
+        modelId: "sonnet",
+        expectedRevision: "revision:stale",
+      })
+      .catch((error: unknown) => error);
+
+    expect(caught).toBeInstanceOf(
+      CoworkDocumentConversationBindingError,
+    );
+    expect(
+      (caught as CoworkDocumentConversationBindingError)
+        .authoritativeExecution?.selection,
+    ).toMatchObject({
+      providerId: "codex",
+      modelId: "gpt-5.6",
+      revision: "revision:new",
+    });
   });
 
   it("fails closed on a malformed success payload", async () => {

--- a/dashboard-react/src/apps/cowork/chat/documentConversationBinding.ts
+++ b/dashboard-react/src/apps/cowork/chat/documentConversationBinding.ts
@@ -9,6 +9,11 @@
  */
 
 import type { FeedbackCapture } from "./contracts";
+import { normalizeChatExecutionSnapshot } from "../../../dashboard/conversations";
+import type {
+  ChatExecutionSelectionInput,
+  ChatExecutionSnapshot,
+} from "../../../widget-library/chat";
 
 export type CoworkDocumentAgentStatus =
   | "not_started"
@@ -29,6 +34,8 @@ export interface CoworkDocumentConversationBinding {
   readonly agent: CoworkDocumentAgent;
   /** Persisted span annotations for feedback already in this conversation. */
   readonly feedback: readonly FeedbackCapture[];
+  /** Server-authoritative provider/model selection and catalog, when supported. */
+  readonly execution?: ChatExecutionSnapshot;
 }
 
 export interface CoworkDocumentConversationBindingClient {
@@ -39,7 +46,19 @@ export interface CoworkDocumentConversationBindingClient {
   ensure(
     documentId: string,
     storeId: string,
+    execution?: ChatExecutionSelectionInput,
   ): Promise<CoworkDocumentConversationBinding>;
+}
+
+/** A failed binding mutation that still carried newer server authority. */
+export class CoworkDocumentConversationBindingError extends Error {
+  constructor(
+    message: string,
+    readonly authoritativeExecution?: ChatExecutionSnapshot,
+  ) {
+    super(message);
+    this.name = "CoworkDocumentConversationBindingError";
+  }
 }
 
 interface RawBindingPayload {
@@ -50,6 +69,7 @@ interface RawBindingPayload {
   readonly agent_status?: unknown;
   readonly agent_error?: unknown;
   readonly feedback?: unknown;
+  readonly execution?: unknown;
   readonly error?: unknown;
 }
 
@@ -132,6 +152,10 @@ const normalizeBinding = (
     created: payload.created === true,
     agent: normalizeCoworkDocumentAgent(payload),
     feedback,
+    execution:
+      payload.execution === undefined
+        ? undefined
+        : normalizeChatExecutionSnapshot(payload.execution),
   };
 };
 
@@ -218,8 +242,19 @@ const readJson = async (response: Response): Promise<RawBindingPayload> => {
   }
 };
 
-const endpoint = (documentId: string, storeId: string): string =>
+export const coworkConversationEndpoint = (
+  documentId: string,
+  storeId: string,
+): string =>
   `/api/truth/doc/${encodeURIComponent(documentId)}/conversation?store_id=${encodeURIComponent(storeId)}`;
+
+export const coworkConversationExecutionEndpoint = (
+  documentId: string,
+  storeId: string,
+): string => {
+  const query = new URLSearchParams({ store_id: storeId });
+  return `/api/truth/doc/${encodeURIComponent(documentId)}/conversation/execution?${query}`;
+};
 
 export class HttpCoworkDocumentConversationBindingClient
   implements CoworkDocumentConversationBindingClient
@@ -240,26 +275,56 @@ export class HttpCoworkDocumentConversationBindingClient
   ensure(
     documentId: string,
     storeId: string,
+    execution?: ChatExecutionSelectionInput,
   ): Promise<CoworkDocumentConversationBinding> {
-    return this.#request(documentId, storeId, "POST");
+    return this.#request(documentId, storeId, "POST", execution);
   }
 
   async #request(
     documentId: string,
     storeId: string,
     method: "GET" | "POST",
+    execution?: ChatExecutionSelectionInput,
   ): Promise<CoworkDocumentConversationBinding> {
-    const response = await this.#fetch(endpoint(documentId, storeId), {
-      method,
-      headers: { Accept: "application/json" },
-    });
+    const response = await this.#fetch(
+      coworkConversationEndpoint(documentId, storeId),
+      {
+        method,
+        headers: {
+          Accept: "application/json",
+          ...(execution === undefined
+            ? {}
+            : { "Content-Type": "application/json" }),
+        },
+        ...(execution === undefined
+          ? {}
+          : {
+              body: JSON.stringify({
+                provider_id: execution.providerId,
+                model_id: execution.modelId,
+                expected_revision: execution.expectedRevision,
+              }),
+            }),
+      },
+    );
     const payload = await readJson(response);
     if (!response.ok || payload.ok !== true) {
-      throw new Error(
+      let authoritativeExecution: ChatExecutionSnapshot | undefined;
+      if (payload.execution !== undefined) {
+        try {
+          authoritativeExecution = normalizeChatExecutionSnapshot(
+            payload.execution,
+          );
+        } catch {
+          authoritativeExecution = undefined;
+        }
+      }
+      throw new CoworkDocumentConversationBindingError(
         errorMessage(payload.error) ??
           (method === "GET"
             ? "Chat could not be loaded."
             : "Chat couldn’t start. Try again."),
+        authoritativeExecution,
       );
     }
     if (!isRecord(payload.agent)) {

--- a/dashboard-react/src/apps/cowork/chat/index.ts
+++ b/dashboard-react/src/apps/cowork/chat/index.ts
@@ -15,6 +15,8 @@ export {
 
 export {
   HttpCoworkDocumentConversationBindingClient,
+  coworkConversationEndpoint,
+  coworkConversationExecutionEndpoint,
   normalizeCoworkDocumentAgent,
   type CoworkDocumentAgent,
   type CoworkDocumentAgentStatus,

--- a/dashboard-react/src/apps/cowork/chat/useDocumentConversationBinding.test.tsx
+++ b/dashboard-react/src/apps/cowork/chat/useDocumentConversationBinding.test.tsx
@@ -1,10 +1,12 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+import type { ChatExecutionSnapshot } from "../../../widget-library/chat";
 import type { FeedbackCapture } from "./contracts";
-import type {
-  CoworkDocumentConversationBinding,
-  CoworkDocumentConversationBindingClient,
+import {
+  CoworkDocumentConversationBindingError,
+  type CoworkDocumentConversationBinding,
+  type CoworkDocumentConversationBindingClient,
 } from "./documentConversationBinding";
 import { useDocumentConversationBinding } from "./useDocumentConversationBinding";
 
@@ -20,6 +22,34 @@ const runningBinding = (
     error: null,
   },
   feedback: [],
+});
+
+const execution = (
+  providerId: string,
+  modelId: string,
+  revision: string,
+): ChatExecutionSnapshot => ({
+  selection: {
+    providerId,
+    modelId,
+    providerLabel: providerId === "codex" ? "Codex" : "Claude Code",
+    modelLabel: modelId === "gpt-5.6" ? "GPT-5.6" : "Sonnet",
+    revision,
+  },
+  providers: [
+    {
+      id: "claude-code",
+      label: "Claude Code",
+      available: true,
+      models: [{ id: "sonnet", label: "Sonnet", available: true }],
+    },
+    {
+      id: "codex",
+      label: "Codex",
+      available: true,
+      models: [{ id: "gpt-5.6", label: "GPT-5.6", available: true }],
+    },
+  ],
 });
 
 describe("useDocumentConversationBinding", () => {
@@ -150,6 +180,57 @@ describe("useDocumentConversationBinding", () => {
     expect(result.current.error).toBe("The network is unavailable.");
   });
 
+  it("adopts the newer execution revision from a failed start before retry", async () => {
+    const currentExecution = execution(
+      "claude-code",
+      "sonnet",
+      "revision:stale",
+    );
+    const authoritative = execution(
+      "codex",
+      "gpt-5.6",
+      "revision:new",
+    );
+    const client: CoworkDocumentConversationBindingClient = {
+      load: vi.fn(async () => ({
+        ...runningBinding("unused"),
+        conversationId: null,
+        execution: currentExecution,
+      })),
+      ensure: vi.fn(async () => {
+        throw new CoworkDocumentConversationBindingError(
+          "The model choice changed elsewhere.",
+          authoritative,
+        );
+      }),
+    };
+    const { result } = renderHook(() =>
+      useDocumentConversationBinding({
+        documentId: "doc-1",
+        storeId: "store-1",
+        client,
+      }),
+    );
+    await waitFor(() => expect(result.current.phase).toBe("idle"));
+
+    await act(() =>
+      result.current.ensure({
+        providerId: "claude-code",
+        modelId: "sonnet",
+        expectedRevision: "revision:stale",
+      }),
+    );
+
+    expect(result.current.execution?.selection).toMatchObject({
+      providerId: "codex",
+      modelId: "gpt-5.6",
+      revision: "revision:new",
+    });
+    expect(result.current.error).toBe(
+      "The model choice changed elsewhere.",
+    );
+  });
+
   it("adopts R9's real id and rejects a cross-conversation rebind", async () => {
     const client: CoworkDocumentConversationBindingClient = {
       load: vi.fn(async () => ({
@@ -174,11 +255,21 @@ describe("useDocumentConversationBinding", () => {
       conversationId: "opaque-feedback-54",
       messageId: "feedback-message-1",
       agent: runningBinding("ignored").agent,
+      execution: execution(
+        "codex",
+        "gpt-5.6",
+        "revision:feedback",
+      ),
       text: "Tighten this.",
     };
 
     act(() => result.current.adoptFeedback(capture));
     expect(result.current.conversationId).toBe("opaque-feedback-54");
+    expect(result.current.execution?.selection).toMatchObject({
+      providerId: "codex",
+      modelId: "gpt-5.6",
+      revision: "revision:feedback",
+    });
 
     act(() =>
       result.current.adoptFeedback({
@@ -189,6 +280,118 @@ describe("useDocumentConversationBinding", () => {
     expect(result.current.conversationId).toBe("opaque-feedback-54");
     expect(result.current.phase).toBe("error");
     expect(result.current.error).toMatch(/changed unexpectedly/i);
+  });
+
+  it("rejects an execution envelope from the previously open document", async () => {
+    const client: CoworkDocumentConversationBindingClient = {
+      load: vi.fn(async (documentId) => ({
+        ...runningBinding(`conversation:${documentId}`),
+        execution: execution(
+          "claude-code",
+          "sonnet",
+          `revision:${documentId}`,
+        ),
+      })),
+      ensure: vi.fn(),
+    };
+    const { result, rerender } = renderHook(
+      ({
+        documentId,
+        storeId,
+      }: {
+        documentId: string;
+        storeId: string;
+      }) =>
+        useDocumentConversationBinding({
+          documentId,
+          storeId,
+          client,
+        }),
+      {
+        initialProps: {
+          documentId: "doc-old",
+          storeId: "store-old",
+        },
+      },
+    );
+    await waitFor(() =>
+      expect(result.current.execution?.selection.revision).toBe(
+        "revision:doc-old",
+      ),
+    );
+
+    rerender({ documentId: "doc-new", storeId: "store-new" });
+    await waitFor(() =>
+      expect(result.current.execution?.selection.revision).toBe(
+        "revision:doc-new",
+      ),
+    );
+
+    act(() =>
+      result.current.adoptExecution(
+        "doc-old",
+        "store-old",
+        execution("codex", "gpt-5.6", "revision:late-old"),
+      ),
+    );
+    expect(result.current.execution?.selection).toMatchObject({
+      providerId: "claude-code",
+      modelId: "sonnet",
+      revision: "revision:doc-new",
+    });
+  });
+
+  it("does not let a slow initial load overwrite a sitting-adopted binding", async () => {
+    let resolveLoad!: (
+      value: CoworkDocumentConversationBinding,
+    ) => void;
+    const pendingLoad = new Promise<CoworkDocumentConversationBinding>(
+      (resolve) => {
+        resolveLoad = resolve;
+      },
+    );
+    const client: CoworkDocumentConversationBindingClient = {
+      load: vi.fn(() => pendingLoad),
+      ensure: vi.fn(),
+    };
+    const { result } = renderHook(() =>
+      useDocumentConversationBinding({
+        documentId: "doc-1",
+        storeId: "store-1",
+        client,
+      }),
+    );
+
+    act(() =>
+      result.current.adoptExecution(
+        "doc-1",
+        "store-1",
+        execution("codex", "gpt-5.6", "revision:sitting"),
+        runningBinding("ignored").agent,
+        "conversation-from-sitting",
+      ),
+    );
+    expect(result.current.conversationId).toBe("conversation-from-sitting");
+
+    await act(async () => {
+      resolveLoad({
+        ...runningBinding("unused"),
+        conversationId: null,
+        execution: execution(
+          "claude-code",
+          "sonnet",
+          "revision:old-load",
+        ),
+      });
+      await pendingLoad;
+    });
+
+    expect(result.current.conversationId).toBe("conversation-from-sitting");
+    expect(result.current.execution?.selection).toMatchObject({
+      providerId: "codex",
+      modelId: "gpt-5.6",
+      revision: "revision:sitting",
+    });
   });
 
   it("does not let a superseded ensure clear a newer retry", async () => {

--- a/dashboard-react/src/apps/cowork/chat/useDocumentConversationBinding.ts
+++ b/dashboard-react/src/apps/cowork/chat/useDocumentConversationBinding.ts
@@ -1,8 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import type {
+  ChatExecutionSelectionInput,
+  ChatExecutionSnapshot,
+} from "../../../widget-library/chat";
 import type { FeedbackCapture } from "./contracts";
 import {
   HttpCoworkDocumentConversationBindingClient,
+  CoworkDocumentConversationBindingError,
+  normalizeCoworkDocumentAgent,
   type CoworkDocumentAgent,
   type CoworkDocumentConversationBinding,
   type CoworkDocumentConversationBindingClient,
@@ -20,6 +26,7 @@ export interface CoworkConversationBindingState {
   readonly conversationId: string | null;
   readonly agent: CoworkDocumentAgent;
   readonly feedback: readonly FeedbackCapture[];
+  readonly execution?: ChatExecutionSnapshot;
   /** True while a user-authorized start/restart POST is in flight. */
   readonly ensuring: boolean;
   readonly error: string | null;
@@ -28,9 +35,17 @@ export interface CoworkConversationBindingState {
 export interface UseDocumentConversationBindingResult
   extends CoworkConversationBindingState {
   /** Present-user-intent mutation: ensure the binding and start/restart its agent. */
-  ensure(): Promise<void>;
+  ensure(execution?: ChatExecutionSelectionInput): Promise<void>;
   /** Adopt the authoritative binding returned by a successful feedback POST. */
   adoptFeedback(capture: FeedbackCapture): void;
+  /** Adopt an execution PATCH and its atomically returned agent state. */
+  adoptExecution(
+    sourceDocumentId: string,
+    sourceStoreId: string,
+    snapshot: ChatExecutionSnapshot,
+    agent?: unknown,
+    conversationId?: string,
+  ): void;
 }
 
 const NOT_STARTED_AGENT: CoworkDocumentAgent = {
@@ -45,6 +60,7 @@ const initialState = (): CoworkConversationBindingState => ({
   conversationId: null,
   agent: NOT_STARTED_AGENT,
   feedback: [],
+  execution: undefined,
   ensuring: false,
   error: null,
 });
@@ -61,6 +77,7 @@ const stateFromBinding = (
   conversationId: binding.conversationId,
   agent: binding.agent,
   feedback: binding.feedback,
+  execution: binding.execution,
   ensuring: false,
   error: null,
 });
@@ -127,61 +144,74 @@ export function useDocumentConversationBinding({
       });
   }, [documentId, identity, resolvedClient, storeId]);
 
-  const ensure = useCallback((): Promise<void> => {
-    if (ensureInFlight.current !== null) return ensureInFlight.current;
-    const expectedIdentity = identity;
-    const sequence = ++requestSequence.current;
-    stateIdentityRef.current = expectedIdentity;
-    setState((current) => ({
-      ...current,
-      // Keep an existing transcript mounted while its agent restarts. Only a
-      // first-ever start uses the full-pane ensuring gate.
-      phase: current.conversationId === null ? "ensuring" : "ready",
-      ensuring: true,
-      error: null,
-    }));
-    const pending = resolvedClient
-      .ensure(documentId, storeId)
-      .then((binding) => {
-        if (
-          identityRef.current !== expectedIdentity ||
-          requestSequence.current !== sequence
-        ) {
-          return;
-        }
-        if (binding.conversationId === null) {
-          throw new Error("The server did not return a document conversation.");
-        }
-        setState(stateFromBinding(binding));
-      })
-      .catch((error: unknown) => {
-        if (
-          identityRef.current !== expectedIdentity ||
-          requestSequence.current !== sequence
-        ) {
-          return;
-        }
-        setState((current) => ({
-          // A restart failure must not throw away an already loaded transcript.
-          phase: current.conversationId === null ? "error" : "ready",
-          conversationId: current.conversationId,
-          agent: current.agent,
-          feedback: current.feedback,
-          ensuring: false,
-          error: errorText(error),
-        }));
-      })
-      .finally(() => {
-        if (
-          identityRef.current === expectedIdentity &&
-          ensureInFlight.current === pending
-        ) {
-          ensureInFlight.current = null;
-        }
-      });
-    ensureInFlight.current = pending;
-    return pending;
-  }, [documentId, identity, resolvedClient, storeId]);
+  const ensure = useCallback(
+    (execution?: ChatExecutionSelectionInput): Promise<void> => {
+      if (ensureInFlight.current !== null) return ensureInFlight.current;
+      const expectedIdentity = identity;
+      const sequence = ++requestSequence.current;
+      stateIdentityRef.current = expectedIdentity;
+      setState((current) => ({
+        ...current,
+        // Keep an existing transcript mounted while its agent restarts. Only a
+        // first-ever start uses the full-pane ensuring gate.
+        phase: current.conversationId === null ? "ensuring" : "ready",
+        ensuring: true,
+        error: null,
+      }));
+      const pending = (
+        execution === undefined
+          ? resolvedClient.ensure(documentId, storeId)
+          : resolvedClient.ensure(documentId, storeId, execution)
+      )
+        .then((binding) => {
+          if (
+            identityRef.current !== expectedIdentity ||
+            requestSequence.current !== sequence
+          ) {
+            return;
+          }
+          if (binding.conversationId === null) {
+            throw new Error(
+              "The server did not return a document conversation.",
+            );
+          }
+          setState(stateFromBinding(binding));
+        })
+        .catch((error: unknown) => {
+          if (
+            identityRef.current !== expectedIdentity ||
+            requestSequence.current !== sequence
+          ) {
+            return;
+          }
+          setState((current) => ({
+            // A restart failure must not throw away an already loaded transcript.
+            phase: current.conversationId === null ? "error" : "ready",
+            conversationId: current.conversationId,
+            agent: current.agent,
+            feedback: current.feedback,
+            execution:
+              error instanceof CoworkDocumentConversationBindingError &&
+              error.authoritativeExecution !== undefined
+                ? error.authoritativeExecution
+                : current.execution,
+            ensuring: false,
+            error: errorText(error),
+          }));
+        })
+        .finally(() => {
+          if (
+            identityRef.current === expectedIdentity &&
+            ensureInFlight.current === pending
+          ) {
+            ensureInFlight.current = null;
+          }
+        });
+      ensureInFlight.current = pending;
+      return pending;
+    },
+    [documentId, identity, resolvedClient, storeId],
+  );
 
   const adoptFeedback = useCallback(
     (capture: FeedbackCapture): void => {
@@ -220,7 +250,58 @@ export function useDocumentConversationBinding({
             ),
             capture,
           ],
+          execution: capture.execution ?? current.execution,
           ensuring: false,
+          error: null,
+        };
+      });
+    },
+    [documentId, identity, storeId],
+  );
+
+  const adoptExecution = useCallback(
+    (
+      sourceDocumentId: string,
+      sourceStoreId: string,
+      snapshot: ChatExecutionSnapshot,
+      agent?: unknown,
+      conversationId?: string,
+    ): void => {
+      if (
+        identityRef.current !== identity ||
+        sourceDocumentId !== documentId ||
+        sourceStoreId !== storeId
+      ) {
+        return;
+      }
+      requestSequence.current += 1;
+      ensureInFlight.current = null;
+      stateIdentityRef.current = identity;
+      setState((current) => {
+        if (
+          conversationId !== undefined &&
+          current.conversationId !== null &&
+          current.conversationId !== conversationId
+        ) {
+          return {
+            ...current,
+            phase: "error",
+            error:
+              "The document conversation changed unexpectedly. Reload before continuing.",
+          };
+        }
+        const nextConversationId =
+          conversationId ?? current.conversationId;
+        return {
+          ...current,
+          phase:
+            nextConversationId === null ? current.phase : "ready",
+          conversationId: nextConversationId,
+          execution: snapshot,
+          agent:
+            agent === undefined
+              ? current.agent
+              : normalizeCoworkDocumentAgent({ agent }),
           error: null,
         };
       });
@@ -230,5 +311,5 @@ export function useDocumentConversationBinding({
 
   const visibleState =
     stateIdentityRef.current === identity ? state : initialState();
-  return { ...visibleState, ensure, adoptFeedback };
+  return { ...visibleState, ensure, adoptFeedback, adoptExecution };
 }

--- a/dashboard-react/src/apps/cowork/feedback/CoworkFeedbackAffordance.test.tsx
+++ b/dashboard-react/src/apps/cowork/feedback/CoworkFeedbackAffordance.test.tsx
@@ -94,6 +94,7 @@ describe("CoworkFeedbackAffordance", () => {
     expect(capture.spanId).toBe("span-doc-1");
     expect(capture.messageId).toBe("feedback-message-doc-1");
     expect(capture.conversationId).toBe("server-feedback-conversation-doc-1");
+    expect(capture.execution?.selection.revision).toBe("execution-doc-1");
     expect(capture.text).toBe("  make this measurable  ");
     expect(capture.anchor?.exact).toBe("precise");
 

--- a/dashboard-react/src/apps/cowork/feedback/CoworkFeedbackAffordance.tsx
+++ b/dashboard-react/src/apps/cowork/feedback/CoworkFeedbackAffordance.tsx
@@ -185,6 +185,7 @@ export function CoworkFeedbackAffordance({
         messageId: response.message_id,
         conversationId: response.conversation_id,
         agent: response.agent,
+        execution: response.execution,
         text,
         anchor: {
           exact: draft.anchor.exact,

--- a/dashboard-react/src/apps/cowork/feedback/feedbackClient.test.ts
+++ b/dashboard-react/src/apps/cowork/feedback/feedbackClient.test.ts
@@ -15,6 +15,30 @@ const jsonResponse = (
     json: async () => body,
   }) as unknown as Response;
 
+const rawExecution = {
+  selection: {
+    provider_id: "codex",
+    model_id: "gpt-5.6-sol",
+    provider_label: "Codex",
+    model_label: "GPT-5.6 Sol",
+    revision: "execution:feedback",
+  },
+  providers: [
+    {
+      id: "codex",
+      label: "Codex",
+      available: true,
+      models: [
+        {
+          id: "gpt-5.6-sol",
+          label: "GPT-5.6 Sol",
+          available: true,
+        },
+      ],
+    },
+  ],
+} as const;
+
 describe("HttpCoworkFeedbackTransport", () => {
   it("POSTs the R9 route with the store_id query and the span-plus-text body", async () => {
     const fetchImpl = vi.fn(async () =>
@@ -30,6 +54,7 @@ describe("HttpCoworkFeedbackTransport", () => {
           started: true,
           error: null,
         },
+        execution: rawExecution,
       }),
     );
     const transport = new HttpCoworkFeedbackTransport(
@@ -53,6 +78,11 @@ describe("HttpCoworkFeedbackTransport", () => {
     expect(response.message_id).toBe("message-1");
     expect(response.conversation_id).toBe("c-1");
     expect(response.agent.status).toBe("running");
+    expect(response.execution.selection).toMatchObject({
+      providerId: "codex",
+      modelId: "gpt-5.6-sol",
+      revision: "execution:feedback",
+    });
 
     const [url, init] = fetchImpl.mock.calls[0] as unknown as [
       string,
@@ -189,6 +219,29 @@ describe("InMemoryCoworkFeedbackTransport", () => {
         alive: true,
         started: true,
         error: null,
+      },
+      execution: {
+        selection: {
+          providerId: "claude-code",
+          modelId: "sonnet",
+          providerLabel: "Claude Code",
+          modelLabel: "Sonnet",
+          revision: "execution-d1",
+        },
+        providers: [
+          {
+            id: "claude-code",
+            label: "Claude Code",
+            available: true,
+            models: [
+              {
+                id: "sonnet",
+                label: "Sonnet",
+                available: true,
+              },
+            ],
+          },
+        ],
       },
     });
     expect(transport.lastRequest?.text).toBe("note");

--- a/dashboard-react/src/apps/cowork/feedback/feedbackClient.ts
+++ b/dashboard-react/src/apps/cowork/feedback/feedbackClient.ts
@@ -20,6 +20,8 @@ import {
   type CoworkDocumentAgent,
   type CoworkDocumentAgentStatus,
 } from "../chat/documentConversationBinding";
+import { normalizeChatExecutionSnapshot } from "../../../dashboard/conversations";
+import type { ChatExecutionSnapshot } from "../../../widget-library/chat";
 import {
   CoworkHttpError,
   normalizeCoworkError,
@@ -49,6 +51,7 @@ export interface CoworkFeedbackResponse {
   readonly message_id: string;
   readonly conversation_id: string;
   readonly agent: CoworkDocumentAgent;
+  readonly execution: ChatExecutionSnapshot;
 }
 
 /** The seam the affordance depends on, satisfied by fetch or an in-memory double. */
@@ -81,7 +84,12 @@ const requiredString = (
 const normalizeFeedbackResponse = (
   value: unknown,
 ): CoworkFeedbackResponse => {
-  if (!isRecord(value) || value.ok !== true || !isRecord(value.agent)) {
+  if (
+    !isRecord(value) ||
+    value.ok !== true ||
+    !isRecord(value.agent) ||
+    !isRecord(value.execution)
+  ) {
     throw new Error(RECONCILIATION_ERROR);
   }
   const evidenceId = requiredString(value, "evidence_id");
@@ -108,6 +116,7 @@ const normalizeFeedbackResponse = (
     message_id: messageId,
     conversation_id: conversationId,
     agent: normalizeCoworkDocumentAgent({ agent: rawAgent }),
+    execution: normalizeChatExecutionSnapshot(value.execution),
   };
 };
 
@@ -196,6 +205,29 @@ export class InMemoryCoworkFeedbackTransport implements CoworkFeedbackTransport 
         alive: true,
         started: true,
         error: null,
+      },
+      execution: {
+        selection: {
+          providerId: "claude-code",
+          modelId: "sonnet",
+          providerLabel: "Claude Code",
+          modelLabel: "Sonnet",
+          revision: `execution-${request.documentId}`,
+        },
+        providers: [
+          {
+            id: "claude-code",
+            label: "Claude Code",
+            available: true,
+            models: [
+              {
+                id: "sonnet",
+                label: "Sonnet",
+                available: true,
+              },
+            ],
+          },
+        ],
       },
     });
   }

--- a/dashboard-react/src/apps/cowork/rail/CoworkRail.test.tsx
+++ b/dashboard-react/src/apps/cowork/rail/CoworkRail.test.tsx
@@ -4,7 +4,10 @@ import { describe, expect, it, vi } from "vitest";
 
 import { DashboardHelpProvider } from "../../../dashboard/help";
 import { expectNoAccessibilityViolations } from "../../../test/setup";
-import type { ChatConversationProvider } from "../../../widget-library/chat";
+import type {
+  ChatConversationProvider,
+  ChatExecutionControl,
+} from "../../../widget-library/chat";
 import { CoworkChatAnnotations } from "../chat";
 import {
   loadChatDraft,
@@ -62,6 +65,41 @@ function renderRail(storage: Storage = new MemoryStorage()) {
 }
 
 const S1_TLDR = "Add the vault content hash to the cache key.";
+
+const chatExecution = (
+  select: ChatExecutionControl["select"] = vi.fn(async () => {}),
+): ChatExecutionControl => ({
+  snapshot: {
+    selection: {
+      providerId: "claude-code",
+      modelId: "sonnet",
+      providerLabel: "Claude Code",
+      modelLabel: "Sonnet",
+      revision: "",
+    },
+    providers: [
+      {
+        id: "claude-code",
+        label: "Claude Code",
+        available: true,
+        models: [{ id: "sonnet", label: "Sonnet", available: true }],
+      },
+      {
+        id: "codex",
+        label: "Codex",
+        available: true,
+        models: [{ id: "gpt-5.6", label: "GPT-5.6", available: true }],
+      },
+    ],
+  },
+  status: "ready",
+  selecting: false,
+  error: null,
+  announcement: null,
+  currentAvailable: true,
+  select,
+  retry: vi.fn(),
+});
 
 describe("CoworkRail", () => {
   it("frames the Review and Chat tabs with Review active", async () => {
@@ -131,6 +169,69 @@ describe("CoworkRail", () => {
     expect(onChatSelected).not.toHaveBeenCalled();
     await userEvent.click(screen.getByRole("tab", { name: /Chat/ }));
     expect(onChatSelected).toHaveBeenCalledOnce();
+  });
+
+  it("lets the user choose the execution pair before explicitly starting chat", async () => {
+    const select = vi.fn(async () => {});
+    const onStart = vi.fn();
+    render(
+      <CoworkRail
+        documentId="demo-doc"
+        reviewProvider={new InMemoryReviewProvider()}
+        chat={{
+          kind: "idle",
+          draftStorageId: "document:demo-doc",
+          onStart,
+        }}
+        chatExecution={chatExecution(select)}
+        storage={new MemoryStorage()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("tab", { name: /Chat/ }));
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: "Run with Claude Code · Sonnet",
+      }),
+    );
+    await userEvent.click(
+      screen.getByRole("option", { name: "Codex, GPT-5.6" }),
+    );
+
+    expect(select).toHaveBeenCalledWith("codex", "gpt-5.6");
+    expect(onStart).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole("button", { name: "Start chat" }));
+    expect(onStart).toHaveBeenCalledOnce();
+  });
+
+  it("does not start an idle chat from a server read-only execution profile", () => {
+    const onStart = vi.fn();
+    const execution = chatExecution();
+    render(
+      <CoworkRail
+        documentId="demo-doc"
+        reviewProvider={new InMemoryReviewProvider()}
+        chat={{
+          kind: "idle",
+          draftStorageId: "document:demo-doc",
+          onStart,
+        }}
+        chatExecution={{
+          ...execution,
+          snapshot: {
+            ...execution.snapshot!,
+            readOnly: true,
+          },
+        }}
+        initialTab="chat"
+        storage={new MemoryStorage()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Start chat" }),
+    ).toBeDisabled();
+    expect(onStart).not.toHaveBeenCalled();
   });
 
   it("does not let a hidden Queue consume shortcuts from Chat", async () => {

--- a/dashboard-react/src/apps/cowork/rail/CoworkRail.tsx
+++ b/dashboard-react/src/apps/cowork/rail/CoworkRail.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from "react";
 import { HelpTarget, type HelpContent } from "../../../dashboard/help";
 import {
   type ChatConversationProvider,
+  type ChatExecutionControl,
   type ChatMessage,
   ChatPanelState,
 } from "../../../widget-library/chat";
@@ -67,6 +68,8 @@ export interface CoworkRailProps {
   readonly chatAnnotations?: CoworkChatAnnotations;
   /** The scroll-to-passage seam for a feedback span link, wired by the surface. */
   readonly onScrollToChatAnchor?: (target: ScrollAnchorTarget) => void;
+  /** Shared provider/model selection, available before a conversation starts. */
+  readonly chatExecution?: ChatExecutionControl;
 }
 
 export type CoworkRailChat =
@@ -104,8 +107,10 @@ export type CoworkRailChat =
 
 function CoworkConversationGate({
   chat,
+  execution,
 }: {
   readonly chat: Exclude<CoworkRailChat, { kind: "ready" }>;
+  readonly execution?: ChatExecutionControl;
 }) {
   if (chat.kind === "loading" || chat.kind === "ensuring") {
     return (
@@ -116,6 +121,8 @@ function CoworkConversationGate({
         detail={
           chat.kind === "loading" ? "Checking for messages." : undefined
         }
+        execution={execution}
+        executionDisabled
       />
     );
   }
@@ -126,7 +133,12 @@ function CoworkConversationGate({
         kind="empty"
         title="Chat hasn’t started."
         detail="Start chat to ask about this document."
-        action={{ label: "Start chat", onAction: chat.onStart }}
+        action={{
+          label: "Start chat",
+          onAction: chat.onStart,
+          requiresExecution: true,
+        }}
+        execution={execution}
       />
     );
   }
@@ -139,7 +151,9 @@ function CoworkConversationGate({
       action={{
         label: chat.action === "restart" ? "Restart chat" : "Start chat",
         onAction: chat.onRetry,
+        requiresExecution: true,
       }}
+      execution={execution}
     />
   );
 }
@@ -254,7 +268,10 @@ export function CoworkRail(props: CoworkRailProps) {
         hidden={tab !== "chat"}
       >
         {props.chat.kind !== "ready" ? (
-          <CoworkConversationGate chat={props.chat} />
+          <CoworkConversationGate
+            chat={props.chat}
+            execution={props.chatExecution}
+          />
         ) : (
           <CoworkChatPanel
             provider={props.chat.provider}
@@ -266,6 +283,7 @@ export function CoworkRail(props: CoworkRailProps) {
             ensureError={props.chat.ensureError}
             onEnsureAgent={props.chat.onEnsureAgent}
             onMessagesChange={setMessages}
+            execution={props.chatExecution}
             composerInitialValue={
               loadChatDraft(
                 props.storage ?? window.localStorage,

--- a/dashboard-react/src/apps/cowork/suggestions/types.ts
+++ b/dashboard-react/src/apps/cowork/suggestions/types.ts
@@ -198,6 +198,8 @@ export interface SittingResponse {
       readonly started: boolean;
       readonly error: string | null;
     };
+    /** Server-authoritative execution projection for the ensured driver. */
+    readonly execution?: unknown;
   }[];
 }
 

--- a/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.test.tsx
+++ b/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.test.tsx
@@ -20,7 +20,10 @@ import { saveRailTab } from "../guards";
 import CoworkWorkspaceWidget, {
   reimportReceiptMatchesDocument,
 } from "../widget/CoworkWorkspaceWidget";
-import { resolveFixtureMode } from "./CoworkWorkspaceSurface";
+import {
+  coworkExecutionSwitchConfirmation,
+  resolveFixtureMode,
+} from "./CoworkWorkspaceSurface";
 
 /**
  * The composite workspace card is a normal grid widget now, so the tests drive its renderer
@@ -85,6 +88,32 @@ const renderWorkspace = (
   render(
     workspaceElement(input, emit),
   );
+
+describe("Co-work execution switch impact", () => {
+  const candidate = {
+    providerId: "codex",
+    modelId: "gpt-5.6",
+    providerLabel: "Codex",
+    modelLabel: "GPT-5.6",
+  } as const;
+
+  it("confirms only when switching would restart an active agent", () => {
+    expect(
+      coworkExecutionSwitchConfirmation("not_started", candidate),
+    ).toBeNull();
+    expect(
+      coworkExecutionSwitchConfirmation("stopped", candidate),
+    ).toBeNull();
+    expect(
+      coworkExecutionSwitchConfirmation("running", candidate),
+    ).toEqual({
+      title: "Switch to Codex · GPT-5.6?",
+      description:
+        "This restarts the assistant with the new model. Your messages and draft stay here.",
+      confirmLabel: "Switch",
+    });
+  });
+});
 
 describe("CoworkWorkspaceWidget default (empty) mode", () => {
   const originalUrl = window.location.href;
@@ -926,6 +955,39 @@ const LIVE_AGENT = {
   error: null,
 } as const;
 
+const executionPayload = (
+  providerId = "claude-code",
+  modelId = "sonnet",
+  revision = "",
+) => ({
+  selection: {
+    provider_id: providerId,
+    model_id: modelId,
+    provider_label: providerId === "codex" ? "Codex" : "Claude Code",
+    model_label: modelId === "gpt-5.6" ? "GPT-5.6" : "Sonnet",
+    revision,
+  },
+  providers: [
+    {
+      id: "claude-code",
+      label: "Claude Code",
+      available: true,
+      availability: "ready",
+      auth_mode: "subscription",
+      models: [{ id: "sonnet", label: "Sonnet", available: true }],
+    },
+    {
+      id: "codex",
+      label: "Codex",
+      available: true,
+      availability: "ready",
+      auth_mode: "chatgpt",
+      models: [{ id: "gpt-5.6", label: "GPT-5.6", available: true }],
+    },
+  ],
+  read_only: false,
+});
+
 const liveConversationPayload = () => ({
   conversation: {
     conversation_id: LIVE_CONVERSATION_ID,
@@ -1240,7 +1302,7 @@ describe("CoworkWorkspaceWidget live mode", () => {
     saveRailTab(window.localStorage, "live-doc", "review");
   });
 
-  it("ensures on a current Chat click, then loads only the returned opaque id", async () => {
+  it("starts only from the explicit Chat action, then loads the returned opaque id", async () => {
     const baseFetch = liveFetch();
     const ensuredId = "server-issued-after-click-72";
     const fetchImpl = vi.fn(
@@ -1305,6 +1367,16 @@ describe("CoworkWorkspaceWidget live mode", () => {
     ).toBe(false);
 
     await userEvent.click(screen.getByRole("tab", { name: /Chat/ }));
+    expect(
+      fetchImpl.mock.calls.some(
+        ([input, init]) =>
+          String(input).includes("/conversation?store_id=live-store") &&
+          init?.method === "POST",
+      ),
+    ).toBe(false);
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Start chat" }),
+    );
     expect(await screen.findByText("Chat started from this click.")).toBeVisible();
     expect(
       fetchImpl.mock.calls.some(
@@ -1323,6 +1395,134 @@ describe("CoworkWorkspaceWidget live mode", () => {
         String(input).includes("/api/conversations/cowork-doc-"),
       ),
     ).toBe(false);
+    saveRailTab(window.localStorage, "live-doc", "review");
+  });
+
+  it("selects before first start and POSTs that confirmed pair and revision", async () => {
+    const baseFetch = liveFetch();
+    const startedConversationId = "server-issued-codex-chat";
+    const patchBodies: unknown[] = [];
+    const postBodies: unknown[] = [];
+    let execution = executionPayload();
+    const fetchImpl = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = String(input);
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (
+          url.includes(
+            "/api/truth/doc/live-doc/conversation/execution?store_id=live-store",
+          )
+        ) {
+          patchBodies.push(JSON.parse(String(init?.body)));
+          execution = executionPayload(
+            "codex",
+            "gpt-5.6",
+            "execution:codex",
+          );
+          return jsonResponse({
+            ok: true,
+            execution,
+            agent: {
+              status: "not_started",
+              alive: null,
+              started: false,
+              error: null,
+            },
+          });
+        }
+        if (
+          url.includes(
+            "/api/truth/doc/live-doc/conversation?store_id=live-store",
+          )
+        ) {
+          if (method === "POST") {
+            postBodies.push(JSON.parse(String(init?.body)));
+            return jsonResponse({
+              ok: true,
+              conversation_id: startedConversationId,
+              created: false,
+              execution,
+              agent: { ...LIVE_AGENT, started: true },
+            });
+          }
+          return jsonResponse({
+            ok: true,
+            conversation_id: null,
+            created: false,
+            execution,
+            agent: {
+              status: "not_started",
+              alive: null,
+              started: false,
+              error: null,
+            },
+          });
+        }
+        if (url === `/api/conversations/${startedConversationId}`) {
+          return jsonResponse({
+            conversation: {
+              conversation_id: startedConversationId,
+              title: "Chat about this document",
+              status: "open",
+              agent_alive: true,
+            },
+            messages: [
+              {
+                message_id: "codex-ready",
+                role: "agent",
+                content: "Codex chat is ready.",
+                producer: {
+                  provider_id: "codex",
+                  model_id: "gpt-5.6",
+                  provider_label: "Codex",
+                  model_label: "GPT-5.6",
+                },
+              },
+            ],
+          });
+        }
+        return baseFetch(input, init);
+      },
+    );
+    renderLive(noopEmit, fetchImpl as unknown as typeof fetch);
+
+    await userEvent.click(screen.getByRole("tab", { name: /Chat/ }));
+    const trigger = await screen.findByRole("button", {
+      name: "Run with Claude Code · Sonnet",
+    });
+    await userEvent.click(trigger);
+    await userEvent.click(
+      screen.getByRole("option", { name: "Codex, GPT-5.6" }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", {
+          name: "Run with Codex · GPT-5.6",
+        }),
+      ).toBeVisible(),
+    );
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(patchBodies).toEqual([
+      {
+        provider_id: "codex",
+        model_id: "gpt-5.6",
+        expected_revision: "",
+      },
+    ]);
+
+    await userEvent.click(screen.getByRole("button", { name: "Start chat" }));
+    expect(await screen.findByText("Codex chat is ready.")).toBeVisible();
+    expect(postBodies).toEqual([
+      {
+        provider_id: "codex",
+        model_id: "gpt-5.6",
+        expected_revision: "execution:codex",
+      },
+    ]);
+    expect(
+      screen.getByLabelText("Produced by Codex, GPT-5.6"),
+    ).toBeVisible();
     saveRailTab(window.localStorage, "live-doc", "review");
   });
 

--- a/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.tsx
+++ b/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.tsx
@@ -15,7 +15,16 @@ import {
   useDashboardHelpEnabled,
   type HelpContent,
 } from "../../../dashboard/help";
-import { createHttpChatProvider } from "../../../dashboard/conversations";
+import {
+  createHttpChatExecutionProfileProvider,
+  createHttpChatProvider,
+} from "../../../dashboard/conversations";
+import {
+  useChatExecutionProfile,
+  type ChatExecutionSelectionCandidate,
+  type ChatExecutionSelectionInput,
+  type ChatExecutionSwitchConfirmation,
+} from "../../../widget-library/chat";
 import type {
   CoworkDocumentSummary,
   CoworkDriftState,
@@ -30,8 +39,11 @@ import type {
 import { CoworkBridgeEditor, useCoworkBridge } from "../bridge";
 import {
   CoworkChatAnnotations,
+  coworkConversationEndpoint,
+  coworkConversationExecutionEndpoint,
   useDocumentConversationBinding,
   type CoworkDocumentConversationBindingClient,
+  type CoworkDocumentAgentStatus,
   type FeedbackCapture,
   type ScrollAnchorTarget,
 } from "../chat";
@@ -72,6 +84,19 @@ const DRIFT_LABEL: Record<string, string> = {
   drifted: "Drifted from file",
   missing: "File missing",
 };
+
+export const coworkExecutionSwitchConfirmation = (
+  agentStatus: CoworkDocumentAgentStatus,
+  { providerLabel, modelLabel }: ChatExecutionSelectionCandidate,
+): ChatExecutionSwitchConfirmation | null =>
+  agentStatus === "running"
+    ? {
+        title: `Switch to ${providerLabel} · ${modelLabel}?`,
+        description:
+          "This restarts the assistant with the new model. Your messages and draft stay here.",
+        confirmLabel: "Switch",
+      }
+    : null;
 
 /**
  * Hover-help for the three Co-work regions, surfaced when app-shell help mode is on. The
@@ -482,6 +507,52 @@ export function CoworkLiveWorkspace({
   useEffect(() => {
     annotations.replaceFeedback(conversation.feedback);
   }, [annotations, conversation.feedback]);
+  const adoptExecutionRef = useRef(conversation.adoptExecution);
+  adoptExecutionRef.current = conversation.adoptExecution;
+  const executionProvider = useMemo(
+    () => {
+      const providerWorkspaceIdentity = workspaceIdentity;
+      return createHttpChatExecutionProfileProvider({
+        targetId: workspaceIdentity,
+        loadUrl: coworkConversationEndpoint(documentId, storeId),
+        selectUrl: coworkConversationExecutionEndpoint(documentId, storeId),
+        onEnvelope: (envelope) => {
+          if (
+            workspaceIdentityRef.current !== providerWorkspaceIdentity
+          ) {
+            return;
+          }
+          adoptExecutionRef.current(
+            documentId,
+            storeId,
+            envelope.execution,
+            envelope.agent,
+          );
+        },
+      });
+    },
+    [documentId, storeId, workspaceIdentity],
+  );
+  useEffect(() => {
+    if (conversation.execution !== undefined) {
+      executionProvider.replaceSnapshot(conversation.execution);
+    }
+  }, [conversation.execution, executionProvider]);
+  const chatExecution = useChatExecutionProfile(
+    conversation.execution === undefined ? null : executionProvider,
+    workspaceIdentity,
+  );
+  const presentedChatExecution = useMemo(() => {
+    if (chatExecution === undefined) return undefined;
+    return {
+      ...chatExecution,
+      confirmSelection: (candidate: ChatExecutionSelectionCandidate) =>
+        coworkExecutionSwitchConfirmation(
+          conversation.agent.status,
+          candidate,
+        ),
+    };
+  }, [chatExecution, conversation.agent.status]);
   const chatDraftStorageId = `document:${storeId}:${documentId}`;
   const chatProvider = useMemo(
     () =>
@@ -492,25 +563,17 @@ export function CoworkLiveWorkspace({
         : null,
     [conversation.conversationId, conversation.phase],
   );
+  const selectedExecution: ChatExecutionSelectionInput | undefined =
+    chatExecution?.snapshot === null || chatExecution?.snapshot === undefined
+      ? undefined
+      : {
+          providerId: chatExecution.snapshot.selection.providerId,
+          modelId: chatExecution.snapshot.selection.modelId,
+          expectedRevision: chatExecution.snapshot.selection.revision,
+        };
   const ensureConversation = useCallback((): void => {
-    void conversation.ensure();
-  }, [conversation.ensure]);
-  const activateChat = useCallback((): void => {
-    if (
-      conversation.phase === "ensuring" ||
-      conversation.ensuring ||
-      (conversation.phase === "ready" &&
-        conversation.agent.status === "running")
-    ) {
-      return;
-    }
-    void conversation.ensure();
-  }, [
-    conversation.agent.status,
-    conversation.ensure,
-    conversation.ensuring,
-    conversation.phase,
-  ]);
+    void conversation.ensure(selectedExecution);
+  }, [conversation.ensure, selectedExecution]);
   const chat: CoworkRailChat = useMemo(() => {
     if (
       conversation.phase === "ready" &&
@@ -568,9 +631,8 @@ export function CoworkLiveWorkspace({
     (pane: CoworkWorkspacePane): void => {
       setActivePane(pane);
       if (pane !== "editor") railStore.setTab(pane);
-      if (pane === "chat") activateChat();
     },
-    [activateChat, railStore],
+    [railStore],
   );
   useEffect(
     () =>
@@ -593,7 +655,21 @@ export function CoworkLiveWorkspace({
     onMaterializationState,
     onMaterializationController,
     onMaterialized,
-    onRoutingDelivery: (delivery) => annotations.annotateRoutingDelivery(delivery),
+    onRoutingDelivery: (delivery) => {
+      annotations.annotateRoutingDelivery(delivery);
+      if (
+        delivery.conversationId !== undefined &&
+        delivery.execution !== undefined
+      ) {
+        conversation.adoptExecution(
+          documentId,
+          storeId,
+          delivery.execution,
+          delivery.agent,
+          delivery.conversationId,
+        );
+      }
+    },
     // The last link of the feedback loop: R9 landed, so record the span-linked message on
     // the Chat tab and switch the rail to Chat so the human sees the feedback land.
     ...(feedbackCapture
@@ -703,11 +779,11 @@ export function CoworkLiveWorkspace({
           documentId={documentId}
           reviewProvider={bridge.reviewProvider}
           chat={chat}
-          onChatSelected={activateChat}
           anchorRects={bridge.anchorRects}
           store={railStore}
           queueBindings={navBinding}
           chatAnnotations={annotations}
+          chatExecution={presentedChatExecution}
           onScrollToChatAnchor={scrollToChatAnchor}
           narrow={narrowWorkspace}
           reviewVisible={

--- a/dashboard-react/src/dashboard/conversations/HttpChatExecutionProfileProvider.test.ts
+++ b/dashboard-react/src/dashboard/conversations/HttpChatExecutionProfileProvider.test.ts
@@ -1,0 +1,368 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ChatExecutionSelectionError } from "../../widget-library/chat";
+import {
+  HttpChatExecutionProfileProvider,
+  normalizeChatExecutionEnvelope,
+} from "./HttpChatExecutionProfileProvider";
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "",
+    json: async () => body,
+  }) as unknown as Response;
+
+const deferred = <T,>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
+
+const executionPayload = (
+  providerId = "claude-code",
+  modelId = "sonnet",
+  revision = "",
+) => ({
+  execution: {
+    selection: {
+      provider_id: providerId,
+      model_id: modelId,
+      provider_label: providerId === "codex" ? "Codex" : "Claude Code",
+      model_label: modelId === "gpt-5.6" ? "GPT-5.6" : "Sonnet",
+      revision,
+    },
+    providers: [
+      {
+        id: "claude-code",
+        label: "Claude Code",
+        available: true,
+        availability: "ready",
+        auth_mode: "subscription",
+        models: [{ id: "sonnet", label: "Sonnet", available: true }],
+      },
+      {
+        id: "codex",
+        label: "Codex",
+        available: false,
+        availability: "auth_required",
+        unavailable_reason: "Sign in to Codex",
+        auth_mode: "chatgpt",
+        models: [
+          {
+            id: "gpt-5.6",
+            label: "GPT-5.6",
+            available: false,
+            unavailable_reason: "Codex is not signed in",
+          },
+        ],
+      },
+    ],
+    read_only: false,
+  },
+  agent: {
+    status: "not_started",
+    alive: null,
+    started: false,
+    error: null,
+  },
+});
+
+describe("HttpChatExecutionProfileProvider", () => {
+  it("normalizes the server catalog, projected revision, and host envelope", () => {
+    const envelope = normalizeChatExecutionEnvelope(executionPayload());
+
+    expect(envelope.execution).toMatchObject({
+      selection: {
+        providerId: "claude-code",
+        modelId: "sonnet",
+        providerLabel: "Claude Code",
+        modelLabel: "Sonnet",
+        revision: "",
+      },
+      providers: [
+        {
+          id: "claude-code",
+          authMode: "subscription",
+          available: true,
+        },
+        {
+          id: "codex",
+          authMode: "chatgpt",
+          available: false,
+          unavailableReason: "Sign in to Codex",
+          models: [
+            {
+              id: "gpt-5.6",
+              available: false,
+              unavailableReason: "Codex is not signed in",
+            },
+          ],
+        },
+      ],
+    });
+    expect(envelope.agent).toMatchObject({ status: "not_started" });
+  });
+
+  it("PATCHes the exact atomic pair and optimistic revision", async () => {
+    const onEnvelope = vi.fn();
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(executionPayload("codex", "gpt-5.6", "execution:2")),
+    );
+    const provider = new HttpChatExecutionProfileProvider({
+      targetId: "store\u0000doc",
+      loadUrl: "/load",
+      selectUrl: "/select",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      onEnvelope,
+    });
+
+    const result = await provider.select("store\u0000doc", {
+      providerId: "codex",
+      modelId: "gpt-5.6",
+      expectedRevision: "execution:1",
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith("/select", {
+      method: "PATCH",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        provider_id: "codex",
+        model_id: "gpt-5.6",
+        expected_revision: "execution:1",
+      }),
+    });
+    expect(result.selection).toMatchObject({
+      providerId: "codex",
+      modelId: "gpt-5.6",
+      revision: "execution:2",
+    });
+    expect(onEnvelope).toHaveBeenCalledWith(
+      expect.objectContaining({ execution: result }),
+    );
+  });
+
+  it("carries an authoritative conflict snapshot to the state hook", async () => {
+    const onEnvelope = vi.fn();
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(
+        {
+          ...executionPayload("codex", "gpt-5.6", "execution:9"),
+          error: "The selection changed in another window.",
+        },
+        409,
+      ),
+    );
+    const provider = new HttpChatExecutionProfileProvider({
+      targetId: "document:1",
+      loadUrl: "/load",
+      selectUrl: "/select",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      onEnvelope,
+    });
+
+    try {
+      await provider.select("document:1", {
+        providerId: "codex",
+        modelId: "gpt-5.6",
+        expectedRevision: "execution:1",
+      });
+      throw new Error("Expected selection conflict.");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ChatExecutionSelectionError);
+      expect(
+        (error as ChatExecutionSelectionError).authoritativeSnapshot?.selection,
+      ).toMatchObject({
+        providerId: "codex",
+        modelId: "gpt-5.6",
+        revision: "execution:9",
+      });
+      expect(onEnvelope).toHaveBeenCalledWith(
+        expect.objectContaining({
+          execution: expect.objectContaining({
+            selection: expect.objectContaining({ revision: "execution:9" }),
+          }),
+        }),
+      );
+    }
+  });
+
+  it("reloads an authoritative snapshot when a conflict has no envelope", async () => {
+    const onEnvelope = vi.fn();
+    const fetchImpl = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) =>
+        init?.method === "PATCH"
+          ? jsonResponse(
+              { ok: false, error: "The selection changed elsewhere." },
+              409,
+            )
+          : jsonResponse(
+              executionPayload("codex", "gpt-5.6", "execution:11"),
+            ),
+    );
+    const provider = new HttpChatExecutionProfileProvider({
+      targetId: "document:1",
+      loadUrl: "/load",
+      selectUrl: "/select",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      onEnvelope,
+    });
+
+    await expect(
+      provider.select("document:1", {
+        providerId: "codex",
+        modelId: "gpt-5.6",
+        expectedRevision: "execution:1",
+      }),
+    ).rejects.toMatchObject({
+      authoritativeSnapshot: expect.objectContaining({
+        selection: expect.objectContaining({ revision: "execution:11" }),
+      }),
+    });
+    expect(fetchImpl).toHaveBeenNthCalledWith(2, "/load", {
+      headers: { Accept: "application/json" },
+    });
+    expect(onEnvelope).toHaveBeenCalledOnce();
+  });
+
+  it("notifies a mounted hook when a containing feature adopts a newer snapshot", () => {
+    const initial = normalizeChatExecutionEnvelope(
+      executionPayload(),
+    ).execution;
+    const pinned = normalizeChatExecutionEnvelope(
+      executionPayload("claude-code", "sonnet", "execution:pinned"),
+    ).execution;
+    const provider = new HttpChatExecutionProfileProvider({
+      targetId: "document:1",
+      loadUrl: "/load",
+      selectUrl: "/select",
+      initialSnapshot: initial,
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+    });
+    const invalidate = vi.fn();
+    provider.subscribe("document:1", invalidate);
+
+    provider.replaceSnapshot(initial);
+    expect(invalidate).not.toHaveBeenCalled();
+    provider.replaceSnapshot(pinned);
+    expect(invalidate).toHaveBeenCalledOnce();
+  });
+
+  it("does not adopt a late GET after the host replaces the snapshot", async () => {
+    const pendingLoad = deferred<Response>();
+    const onEnvelope = vi.fn();
+    const provider = new HttpChatExecutionProfileProvider({
+      targetId: "document:1",
+      loadUrl: "/load",
+      selectUrl: "/select",
+      fetchImpl: vi.fn(() => pendingLoad.promise) as unknown as typeof fetch,
+      onEnvelope,
+    });
+    const replacement = normalizeChatExecutionEnvelope(
+      executionPayload("codex", "gpt-5.6", "execution:host"),
+    ).execution;
+
+    const load = provider.load("document:1");
+    provider.replaceSnapshot(replacement);
+    pendingLoad.resolve(
+      jsonResponse(
+        executionPayload("claude-code", "sonnet", "execution:stale"),
+      ),
+    );
+
+    await expect(load).resolves.toBe(replacement);
+    await expect(provider.load("document:1")).resolves.toBe(replacement);
+    expect(onEnvelope).not.toHaveBeenCalled();
+  });
+
+  it("lets a successful PATCH supersede an older in-flight GET", async () => {
+    const pendingLoad = deferred<Response>();
+    const pendingPatch = deferred<Response>();
+    const onEnvelope = vi.fn();
+    const fetchImpl = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        init?.method === "PATCH"
+          ? pendingPatch.promise
+          : pendingLoad.promise,
+    );
+    const provider = new HttpChatExecutionProfileProvider({
+      targetId: "document:1",
+      loadUrl: "/load",
+      selectUrl: "/select",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      onEnvelope,
+    });
+
+    const load = provider.load("document:1");
+    const select = provider.select("document:1", {
+      providerId: "codex",
+      modelId: "gpt-5.6",
+      expectedRevision: "execution:1",
+    });
+    pendingPatch.resolve(
+      jsonResponse(executionPayload("codex", "gpt-5.6", "execution:2")),
+    );
+    const selected = await select;
+    pendingLoad.resolve(
+      jsonResponse(
+        executionPayload("claude-code", "sonnet", "execution:stale"),
+      ),
+    );
+
+    await expect(load).resolves.toBe(selected);
+    expect(selected.selection).toMatchObject({
+      providerId: "codex",
+      modelId: "gpt-5.6",
+      revision: "execution:2",
+    });
+    expect(onEnvelope).toHaveBeenCalledOnce();
+    expect(onEnvelope).toHaveBeenCalledWith(
+      expect.objectContaining({ execution: selected }),
+    );
+  });
+
+  it("drops its cached projection before an explicit refresh", async () => {
+    const initial = normalizeChatExecutionEnvelope(
+      executionPayload(),
+    ).execution;
+    const refreshed = executionPayload(
+      "claude-code",
+      "sonnet",
+      "execution:refreshed",
+    );
+    const fetchImpl = vi.fn(async () => jsonResponse(refreshed));
+    const provider = new HttpChatExecutionProfileProvider({
+      targetId: "document:1",
+      loadUrl: "/load",
+      selectUrl: "/select",
+      initialSnapshot: initial,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(await provider.load("document:1")).toBe(initial);
+    provider.refresh("document:1");
+    expect((await provider.load("document:1")).selection.revision).toBe(
+      "execution:refreshed",
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "/load?refresh_execution=1",
+      { headers: { Accept: "application/json" } },
+    );
+  });
+
+  it("rejects a malformed execution response", () => {
+    expect(() =>
+      normalizeChatExecutionEnvelope({
+        execution: { selection: {}, providers: [] },
+      }),
+    ).toThrow(/provider_id/);
+  });
+});

--- a/dashboard-react/src/dashboard/conversations/HttpChatExecutionProfileProvider.ts
+++ b/dashboard-react/src/dashboard/conversations/HttpChatExecutionProfileProvider.ts
@@ -1,0 +1,442 @@
+import {
+  ChatExecutionSelectionError,
+  type ChatExecutionModelOption,
+  type ChatExecutionProfileProvider,
+  type ChatExecutionProviderOption,
+  type ChatExecutionSelectionInput,
+  type ChatExecutionSnapshot,
+  type ChatInvalidationListener,
+  type ChatUnsubscribe,
+} from "../../widget-library/chat";
+
+type JsonRecord = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const array = (value: unknown): readonly unknown[] =>
+  Array.isArray(value) ? value : [];
+
+function optionalString(record: JsonRecord, ...names: string[]): string | undefined {
+  for (const name of names) {
+    const value = record[name];
+    if (typeof value === "string" && value.trim().length > 0) return value;
+  }
+  return undefined;
+}
+
+function requiredString(record: JsonRecord, ...names: string[]): string {
+  const value = optionalString(record, ...names);
+  if (value !== undefined) return value;
+  throw new Error(`Missing execution field: ${names[0]}`);
+}
+
+function availabilityReason(record: JsonRecord): string | undefined {
+  const direct = optionalString(
+    record,
+    "unavailable_reason",
+    "unavailableReason",
+    "reason",
+  );
+  if (direct !== undefined) return direct;
+  if (
+    typeof record.availability === "string" &&
+    record.availability !== "available"
+  ) {
+    return record.availability;
+  }
+  if (isRecord(record.availability)) {
+    return optionalString(record.availability, "message", "reason");
+  }
+  return undefined;
+}
+
+function normalizeModel(value: unknown): ChatExecutionModelOption {
+  if (!isRecord(value)) throw new Error("Execution model must be an object.");
+  return {
+    id: requiredString(value, "id", "model_id", "modelId"),
+    label:
+      optionalString(value, "label", "model_label", "modelLabel") ??
+      requiredString(value, "id", "model_id", "modelId"),
+    available: value.available !== false,
+    description: optionalString(value, "description"),
+    unavailableReason: availabilityReason(value),
+  };
+}
+
+function normalizeProvider(value: unknown): ChatExecutionProviderOption {
+  if (!isRecord(value)) {
+    throw new Error("Execution provider must be an object.");
+  }
+  return {
+    id: requiredString(value, "id", "provider_id", "providerId"),
+    label:
+      optionalString(value, "label", "provider_label", "providerLabel") ??
+      requiredString(value, "id", "provider_id", "providerId"),
+    available: value.available !== false,
+    authMode: optionalString(value, "auth_mode", "authMode"),
+    description: optionalString(value, "description"),
+    unavailableReason: availabilityReason(value),
+    models: array(value.models).map(normalizeModel),
+  };
+}
+
+/**
+ * Normalize the backend's snake_case execution projection. A flat selection is
+ * accepted as a compatibility fallback, but catalog labels remain
+ * server-authored and IDs remain opaque.
+ */
+export function normalizeChatExecutionSnapshot(
+  value: unknown,
+): ChatExecutionSnapshot {
+  if (!isRecord(value)) {
+    throw new Error("Execution profile must be an object.");
+  }
+  const rawSelection = isRecord(value.selection) ? value.selection : value;
+  const rawCatalog = isRecord(value.catalog) ? value.catalog : value;
+  const providers = array(rawCatalog.providers).map(normalizeProvider);
+  const providerId = requiredString(
+    rawSelection,
+    "provider_id",
+    "providerId",
+  );
+  const modelId = requiredString(rawSelection, "model_id", "modelId");
+  const provider = providers.find((candidate) => candidate.id === providerId);
+  const model = provider?.models.find((candidate) => candidate.id === modelId);
+  return {
+    selection: {
+      providerId,
+      modelId,
+      providerLabel:
+        optionalString(
+          rawSelection,
+          "provider_label",
+          "providerLabel",
+        ) ??
+        provider?.label ??
+        providerId,
+      modelLabel:
+        optionalString(rawSelection, "model_label", "modelLabel") ??
+        model?.label ??
+        modelId,
+      revision:
+        typeof rawSelection.revision === "string"
+          ? rawSelection.revision
+          : typeof value.revision === "string"
+            ? value.revision
+            : typeof value.execution_revision === "string"
+              ? value.execution_revision
+              : (() => {
+                  throw new Error("Missing execution field: revision");
+                })(),
+    },
+    providers,
+    readOnly: value.read_only === true || value.readOnly === true,
+  };
+}
+
+export interface HttpChatExecutionEnvelope {
+  readonly execution: ChatExecutionSnapshot;
+  /** Feature-owned lifecycle data carried beside the generic execution shape. */
+  readonly agent?: unknown;
+}
+
+export function normalizeChatExecutionEnvelope(
+  payload: unknown,
+): HttpChatExecutionEnvelope {
+  if (!isRecord(payload)) {
+    throw new Error("Execution response must be an object.");
+  }
+  const rawExecution = payload.execution ?? payload;
+  return {
+    execution: normalizeChatExecutionSnapshot(rawExecution),
+    agent: payload.agent,
+  };
+}
+
+function errorMessage(payload: unknown, fallback: string): string {
+  if (!isRecord(payload)) return fallback;
+  if (typeof payload.message === "string" && payload.message.trim().length > 0) {
+    return payload.message;
+  }
+  if (typeof payload.error === "string" && payload.error.trim().length > 0) {
+    return payload.error;
+  }
+  if (isRecord(payload.error)) {
+    return optionalString(payload.error, "message") ?? fallback;
+  }
+  return fallback;
+}
+
+const sameModel = (
+  left: ChatExecutionModelOption,
+  right: ChatExecutionModelOption,
+): boolean =>
+  left.id === right.id &&
+  left.label === right.label &&
+  left.available === right.available &&
+  left.description === right.description &&
+  left.unavailableReason === right.unavailableReason;
+
+const sameProvider = (
+  left: ChatExecutionProviderOption,
+  right: ChatExecutionProviderOption,
+): boolean =>
+  left.id === right.id &&
+  left.label === right.label &&
+  left.available === right.available &&
+  left.authMode === right.authMode &&
+  left.description === right.description &&
+  left.unavailableReason === right.unavailableReason &&
+  left.models.length === right.models.length &&
+  left.models.every((model, index) =>
+    sameModel(model, right.models[index]),
+  );
+
+const sameSnapshot = (
+  left: ChatExecutionSnapshot | null,
+  right: ChatExecutionSnapshot,
+): boolean =>
+  left !== null &&
+  left.selection.providerId === right.selection.providerId &&
+  left.selection.modelId === right.selection.modelId &&
+  left.selection.providerLabel === right.selection.providerLabel &&
+  left.selection.modelLabel === right.selection.modelLabel &&
+  left.selection.revision === right.selection.revision &&
+  left.readOnly === right.readOnly &&
+  left.providers.length === right.providers.length &&
+  left.providers.every((provider, index) =>
+    sameProvider(provider, right.providers[index]),
+  );
+
+export interface HttpChatExecutionProfileConfig {
+  readonly targetId: string;
+  readonly loadUrl: string;
+  readonly selectUrl: string;
+  readonly initialSnapshot?: ChatExecutionSnapshot;
+  readonly fetchImpl?: typeof fetch;
+  /** Lets a feature adopt lifecycle data returned in the same transaction. */
+  readonly onEnvelope?: (envelope: HttpChatExecutionEnvelope) => void;
+}
+
+interface PendingExecutionRead {
+  readonly sequence: number;
+  readonly promise: Promise<ChatExecutionSnapshot>;
+}
+
+/**
+ * Neutral same-origin HTTP adapter. Endpoint ownership remains with the host;
+ * this class only normalizes execution envelopes and sends an atomic pair.
+ */
+export class HttpChatExecutionProfileProvider
+  implements ChatExecutionProfileProvider
+{
+  readonly #targetId: string;
+  readonly #loadUrl: string;
+  readonly #selectUrl: string;
+  readonly #injectedFetch: typeof fetch | undefined;
+  readonly #onEnvelope:
+    | ((envelope: HttpChatExecutionEnvelope) => void)
+    | undefined;
+  readonly #listeners = new Set<ChatInvalidationListener>();
+  #snapshot: ChatExecutionSnapshot | null;
+  #refreshRequested = false;
+  #authoritySequence = 0;
+  #readSequence = 0;
+  #latestRead: PendingExecutionRead | null = null;
+
+  constructor(config: HttpChatExecutionProfileConfig) {
+    this.#targetId = config.targetId;
+    this.#loadUrl = config.loadUrl;
+    this.#selectUrl = config.selectUrl;
+    this.#injectedFetch = config.fetchImpl;
+    this.#onEnvelope = config.onEnvelope;
+    this.#snapshot = config.initialSnapshot ?? null;
+  }
+
+  #fetcher(): typeof fetch {
+    if (this.#injectedFetch !== undefined) return this.#injectedFetch;
+    if (typeof globalThis.fetch !== "function") {
+      throw new Error("global fetch is unavailable, so inject fetchImpl");
+    }
+    return globalThis.fetch.bind(globalThis);
+  }
+
+  #assertTarget(targetId: string): void {
+    if (targetId !== this.#targetId) {
+      throw new Error(
+        `This execution provider is bound to ${this.#targetId}, not ${targetId}`,
+      );
+    }
+  }
+
+  async #json(response: Response): Promise<unknown> {
+    try {
+      return await response.json();
+    } catch {
+      return undefined;
+    }
+  }
+
+  #adopt(envelope: HttpChatExecutionEnvelope): ChatExecutionSnapshot {
+    this.#snapshot = envelope.execution;
+    this.#onEnvelope?.(envelope);
+    return envelope.execution;
+  }
+
+  /**
+   * Fence reads that began before a newer server or host-authoritative
+   * projection. A late GET may resolve to the current snapshot, but it must
+   * never adopt its stale envelope or notify the host with stale lifecycle
+   * data.
+   */
+  #supersedePendingReads(): void {
+    this.#authoritySequence += 1;
+  }
+
+  /** Reconcile an execution projection already loaded by a containing feature. */
+  replaceSnapshot(snapshot: ChatExecutionSnapshot): void {
+    this.#supersedePendingReads();
+    if (sameSnapshot(this.#snapshot, snapshot)) return;
+    this.#snapshot = snapshot;
+    for (const listener of [...this.#listeners]) listener();
+  }
+
+  /** Ask mounted consumers to reconcile after an external server event. */
+  invalidate(): void {
+    this.#supersedePendingReads();
+    this.#snapshot = null;
+    for (const listener of [...this.#listeners]) listener();
+  }
+
+  refresh(targetId: string): void {
+    this.#assertTarget(targetId);
+    this.#supersedePendingReads();
+    this.#snapshot = null;
+    this.#refreshRequested = true;
+  }
+
+  async load(targetId: string): Promise<ChatExecutionSnapshot> {
+    this.#assertTarget(targetId);
+    if (this.#snapshot !== null) return this.#snapshot;
+    const authoritySequence = this.#authoritySequence;
+    const readSequence = ++this.#readSequence;
+    const loadUrl = this.#refreshRequested
+      ? `${this.#loadUrl}${this.#loadUrl.includes("?") ? "&" : "?"}refresh_execution=1`
+      : this.#loadUrl;
+    const promise = (async (): Promise<ChatExecutionSnapshot> => {
+      const response = await this.#fetcher()(loadUrl, {
+        headers: { Accept: "application/json" },
+      });
+      const payload = await this.#json(response);
+      if (!response.ok) {
+        throw new Error(
+          errorMessage(
+            payload,
+            "Provider and model choices could not be loaded.",
+          ),
+        );
+      }
+      const envelope = normalizeChatExecutionEnvelope(payload);
+      if (
+        authoritySequence === this.#authoritySequence &&
+        this.#latestRead?.sequence === readSequence
+      ) {
+        const snapshot = this.#adopt(envelope);
+        this.#refreshRequested = false;
+        return snapshot;
+      }
+
+      if (this.#snapshot !== null) return this.#snapshot;
+      const latestRead = this.#latestRead;
+      if (
+        latestRead !== null &&
+        latestRead.sequence !== readSequence
+      ) {
+        return latestRead.promise;
+      }
+
+      // An invalidation or refresh can fence the only in-flight read before
+      // its replacement is issued. Start that replacement here instead of
+      // leaking the superseded projection to the caller.
+      if (this.#latestRead?.sequence === readSequence) {
+        this.#latestRead = null;
+      }
+      return this.load(targetId);
+    })();
+    this.#latestRead = { sequence: readSequence, promise };
+    try {
+      return await promise;
+    } finally {
+      if (this.#latestRead?.sequence === readSequence) {
+        this.#latestRead = null;
+      }
+    }
+  }
+
+  async select(
+    targetId: string,
+    selection: ChatExecutionSelectionInput,
+  ): Promise<ChatExecutionSnapshot> {
+    this.#assertTarget(targetId);
+    const response = await this.#fetcher()(this.#selectUrl, {
+      method: "PATCH",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        provider_id: selection.providerId,
+        model_id: selection.modelId,
+        expected_revision: selection.expectedRevision,
+      }),
+    });
+    const payload = await this.#json(response);
+    if (response.status === 409) {
+      let authoritative: ChatExecutionSnapshot | undefined;
+      try {
+        const envelope = normalizeChatExecutionEnvelope(payload);
+        this.#supersedePendingReads();
+        authoritative = this.#adopt(envelope);
+      } catch {
+        this.#supersedePendingReads();
+        this.#snapshot = null;
+        try {
+          authoritative = await this.load(targetId);
+        } catch {
+          authoritative = undefined;
+        }
+      }
+      throw new ChatExecutionSelectionError(
+        errorMessage(
+          payload,
+          "The model selection changed elsewhere. The latest selection is shown.",
+        ),
+        authoritative,
+      );
+    }
+    if (!response.ok) {
+      throw new ChatExecutionSelectionError(
+        errorMessage(payload, "The model selection could not be changed."),
+      );
+    }
+    const envelope = normalizeChatExecutionEnvelope(payload);
+    this.#supersedePendingReads();
+    return this.#adopt(envelope);
+  }
+
+  subscribe(
+    targetId: string,
+    onInvalidate: ChatInvalidationListener,
+  ): ChatUnsubscribe {
+    this.#assertTarget(targetId);
+    this.#listeners.add(onInvalidate);
+    return () => this.#listeners.delete(onInvalidate);
+  }
+}
+
+export function createHttpChatExecutionProfileProvider(
+  config: HttpChatExecutionProfileConfig,
+): HttpChatExecutionProfileProvider {
+  return new HttpChatExecutionProfileProvider(config);
+}

--- a/dashboard-react/src/dashboard/conversations/index.ts
+++ b/dashboard-react/src/dashboard/conversations/index.ts
@@ -3,3 +3,11 @@ export {
   createHttpChatProvider,
   type HttpChatConfig,
 } from "./HttpChatConversationProvider";
+export {
+  HttpChatExecutionProfileProvider,
+  createHttpChatExecutionProfileProvider,
+  normalizeChatExecutionEnvelope,
+  normalizeChatExecutionSnapshot,
+  type HttpChatExecutionEnvelope,
+  type HttpChatExecutionProfileConfig,
+} from "./HttpChatExecutionProfileProvider";

--- a/dashboard-react/src/widget-library/chat/ChatComposer.test.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatComposer.test.tsx
@@ -4,6 +4,34 @@ import { describe, expect, it, vi } from "vitest";
 
 import { expectNoAccessibilityViolations } from "../../test/setup";
 import { ChatComposer } from "./ChatComposer";
+import type { ChatExecutionControl } from "./useChatExecutionProfile";
+
+const changingExecution = (): ChatExecutionControl => ({
+  snapshot: {
+    selection: {
+      providerId: "claude-code",
+      modelId: "sonnet",
+      providerLabel: "Claude Code",
+      modelLabel: "Sonnet",
+      revision: "execution:1",
+    },
+    providers: [
+      {
+        id: "claude-code",
+        label: "Claude Code",
+        available: true,
+        models: [{ id: "sonnet", label: "Sonnet", available: true }],
+      },
+    ],
+  },
+  status: "ready",
+  selecting: true,
+  error: null,
+  announcement: null,
+  currentAvailable: true,
+  select: vi.fn(async () => {}),
+  retry: vi.fn(),
+});
 
 describe("ChatComposer", () => {
   it("enables Send only with content and submits the trimmed value", async () => {
@@ -77,6 +105,47 @@ describe("ChatComposer", () => {
     render(<ChatComposer onSend={vi.fn()} sending />);
     expect(screen.getByText("Sending message")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Sending message/ })).toBeDisabled();
+  });
+
+  it("retains a draft and blocks Enter while the execution pair is changing", async () => {
+    const onSend = vi.fn();
+    render(
+      <ChatComposer
+        onSend={onSend}
+        execution={changingExecution()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Message" });
+
+    await userEvent.type(input, "keep this draft{Enter}");
+
+    expect(input).toHaveValue("keep this draft");
+    expect(onSend).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+  });
+
+  it("still delivers to a running conversation when catalog probing is unavailable", async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ChatComposer
+        onSend={onSend}
+        execution={{
+          ...changingExecution(),
+          status: "error",
+          selecting: false,
+          currentAvailable: false,
+        }}
+      />,
+    );
+
+    await userEvent.type(
+      screen.getByRole("textbox", { name: "Message" }),
+      "keep the durable turn{Enter}",
+    );
+
+    await waitFor(() =>
+      expect(onSend).toHaveBeenCalledWith("keep the durable turn"),
+    );
   });
 
   it("surfaces the inline send error and stays accessible", async () => {

--- a/dashboard-react/src/widget-library/chat/ChatComposer.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatComposer.tsx
@@ -7,6 +7,8 @@ import {
 import { TextArea, TextField } from "react-aria-components";
 
 import { Button, InlineAlert, Spinner } from "../../ui";
+import { ChatExecutionPicker } from "./ChatExecutionPicker";
+import type { ChatExecutionControl } from "./useChatExecutionProfile";
 import "./styles.css";
 
 /** Cap the auto-grown textarea height so a long draft scrolls within itself. */
@@ -35,6 +37,8 @@ export interface ChatComposerProps {
    * an unsaved-work guard. The composer still owns the text state.
    */
   onDraftChange?(value: string): void;
+  /** Optional server-authoritative provider/model selection for this chat. */
+  readonly execution?: ChatExecutionControl;
 }
 
 export function ChatComposer({
@@ -46,12 +50,21 @@ export function ChatComposer({
   errorMessage,
   initialValue = "",
   onDraftChange,
+  execution,
 }: ChatComposerProps) {
   const [draft, setDraft] = useState(initialValue);
   const [busy, setBusy] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const isSending = sending || busy;
-  const canSend = !disabled && !isSending && draft.trim().length > 0;
+  const effectiveDisabled =
+    disabled || execution?.snapshot?.readOnly === true;
+  const executionBlocksSend =
+    execution?.selecting === true;
+  const canSend =
+    !effectiveDisabled &&
+    !isSending &&
+    !executionBlocksSend &&
+    draft.trim().length > 0;
 
   const grow = (element: HTMLTextAreaElement | null) => {
     if (element === null) return;
@@ -62,7 +75,14 @@ export function ChatComposer({
 
   const submit = async () => {
     const value = draft.trim();
-    if (value.length === 0 || disabled || isSending) return;
+    if (
+      value.length === 0 ||
+      effectiveDisabled ||
+      isSending ||
+      executionBlocksSend
+    ) {
+      return;
+    }
     setBusy(true);
     try {
       await onSend(value);
@@ -102,12 +122,12 @@ export function ChatComposer({
           {errorMessage}
         </InlineAlert>
       ) : null}
-      <div className="wb-chat-composer__row">
+      <div className="wb-chat-composer__shell">
         <TextField
           className="wb-chat-composer__field"
           aria-label={label}
           value={draft}
-          isDisabled={disabled}
+          isDisabled={effectiveDisabled}
           onChange={(value) => {
             setDraft(value);
             onDraftChange?.(value);
@@ -122,14 +142,24 @@ export function ChatComposer({
             onKeyDown={handleKeyDown}
           />
         </TextField>
-        <Button
-          type="submit"
-          variant="primary"
-          className="wb-chat-composer__send"
-          disabled={!canSend}
-        >
-          {isSending ? <Spinner label="Sending message" /> : "Send"}
-        </Button>
+        <div className="wb-chat-composer__footer">
+          {execution === undefined ? (
+            <span className="wb-chat-composer__footer-spacer" />
+          ) : (
+            <ChatExecutionPicker
+              control={execution}
+              disabled={effectiveDisabled || isSending}
+            />
+          )}
+          <Button
+            type="submit"
+            variant="primary"
+            className="wb-chat-composer__send"
+            disabled={!canSend}
+          >
+            {isSending ? <Spinner label="Sending message" /> : "Send"}
+          </Button>
+        </div>
       </div>
     </form>
   );

--- a/dashboard-react/src/widget-library/chat/ChatExecutionPicker.test.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatExecutionPicker.test.tsx
@@ -1,0 +1,248 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { expectNoAccessibilityViolations } from "../../test/setup";
+import { ChatExecutionPicker } from "./ChatExecutionPicker";
+import type { ChatExecutionSnapshot } from "./contracts";
+import type { ChatExecutionControl } from "./useChatExecutionProfile";
+
+const SNAPSHOT: ChatExecutionSnapshot = {
+  selection: {
+    providerId: "claude-code",
+    modelId: "sonnet",
+    providerLabel: "Claude Code",
+    modelLabel: "Sonnet",
+    revision: "execution:7",
+  },
+  providers: [
+    {
+      id: "claude-code",
+      label: "Claude Code",
+      available: true,
+      authMode: "subscription",
+      description: "Uses your signed-in Claude account.",
+      models: [
+        {
+          id: "sonnet",
+          label: "Sonnet",
+          available: true,
+          description: "Balanced speed and capability",
+        },
+      ],
+    },
+    {
+      id: "codex",
+      label: "Codex",
+      available: true,
+      authMode: "chatgpt",
+      models: [
+        {
+          id: "gpt-5.6",
+          label: "GPT-5.6",
+          available: true,
+          description: "Most capable",
+        },
+        {
+          id: "gpt-retired",
+          label: "Retired model",
+          available: false,
+          unavailableReason: "No longer offered by Codex",
+        },
+      ],
+    },
+  ],
+};
+
+const control = (
+  overrides: Partial<ChatExecutionControl> = {},
+): ChatExecutionControl => ({
+  snapshot: SNAPSHOT,
+  status: "ready",
+  selecting: false,
+  error: null,
+  announcement: null,
+  currentAvailable: true,
+  select: vi.fn(async () => {}),
+  retry: vi.fn(),
+  ...overrides,
+});
+
+describe("ChatExecutionPicker", () => {
+  it("selects one provider/model pair atomically from grouped choices", async () => {
+    const execution = control();
+    const { container } = render(
+      <ChatExecutionPicker control={execution} />,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "Run with Claude Code · Sonnet",
+    });
+    expect(trigger).toBeVisible();
+    await userEvent.click(trigger);
+
+    expect(screen.getByText("Claude Code")).toBeVisible();
+    expect(screen.getByText("Codex")).toBeVisible();
+    expect(
+      screen.getByText("Uses your signed-in Claude account."),
+    ).toBeVisible();
+    const unavailable = screen.getByRole("option", {
+      name: /Codex, Retired model, No longer offered by Codex/,
+    });
+    expect(unavailable).toHaveAttribute("aria-disabled", "true");
+
+    await userEvent.click(
+      screen.getByRole("option", {
+        name: "Codex, GPT-5.6, Most capable",
+      }),
+    );
+    expect(execution.select).toHaveBeenCalledWith("codex", "gpt-5.6");
+    await expectNoAccessibilityViolations(container);
+  });
+
+  it("renders truthful noninteractive metadata in a read-only chat", () => {
+    render(<ChatExecutionPicker control={control()} readOnly />);
+
+    expect(
+      screen.getByLabelText("Run with Claude Code · Sonnet"),
+    ).toHaveTextContent("Run withClaude Code · Sonnet");
+    expect(
+      screen.queryByRole("button", { name: /Run with/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("honors server read-only state without a misleading dropdown", () => {
+    render(
+      <ChatExecutionPicker
+        control={control({
+          snapshot: { ...SNAPSHOT, readOnly: true },
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByLabelText("Run with Claude Code · Sonnet"),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: /Run with/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps a failed load recoverable", async () => {
+    const retry = vi.fn();
+    render(
+      <ChatExecutionPicker
+        control={control({
+          snapshot: null,
+          status: "error",
+          currentAvailable: false,
+          error: "Models could not be reached.",
+          retry,
+        })}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Models could not be reached.",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(retry).toHaveBeenCalledOnce();
+  });
+
+  it("confirms a host-declared active-agent consequence before switching", async () => {
+    const execution = control({
+      confirmSelection: ({ providerLabel, modelLabel }) => ({
+        title: `Switch to ${providerLabel} · ${modelLabel}?`,
+        description:
+          "This restarts the assistant with the new model. Your messages and draft stay here.",
+        confirmLabel: "Switch",
+      }),
+    });
+    render(<ChatExecutionPicker control={execution} />);
+    const trigger = screen.getByRole("button", {
+      name: "Run with Claude Code · Sonnet",
+    });
+
+    await userEvent.click(trigger);
+    await userEvent.click(
+      screen.getByRole("option", {
+        name: "Codex, GPT-5.6, Most capable",
+      }),
+    );
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Switch to Codex · GPT-5.6?",
+    });
+    expect(dialog).toHaveTextContent(
+      "This restarts the assistant with the new model. Your messages and draft stay here.",
+    );
+    expect(execution.select).not.toHaveBeenCalled();
+    await expectNoAccessibilityViolations(dialog);
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(trigger).toHaveFocus());
+    expect(execution.select).not.toHaveBeenCalled();
+
+    await userEvent.click(trigger);
+    await userEvent.click(
+      screen.getByRole("option", {
+        name: "Codex, GPT-5.6, Most capable",
+      }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Switch" }));
+    expect(execution.select).toHaveBeenCalledWith("codex", "gpt-5.6");
+  });
+
+  it("explains an unavailable current selection and offers a refresh", async () => {
+    const retry = vi.fn();
+    const unavailable: ChatExecutionSnapshot = {
+      ...SNAPSHOT,
+      selection: {
+        providerId: "codex",
+        modelId: "gpt-5.6",
+        providerLabel: "Codex",
+        modelLabel: "GPT-5.6",
+        revision: "execution:8",
+      },
+      providers: SNAPSHOT.providers.map((provider) =>
+        provider.id === "codex"
+          ? {
+              ...provider,
+              available: false,
+              unavailableReason: "Sign in to Codex with ChatGPT",
+            }
+          : provider,
+      ),
+    };
+    const { rerender } = render(
+      <ChatExecutionPicker
+        control={control({
+          snapshot: unavailable,
+          currentAvailable: false,
+          retry,
+        })}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Unavailable: Sign in to Codex with ChatGPT",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Check again" }));
+    expect(retry).toHaveBeenCalledOnce();
+
+    rerender(
+      <ChatExecutionPicker
+        readOnly
+        control={control({
+          snapshot: unavailable,
+          currentAvailable: false,
+          retry,
+        })}
+      />,
+    );
+    expect(screen.getByText(/Unavailable: Sign in to Codex/)).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "Check again" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/dashboard-react/src/widget-library/chat/ChatExecutionPicker.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatExecutionPicker.tsx
@@ -1,0 +1,421 @@
+import { CaretDown } from "@phosphor-icons/react/CaretDown";
+import { Check } from "@phosphor-icons/react/Check";
+import { useId, useRef, useState } from "react";
+import {
+  Button as AriaButton,
+  Dialog,
+  Header,
+  Heading,
+  Label,
+  ListBox,
+  ListBoxItem,
+  ListBoxSection,
+  Modal,
+  ModalOverlay,
+  Popover,
+  Select,
+  type Key,
+} from "react-aria-components";
+
+import { Button, InlineAlert, Spinner } from "../../ui";
+import type {
+  ChatExecutionModelOption,
+  ChatExecutionProviderOption,
+} from "./contracts";
+import type {
+  ChatExecutionControl,
+  ChatExecutionSwitchConfirmation,
+} from "./useChatExecutionProfile";
+import "./styles.css";
+
+export interface ChatExecutionPickerProps {
+  readonly control: ChatExecutionControl;
+  /** Host-level lock, e.g. while one response is being generated. */
+  readonly disabled?: boolean;
+  /** Render truthful current metadata without an interactive listbox. */
+  readonly readOnly?: boolean;
+  readonly className?: string;
+}
+
+interface ExecutionChoice {
+  readonly provider: ChatExecutionProviderOption;
+  readonly model: ChatExecutionModelOption;
+}
+
+const choiceKey = (providerId: string, modelId: string): string =>
+  JSON.stringify([providerId, modelId]);
+
+const selectedLabel = (control: ChatExecutionControl): string => {
+  const selection = control.snapshot?.selection;
+  if (selection === undefined) {
+    return control.status === "loading"
+      ? "Checking models…"
+      : "Models unavailable";
+  }
+  return `${selection.providerLabel} · ${selection.modelLabel}`;
+};
+
+function unavailableText(
+  provider: ChatExecutionProviderOption,
+  model: ChatExecutionModelOption,
+): string | undefined {
+  if (!provider.available) {
+    return provider.unavailableReason ?? "Provider unavailable";
+  }
+  if (!model.available) {
+    return model.unavailableReason ?? "Model unavailable";
+  }
+  return undefined;
+}
+
+function currentUnavailableText(
+  control: ChatExecutionControl,
+): string | undefined {
+  const snapshot = control.snapshot;
+  if (snapshot === null || control.currentAvailable) return undefined;
+  const provider = snapshot.providers.find(
+    (candidate) => candidate.id === snapshot.selection.providerId,
+  );
+  if (provider === undefined) {
+    return "The selected provider is no longer available.";
+  }
+  if (!provider.available) {
+    return provider.unavailableReason ?? "The selected provider is unavailable.";
+  }
+  const model = provider.models.find(
+    (candidate) => candidate.id === snapshot.selection.modelId,
+  );
+  if (model === undefined) {
+    return "The selected model is no longer available.";
+  }
+  return model.unavailableReason ?? "The selected model is unavailable.";
+}
+
+export function ChatExecutionPicker({
+  control,
+  disabled = false,
+  readOnly = false,
+  className = "",
+}: ChatExecutionPickerProps) {
+  const messageId = useId();
+  const unavailableId = useId();
+  const confirmationTitleId = useId();
+  const confirmationDescriptionId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [pendingChoice, setPendingChoice] = useState<ExecutionChoice | null>(
+    null,
+  );
+  const [confirmation, setConfirmation] =
+    useState<ChatExecutionSwitchConfirmation | null>(null);
+  const snapshot = control.snapshot;
+  const display = selectedLabel(control);
+  const currentUnavailable = currentUnavailableText(control);
+
+  if (snapshot === null) {
+    return (
+      <div
+        className={`wb-chat-execution wb-chat-execution--unavailable ${className}`.trim()}
+        aria-label="Run chat with"
+      >
+        <span className="wb-chat-execution__label">Run with</span>
+        <Button
+          variant="secondary"
+          size="small"
+          disabled
+          className="wb-chat-execution__fallback-trigger"
+        >
+          {control.status === "loading" ? (
+            <Spinner label="Checking available models" />
+          ) : (
+            display
+          )}
+        </Button>
+        {control.status === "error" ? (
+          <InlineAlert
+            tone="danger"
+            role="alert"
+            className="wb-chat-execution__message"
+          >
+            <span>{control.error ?? "Models could not be loaded."}</span>
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={control.retry}
+              disabled={disabled}
+            >
+              Try again
+            </Button>
+          </InlineAlert>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (readOnly || snapshot.readOnly === true) {
+    return (
+      <div
+        className={`wb-chat-execution wb-chat-execution--metadata ${className}`.trim()}
+        aria-label={`Run with ${display}`}
+      >
+        <span className="wb-chat-execution__label">Run with</span>
+        <span className="wb-chat-execution__metadata-value">{display}</span>
+        {currentUnavailable === undefined ? null : (
+          <span className="wb-chat-execution__metadata-unavailable">
+            Unavailable: {currentUnavailable}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  const choices = new Map<string, ExecutionChoice>();
+  for (const provider of snapshot.providers) {
+    for (const model of provider.models) {
+      choices.set(choiceKey(provider.id, model.id), {
+        provider,
+        model,
+      });
+    }
+  }
+  const selectedKey = choiceKey(
+    snapshot.selection.providerId,
+    snapshot.selection.modelId,
+  );
+  const pickerDisabled = disabled || control.selecting;
+  const returnFocus = (): void => {
+    window.requestAnimationFrame(() => triggerRef.current?.focus());
+  };
+  const closeConfirmation = (): void => {
+    setPendingChoice(null);
+    setConfirmation(null);
+    returnFocus();
+  };
+  const selectChoice = (choice: ExecutionChoice): void => {
+    const impact = control.confirmSelection?.({
+      providerId: choice.provider.id,
+      modelId: choice.model.id,
+      providerLabel: choice.provider.label,
+      modelLabel: choice.model.label,
+    });
+    if (impact !== undefined && impact !== null) {
+      setPendingChoice(choice);
+      setConfirmation(impact);
+      return;
+    }
+    void control.select(choice.provider.id, choice.model.id).catch(() => {});
+  };
+
+  return (
+    <div
+      className={`wb-chat-execution ${className}`.trim()}
+      data-selecting={control.selecting || undefined}
+    >
+      <Select
+        className="wb-chat-execution__select"
+        selectedKey={selectedKey}
+        isDisabled={pickerDisabled}
+        aria-describedby={[
+          control.error === null ? null : messageId,
+          currentUnavailable === undefined ? null : unavailableId,
+        ]
+          .filter((id): id is string => id !== null)
+          .join(" ") || undefined}
+        onSelectionChange={(key: Key | null) => {
+          if (key === null) return;
+          const choice = choices.get(String(key));
+          if (choice === undefined) return;
+          selectChoice(choice);
+        }}
+      >
+        <Label className="wb-visually-hidden">{`Run with ${display}`}</Label>
+        <AriaButton
+          ref={triggerRef}
+          className="wb-chat-execution__trigger"
+        >
+          <span className="wb-chat-execution__label" aria-hidden="true">
+            Run with
+          </span>
+          <span className="wb-chat-execution__value">{display}</span>
+          {control.selecting ? (
+            <Spinner label="Changing model" />
+          ) : (
+            <CaretDown weight="bold" aria-hidden="true" />
+          )}
+        </AriaButton>
+        <Popover
+          className="wb-popover wb-chat-execution__popover"
+          placement="top start"
+        >
+          <ListBox className="wb-listbox wb-chat-execution__listbox">
+            {snapshot.providers.map((provider) => (
+              <ListBoxSection
+                key={provider.id}
+                className="wb-chat-execution__section"
+              >
+                <Header className="wb-chat-execution__provider">
+                  <span>{provider.label}</span>
+                  {!provider.available ? (
+                    <small>
+                      {provider.unavailableReason ?? "Unavailable"}
+                    </small>
+                  ) : provider.description ? (
+                    <small>{provider.description}</small>
+                  ) : null}
+                </Header>
+                {provider.models.length === 0 ? (
+                  <ListBoxItem
+                    id={`provider-unavailable:${provider.id}`}
+                    textValue={`${provider.label}, no models available`}
+                    isDisabled
+                    className="wb-listbox__item"
+                  >
+                    <span className="wb-listbox__check" aria-hidden="true" />
+                    <span className="wb-listbox__copy">
+                      <span>No models available</span>
+                      <small>
+                        {provider.unavailableReason ??
+                          "This provider has no selectable models."}
+                      </small>
+                    </span>
+                  </ListBoxItem>
+                ) : (
+                  provider.models.map((model) => {
+                    const key = choiceKey(provider.id, model.id);
+                    const unavailable = unavailableText(provider, model);
+                    const accessibleDetail =
+                      unavailable ?? model.description;
+                    return (
+                      <ListBoxItem
+                        key={key}
+                        id={key}
+                        textValue={`${provider.label}, ${model.label}`}
+                        aria-label={`${provider.label}, ${model.label}${accessibleDetail ? `, ${accessibleDetail}` : ""}`}
+                        isDisabled={unavailable !== undefined}
+                        className="wb-listbox__item"
+                      >
+                        {({ isSelected }) => (
+                          <>
+                            <span
+                              className="wb-listbox__check"
+                              aria-hidden="true"
+                            >
+                              {isSelected ? <Check weight="bold" /> : null}
+                            </span>
+                            <span className="wb-listbox__copy">
+                              <span>{model.label}</span>
+                              {unavailable !== undefined ? (
+                                <small>{unavailable}</small>
+                              ) : model.description ? (
+                                <small>{model.description}</small>
+                              ) : null}
+                            </span>
+                          </>
+                        )}
+                      </ListBoxItem>
+                    );
+                  })
+                )}
+              </ListBoxSection>
+            ))}
+          </ListBox>
+        </Popover>
+      </Select>
+      {currentUnavailable === undefined ? null : (
+        <div
+          id={unavailableId}
+          className="wb-chat-execution__availability"
+          role="status"
+        >
+          <span>
+            <strong>Unavailable:</strong> {currentUnavailable}
+          </span>
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={control.retry}
+            disabled={disabled || control.selecting}
+          >
+            Check again
+          </Button>
+        </div>
+      )}
+      {control.error !== null ? (
+        <InlineAlert
+          id={messageId}
+          tone="danger"
+          role="alert"
+          className="wb-chat-execution__message"
+        >
+          {control.error}
+        </InlineAlert>
+      ) : null}
+      {control.announcement !== null ? (
+        <span
+          className="wb-visually-hidden"
+          role="status"
+          aria-live="polite"
+        >
+          {control.announcement}
+        </span>
+      ) : null}
+      {pendingChoice !== null && confirmation !== null ? (
+        <ModalOverlay
+          className="wb-confirmation-overlay"
+          isOpen
+          isDismissable={!control.selecting}
+          onOpenChange={(open) => {
+            if (!open && !control.selecting) closeConfirmation();
+          }}
+        >
+          <Modal className="wb-confirmation-modal">
+            <Dialog
+              className="wb-confirmation-dialog"
+              aria-labelledby={confirmationTitleId}
+              aria-describedby={confirmationDescriptionId}
+            >
+              <Heading
+                id={confirmationTitleId}
+                slot="title"
+                className="wb-confirmation-dialog__title"
+              >
+                {confirmation.title}
+              </Heading>
+              <p
+                id={confirmationDescriptionId}
+                className="wb-confirmation-dialog__description"
+              >
+                {confirmation.description}
+              </p>
+              <div className="wb-confirmation-dialog__actions">
+                <Button
+                  onClick={closeConfirmation}
+                  disabled={control.selecting}
+                >
+                  {confirmation.cancelLabel ?? "Cancel"}
+                </Button>
+                <Button
+                  variant="primary"
+                  disabled={disabled || control.selecting}
+                  onClick={() => {
+                    if (disabled || control.selecting) return;
+                    const choice = pendingChoice;
+                    setPendingChoice(null);
+                    setConfirmation(null);
+                    returnFocus();
+                    void control
+                      .select(choice.provider.id, choice.model.id)
+                      .catch(() => {});
+                  }}
+                >
+                  {confirmation.confirmLabel}
+                </Button>
+              </div>
+            </Dialog>
+          </Modal>
+        </ModalOverlay>
+      ) : null}
+    </div>
+  );
+}
+
+export default ChatExecutionPicker;

--- a/dashboard-react/src/widget-library/chat/ChatMessageList.test.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatMessageList.test.tsx
@@ -57,6 +57,30 @@ describe("ChatMessageList", () => {
     expect(screen.getByText("Nothing yet.")).toBeInTheDocument();
   });
 
+  it("shows immutable producer metadata beside an assistant turn", () => {
+    render(
+      <ChatMessageList
+        messages={[
+          {
+            id: "m1",
+            author: "assistant",
+            content: "Generated reply",
+            producer: {
+              providerId: "codex",
+              modelId: "gpt-5.6",
+              providerLabel: "Codex",
+              modelLabel: "GPT-5.6",
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByLabelText("Produced by Codex, GPT-5.6"),
+    ).toHaveTextContent("Codex · GPT-5.6");
+  });
+
   it("autoscrolls to the newest message while pinned to the bottom", () => {
     const initial = [msg("m1", "one", "assistant")];
     const { rerender } = render(<ChatMessageList messages={initial} />);

--- a/dashboard-react/src/widget-library/chat/ChatMessageList.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatMessageList.tsx
@@ -237,9 +237,25 @@ export function ChatMessageList({
                   {renderMessageAccessory?.(message)}
                   {renderAffordances(message)}
                 </div>
-                {message.createdAt !== undefined ? (
-                  <span className="wb-chat-msg__time">
-                    {formatTime(message.createdAt)}
+                {message.createdAt !== undefined ||
+                (message.author === "assistant" &&
+                  message.producer !== undefined) ? (
+                  <span className="wb-chat-msg__meta">
+                    {message.createdAt !== undefined ? (
+                      <span className="wb-chat-msg__time">
+                        {formatTime(message.createdAt)}
+                      </span>
+                    ) : null}
+                    {message.author === "assistant" &&
+                    message.producer !== undefined ? (
+                      <span
+                        className="wb-chat-msg__producer"
+                        aria-label={`Produced by ${message.producer.providerLabel}, ${message.producer.modelLabel}`}
+                      >
+                        {message.producer.providerLabel} ·{" "}
+                        {message.producer.modelLabel}
+                      </span>
+                    ) : null}
                   </span>
                 ) : null}
               </div>

--- a/dashboard-react/src/widget-library/chat/ChatPanel.test.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatPanel.test.tsx
@@ -10,6 +10,7 @@ import {
   type ChatPanelProps,
 } from "./ChatPanel";
 import type { ChatMessage } from "./contracts";
+import type { ChatExecutionControl } from "./useChatExecutionProfile";
 
 const messages: ChatMessage[] = [
   { id: "m1", author: "user", content: "Hi" },
@@ -23,6 +24,36 @@ const pendingQuestion: ChatMessage = {
   pending: true,
   question: { responseType: "boolean" },
 };
+
+const executionControl = (
+  overrides: Partial<ChatExecutionControl> = {},
+): ChatExecutionControl => ({
+  snapshot: {
+    selection: {
+      providerId: "claude-code",
+      modelId: "sonnet",
+      providerLabel: "Claude Code",
+      modelLabel: "Sonnet",
+      revision: "execution:1",
+    },
+    providers: [
+      {
+        id: "claude-code",
+        label: "Claude Code",
+        available: true,
+        models: [{ id: "sonnet", label: "Sonnet", available: true }],
+      },
+    ],
+  },
+  status: "ready",
+  selecting: false,
+  error: null,
+  announcement: null,
+  currentAvailable: true,
+  select: vi.fn(async () => {}),
+  retry: vi.fn(),
+  ...overrides,
+});
 
 describe("ChatPanel", () => {
   it("renders the title header, transcript, and composer when ready", () => {
@@ -96,6 +127,27 @@ describe("ChatPanel", () => {
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 
+  it("does not couple a generic transcript retry to model discovery", async () => {
+    const onRetry = vi.fn();
+    render(
+      <ChatPanel
+        status="error"
+        messages={[]}
+        onRetry={onRetry}
+        execution={executionControl({
+          status: "error",
+          currentAvailable: false,
+          error: "Model discovery is offline.",
+        })}
+      />,
+    );
+
+    const retry = screen.getByRole("button", { name: "Retry" });
+    expect(retry).toBeEnabled();
+    await userEvent.click(retry);
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
   it("offers one reusable pre-conversation state and action", async () => {
     const onStart = vi.fn();
     render(
@@ -115,6 +167,54 @@ describe("ChatPanel", () => {
     expect(onStart).toHaveBeenCalledOnce();
   });
 
+  it("lets a host opt a launch action into execution availability", () => {
+    render(
+      <ChatPanelState
+        kind="empty"
+        title="Chat hasn’t started."
+        action={{
+          label: "Start chat",
+          onAction: vi.fn(),
+          requiresExecution: true,
+        }}
+        execution={executionControl({
+          status: "error",
+          currentAvailable: false,
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Start chat" }),
+    ).toBeDisabled();
+  });
+
+  it("disables an execution-required action for a server read-only profile", () => {
+    const execution = executionControl();
+    render(
+      <ChatPanelState
+        kind="empty"
+        title="Chat hasn’t started."
+        action={{
+          label: "Start chat",
+          onAction: vi.fn(),
+          requiresExecution: true,
+        }}
+        execution={{
+          ...execution,
+          snapshot: {
+            ...execution.snapshot!,
+            readOnly: true,
+          },
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Start chat" }),
+    ).toBeDisabled();
+  });
+
   it("keeps the transcript readable but replaces the composer when read-only", () => {
     render(
       <ChatPanel
@@ -128,6 +228,28 @@ describe("ChatPanel", () => {
     expect(screen.getByRole("log", { name: "Archived" })).toBeInTheDocument();
     expect(screen.getByText("This conversation is closed.")).toBeInTheDocument();
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("honors server-authoritative execution read-only state", () => {
+    render(
+      <ChatPanel
+        title="Archived"
+        messages={messages}
+        onSend={vi.fn()}
+        execution={executionControl({
+          snapshot: {
+            ...executionControl().snapshot!,
+            readOnly: true,
+          },
+        })}
+      />,
+    );
+
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.getByText(/Read-only:/)).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: /Run with/ }),
+    ).not.toBeInTheDocument();
   });
 
   it("wires the composer send intent", async () => {
@@ -286,10 +408,16 @@ describe("ChatPanel", () => {
             pending: true,
           },
         }}
+        execution={executionControl()}
       />,
     );
     expect(
       screen.getByRole("button", { name: "Restarting…" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Run with Claude Code · Sonnet",
+      }),
     ).toBeDisabled();
   });
 

--- a/dashboard-react/src/widget-library/chat/ChatPanel.tsx
+++ b/dashboard-react/src/widget-library/chat/ChatPanel.tsx
@@ -6,12 +6,14 @@ import {
   type InlineAlertTone,
 } from "../../ui";
 import { ChatComposer } from "./ChatComposer";
+import { ChatExecutionPicker } from "./ChatExecutionPicker";
 import { ChatMessageList } from "./ChatMessageList";
 import type {
   ChatAgentActivity,
   ChatMessage,
   ChatPanelStatus,
 } from "./contracts";
+import type { ChatExecutionControl } from "./useChatExecutionProfile";
 import "./styles.css";
 
 /**
@@ -22,6 +24,8 @@ export interface ChatInputRecoveryAction {
   readonly label: string;
   readonly onAction: () => void;
   readonly pending?: boolean;
+  /** Opt in when this host action launches or replaces the selected runtime. */
+  readonly requiresExecution?: boolean;
 }
 
 export interface ChatInputRecovery {
@@ -41,6 +45,8 @@ export interface ChatPanelStateProps {
   readonly detail?: ReactNode;
   readonly action?: ChatInputRecoveryAction;
   readonly header?: ReactNode;
+  readonly execution?: ChatExecutionControl;
+  readonly executionDisabled?: boolean;
 }
 
 /**
@@ -55,25 +61,44 @@ export function ChatPanelState({
   detail,
   action,
   header,
+  execution,
+  executionDisabled = false,
 }: ChatPanelStateProps) {
   return (
     <section className="wb-chat-panel" aria-label={label}>
       {header}
-      <div
-        className="wb-chat-state"
-        role={kind === "error" ? "alert" : "status"}
-      >
-        {kind === "loading" ? (
-          <span className="wb-spinner" aria-hidden="true" />
-        ) : null}
-        <h3 className="wb-chat-state__title">{title}</h3>
-        {detail === undefined ? null : <p>{detail}</p>}
+      <div className="wb-chat-state">
+        <div
+          className="wb-chat-state__copy"
+          role={kind === "error" ? "alert" : "status"}
+        >
+          {kind === "loading" ? (
+            <span className="wb-spinner" aria-hidden="true" />
+          ) : null}
+          <h3 className="wb-chat-state__title">{title}</h3>
+          {detail === undefined ? null : <p>{detail}</p>}
+        </div>
+        {execution === undefined ? null : (
+          <ChatExecutionPicker
+            control={execution}
+            disabled={executionDisabled}
+            className="wb-chat-state__execution"
+          />
+        )}
         {action === undefined ? null : (
           <Button
             variant="secondary"
             className="wb-chat-state__action"
             onClick={action.onAction}
-            disabled={action.pending === true}
+            disabled={
+              action.pending === true ||
+              (action.requiresExecution === true &&
+                execution !== undefined &&
+                (execution.status !== "ready" ||
+                  execution.selecting ||
+                  !execution.currentAvailable ||
+                  execution.snapshot?.readOnly === true))
+            }
           >
             {action.label}
           </Button>
@@ -131,6 +156,8 @@ export interface ChatPanelProps {
   readonly onReachLatest?: () => void;
   /** Empty-transcript copy inside a ready conversation. */
   readonly noMessagesLabel?: string;
+  /** Server-authoritative provider/model selection for the next agent turn. */
+  readonly execution?: ChatExecutionControl;
 }
 
 interface StateCopy {
@@ -176,15 +203,18 @@ export function ChatPanel({
   initialUnreadFromMessageId,
   onReachLatest,
   noMessagesLabel,
+  execution,
 }: ChatPanelProps) {
   const label = title ?? "Conversation";
-  const readOnly = status === "read-only";
+  const readOnly =
+    status === "read-only" || execution?.snapshot?.readOnly === true;
   const structuredResponsesDisabled =
     responsesDisabled ||
     readOnly ||
     agentActivity === "stopped" ||
     inputRecovery !== undefined ||
     composerDisabled ||
+    execution?.selecting === true ||
     sending;
 
   const renderHeader = () => {
@@ -234,33 +264,57 @@ export function ChatPanel({
       <>
         {renderTranscript()}
         {readOnly ? (
-          <InlineAlert
-            tone="info"
-            role="status"
-            className="wb-chat-panel__read-only"
-          >
-            <strong>Read-only:</strong>{" "}
-            {readOnlyReason ?? "Replies are currently disabled."}
-          </InlineAlert>
+          <div className="wb-chat-panel__input-region">
+            {execution === undefined ? null : (
+              <ChatExecutionPicker control={execution} readOnly />
+            )}
+            <InlineAlert
+              tone="info"
+              role="status"
+              className="wb-chat-panel__read-only"
+            >
+              <strong>Read-only:</strong>{" "}
+              {readOnlyReason ?? "Replies are currently disabled."}
+            </InlineAlert>
+          </div>
         ) : inputRecovery !== undefined ? (
-          <InlineAlert
-            tone={inputRecovery.tone}
-            role="status"
-            className="wb-chat-panel__read-only"
-          >
-            <strong>{inputRecovery.title}</strong>{" "}
-            {inputRecovery.detail}
-            {inputRecovery.action !== undefined ? (
-              <Button
-                variant="secondary"
-                className="wb-chat-state__action"
-                onClick={inputRecovery.action.onAction}
-                disabled={inputRecovery.action.pending === true}
-              >
-                {inputRecovery.action.label}
-              </Button>
-            ) : null}
-          </InlineAlert>
+          <div className="wb-chat-panel__input-region">
+            {execution === undefined ? null : (
+              <ChatExecutionPicker
+                control={execution}
+                disabled={
+                  sending ||
+                  agentActivity === "thinking" ||
+                  inputRecovery.action?.pending === true
+                }
+              />
+            )}
+            <InlineAlert
+              tone={inputRecovery.tone}
+              role="status"
+              className="wb-chat-panel__read-only"
+            >
+              <strong>{inputRecovery.title}</strong>{" "}
+              {inputRecovery.detail}
+              {inputRecovery.action !== undefined ? (
+                <Button
+                  variant="secondary"
+                  className="wb-chat-state__action"
+                  onClick={inputRecovery.action.onAction}
+                  disabled={
+                    inputRecovery.action.pending === true ||
+                    (inputRecovery.action.requiresExecution === true &&
+                      execution !== undefined &&
+                      (execution.status !== "ready" ||
+                        execution.selecting ||
+                        !execution.currentAvailable))
+                  }
+                >
+                  {inputRecovery.action.label}
+                </Button>
+              ) : null}
+            </InlineAlert>
+          </div>
         ) : onSend !== undefined ? (
           <ChatComposer
             onSend={onSend}
@@ -270,8 +324,11 @@ export function ChatPanel({
             errorMessage={sendErrorMessage}
             initialValue={initialValue}
             onDraftChange={onDraftChange}
+            execution={execution}
           />
-        ) : null}
+        ) : execution === undefined ? null : (
+          <ChatExecutionPicker control={execution} />
+        )}
       </>
     );
   };
@@ -301,6 +358,8 @@ export function ChatPanel({
             : undefined
         }
         header={renderHeader()}
+        execution={execution}
+        executionDisabled={sending || agentActivity === "thinking"}
       />
     );
   }

--- a/dashboard-react/src/widget-library/chat/contracts.ts
+++ b/dashboard-react/src/widget-library/chat/contracts.ts
@@ -43,6 +43,20 @@ export interface ChatMessage {
   readonly pending?: boolean;
   /** Present when the message is a structured question, drives inline answers. */
   readonly question?: ChatQuestion;
+  /**
+   * Server-verified execution provenance for an assistant turn. This is
+   * recorded when the message is produced, so a later model switch does not
+   * rewrite the history shown beside an earlier reply.
+   */
+  readonly producer?: ChatMessageProducer;
+}
+
+/** Exact provider/model that produced one durable assistant message. */
+export interface ChatMessageProducer {
+  readonly providerId?: string;
+  readonly modelId?: string;
+  readonly providerLabel: string;
+  readonly modelLabel: string;
 }
 
 /** Whether the conversation still accepts input. */
@@ -103,6 +117,71 @@ export interface ChatConversationProvider {
   ): ChatUnsubscribe;
 }
 
+/** One selectable model advertised by an execution provider. */
+export interface ChatExecutionModelOption {
+  readonly id: string;
+  readonly label: string;
+  readonly available: boolean;
+  readonly description?: string;
+  readonly unavailableReason?: string;
+}
+
+/**
+ * An authentication and runtime route such as Claude Code or Codex. Direct API
+ * transports are deliberately separate provider entries.
+ */
+export interface ChatExecutionProviderOption {
+  readonly id: string;
+  readonly label: string;
+  readonly available: boolean;
+  readonly authMode?: string;
+  readonly description?: string;
+  readonly unavailableReason?: string;
+  readonly models: readonly ChatExecutionModelOption[];
+}
+
+/** The server-confirmed atomic provider/model pair for one execution target. */
+export interface ChatExecutionSelection {
+  readonly providerId: string;
+  readonly modelId: string;
+  readonly providerLabel: string;
+  readonly modelLabel: string;
+  readonly revision: string;
+}
+
+/** Atomic selection mutation with optimistic-concurrency protection. */
+export interface ChatExecutionSelectionInput {
+  readonly providerId: string;
+  readonly modelId: string;
+  readonly expectedRevision: string;
+}
+
+/** Point-in-time execution selection and the catalog it was validated against. */
+export interface ChatExecutionSnapshot {
+  readonly selection: ChatExecutionSelection;
+  readonly providers: readonly ChatExecutionProviderOption[];
+  /** A read-only target remains inspectable but cannot change its selection. */
+  readonly readOnly?: boolean;
+}
+
+/**
+ * Transport-neutral execution profile seam. It stays separate from the
+ * transcript provider so message delivery does not acquire model mechanics.
+ */
+export interface ChatExecutionProfileProvider {
+  load(targetId: string): Promise<ChatExecutionSnapshot>;
+  select(
+    targetId: string,
+    selection: ChatExecutionSelectionInput,
+  ): Promise<ChatExecutionSnapshot>;
+  /** Drop transport-side discovery caches before the next explicit reload. */
+  refresh?(targetId: string): void;
+  subscribe(
+    targetId: string,
+    onInvalidate: ChatInvalidationListener,
+  ): ChatUnsubscribe;
+}
+
 /**
  * Derived activity signal for the transcript. "thinking" shows the typing
  * indicator, "stopped" shows the agent-stopped notice, "idle" shows neither.
@@ -143,6 +222,14 @@ export interface RawChatMessage {
   readonly status?: string;
   readonly response_type?: string;
   readonly choices?: readonly RawChatChoice[];
+  readonly producer?: RawChatMessageProducer;
+}
+
+export interface RawChatMessageProducer {
+  readonly provider_id?: unknown;
+  readonly model_id?: unknown;
+  readonly provider_label?: unknown;
+  readonly model_label?: unknown;
 }
 
 export interface RawChatConversation {

--- a/dashboard-react/src/widget-library/chat/index.ts
+++ b/dashboard-react/src/widget-library/chat/index.ts
@@ -6,8 +6,15 @@ export type {
   ChatConversationProvider,
   ChatConversationSnapshot,
   ChatConversationStatus,
+  ChatExecutionModelOption,
+  ChatExecutionProfileProvider,
+  ChatExecutionProviderOption,
+  ChatExecutionSelection,
+  ChatExecutionSelectionInput,
+  ChatExecutionSnapshot,
   ChatInvalidationListener,
   ChatMessage,
+  ChatMessageProducer,
   ChatPanelStatus,
   ChatQuestion,
   ChatResponseType,
@@ -16,6 +23,7 @@ export type {
   RawChatConversation,
   RawChatConversationPayload,
   RawChatMessage,
+  RawChatMessageProducer,
 } from "./contracts";
 export {
   deriveAgentActivity,
@@ -34,6 +42,20 @@ export {
 } from "./useChatConversation";
 export { ChatMessageList, type ChatMessageListProps } from "./ChatMessageList";
 export { ChatComposer, type ChatComposerProps } from "./ChatComposer";
+export {
+  ChatExecutionPicker,
+  type ChatExecutionPickerProps,
+} from "./ChatExecutionPicker";
+export {
+  ChatExecutionSelectionError,
+  isCurrentExecutionAvailable,
+  useChatExecutionProfile,
+  type ChatExecutionConfirmSelection,
+  type ChatExecutionControl,
+  type ChatExecutionLoadStatus,
+  type ChatExecutionSelectionCandidate,
+  type ChatExecutionSwitchConfirmation,
+} from "./useChatExecutionProfile";
 export {
   ChatPanel,
   ChatPanelState,

--- a/dashboard-react/src/widget-library/chat/mapping.test.ts
+++ b/dashboard-react/src/widget-library/chat/mapping.test.ts
@@ -50,6 +50,12 @@ describe("normalizeConversationPayload", () => {
           message_id: "m-2",
           role: "agent",
           content: "Pick one",
+          producer: {
+            provider_id: "codex",
+            model_id: "gpt-5.6",
+            provider_label: "Codex",
+            model_label: "GPT-5.6",
+          },
           message_type: "question",
           status: "pending",
           response_type: "choice",
@@ -85,6 +91,12 @@ describe("normalizeConversationPayload", () => {
           { key: "a", label: "Option A" },
           { key: "b", label: "Option B" },
         ],
+      },
+      producer: {
+        providerId: "codex",
+        modelId: "gpt-5.6",
+        providerLabel: "Codex",
+        modelLabel: "GPT-5.6",
       },
     });
   });

--- a/dashboard-react/src/widget-library/chat/mapping.ts
+++ b/dashboard-react/src/widget-library/chat/mapping.ts
@@ -10,6 +10,7 @@ import type {
   ChatConversationSnapshot,
   ChatConversationStatus,
   ChatMessage,
+  ChatMessageProducer,
   ChatQuestion,
   ChatResponseType,
   RawChatConversationPayload,
@@ -45,6 +46,35 @@ function toResponseType(raw: string | undefined): ChatResponseType {
   return "freeform";
 }
 
+function optionalProducer(raw: RawChatMessage): ChatMessageProducer | undefined {
+  const producer = raw.producer;
+  if (producer === undefined || producer === null) return undefined;
+  const providerId =
+    typeof producer.provider_id === "string" && producer.provider_id.length > 0
+      ? producer.provider_id
+      : undefined;
+  const modelId =
+    typeof producer.model_id === "string" && producer.model_id.length > 0
+      ? producer.model_id
+      : undefined;
+  const providerLabel =
+    typeof producer.provider_label === "string" &&
+    producer.provider_label.length > 0
+      ? producer.provider_label
+      : providerId;
+  const modelLabel =
+    typeof producer.model_label === "string" && producer.model_label.length > 0
+      ? producer.model_label
+      : modelId;
+  if (providerLabel === undefined || modelLabel === undefined) return undefined;
+  return {
+    providerId,
+    modelId,
+    providerLabel,
+    modelLabel,
+  };
+}
+
 function toMessage(raw: RawChatMessage, index: number): ChatMessage {
   const pending = raw.status === "pending" && raw.message_type === "question";
   let question: ChatQuestion | undefined;
@@ -72,6 +102,7 @@ function toMessage(raw: RawChatMessage, index: number): ChatMessage {
     createdAt: raw.created_at,
     pending,
     question,
+    producer: optionalProducer(raw),
   };
 }
 

--- a/dashboard-react/src/widget-library/chat/styles.css
+++ b/dashboard-react/src/widget-library/chat/styles.css
@@ -108,11 +108,30 @@
     white-space: pre-wrap;
   }
 
-  .wb-chat-msg__time {
+  .wb-chat-msg__meta {
+    display: flex;
+    max-width: 100%;
+    flex-wrap: wrap;
+    gap: var(--wb-space-2);
     color: var(--wb-color-text-muted);
     font-family: var(--wb-font-mono);
     font-size: var(--wb-font-size-2xs);
+  }
+
+  .wb-chat-msg__time {
+    color: var(--wb-color-text-muted);
     font-variant-numeric: tabular-nums;
+  }
+
+  .wb-chat-msg__producer {
+    overflow: hidden;
+    max-width: 100%;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .wb-chat-msg__time + .wb-chat-msg__producer::before {
+    content: "· ";
   }
 
   .wb-chat-msg__choices {
@@ -217,12 +236,14 @@
     flex: 0 0 auto;
     flex-direction: column;
     gap: var(--wb-space-3);
+    container-type: inline-size;
   }
 
-  .wb-chat-composer__row {
+  .wb-chat-composer__shell {
     display: flex;
-    align-items: flex-end;
-    gap: var(--wb-space-4);
+    min-width: 0;
+    flex-direction: column;
+    gap: var(--wb-space-3);
   }
 
   .wb-chat-composer__field {
@@ -261,8 +282,190 @@
     flex: 0 0 auto;
   }
 
+  .wb-chat-composer__footer {
+    display: flex;
+    min-width: 0;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: var(--wb-space-3);
+  }
+
+  .wb-chat-composer__footer-spacer {
+    flex: 1 1 auto;
+  }
+
   .wb-chat-composer__error {
     flex: 0 0 auto;
+  }
+
+  .wb-chat-panel__input-region {
+    display: flex;
+    flex: 0 0 auto;
+    min-width: 0;
+    flex-direction: column;
+    gap: var(--wb-space-3);
+  }
+
+  /* --- Provider and model selection -------------------------------------- */
+
+  .wb-chat-execution {
+    display: grid;
+    min-width: 0;
+    max-width: 100%;
+    gap: var(--wb-space-2);
+  }
+
+  .wb-chat-composer__footer > .wb-chat-execution {
+    flex: 1 1 auto;
+  }
+
+  .wb-chat-execution__select {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .wb-chat-execution__trigger,
+  .wb-chat-execution__fallback-trigger.wb-button {
+    display: flex;
+    min-width: 0;
+    max-width: 100%;
+    min-height: var(--wb-control-height-sm);
+    align-items: center;
+    gap: var(--wb-space-2);
+    padding: var(--wb-space-2) var(--wb-space-3);
+    border: var(--wb-border-width) solid var(--wb-color-border-default);
+    border-radius: var(--wb-radius-control);
+    background: var(--wb-color-surface-inset);
+    color: var(--wb-color-text-secondary);
+    font: inherit;
+    font-size: var(--wb-font-size-xs);
+    cursor: pointer;
+  }
+
+  .wb-chat-execution__fallback-trigger.wb-button {
+    justify-self: start;
+  }
+
+  .wb-chat-execution__trigger[data-hovered]:not([data-disabled]) {
+    border-color: var(--wb-color-border-strong);
+    background: var(--wb-color-surface-raised);
+  }
+
+  .wb-chat-execution__trigger[data-focus-visible] {
+    outline: var(--wb-focus-width) solid var(--wb-color-focus-ring);
+    outline-offset: 1px;
+    box-shadow: var(--wb-shadow-focus);
+  }
+
+  .wb-chat-execution__trigger[data-disabled] {
+    color: var(--wb-color-text-disabled);
+    cursor: not-allowed;
+  }
+
+  .wb-chat-execution__trigger svg {
+    width: var(--wb-icon-size-sm);
+    height: var(--wb-icon-size-sm);
+    flex: 0 0 auto;
+  }
+
+  .wb-chat-execution__label {
+    flex: 0 0 auto;
+    color: var(--wb-color-text-muted);
+    font-size: var(--wb-font-size-2xs);
+    font-weight: var(--wb-font-weight-semibold);
+  }
+
+  .wb-chat-execution__value {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--wb-color-text-primary);
+    font-weight: var(--wb-font-weight-medium);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .wb-chat-execution__popover {
+    width: max(var(--trigger-width), 17rem);
+    max-width: min(26rem, calc(100vw - var(--wb-space-6)));
+    max-height: min(24rem, 60vh);
+    padding: var(--wb-space-2);
+  }
+
+  .wb-chat-execution__listbox {
+    gap: var(--wb-space-2);
+  }
+
+  .wb-chat-execution__section {
+    display: grid;
+    gap: var(--wb-space-1);
+  }
+
+  .wb-chat-execution__section + .wb-chat-execution__section {
+    margin-top: var(--wb-space-2);
+    padding-top: var(--wb-space-2);
+    border-top: var(--wb-border-width) solid var(--wb-color-border-subtle);
+  }
+
+  .wb-chat-execution__provider {
+    display: grid;
+    gap: var(--wb-space-1);
+    padding: var(--wb-space-2) var(--wb-space-3);
+    color: var(--wb-color-text-strong);
+    font-size: var(--wb-font-size-xs);
+    font-weight: var(--wb-font-weight-semibold);
+  }
+
+  .wb-chat-execution__provider small {
+    color: var(--wb-color-text-muted);
+    font-size: var(--wb-font-size-2xs);
+    font-weight: var(--wb-font-weight-normal);
+  }
+
+  .wb-chat-execution__message {
+    max-width: min(28rem, 100%);
+  }
+
+  .wb-chat-execution__availability {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--wb-space-3);
+    color: var(--wb-color-text-secondary);
+    font-size: var(--wb-font-size-2xs);
+  }
+
+  .wb-chat-execution__availability > span {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .wb-chat-execution--metadata {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: var(--wb-space-2);
+    color: var(--wb-color-text-secondary);
+    font-size: var(--wb-font-size-xs);
+  }
+
+  .wb-chat-execution__metadata-value {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .wb-chat-execution__metadata-unavailable {
+    flex-basis: 100%;
+    color: var(--wb-color-text-muted);
+    overflow-wrap: anywhere;
+  }
+
+  .wb-chat-state__execution {
+    width: min(22rem, 100%);
+    justify-self: center;
+    text-align: start;
   }
 
   /* --- Full-panel host states --------------------------------------------- */
@@ -278,6 +481,12 @@
     text-align: center;
   }
 
+  .wb-chat-state__copy {
+    display: grid;
+    gap: var(--wb-space-3);
+    justify-items: center;
+  }
+
   .wb-chat-state__title {
     color: var(--wb-color-text-strong);
     font-size: var(--wb-font-size-sm);
@@ -286,5 +495,58 @@
 
   .wb-chat-state__action {
     justify-self: center;
+  }
+
+  @media (max-width: 480px) {
+    .wb-chat-composer__footer {
+      align-items: stretch;
+      flex-wrap: wrap;
+    }
+
+    .wb-chat-composer__footer > .wb-chat-execution {
+      flex-basis: 100%;
+    }
+
+    .wb-chat-execution__trigger {
+      width: 100%;
+    }
+
+    .wb-chat-composer__send.wb-button {
+      margin-inline-start: auto;
+    }
+  }
+
+  @container (max-width: 22rem) {
+    .wb-chat-composer__footer {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: stretch;
+    }
+
+    .wb-chat-composer__footer > .wb-chat-execution {
+      grid-column: 1 / -1;
+    }
+
+    .wb-chat-execution__trigger {
+      width: 100%;
+    }
+
+    .wb-chat-composer__send.wb-button {
+      grid-column: 2;
+    }
+  }
+
+  @media (forced-colors: active) {
+    .wb-chat-execution__trigger {
+      border-color: CanvasText;
+    }
+
+    .wb-chat-execution__trigger[data-focus-visible] {
+      outline-color: Highlight;
+    }
+
+    .wb-chat-msg__producer {
+      color: CanvasText;
+    }
   }
 }

--- a/dashboard-react/src/widget-library/chat/useChatExecutionProfile.test.tsx
+++ b/dashboard-react/src/widget-library/chat/useChatExecutionProfile.test.tsx
@@ -1,0 +1,244 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  ChatExecutionProfileProvider,
+  ChatExecutionSnapshot,
+} from "./contracts";
+import {
+  ChatExecutionSelectionError,
+  useChatExecutionProfile,
+} from "./useChatExecutionProfile";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const snapshot = (
+  providerId = "claude-code",
+  modelId = "sonnet",
+  revision = "execution:1",
+): ChatExecutionSnapshot => ({
+  selection: {
+    providerId,
+    modelId,
+    providerLabel: providerId === "codex" ? "Codex" : "Claude Code",
+    modelLabel: modelId === "gpt-5.6" ? "GPT-5.6" : "Sonnet",
+    revision,
+  },
+  providers: [
+    {
+      id: "claude-code",
+      label: "Claude Code",
+      available: true,
+      models: [{ id: "sonnet", label: "Sonnet", available: true }],
+    },
+    {
+      id: "codex",
+      label: "Codex",
+      available: true,
+      models: [{ id: "gpt-5.6", label: "GPT-5.6", available: true }],
+    },
+  ],
+});
+
+const provider = (
+  load: ChatExecutionProfileProvider["load"],
+  select: ChatExecutionProfileProvider["select"],
+): ChatExecutionProfileProvider => ({
+  load,
+  select,
+  subscribe: () => () => {},
+});
+
+describe("useChatExecutionProfile", () => {
+  it("loads and commits an atomic selection with the observed revision", async () => {
+    const initial = snapshot();
+    const changed = snapshot("codex", "gpt-5.6", "execution:2");
+    const select = vi.fn(async () => changed);
+    const executionProvider = provider(
+      vi.fn(async () => initial),
+      select,
+    );
+    const { result } = renderHook(() =>
+      useChatExecutionProfile(executionProvider, "document:1"),
+    );
+    await waitFor(() => expect(result.current?.status).toBe("ready"));
+
+    await act(async () => {
+      await result.current?.select("codex", "gpt-5.6");
+    });
+
+    expect(select).toHaveBeenCalledWith("document:1", {
+      providerId: "codex",
+      modelId: "gpt-5.6",
+      expectedRevision: "execution:1",
+    });
+    expect(result.current?.snapshot).toBe(changed);
+    expect(result.current?.announcement).toBe(
+      "Now using Codex · GPT-5.6.",
+    );
+  });
+
+  it("keeps a selection authoritative over a subscription reload issued while it is pending", async () => {
+    const initial = snapshot();
+    const stale = snapshot("claude-code", "sonnet", "execution:stale");
+    const changed = snapshot("codex", "gpt-5.6", "execution:2");
+    const staleLoad = deferred<ChatExecutionSnapshot>();
+    const pendingSelection = deferred<ChatExecutionSnapshot>();
+    let invalidate = () => {};
+    let loadCount = 0;
+    const load = vi.fn(() => {
+      loadCount += 1;
+      return loadCount === 1 ? Promise.resolve(initial) : staleLoad.promise;
+    });
+    const executionProvider: ChatExecutionProfileProvider = {
+      load,
+      select: vi.fn(() => pendingSelection.promise),
+      subscribe: (_targetId, onInvalidate) => {
+        invalidate = onInvalidate;
+        return () => {};
+      },
+    };
+    const { result } = renderHook(() =>
+      useChatExecutionProfile(executionProvider, "document:1"),
+    );
+    await waitFor(() => expect(result.current?.status).toBe("ready"));
+
+    let selection!: Promise<void>;
+    act(() => {
+      selection = result.current!.select("codex", "gpt-5.6");
+      invalidate();
+    });
+    expect(load).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      staleLoad.resolve(stale);
+      await staleLoad.promise;
+    });
+    expect(result.current?.snapshot).toBe(initial);
+
+    await act(async () => {
+      pendingSelection.resolve(changed);
+      await selection;
+    });
+    expect(result.current?.snapshot).toBe(changed);
+    expect(result.current?.announcement).toBe(
+      "Now using Codex · GPT-5.6.",
+    );
+  });
+
+  it("adopts the authoritative snapshot returned with a conflict", async () => {
+    const authoritative = snapshot("codex", "gpt-5.6", "execution:9");
+    const executionProvider = provider(
+      vi.fn(async () => snapshot()),
+      vi.fn(async () => {
+        throw new ChatExecutionSelectionError(
+          "The model selection changed elsewhere.",
+          authoritative,
+        );
+      }),
+    );
+    const { result } = renderHook(() =>
+      useChatExecutionProfile(executionProvider, "document:1"),
+    );
+    await waitFor(() => expect(result.current?.status).toBe("ready"));
+
+    await act(async () => {
+      await expect(
+        result.current?.select("codex", "gpt-5.6"),
+      ).rejects.toThrow("changed elsewhere");
+    });
+
+    expect(result.current?.snapshot).toBe(authoritative);
+    expect(result.current?.error).toBe(
+      "The model selection changed elsewhere.",
+    );
+    expect(result.current?.selecting).toBe(false);
+  });
+
+  it("drops a load that resolves after the target is rebound", async () => {
+    const oldLoad = deferred<ChatExecutionSnapshot>();
+    const load = vi.fn((targetId: string) =>
+      targetId === "document:old"
+        ? oldLoad.promise
+        : Promise.resolve(snapshot("codex", "gpt-5.6", "execution:new")),
+    );
+    const executionProvider = provider(load, vi.fn());
+    const { result, rerender } = renderHook(
+      ({ targetId }) =>
+        useChatExecutionProfile(executionProvider, targetId),
+      { initialProps: { targetId: "document:old" } },
+    );
+
+    rerender({ targetId: "document:new" });
+    await waitFor(() =>
+      expect(result.current?.snapshot?.selection.revision).toBe(
+        "execution:new",
+      ),
+    );
+
+    await act(async () => {
+      oldLoad.resolve(snapshot("claude-code", "sonnet", "execution:old"));
+      await oldLoad.promise;
+    });
+    expect(result.current?.snapshot?.selection.revision).toBe("execution:new");
+  });
+
+  it("allows only one atomic selection request at a time", async () => {
+    const pending = deferred<ChatExecutionSnapshot>();
+    const executionProvider = provider(
+      vi.fn(async () => snapshot()),
+      vi.fn(() => pending.promise),
+    );
+    const { result } = renderHook(() =>
+      useChatExecutionProfile(executionProvider, "document:1"),
+    );
+    await waitFor(() => expect(result.current?.status).toBe("ready"));
+
+    let first!: Promise<void>;
+    let duplicate!: Promise<void>;
+    act(() => {
+      first = result.current!.select("codex", "gpt-5.6");
+      duplicate = result.current!.select("codex", "gpt-5.6");
+    });
+    await expect(duplicate).rejects.toThrow("not ready");
+    expect(result.current?.selecting).toBe(true);
+
+    await act(async () => {
+      pending.resolve(snapshot("codex", "gpt-5.6", "execution:2"));
+      await first;
+    });
+    expect(result.current?.selecting).toBe(false);
+  });
+
+  it("asks the provider to refresh before retrying discovery", async () => {
+    let current = snapshot();
+    const refresh = vi.fn(() => {
+      current = snapshot("codex", "gpt-5.6", "execution:refreshed");
+    });
+    const executionProvider: ChatExecutionProfileProvider = {
+      load: vi.fn(async () => current),
+      select: vi.fn(),
+      refresh,
+      subscribe: () => () => {},
+    };
+    const { result } = renderHook(() =>
+      useChatExecutionProfile(executionProvider, "document:1"),
+    );
+    await waitFor(() => expect(result.current?.status).toBe("ready"));
+
+    act(() => result.current?.retry());
+
+    await waitFor(() =>
+      expect(result.current?.snapshot?.selection.revision).toBe(
+        "execution:refreshed",
+      ),
+    );
+    expect(refresh).toHaveBeenCalledWith("document:1");
+  });
+});

--- a/dashboard-react/src/widget-library/chat/useChatExecutionProfile.ts
+++ b/dashboard-react/src/widget-library/chat/useChatExecutionProfile.ts
@@ -1,0 +1,320 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type {
+  ChatExecutionProfileProvider,
+  ChatExecutionSelectionInput,
+  ChatExecutionSnapshot,
+} from "./contracts";
+
+export type ChatExecutionLoadStatus =
+  | "loading"
+  | "ready"
+  | "error"
+  | "unavailable";
+
+export interface ChatExecutionSelectionCandidate {
+  readonly providerId: string;
+  readonly modelId: string;
+  readonly providerLabel: string;
+  readonly modelLabel: string;
+}
+
+/** Host-authored consequence copy for a selection that needs confirmation. */
+export interface ChatExecutionSwitchConfirmation {
+  readonly title: string;
+  readonly description: string;
+  readonly confirmLabel: string;
+  readonly cancelLabel?: string;
+}
+
+export type ChatExecutionConfirmSelection = (
+  selection: ChatExecutionSelectionCandidate,
+) => ChatExecutionSwitchConfirmation | null;
+
+/**
+ * Transport errors may carry the server's newer authoritative snapshot. The
+ * hook adopts it while still reporting that the requested switch did not land.
+ */
+export class ChatExecutionSelectionError extends Error {
+  constructor(
+    message: string,
+    readonly authoritativeSnapshot?: ChatExecutionSnapshot,
+  ) {
+    super(message);
+    this.name = "ChatExecutionSelectionError";
+  }
+}
+
+export interface ChatExecutionControl {
+  readonly snapshot: ChatExecutionSnapshot | null;
+  readonly status: ChatExecutionLoadStatus;
+  readonly selecting: boolean;
+  readonly error: string | null;
+  readonly announcement: string | null;
+  readonly currentAvailable: boolean;
+  /**
+   * Optional host policy. Returning copy asks the shared picker to confirm;
+   * returning null keeps low-impact choices immediate.
+   */
+  readonly confirmSelection?: ChatExecutionConfirmSelection;
+  select(providerId: string, modelId: string): Promise<void>;
+  retry(): void;
+}
+
+interface ActiveExecutionBinding {
+  readonly provider: ChatExecutionProfileProvider;
+  readonly targetId: string;
+  cancelled: boolean;
+  sequence: number;
+  appliedSequence: number;
+  selectingSequence: number | null;
+  deferredReload: boolean;
+  reload: (() => void) | null;
+}
+
+function messageOf(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+  return "The model selection could not be changed.";
+}
+
+export function isCurrentExecutionAvailable(
+  snapshot: ChatExecutionSnapshot | null,
+): boolean {
+  if (snapshot === null) return false;
+  const provider = snapshot.providers.find(
+    (candidate) => candidate.id === snapshot.selection.providerId,
+  );
+  const model = provider?.models.find(
+    (candidate) => candidate.id === snapshot.selection.modelId,
+  );
+  return provider?.available === true && model?.available === true;
+}
+
+/**
+ * Bind an opaque execution target to the reusable picker state. Async results
+ * are fenced by provider and target identity, mirroring the transcript hook.
+ */
+export function useChatExecutionProfile(
+  provider: ChatExecutionProfileProvider | null | undefined,
+  targetId: string,
+): ChatExecutionControl | undefined {
+  const [snapshot, setSnapshot] = useState<ChatExecutionSnapshot | null>(null);
+  const [status, setStatus] =
+    useState<ChatExecutionLoadStatus>("unavailable");
+  const [selecting, setSelecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+  const activeRef = useRef<ActiveExecutionBinding | null>(null);
+
+  useEffect(() => {
+    if (provider === null || provider === undefined) {
+      activeRef.current = null;
+      setSnapshot(null);
+      setStatus("unavailable");
+      setSelecting(false);
+      setError(null);
+      setAnnouncement(null);
+      return;
+    }
+
+    const active: ActiveExecutionBinding = {
+      provider,
+      targetId,
+      cancelled: false,
+      sequence: 0,
+      appliedSequence: 0,
+      selectingSequence: null,
+      deferredReload: false,
+      reload: null,
+    };
+    activeRef.current = active;
+    const isCurrent = () =>
+      !active.cancelled && activeRef.current === active;
+
+    setSnapshot(null);
+    setStatus("loading");
+    setSelecting(false);
+    setError(null);
+    setAnnouncement(null);
+
+    const load = (showLoading: boolean) => {
+      const selectingSequence = active.selectingSequence;
+      if (selectingSequence !== null) {
+        active.deferredReload = true;
+      }
+      const sequence = ++active.sequence;
+      if (showLoading) {
+        setStatus("loading");
+        setError(null);
+      }
+      provider
+        .load(targetId)
+        .then((next) => {
+          // A subscription reload issued during a selection is observationally
+          // older than that mutation, even if its promise resolves first. The
+          // PATCH response is the authoritative projection; on failure we
+          // issue a fresh reload after the mutation settles.
+          if (selectingSequence !== null) return;
+          if (
+            !isCurrent() ||
+            sequence < active.appliedSequence
+          ) {
+            return;
+          }
+          active.appliedSequence = sequence;
+          setSnapshot(next);
+          setStatus("ready");
+          setError(null);
+        })
+        .catch((cause: unknown) => {
+          if (selectingSequence !== null) return;
+          if (!isCurrent() || sequence < active.appliedSequence) return;
+          if (showLoading) {
+            setSnapshot(null);
+            setStatus("error");
+          }
+          setError(messageOf(cause));
+        });
+    };
+    active.reload = () => load(false);
+
+    load(true);
+    const unsubscribe = provider.subscribe(targetId, () => load(false));
+    return () => {
+      active.cancelled = true;
+      active.reload = null;
+      unsubscribe();
+    };
+  }, [provider, reloadToken, targetId]);
+
+  const select = useCallback(
+    async (providerId: string, modelId: string): Promise<void> => {
+      const active = activeRef.current;
+      if (
+        provider === null ||
+        provider === undefined ||
+        active === null ||
+        active.cancelled ||
+        active.provider !== provider ||
+        active.targetId !== targetId
+      ) {
+        throw new Error("Model selection is not ready.");
+      }
+      const current = snapshot;
+      if (
+        current === null ||
+        status !== "ready" ||
+        active.selectingSequence !== null
+      ) {
+        throw new Error("Model selection is not ready.");
+      }
+      const providerOption = current.providers.find(
+        (candidate) => candidate.id === providerId,
+      );
+      const modelOption = providerOption?.models.find(
+        (candidate) => candidate.id === modelId,
+      );
+      if (
+        providerOption?.available !== true ||
+        modelOption?.available !== true ||
+        current.readOnly === true
+      ) {
+        throw new Error("That provider and model are not available.");
+      }
+      if (
+        providerId === current.selection.providerId &&
+        modelId === current.selection.modelId
+      ) {
+        return;
+      }
+
+      const sequence = ++active.sequence;
+      const input: ChatExecutionSelectionInput = {
+        providerId,
+        modelId,
+        expectedRevision: current.selection.revision,
+      };
+      active.selectingSequence = sequence;
+      setSelecting(true);
+      setError(null);
+      setAnnouncement(null);
+      let selectionReconciled = false;
+      try {
+        const next = await provider.select(targetId, input);
+        if (
+          activeRef.current !== active ||
+          active.cancelled ||
+          sequence < active.appliedSequence
+        ) {
+          return;
+        }
+        active.appliedSequence = sequence;
+        active.deferredReload = false;
+        selectionReconciled = true;
+        setSnapshot(next);
+        setStatus("ready");
+        setAnnouncement(
+          `Now using ${next.selection.providerLabel} · ${next.selection.modelLabel}.`,
+        );
+      } catch (cause: unknown) {
+        if (
+          activeRef.current === active &&
+          !active.cancelled &&
+          sequence >= active.appliedSequence
+        ) {
+          if (
+            cause instanceof ChatExecutionSelectionError &&
+            cause.authoritativeSnapshot !== undefined
+          ) {
+            active.appliedSequence = sequence;
+            active.deferredReload = false;
+            selectionReconciled = true;
+            setSnapshot(cause.authoritativeSnapshot);
+            setStatus("ready");
+          }
+          setError(messageOf(cause));
+        }
+        throw cause;
+      } finally {
+        if (
+          activeRef.current === active &&
+          !active.cancelled &&
+          active.selectingSequence === sequence
+        ) {
+          const reload =
+            active.deferredReload && !selectionReconciled
+              ? active.reload
+              : null;
+          active.deferredReload = false;
+          active.selectingSequence = null;
+          setSelecting(false);
+          reload?.();
+        }
+      }
+    },
+    [provider, snapshot, status, targetId],
+  );
+
+  const retry = useCallback(() => {
+    provider?.refresh?.(targetId);
+    setReloadToken((token) => token + 1);
+  }, [provider, targetId]);
+
+  const control = useMemo(
+    () => ({
+      snapshot,
+      status,
+      selecting,
+      error,
+      announcement,
+      currentAvailable: isCurrentExecutionAvailable(snapshot),
+      select,
+      retry,
+    }),
+    [announcement, error, select, selecting, snapshot, status, retry],
+  );
+  return provider === null || provider === undefined ? undefined : control;
+}

--- a/knowledge/store/architecture/agent-execution.md
+++ b/knowledge/store/architecture/agent-execution.md
@@ -1,0 +1,120 @@
+---
+name: Account-backed Agent Execution
+kind: concept
+description: Provider-neutral execution of long-running agents through locally authenticated Claude Code and Codex hosts, with server-authoritative model discovery and conversation-scoped provenance.
+tags:
+- agents
+- execution
+- providers
+- models
+- claude-code
+- codex
+- conversations
+- security
+aliases:
+- agent execution
+- execution profile
+- provider picker
+- model picker
+- account-backed agents
+parents:
+- architecture
+dev_notes: |-
+  This subsystem is not `LLMRunner`. `LLMRunner` serves internal, usually one-shot inference calls through configured API or local-model tiers. `work_buddy.agent_execution` starts a long-running agent host that uses the user's existing Claude Code or ChatGPT sign-in.
+
+  Provider and model IDs are untrusted until the server registry re-probes and validates the exact pair. Persist only the registry-authored labels returned by validation. Provider discovery failures must remain isolated and user-safe; never surface raw SDK, CLI, path, account, subprocess, or authentication diagnostics in the catalog.
+
+  A Co-work execution process owns the exact entropy-first `<generation>-cowork` MCP session. The gateway replaces caller-asserted session identity with its transport identity and applies the non-overridable Co-work ACL. Every read, write, inbox operation, and assistant message is fenced to the lease's exact store, document, conversation, consumer, generation, and execution snapshot.
+
+  Process ownership is `(pid, generation-owner-token)`, not PID alone. Natural-exit cleanup removes only the exact registered handle, failed termination retains ownership for a later retry, and cleanup must never kill an unowned or recycled PID.
+
+  Claude user/project/local settings are suppressed, but operating-system or organization-managed policy is part of the host administrator trust boundary and cannot be bypassed by a child process. Do not describe the worker as suppressing that managed layer.
+---
+
+# Account-backed agent execution
+
+`work_buddy.agent_execution` is the provider-neutral boundary for starting a
+long-running agent through a locally installed, already authenticated agent
+host. It lets a surface select one atomic provider/model pair without teaching
+the conversation store or reusable Chat UI how either vendor's runtime works.
+
+The first providers are:
+
+- **Claude Code**, using the user's signed-in Claude account and the supported
+  Sonnet or Opus aliases; and
+- **Codex**, using the official `openai-codex` SDK/App Server and the user's
+  ChatGPT-managed account. Its available model catalog is discovered from the
+  installed runtime rather than hard-coded.
+
+These routes use the user's existing product subscription. A future direct API
+route must be a separate, plainly named provider with its own authentication
+and cost semantics; an API key must never silently replace an account-backed
+selection.
+
+## Registry and catalog
+
+`ProviderRegistry` is the server authority for provider availability, model
+discovery, selection validation, and detached startup. Provider probes are
+bounded, cached, and isolated: one unavailable runtime does not prevent other
+providers from appearing. Catalog responses contain redacted, user-safe
+availability states and descriptions only.
+
+A selection is one indivisible `{provider_id, model_id}` pair. The server
+re-probes and validates the pair before both persistence and launch. A provider
+or model that disappeared after the catalog was shown therefore fails closed
+instead of falling back to a different runtime or model.
+
+## Conversation authority
+
+For Co-work, the conversations database durably owns the selected execution
+profile. A read projects the configured Claude Code default without writing;
+the first explicit Chat start or confirmed selection pins the validated pair.
+Changes use an opaque revision and compare-and-swap. Repeating the same pair is
+idempotent, while a stale conflicting change returns the current authoritative
+snapshot.
+
+Changing the pair while a document agent is active restarts only that driver.
+The durable conversation, transcript, pending human draft, document binding,
+and review state remain. Every assistant message stores producer provenance
+copied from the exact active lease, so history continues to show which
+provider/model produced an older turn after a later switch.
+
+Corrupt execution metadata is not treated as an absent selection. Reads and
+mutations fail with a typed error, while already-committed document feedback or
+review gestures return their durable receipt with a read-only degraded
+execution projection rather than pretending the human action failed.
+
+## Isolation and fencing
+
+Each Co-work driver receives a fresh, exact session identity and only the
+document-scoped Work Buddy MCP surface. The gateway pins the transport's real
+session identity and enforces an immutable Co-work ACL for the selected folder,
+document, conversation, lease consumer, and generation. Global status,
+workflow, result-retrieval, and unrelated document operations are unavailable.
+A restarted or retired generation loses all inbox and mutation authority.
+
+Claude Code runs with an empty neutral working directory, no session
+persistence, browser/IDE integration, project instruction files, auto-memory,
+attachments, inherited Anthropic credential/routing variables, prompt/tool
+telemetry, debug logs, account-synced skills/plugins, marketplace auto-install,
+slash commands, or inherited Claude OAuth tokens. User, project, and local
+settings are suppressed;
+administrator-managed policy remains a host trust boundary. Codex runs an
+ephemeral read-only thread with inherited MCP servers, plugins, skills,
+instructions, shell snapshots, analytics, proxies, and network capabilities
+disabled. The selected host folder is represented only by the constrained
+server-side resource binding; it is not placed in either provider's prompt,
+arguments, or working directory.
+
+The private brief is delivered through bounded stdin. A natural-exit reaper is
+armed before delivery; if delivery fails and termination is not immediately
+confirmed, an exact-handle background retrier continues cleanup while ownership
+remains registered.
+
+## Relationship to LLMRunner
+
+`architecture/llm-runner` remains the unified interface for internal inference
+calls selected by semantic capability tier. Account-backed agent execution
+instead owns interactive, multi-turn, tool-using agent processes selected by a
+human-visible provider/model profile. The two systems intentionally do not
+share provider IDs, model configuration, persistence, or fallback behavior.

--- a/knowledge/store/conversations/conversation-directions.md
+++ b/knowledge/store/conversations/conversation-directions.md
@@ -72,6 +72,9 @@ mcp__work-buddy__wb_run("conversation_list")
 - a leased driver must pass the same `consumer` and `generation` to
   conversation_send and conversation_ask; this fences late writes after a
   restart or close
+- when the lease carries a validated execution snapshot, assistant messages
+  receive their provider/model producer provenance from that exact lease; a
+  caller cannot assert or override it
 - a `lease_lost` result from receive, acknowledge, send, or ask means a newer
   driver owns the conversation; stop immediately
 - Sidebar auto-polls every 3s for new messages

--- a/knowledge/store/cowork.md
+++ b/knowledge/store/cowork.md
@@ -28,6 +28,10 @@ dev_notes: |
 
   A document conversation ID is opaque and server-issued. GET binding inspection is read-only; only explicit Chat activation, feedback submission, or a routing decision may create the binding and ensure its driver. The driver receives durable user turns through a generation-scoped lease/cursor inbox and acknowledges each message only after handling it. Driver writes, questions, proposals, and comments carry the same generation fence so a stopped, restarted, or retired generation cannot mutate the document.
 
+  The provider/model selection is durable conversation authority, not browser settings. The first explicit start pins the projected server default. A live change is one revision-checked atomic pair and restarts only the document driver; transcript, draft, binding, and document state remain. Copy producer attribution from the exact active lease, never from request fields or the conversation's current selection.
+
+  On a changed selection, raw lease status is the fencing authority: any persisted `starting` or `running` lease must be stopped before the new selection is launched even if a stale heartbeat or failed liveness probe projects it as stopped. The write guard accepts raw active leases, so using only presentation status would leave the old generation authorized.
+
   `CoworkChatPanel` is a thin domain adapter over the canonical `widget-library/chat` `ConversationChat` surface. Co-work owns exact server-message-id-to-passage resolution, **Jump to passage**, routing notices, document-agent recovery mapping, document-scoped draft observation, and the surrounding editor/rail orchestration. Before a binding exists, the rail maps its document lifecycle into the shared `ChatPanelState`; it does not recreate the panel shell. Co-work must not fork canonical message rendering, question controls, composer behavior, loading/retry, or activity state. Co-work remains one cohesive durable Dashboard Core widget; the embedded reusable conversation surface is not a separately placeable widget instance.
 
   Document lifecycle operations span the folder's Truth/Ydoc databases and the house conversations database. They therefore acquire the cross-process per-store-and-document lifecycle lock before either side: start, feedback, and sitting routing hold it from active-state validation through their conversation effects, while retirement holds it through Truth commit and conversation close/lease revocation. Keep database work in the order lifecycle lock → Truth/Ydoc → conversations; never introduce the inverse nesting.
@@ -210,6 +214,22 @@ read-only binding lookup and does not start an agent. The first explicit Chat
 action, selected-text feedback submission, redirect, or endorsement can create
 the binding and ensure one document agent.
 
+The Chat header's optional **Run with** picker selects one provider/model pair
+for that durable conversation. Claude Code uses the user's signed-in Claude
+account; Codex uses the user's ChatGPT account through the official Codex
+runtime. Provider and model availability is server-discovered. The picker does
+not imply API billing, store a browser-only preference, or silently fall back to
+another provider.
+
+Before the conversation exists, the picker shows the server default without
+creating anything. The first explicit Chat start pins that validated pair.
+Changing an active conversation asks for confirmation, then restarts only the
+assistant driver. The messages and unsent draft stay. The selection is
+revisioned so two open surfaces cannot silently overwrite each other, and
+assistant messages retain the provider/model that actually produced them.
+Read-only documents may inspect the saved selection but cannot change it or
+start a new Chat driver.
+
 Selected-text feedback is saved verbatim as human-authored evidence, anchored to
 the exact document passage, and posted as an ordinary user turn in that same
 conversation. The response returns the real conversation and message IDs so the
@@ -227,6 +247,12 @@ turn only after processing it. Restarting creates a new generation and fences
 the old one from sending messages, asking questions, proposing edits, or adding
 comments. Ordinary composer messages never answer a pending structured question
 implicitly; a structured response names the exact question it answers.
+
+The driver runs outside the selected folder and receives document authority only
+through a generation-scoped, server-enforced MCP session. Neither provider gets
+the folder path or project instructions through its working directory, command
+arguments, or prompt. See `architecture/agent-execution` for provider isolation,
+catalog, persistence, and process-ownership details.
 
 Redirect and endorsement notices distinguish three outcomes: saved and sent to
 a running agent, saved in Chat but awaiting restart, or not saved. A review

--- a/knowledge/store/services/dashboard/react/chat-primitives.md
+++ b/knowledge/store/services/dashboard/react/chat-primitives.md
@@ -12,6 +12,8 @@ aliases:
 - ChatPanel
 - chat primitives
 - useChatConversation
+- ChatExecutionPicker
+- useChatExecutionProfile
 - React chat
 parents:
 - services/dashboard/react
@@ -25,6 +27,14 @@ dev_notes: |-
   `ConversationChat` keys the panel by opaque conversation id so composer state cannot leak when a mounted host changes conversations. Keep host-persisted drafts scoped at least as narrowly. The shared availability decision disables both freeform composition and structured Yes/No or choice responses while sending, read-only, stopped, explicitly disabled, or recovering; do not gate only the text composer.
 
   Keep transport out of `widget-library/chat`. The generic same-origin HTTP implementation lives at `dashboard-react/src/dashboard/conversations/`; App adapters inject it through the provider seam.
+
+  Keep `ChatConversationProvider` and `ChatExecutionProfileProvider` separate. Transcript loading/sending must not acquire provider discovery, selection, revision, or agent-restart semantics. A host opts into execution controls explicitly and owns the consequence copy for a live switch.
+
+  The execution hook has the same captured-identity rule as the conversation hook. Late loads and selections from a previous provider/target are discarded. A 409 may carry a newer authoritative snapshot; adopt it before showing the conflict.
+
+  The HTTP adapter also fences its internal cache and `onEnvelope` callback. A successful PATCH, conflict envelope, host `replaceSnapshot`, invalidation, or explicit refresh supersedes older GETs before they can adopt; hook-level sequencing alone is too late to protect feature-owned lifecycle state.
+
+  Selection mutations outrank subscription reloads in `useChatExecutionProfile`. A reload issued while selection is pending must not apply its stale snapshot or error; successful/authoritative mutation results clear it, while a non-authoritative mutation failure triggers one fresh post-mutation reconciliation. Execution-required host actions are unavailable whenever the snapshot is read-only, not merely when the provider/model is unavailable.
 ---
 
 Reusable React chat components for conversational surfaces in the React dashboard, at `dashboard-react/src/widget-library/chat/`. They render the same backend conversations the root dashboard's chat sidebar shows, behind a typed, transport-agnostic provider seam. The root dashboard's own surface remains `services/dashboard/chat-sidebar` and is unchanged by these primitives.
@@ -36,6 +46,10 @@ Reusable React chat components for conversational surfaces in the React dashboar
 - **ChatPanelState**: the canonical loading, empty, or error shell for a host that does not yet have a ready conversation. The host supplies state kind, direct copy, and at most one action without recreating panel markup or importing private chat styles.
 - **ChatMessageList**: author attribution, timestamps, unread boundary with scroll lock and jump-to-latest, inline choice and boolean answers, typing indicator and agent-stopped notice.
 - **ChatComposer**: Enter submits, Shift plus Enter inserts a newline, the draft is retained on send failure. Optional draft-observation seam: `initialValue` seeds the draft once on mount and `onDraftChange` fires on every edit (empty string after a successful send), so a host can persist the unsent draft and arm an unsaved-work guard while the composer keeps owning the text state.
+- **ChatExecutionPicker**: an optional, compact **Run with** control that shows
+  one atomic provider/model choice grouped by provider. Server-authored
+  availability and descriptions stay visible and accessible; unavailable
+  choices cannot be selected.
 
 ## Host extensions
 
@@ -61,12 +75,45 @@ composer and any structured Yes/No or choice controls are unavailable.
 itself, a separately placeable Dashboard Core widget. A cohesive durable App
 such as Co-work may embed it while retaining one durable widget boundary.
 
+## Optional execution profile
+
+Model selection is reusable without becoming part of transcript transport.
+`ChatExecutionProfileProvider` independently loads and changes one opaque
+execution target, while `useChatExecutionProfile` owns loading, retry,
+selection, optimistic-concurrency recovery, and live announcements. The
+containing App passes that control to the shared Chat surface only when its
+conversation has a selectable agent runtime.
+
+The server supplies the provider/model catalog and the current validated pair.
+The browser does not persist a competing default in local storage or settings.
+Selection is atomic and revisioned; if another surface wins a race, the shared
+hook adopts the newer server snapshot and reports that the requested switch did
+not land.
+
+The generic picker knows how to render and select a profile, but not what a
+switch does. A host may provide `confirmSelection` consequence copy when an
+active agent must restart. This keeps Co-work-specific restart semantics out of
+the widget library while allowing other Chat hosts to make low-impact choices
+immediate. A read-only execution snapshot remains inspectable but disables
+selection and composition.
+
 ## State and mapping
 
 `useChatConversation(provider, conversationId)` binds a `ChatConversationProvider` (loadConversation, sendMessage, subscribe) to React state with load, silent-refresh, and send lifecycles. `normalizeConversationPayload` converts the raw `GET /api/conversations/<id>` payload into canonical types, and `deriveAgentActivity` mirrors the legacy typing and stopped logic from `conversation.agent_alive`.
 
 Message identity: the endpoint serializes message ids as `message_id`, which the mapping prefers. A bare `id` is accepted as a fixture-side fallback and a positional id is the last resort.
 
+Assistant messages may include server-verified producer provenance. The shared
+mapping renders its provider/model labels from the durable message, never from
+the conversation's current selection, so historical attribution survives later
+model changes.
+
 ## Transport posture
 
-No HTTP wiring lives in the package. A live transport implements the provider seam. `InMemoryChatProvider` is the test and development fixture. The components consume the appearance system's semantic tokens only, honor forced-colors and reduced-motion with non-color encodings, and are keyboard complete.
+No HTTP wiring lives in the package. Live transports implement the conversation
+and, optionally, execution-profile seams. `InMemoryChatProvider` is the
+conversation test and development fixture. The generic same-origin execution
+adapter lives in `dashboard-react/src/dashboard/conversations/` and normalizes
+server envelopes without owning App lifecycle policy. The components consume
+the appearance system's semantic tokens only, honor forced-colors and
+reduced-motion with non-color encodings, and are keyboard complete.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "flask>=3.1.3,<4",
     "mcp[cli]>=1.27.0,<2",
     "anthropic>=0.89.0,<0.90",
+    "openai-codex>=0.144.4,<0.145",
     "jinja2>=3.1.6,<4",
     "cron-descriptor>=2.0.8,<3",
     "simhash>=2.1.2,<3",

--- a/tests/unit/cowork/conftest.py
+++ b/tests/unit/cowork/conftest.py
@@ -61,6 +61,79 @@ def fake_document_agent(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]
         )
 
     monkeypatch.setattr(document_agent, "ensure_document_agent", _ensure)
+    from work_buddy.agent_execution import registry as execution_registry
+    from work_buddy.agent_execution.models import (
+        AgentExecutionCatalog,
+        AgentExecutionSelection,
+        ModelDescriptor,
+        ProviderAvailability,
+        ProviderDescriptor,
+        UnknownModelError,
+        UnknownProviderError,
+    )
+
+    default = AgentExecutionSelection(
+        provider_id="claude-code",
+        model_id="sonnet",
+        provider_label="Claude Code",
+        model_label="Sonnet",
+    )
+    catalog = AgentExecutionCatalog(
+        providers=(
+            ProviderDescriptor(
+                id="claude-code",
+                label="Claude Code",
+                availability=ProviderAvailability.READY,
+                auth_mode="claude_account",
+                models=(
+                    ModelDescriptor(id="sonnet", label="Sonnet", is_default=True),
+                    ModelDescriptor(id="opus", label="Opus"),
+                ),
+            ),
+            ProviderDescriptor(
+                id="codex",
+                label="Codex",
+                availability=ProviderAvailability.READY,
+                auth_mode="chatgpt_account",
+                models=(
+                    ModelDescriptor(
+                        id="gpt-5.6-sol",
+                        label="GPT-5.6 Sol",
+                        is_default=True,
+                    ),
+                ),
+            ),
+        ),
+        default_selection=default,
+    )
+
+    def _validate(selection, *, refresh=False):
+        del refresh
+        for provider in catalog.providers:
+            if provider.id != selection.provider_id:
+                continue
+            for model in provider.models:
+                if model.id == selection.model_id:
+                    return AgentExecutionSelection(
+                        provider_id=provider.id,
+                        model_id=model.id,
+                        provider_label=provider.label,
+                        model_label=model.label,
+                    )
+            raise UnknownModelError(
+                f"Unknown model for {provider.label}: {selection.model_id}"
+            )
+        raise UnknownProviderError(
+            f"Unknown agent execution provider: {selection.provider_id}"
+        )
+
+    monkeypatch.setattr(execution_registry, "default_selection", lambda: default)
+    monkeypatch.setattr(
+        execution_registry,
+        "get_catalog",
+        lambda **_kwargs: catalog,
+    )
+    monkeypatch.setattr(execution_registry, "validate_selection", _validate)
     return calls
 
 

--- a/tests/unit/cowork/test_api_routes.py
+++ b/tests/unit/cowork/test_api_routes.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import struct
 
 from work_buddy.conversations import store as conversation_store
+from work_buddy.conversations.execution import EXECUTION_METADATA_KEY
 from work_buddy.cowork import api
 from work_buddy.cowork import conversations, document_agent
 from work_buddy.truth import documents, expressions, proposals, ydoc_store
@@ -883,17 +885,29 @@ def test_conversation_get_is_read_only_and_post_lazily_creates_real_binding(
 
     opened = client.get(url)
     assert opened.status_code == 200
-    assert opened.get_json() == {
-        "ok": True,
-        "conversation_id": None,
-        "agent": {
-            "status": "not_started",
-            "alive": None,
-            "started": False,
-            "error": None,
-        },
-        "feedback": [],
+    opened_payload = opened.get_json()
+    assert opened_payload["ok"] is True
+    assert opened_payload["conversation_id"] is None
+    assert opened_payload["agent"] == {
+        "status": "not_started",
+        "alive": None,
+        "started": False,
+        "error": None,
     }
+    assert opened_payload["feedback"] == []
+    assert opened_payload["execution"]["selection"] == {
+        "schema_version": 1,
+        "provider_id": "claude-code",
+        "model_id": "sonnet",
+        "provider_label": "Claude Code",
+        "model_label": "Sonnet",
+        "revision": "",
+        "persisted": False,
+    }
+    assert [provider["id"] for provider in opened_payload["execution"]["providers"]] == [
+        "claude-code",
+        "codex",
+    ]
     conn = conversation_store.get_connection()
     try:
         assert conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0] == before["conversations"]
@@ -910,12 +924,45 @@ def test_conversation_get_is_read_only_and_post_lazily_creates_real_binding(
     assert payload["conversation_id"]
     assert payload["feedback"] == []
     assert payload["agent"]["status"] == "running"
+    assert payload["execution"]["selection"]["persisted"] is True
+    assert payload["execution"]["selection"]["revision"]
     assert len(fake_document_agent) == 1
     assert fake_document_agent[0]["conversation_id"] == payload["conversation_id"]
+    assert fake_document_agent[0]["execution"].provider_id == "claude-code"
 
     repeated = client.post(url).get_json()
     assert repeated["conversation_id"] == payload["conversation_id"]
     assert repeated["created"] is False
+
+
+def test_conversation_catalog_refresh_is_explicit(
+    client,
+    seeded,
+    monkeypatch,
+):
+    from work_buddy.agent_execution import registry as execution_registry
+
+    original = execution_registry.get_catalog
+    refreshes: list[bool] = []
+
+    def _recording_catalog(*, refresh: bool = False):
+        refreshes.append(refresh)
+        return original(refresh=refresh)
+
+    monkeypatch.setattr(
+        execution_registry,
+        "get_catalog",
+        _recording_catalog,
+    )
+    base = _url(
+        f"/api/truth/doc/{seeded['document'].id}/conversation",
+        seeded["store_id"],
+    )
+
+    assert client.get(base).status_code == 200
+    assert client.get(f"{base}&refresh_execution=1").status_code == 200
+
+    assert refreshes == [False, True]
 
 
 def test_closed_document_conversation_cannot_spawn_again(
@@ -939,6 +986,423 @@ def test_closed_document_conversation_cannot_spawn_again(
     assert response.status_code == 409
     assert response.get_json()["error"]["code"] == "conversation_closed"
     assert fake_document_agent == []
+
+
+def test_closed_document_conversation_cannot_change_execution(
+    client,
+    seeded,
+    fake_document_agent,
+):
+    binding = conversations.ensure_document_conversation(
+        document_id=seeded["document"].id,
+        store_id=seeded["store_id"],
+    )
+    assert conversation_store.close_conversation(binding.conversation_id)
+    fake_document_agent.clear()
+
+    response = client.patch(
+        _url(
+            (
+                f"/api/truth/doc/{seeded['document'].id}"
+                "/conversation/execution"
+            ),
+            seeded["store_id"],
+        ),
+        json={
+            "provider_id": "codex",
+            "model_id": "gpt-5.6-sol",
+            "expected_revision": "",
+        },
+    )
+
+    assert response.status_code == 409
+    payload = response.get_json()
+    assert payload["error"] == {
+        "code": "conversation_closed",
+        "message": (
+            "This document's conversation is closed and cannot change models."
+        ),
+        "details": {},
+        "retryable": False,
+    }
+    assert fake_document_agent == []
+
+
+def test_execution_picker_can_select_before_chat_starts(
+    client,
+    seeded,
+    fake_document_agent,
+):
+    base = f"/api/truth/doc/{seeded['document'].id}/conversation"
+    selected = client.patch(
+        _url(f"{base}/execution", seeded["store_id"]),
+        json={
+            "provider_id": "codex",
+            "model_id": "gpt-5.6-sol",
+            "expected_revision": "",
+        },
+    )
+    assert selected.status_code == 200
+    payload = selected.get_json()
+    assert payload["created"] is True
+    assert payload["agent"]["status"] == "not_started"
+    assert payload["execution"]["selection"]["provider_id"] == "codex"
+    assert payload["execution"]["selection"]["model_id"] == "gpt-5.6-sol"
+    assert payload["execution"]["selection"]["revision"]
+    assert fake_document_agent == []
+
+    opened = client.get(_url(base, seeded["store_id"])).get_json()
+    assert opened["conversation_id"] == payload["conversation_id"]
+    assert opened["execution"]["selection"]["provider_id"] == "codex"
+
+    started = client.post(_url(base, seeded["store_id"]))
+    assert started.status_code == 200
+    assert len(fake_document_agent) == 1
+    assert fake_document_agent[0]["execution"].provider_id == "codex"
+    assert fake_document_agent[0]["execution"].model_id == "gpt-5.6-sol"
+
+
+def test_execution_picker_same_pair_retry_is_idempotent_after_response_loss(
+    client,
+    seeded,
+    fake_document_agent,
+):
+    base = f"/api/truth/doc/{seeded['document'].id}/conversation"
+    request_body = {
+        "provider_id": "codex",
+        "model_id": "gpt-5.6-sol",
+        "expected_revision": "",
+    }
+    selected = client.patch(
+        _url(f"{base}/execution", seeded["store_id"]),
+        json=request_body,
+    )
+    assert selected.status_code == 200
+    selected_payload = selected.get_json()
+    revision = selected_payload["execution"]["selection"]["revision"]
+    assert revision
+
+    replayed = client.patch(
+        _url(f"{base}/execution", seeded["store_id"]),
+        json=request_body,
+    )
+
+    assert replayed.status_code == 200
+    replayed_payload = replayed.get_json()
+    assert replayed_payload["execution"]["selection"]["revision"] == revision
+    assert replayed_payload["execution"]["selection"]["provider_id"] == "codex"
+    assert replayed_payload["execution"]["selection"]["model_id"] == "gpt-5.6-sol"
+    assert replayed_payload["agent"]["status"] == "not_started"
+    assert fake_document_agent == []
+
+
+def test_execution_routes_fail_closed_for_a_corrupt_saved_selection(
+    client,
+    seeded,
+    fake_document_agent,
+):
+    binding = conversations.ensure_document_conversation(
+        document_id=seeded["document"].id,
+        store_id=seeded["store_id"],
+    )
+    conn = conversation_store.get_connection()
+    try:
+        row = conn.execute(
+            "SELECT metadata FROM conversations WHERE conversation_id = ?",
+            (binding.conversation_id,),
+        ).fetchone()
+        assert row is not None
+        metadata = json.loads(row["metadata"])
+        metadata[EXECUTION_METADATA_KEY] = {"schema_version": 999}
+        conn.execute(
+            "UPDATE conversations SET metadata = ? WHERE conversation_id = ?",
+            (json.dumps(metadata), binding.conversation_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    base = f"/api/truth/doc/{seeded['document'].id}/conversation"
+    responses = (
+        client.get(_url(base, seeded["store_id"])),
+        client.patch(
+            _url(f"{base}/execution", seeded["store_id"]),
+            json={
+                "provider_id": "codex",
+                "model_id": "gpt-5.6-sol",
+                "expected_revision": "",
+            },
+        ),
+        client.post(_url(base, seeded["store_id"])),
+    )
+
+    for response in responses:
+        assert response.status_code == 409
+        assert response.get_json()["error"] == {
+            "code": "execution_selection_corrupt",
+            "message": (
+                "This chat's saved provider and model choice could not be read."
+            ),
+            "details": {},
+            "retryable": False,
+        }
+    assert fake_document_agent == []
+
+
+def test_execution_routes_fail_closed_for_malformed_conversation_metadata(
+    client,
+    seeded,
+):
+    binding = conversations.ensure_document_conversation(
+        document_id=seeded["document"].id,
+        store_id=seeded["store_id"],
+    )
+    conn = conversation_store.get_connection()
+    try:
+        conn.execute(
+            "UPDATE conversations SET metadata = ? WHERE conversation_id = ?",
+            ('{"broken"', binding.conversation_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    base = f"/api/truth/doc/{seeded['document'].id}/conversation"
+    responses = (
+        client.get(_url(base, seeded["store_id"])),
+        client.post(_url(base, seeded["store_id"])),
+        client.patch(
+            _url(f"{base}/execution", seeded["store_id"]),
+            json={
+                "provider_id": "codex",
+                "model_id": "gpt-5.6-sol",
+                "expected_revision": "",
+            },
+        ),
+    )
+
+    for response in responses:
+        assert response.status_code == 409
+        assert response.get_json()["error"] == {
+            "code": "execution_selection_corrupt",
+            "message": (
+                "This chat's saved provider and model choice could not be read."
+            ),
+            "details": {},
+            "retryable": False,
+        }
+    conn = conversation_store.get_connection()
+    try:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM conversations WHERE source = ?",
+            (conversations.CONVERSATION_SOURCE,),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 1
+
+
+def test_execution_switch_fences_existing_generation_and_restarts(
+    client,
+    seeded,
+    fake_document_agent,
+):
+    base = f"/api/truth/doc/{seeded['document'].id}/conversation"
+    started = client.post(_url(base, seeded["store_id"])).get_json()
+    conversation_id = started["conversation_id"]
+    revision = started["execution"]["selection"]["revision"]
+    consumer = document_agent.document_agent_consumer(
+        seeded["store_id"],
+        seeded["document"].id,
+    )
+    lease = conversation_store.claim_agent_lease(
+        conversation_id,
+        consumer,
+        "generation-before-switch",
+        execution={
+            "schema_version": 1,
+            "provider_id": "claude-code",
+            "model_id": "sonnet",
+            "provider_label": "Claude Code",
+            "model_label": "Sonnet",
+        },
+    )
+    assert lease is not None and lease["claimed"] is True
+    fake_document_agent.clear()
+
+    switched = client.patch(
+        _url(f"{base}/execution", seeded["store_id"]),
+        json={
+            "provider_id": "codex",
+            "model_id": "gpt-5.6-sol",
+            "expected_revision": revision,
+        },
+    )
+    assert switched.status_code == 200
+    payload = switched.get_json()
+    assert payload["execution"]["selection"]["provider_id"] == "codex"
+    assert len(fake_document_agent) == 1
+    assert fake_document_agent[0]["execution"].provider_id == "codex"
+    fenced = conversation_store.get_agent_lease(conversation_id, consumer)
+    assert fenced is not None
+    assert fenced["status"] == "stopped"
+
+
+def test_execution_switch_fences_raw_running_lease_even_when_projection_is_stale(
+    client,
+    seeded,
+    fake_document_agent,
+    monkeypatch,
+):
+    base = f"/api/truth/doc/{seeded['document'].id}/conversation"
+    started = client.post(_url(base, seeded["store_id"])).get_json()
+    conversation_id = started["conversation_id"]
+    revision = started["execution"]["selection"]["revision"]
+    consumer = document_agent.document_agent_consumer(
+        seeded["store_id"],
+        seeded["document"].id,
+    )
+    generation = "stale-heartbeat-before-switch"
+    lease = conversation_store.claim_agent_lease(
+        conversation_id,
+        consumer,
+        generation,
+        execution={
+            "schema_version": 1,
+            "provider_id": "claude-code",
+            "model_id": "sonnet",
+            "provider_label": "Claude Code",
+            "model_label": "Sonnet",
+        },
+    )
+    assert lease is not None and lease["claimed"] is True
+    assert conversation_store.activate_agent_lease(
+        conversation_id,
+        consumer,
+        generation,
+        os.getpid(),
+    )
+    conn = conversation_store.get_connection()
+    try:
+        conn.execute(
+            """UPDATE conversation_agent_leases
+               SET heartbeat_at = ?, updated_at = ?
+               WHERE conversation_id = ? AND consumer = ?""",
+            (
+                "2000-01-01T00:00:00+00:00",
+                "2000-01-01T00:00:00+00:00",
+                conversation_id,
+                consumer,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    assert (
+        document_agent.inspect_document_agent(
+            conversation_id,
+            consumer=consumer,
+        ).status
+        == "stopped"
+    )
+    fake_document_agent.clear()
+    observed = {}
+    restarted_generation = "generation-after-switch"
+
+    def _restart(**kwargs):
+        observed["before_restart"] = conversation_store.get_agent_lease(
+            conversation_id,
+            consumer,
+        )
+        selection = kwargs["execution"]
+        claimed = conversation_store.claim_agent_lease(
+            conversation_id,
+            consumer,
+            restarted_generation,
+            execution={
+                "schema_version": 1,
+                **selection.to_dict(),
+            },
+        )
+        fake_document_agent.append(dict(kwargs))
+        assert claimed is not None and claimed["claimed"] is True
+        return document_agent.DocumentAgentStatus(
+            status="running",
+            alive=None,
+            started=True,
+            error=None,
+        )
+
+    monkeypatch.setattr(document_agent, "ensure_document_agent", _restart)
+
+    switched = client.patch(
+        _url(f"{base}/execution", seeded["store_id"]),
+        json={
+            "provider_id": "codex",
+            "model_id": "gpt-5.6-sol",
+            "expected_revision": revision,
+        },
+    )
+
+    assert switched.status_code == 200
+    assert switched.get_json()["execution"]["selection"]["provider_id"] == "codex"
+    assert len(fake_document_agent) == 1
+    assert fake_document_agent[0]["execution"].provider_id == "codex"
+    assert observed["before_restart"]["status"] == "stopped"
+    assert observed["before_restart"]["generation"] == generation
+    restarted = conversation_store.get_agent_lease(conversation_id, consumer)
+    assert restarted is not None
+    assert restarted["status"] == "starting"
+    assert restarted["generation"] == restarted_generation
+    assert restarted["execution"]["provider_id"] == "codex"
+
+
+def test_execution_picker_rejects_stale_revision_without_fencing(
+    client,
+    seeded,
+):
+    base = f"/api/truth/doc/{seeded['document'].id}/conversation"
+    started = client.post(_url(base, seeded["store_id"])).get_json()
+    response = client.patch(
+        _url(f"{base}/execution", seeded["store_id"]),
+        json={
+            "provider_id": "codex",
+            "model_id": "gpt-5.6-sol",
+            "expected_revision": "stale-revision",
+        },
+    )
+    assert response.status_code == 409
+    payload = response.get_json()
+    assert payload["error"]["code"] == "execution_selection_changed"
+    assert (
+        payload["execution"]["selection"]["revision"]
+        == started["execution"]["selection"]["revision"]
+    )
+    assert payload["execution"]["selection"]["provider_id"] == "claude-code"
+    assert payload["agent"]["status"] == "not_started"
+    opened = client.get(_url(base, seeded["store_id"])).get_json()
+    assert (
+        opened["execution"]["selection"]["revision"]
+        == started["execution"]["selection"]["revision"]
+    )
+    assert opened["execution"]["selection"]["provider_id"] == "claude-code"
+
+
+def test_execution_picker_rejects_unknown_model(
+    client,
+    seeded,
+):
+    base = f"/api/truth/doc/{seeded['document'].id}/conversation"
+    response = client.patch(
+        _url(f"{base}/execution", seeded["store_id"]),
+        json={
+            "provider_id": "codex",
+            "model_id": "invented-model",
+            "expected_revision": "",
+        },
+    )
+    assert response.status_code == 409
+    assert response.get_json()["error"]["code"] == "unknown_model"
 
 
 def test_feedback_captures_user_authored_utterance(
@@ -1021,6 +1485,68 @@ def test_feedback_spawn_failure_keeps_authored_turn_and_returns_safe_status(
     assert authored[0]["role"] == "user"
     assert authored[0]["content"] == (
         "Keep this feedback even if chat cannot start."
+    )
+
+
+def test_feedback_keeps_authored_turn_when_saved_execution_is_corrupt(
+    client,
+    seeded,
+    fake_document_agent,
+):
+    binding = conversations.ensure_document_conversation(
+        document_id=seeded["document"].id,
+        store_id=seeded["store_id"],
+    )
+    conn = conversation_store.get_connection()
+    try:
+        row = conn.execute(
+            "SELECT metadata FROM conversations WHERE conversation_id = ?",
+            (binding.conversation_id,),
+        ).fetchone()
+        assert row is not None
+        metadata = json.loads(row["metadata"])
+        metadata[EXECUTION_METADATA_KEY] = {"schema_version": 999}
+        conn.execute(
+            "UPDATE conversations SET metadata = ? WHERE conversation_id = ?",
+            (json.dumps(metadata), binding.conversation_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client.post(
+        _url(
+            f"/api/truth/doc/{seeded['document'].id}/feedback",
+            seeded["store_id"],
+        ),
+        json={
+            "span": {"exact": DOC_QUOTE, "prefix": "", "suffix": ""},
+            "text": "Keep this even though the model choice is unreadable.",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["ok"] is True
+    assert payload["agent"]["status"] == "spawn_failed"
+    assert payload["execution"]["read_only"] is True
+    assert payload["execution"]["error"]["code"] == (
+        "execution_selection_corrupt"
+    )
+    assert payload["execution"]["selection"]["provider_id"] == (
+        "execution-unavailable"
+    )
+    assert fake_document_agent == []
+    bundle = conversation_store.get_conversation_with_messages(
+        binding.conversation_id
+    )
+    assert bundle is not None
+    assert any(
+        item["message_id"] == payload["message_id"]
+        and item["role"] == "user"
+        and item["content"]
+        == "Keep this even though the model choice is unreadable."
+        for item in bundle["messages"]
     )
 
 

--- a/tests/unit/cowork/test_document_lifecycle_serialization.py
+++ b/tests/unit/cowork/test_document_lifecycle_serialization.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable
@@ -10,6 +11,7 @@ from typing import Callable
 import pytest
 
 from work_buddy.conversations import store as conversation_store
+from work_buddy.conversations import execution as conversation_execution
 from work_buddy.cowork import (
     api,
     bootstrap,
@@ -410,6 +412,16 @@ def test_routing_commit_reports_durable_delivery_agent_status_and_reconciles_pre
             "started": True,
             "error": None,
         },
+        "execution": delivery["execution"],
+    }
+    assert delivery["execution"]["selection"] == {
+        "provider_id": "claude-code",
+        "model_id": "sonnet",
+        "provider_label": "Claude Code",
+        "model_label": "Sonnet",
+        "revision": delivery["execution"]["selection"]["revision"],
+        "schema_version": 1,
+        "persisted": True,
     }
     assert delivery["delivery_id"]
     assert delivery["conversation_id"]
@@ -419,6 +431,8 @@ def test_routing_commit_reports_durable_delivery_agent_status_and_reconciles_pre
         fake_document_agent[0]["conversation_id"]
         == delivery["conversation_id"]
     )
+    assert fake_document_agent[0]["execution"].provider_id == "claude-code"
+    assert fake_document_agent[0]["execution"].model_id == "sonnet"
 
     # A lost commit response is recovered through repeated prepare. The
     # deterministic delivery id is replayed, not duplicated, and its real
@@ -436,6 +450,7 @@ def test_routing_commit_reports_durable_delivery_agent_status_and_reconciles_pre
     assert replay["conversation_id"] == delivery["conversation_id"]
     assert replay["message_id"] == delivery["message_id"]
     assert replay["agent"]["status"] == "running"
+    assert replay["execution"]["selection"] == delivery["execution"]["selection"]
     conn = conversation_store.get_connection()
     try:
         assert (
@@ -447,6 +462,53 @@ def test_routing_commit_reports_durable_delivery_agent_status_and_reconciles_pre
         )
     finally:
         conn.close()
+
+
+def test_routing_commit_preserves_the_conversation_pinned_execution(
+    store_ctx,
+    client,
+    fake_document_agent,
+):
+    store = store_ctx["store"]
+    document = _ready(
+        store_ctx,
+        path="docs/routing-delivery-codex.md",
+        key="routing-delivery-codex-bootstrap-0001",
+    )
+    binding = conversations.ensure_document_conversation(
+        document_id=document.id,
+        store_id=store.store_id,
+    )
+    pinned = conversation_execution.set_execution(
+        binding.conversation_id,
+        {
+            "provider_id": "codex",
+            "model_id": "gpt-5.6",
+            "provider_label": "Codex",
+            "model_label": "GPT-5.6",
+        },
+    )
+    _proposal, _prepare_body, sitting_id = _prepare_redirect_sitting(
+        client,
+        store,
+        document,
+        key="routing-delivery-codex-sitting-0001",
+    )
+
+    response = client.put(
+        f"/api/truth/doc/{document.id}/sitting/{sitting_id}/commit"
+        f"?store_id={store.store_id}",
+        json={},
+    )
+
+    assert response.status_code == 200
+    delivery = response.get_json()["routing_deliveries"][0]
+    assert delivery["execution"]["selection"]["provider_id"] == "codex"
+    assert delivery["execution"]["selection"]["model_id"] == "gpt-5.6"
+    assert delivery["execution"]["selection"]["revision"] == pinned.revision
+    assert len(fake_document_agent) == 1
+    assert fake_document_agent[0]["execution"].provider_id == "codex"
+    assert fake_document_agent[0]["execution"].model_id == "gpt-5.6"
 
 
 def test_routing_write_failure_is_truthful_without_undoing_sitting(
@@ -534,3 +596,84 @@ def test_routing_spawn_failure_keeps_delivery_and_returns_safe_agent_status(
         "error": "Chat couldn’t start. Try again.",
     }
     assert "secret" not in delivery["agent"]["error"]
+
+
+def test_routing_commit_keeps_delivery_when_saved_execution_is_corrupt(
+    store_ctx,
+    client,
+    fake_document_agent,
+):
+    store = store_ctx["store"]
+    document = _ready(
+        store_ctx,
+        path="docs/routing-corrupt-execution.md",
+        key="routing-corrupt-execution-bootstrap-0001",
+    )
+    binding = conversations.ensure_document_conversation(
+        document_id=document.id,
+        store_id=store.store_id,
+    )
+    proposal, _prepare_body, sitting_id = _prepare_redirect_sitting(
+        client,
+        store,
+        document,
+        key="routing-corrupt-execution-sitting-0001",
+    )
+    conn = conversation_store.get_connection()
+    try:
+        row = conn.execute(
+            "SELECT metadata FROM conversations WHERE conversation_id = ?",
+            (binding.conversation_id,),
+        ).fetchone()
+        assert row is not None
+        metadata = json.loads(row["metadata"])
+        metadata[conversation_execution.EXECUTION_METADATA_KEY] = {
+            "schema_version": True,
+            "provider_id": "claude-code",
+            "model_id": "sonnet",
+            "provider_label": "Claude Code",
+            "model_label": "Sonnet",
+            "revision": "invalid-bool-schema",
+        }
+        conn.execute(
+            "UPDATE conversations SET metadata = ? WHERE conversation_id = ?",
+            (json.dumps(metadata), binding.conversation_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client.put(
+        f"/api/truth/doc/{document.id}/sitting/{sitting_id}/commit"
+        f"?store_id={store.store_id}",
+        json={},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["results"][0]["result"] == "kept_open_redirected"
+    delivery = payload["routing_deliveries"][0]
+    assert delivery["proposal_id"] == proposal.id
+    assert delivery["delivered"] is True
+    assert delivery["conversation_id"] == binding.conversation_id
+    assert delivery["message_id"] == delivery["delivery_id"]
+    assert delivery["agent"]["status"] == "spawn_failed"
+    assert delivery["execution"]["read_only"] is True
+    assert delivery["execution"]["error"]["code"] == (
+        "execution_selection_corrupt"
+    )
+    assert delivery["execution"]["selection"]["model_id"] == (
+        "saved-selection-unreadable"
+    )
+    assert fake_document_agent == []
+    conn = conversation_store.get_connection()
+    try:
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE message_id = ?",
+                (delivery["delivery_id"],),
+            ).fetchone()[0]
+            == 1
+        )
+    finally:
+        conn.close()

--- a/tests/unit/cowork/test_ops.py
+++ b/tests/unit/cowork/test_ops.py
@@ -219,6 +219,41 @@ def test_list_and_get_report_document_and_open_layer(cowork: dict[str, object]) 
     assert got["feedback"] == []
 
 
+def test_cowork_execution_session_cannot_read_another_document(
+    cowork: dict[str, object],
+) -> None:
+    store_id = str(cowork["store_id"])
+    own_doc_id, _ = _register_doc(cowork["store"])
+    other_doc_id, _ = _register_doc(
+        cowork["store"],
+        path="docs/other.md",
+        body="# Other\n\nOther document.\n",
+    )
+    own_generation = "generation-own"
+    other_generation = "generation-other"
+    _activate_document_lease(store_id, own_doc_id, own_generation)
+    _activate_document_lease(store_id, other_doc_id, other_generation)
+
+    own = cowork_ops.cowork_doc_get(
+        store_id,
+        own_doc_id,
+        agent_session_id=f"{own_generation}-cowork",
+    )
+    other = cowork_ops.cowork_doc_get(
+        store_id,
+        other_doc_id,
+        agent_session_id=f"{own_generation}-cowork",
+    )
+
+    assert own["ok"] is True
+    assert other == {
+        "ok": False,
+        "status": "lease_lost",
+        "document_id": other_doc_id,
+        "store_id": store_id,
+    }
+
+
 def test_get_exposes_truth_backed_feedback_by_exact_message_id(
     cowork: dict[str, object],
 ) -> None:
@@ -630,6 +665,35 @@ def test_propose_edit_rejects_claim_refs_on_deletion_atomically(
         )
 
     assert proposals.open_proposals(cowork["store"], document_id=doc_id) == ()
+
+
+def test_cowork_execution_session_cannot_omit_its_document_write_fence(
+    cowork: dict[str, object],
+) -> None:
+    store_id = str(cowork["store_id"])
+    doc_id, _ = _register_doc(cowork["store"])
+    generation = "generation-bound"
+    _binding, _consumer = _activate_document_lease(
+        store_id,
+        doc_id,
+        generation,
+    )
+
+    result = cowork_ops.cowork_doc_propose_edit(
+        store_id,
+        doc_id,
+        _one_hunk(),
+        "reason",
+        "tldr",
+        MODEL,
+        agent_session_id=f"{generation}-cowork",
+    )
+
+    assert result == {"ok": False, "status": "lease_lost"}
+    assert proposals.open_proposals(
+        cowork["store"],
+        document_id=doc_id,
+    ) == ()
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/test_agent_execution.py
+++ b/tests/unit/test_agent_execution.py
@@ -1,0 +1,1336 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from work_buddy.agent_execution import registry as execution_registry
+from work_buddy.agent_execution.cache import ProbeCache
+from work_buddy.agent_execution.claude_code import (
+    ClaudeCodeProvider,
+    claude_account_environment,
+)
+from work_buddy.agent_execution.claude_worker import (
+    run_worker as run_claude_worker,
+)
+from work_buddy.agent_execution.codex import (
+    CodexConfigIsolationError,
+    CodexProvider,
+    codex_chatgpt_environment,
+    codex_entry_isolation_overrides,
+    codex_subscription_config,
+    effective_mcp_server_names,
+    effective_plugin_ids,
+    read_effective_codex_config,
+    validate_entry_isolation,
+    validate_subscription_codex_config,
+)
+from work_buddy.agent_execution.codex_probe_worker import collect_redacted_probe
+from work_buddy.agent_execution.codex_worker import (
+    _local_mcp_url,
+    build_thread_config,
+    run_worker,
+)
+from work_buddy.agent_execution.models import (
+    AgentExecutionSelection,
+    AgentSpawnRequest,
+    ModelDescriptor,
+    ProviderAvailability,
+    ProviderDescriptor,
+    ProviderUnavailableError,
+    UnknownModelError,
+    UnknownProviderError,
+)
+from work_buddy.agent_execution.registry import ProviderRegistry
+
+
+def _isolated_effective_codex_config(
+    *mcp_server_names: str,
+    plugin_ids: tuple[str, ...] = (),
+) -> dict[str, object]:
+    return {
+        "forced_login_method": "chatgpt",
+        "model_provider": "openai",
+        "chatgpt_base_url": "https://chatgpt.com/backend-api/",
+        "openai_base_url": "https://api.openai.com/v1",
+        "approval_policy": "never",
+        "sandbox_mode": "read-only",
+        "allow_login_shell": False,
+        "features": {
+            "hooks": False,
+            "apps": False,
+            "plugins": False,
+            "plugin_sharing": False,
+            "remote_plugin": False,
+            "multi_agent": False,
+            "shell_tool": False,
+            "shell_snapshot": False,
+            "unified_exec": False,
+            "skill_mcp_dependency_install": False,
+            "browser_use": False,
+            "browser_use_external": False,
+            "browser_use_full_cdp_access": False,
+            "computer_use": False,
+            "in_app_browser": False,
+            "code_mode": False,
+            "code_mode_host": False,
+            "enable_mcp_apps": False,
+            "image_generation": False,
+            "workspace_dependencies": False,
+            "tool_suggest": False,
+            "auth_elicitation": False,
+            "tool_call_mcp_elicitation": False,
+            "goals": False,
+            "memories": False,
+            "external_migration": False,
+            "mentions_v2": False,
+            "personality": False,
+            "realtime_conversation": False,
+            "artifact": False,
+            "request_permissions_tool": False,
+            "remote_control": False,
+            "network_proxy": False,
+        },
+        "web_search": "disabled",
+        "tools": {
+            "web_search": None,
+            "view_image": None,
+        },
+        "apps": {
+            "_default": {
+                "enabled": False,
+                "destructive_enabled": False,
+                "open_world_enabled": False,
+            }
+        },
+        "developer_instructions": "",
+        "instructions": "",
+        "compact_prompt": "",
+        "project_doc_max_bytes": 0,
+        "project_doc_fallback_filenames": [],
+        "include_apps_instructions": False,
+        "skills": {"include_instructions": False},
+        "include_environment_context": False,
+        "include_permissions_instructions": False,
+        "include_collaboration_mode_instructions": False,
+        "notify": [],
+        "history": {"persistence": "none"},
+        "check_for_update_on_startup": False,
+        "feedback": {"enabled": False},
+        "analytics": {"enabled": False},
+        "orchestrator": {
+            "skills": {"enabled": False},
+            "mcp": {"enabled": False},
+        },
+        "otel": {
+            "exporter": "none",
+            "trace_exporter": "none",
+            "metrics_exporter": "none",
+            "log_user_prompt": False,
+        },
+        "mcp_servers": {
+            name: {
+                "command": sys.executable,
+                "args": ["-m", "example"],
+                "enabled": True,
+            }
+            for name in mcp_server_names
+        },
+        "plugins": {
+            plugin_id: {"enabled": True}
+            for plugin_id in plugin_ids
+        },
+    }
+
+
+def test_selection_has_stable_json_projection() -> None:
+    selection = AgentExecutionSelection(
+        provider_id="codex",
+        model_id="gpt-test",
+        provider_label="Codex",
+        model_label="GPT Test",
+    )
+
+    assert selection.to_dict() == {
+        "provider_id": "codex",
+        "model_id": "gpt-test",
+        "provider_label": "Codex",
+        "model_label": "GPT Test",
+    }
+
+
+def test_probe_cache_reuses_then_refreshes() -> None:
+    now = [100.0]
+    calls: list[int] = []
+    cache: ProbeCache[str] = ProbeCache(
+        ttl_seconds=30,
+        clock=lambda: now[0],
+    )
+
+    def load() -> str:
+        calls.append(1)
+        return f"value-{len(calls)}"
+
+    assert cache.get_or_load("provider", load) == "value-1"
+    assert cache.get_or_load("provider", load) == "value-1"
+    assert cache.get_or_load("provider", load, refresh=True) == "value-2"
+    now[0] = 131.0
+    assert cache.get_or_load("provider", load) == "value-3"
+
+
+def test_claude_probe_is_cached_and_strips_api_billing_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "do-not-pass")
+    monkeypatch.setenv("SubAgent_Anthropic_Api_Key", "do-not-pass-either")
+    calls: list[dict[str, object]] = []
+
+    def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append({"command": command, **kwargs})
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=(
+                '{"loggedIn":true,"authMethod":"claude.ai",'
+                '"apiProvider":"firstParty","subscriptionType":"max",'
+                '"email":"private@example.test"}'
+            ),
+            stderr="",
+        )
+
+    provider = ClaudeCodeProvider(command_runner=run)
+    first = provider.probe()
+    second = provider.probe()
+
+    assert first is second
+    assert first.availability is ProviderAvailability.READY
+    assert [model.id for model in first.models] == ["sonnet", "opus"]
+    assert len(calls) == 1
+    assert calls[0]["command"] == [
+        "claude",
+        "--setting-sources",
+        "",
+        "--settings",
+        "{}",
+        "auth",
+        "status",
+    ]
+    assert calls[0]["shell"] is False
+    child_env = calls[0]["env"]
+    assert isinstance(child_env, dict)
+    assert all(
+        key.casefold()
+        not in {"anthropic_api_key", "subagent_anthropic_api_key"}
+        for key in child_env
+    )
+    assert "private@example.test" not in json.dumps(first.to_dict())
+
+
+def test_claude_probe_auth_required_and_allowlist_validation() -> None:
+    def run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            command,
+            1,
+            stdout='{"loggedIn":false}',
+            stderr="",
+        )
+
+    provider = ClaudeCodeProvider(command_runner=run)
+    descriptor = provider.probe()
+
+    assert descriptor.availability is ProviderAvailability.AUTH_REQUIRED
+    assert descriptor.unavailable_reason == (
+        "Sign in to Claude Code with your Claude account."
+    )
+    assert all(not model.available for model in descriptor.models)
+    with pytest.raises(ProviderUnavailableError):
+        provider.validate_selection(
+            AgentExecutionSelection("claude-code", "sonnet")
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "loggedIn": True,
+            "authMethod": "api_key",
+            "apiProvider": "firstParty",
+            "subscriptionType": "",
+            "email": "private@example.test",
+        },
+        {
+            "loggedIn": True,
+            "authMethod": "claude.ai",
+            "apiProvider": "bedrock",
+            "subscriptionType": "max",
+            "orgName": "Private Organization",
+        },
+        {
+            "loggedIn": True,
+            "authMethod": "claude.ai",
+            "apiProvider": "firstParty",
+            "subscriptionType": "",
+        },
+    ],
+)
+def test_claude_probe_rejects_non_subscription_auth_without_identity(
+    payload: dict[str, object],
+) -> None:
+    def run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(payload),
+            stderr="",
+        )
+
+    descriptor = ClaudeCodeProvider(command_runner=run).probe()
+
+    assert descriptor.availability is ProviderAvailability.UNAVAILABLE
+    assert descriptor.unavailable_reason == (
+        "Sign in to Claude Code with your Claude account."
+    )
+    public = json.dumps(descriptor.to_dict())
+    assert "private@example.test" not in public
+    assert "Private Organization" not in public
+
+
+def test_claude_probe_never_trusts_non_json_logged_in_text() -> None:
+    def run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="Logged in and authenticated with some credential.",
+            stderr="",
+        )
+
+    descriptor = ClaudeCodeProvider(command_runner=run).probe()
+
+    assert descriptor.availability is ProviderAvailability.UNKNOWN
+    assert descriptor.available is False
+
+
+def test_claude_rejects_model_outside_allowlist() -> None:
+    def run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=(
+                '{"loggedIn":true,"authMethod":"claude.ai",'
+                '"apiProvider":"firstParty","subscriptionType":"max"}'
+            ),
+            stderr="",
+        )
+
+    provider = ClaudeCodeProvider(command_runner=run)
+    with pytest.raises(UnknownModelError):
+        provider.validate_selection(
+            AgentExecutionSelection("claude-code", "haiku")
+        )
+
+
+def test_claude_start_passes_exact_model_and_account_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "not-in-child")
+    monkeypatch.setenv("WORK_BUDDY_SESSION_ID", "inherited-bootstrap-id")
+
+    def run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=(
+                '{"loggedIn":true,"authMethod":"claude.ai",'
+                '"apiProvider":"firstParty","subscriptionType":"max"}'
+            ),
+            stderr="",
+        )
+
+    captured: dict[str, object] = {}
+
+    def spawn(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"status": "ok", "pid": 42}
+
+    monkeypatch.setattr(
+        "work_buddy.sidecar.dispatch.executor.spawn_detached_process_authorized",
+        spawn,
+    )
+    provider = ClaudeCodeProvider(command_runner=run)
+    outcome = provider.start_detached(
+        AgentSpawnRequest(
+            name="document",
+            prompt="brief",
+            selection=AgentExecutionSelection("claude-code", "opus"),
+            working_directory=tmp_path,
+            session_id="claude-generation-cowork",
+            max_budget_usd=3.5,
+        )
+    )
+
+    argv = captured["argv"]
+    assert isinstance(argv, list)
+    assert argv[:3] == [
+        sys.executable,
+        "-m",
+        "work_buddy.agent_execution.claude_worker",
+    ]
+    assert argv[argv.index("--model") + 1] == "opus"
+    assert argv[argv.index("--max-budget-usd") + 1] == "3.5"
+    assert captured["session_name"] == "claude-generation-cowork"
+    assert "brief" not in argv
+    stdin_text = captured["stdin_text"]
+    assert isinstance(stdin_text, str)
+    assert '`session_id="claude-generation-cowork"`' in stdin_text
+    assert '`harness_id="claudecode"`' in stdin_text
+    assert "`workspace=" not in stdin_text
+    assert str(tmp_path.resolve()) not in stdin_text
+    assert "inherited-bootstrap-id" not in stdin_text
+    assert stdin_text.endswith("brief")
+    assert Path(captured["cwd"]) != tmp_path.resolve()
+    child_env = captured["env"]
+    assert isinstance(child_env, dict)
+    assert "ANTHROPIC_API_KEY" not in child_env
+    assert (
+        child_env["WORK_BUDDY_SESSION_ID"]
+        == "claude-generation-cowork"
+    )
+    assert outcome.ok and outcome.pid == 42
+    assert outcome.session_id == "claude-generation-cowork"
+    assert outcome.selection.model_label == "Opus"
+
+
+def test_claude_worker_uses_empty_neutral_cwd_and_no_session_persistence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "not-in-claude")
+    monkeypatch.setenv("WORK_BUDDY_SESSION_ID", "inherited-bootstrap-id")
+    calls: dict[str, object] = {}
+
+    def run(command: list[str], **kwargs: object) -> object:
+        calls["command"] = command
+        calls.update(kwargs)
+        host_cwd = Path(kwargs["cwd"])
+        assert host_cwd.is_dir()
+        assert list(host_cwd.iterdir()) == []
+        assert host_cwd != tmp_path.resolve()
+        return SimpleNamespace(returncode=0)
+
+    result = run_claude_worker(
+        model="opus",
+        prompt="private brief",
+        session_id="claude-generation-cowork",
+        max_budget_usd=3.5,
+        command_runner=run,
+    )
+
+    assert result == 0
+    argv = calls["command"]
+    assert isinstance(argv, list)
+    assert argv[argv.index("--model") + 1] == "opus"
+    assert argv[argv.index("--max-budget-usd") + 1] == "3.5"
+    assert argv[argv.index("--setting-sources") + 1] == ""
+    assert argv[argv.index("--settings") + 1] == "{}"
+    assert "--strict-mcp-config" in argv
+    assert "--no-session-persistence" in argv
+    assert "--no-chrome" in argv
+    assert argv.count("--disable-slash-commands") == 1
+    assert argv[argv.index("--tools") + 1] == ""
+    assert "--bare" not in argv
+    assert "private brief" not in argv
+    mcp_config = json.loads(argv[argv.index("--mcp-config") + 1])
+    assert mcp_config == {
+        "mcpServers": {
+            "work-buddy": {
+                "type": "http",
+                "url": "http://localhost:5126/mcp",
+                "headers": {
+                    "X-Work-Buddy-Session": "claude-generation-cowork",
+                },
+            }
+        }
+    }
+    assert calls["input"] == "private brief"
+    assert calls["shell"] is False
+    assert calls["stdout"] is subprocess.DEVNULL
+    assert calls["stderr"] is subprocess.DEVNULL
+    assert not Path(calls["cwd"]).exists()
+    child_env = calls["env"]
+    assert isinstance(child_env, dict)
+    assert "ANTHROPIC_API_KEY" not in child_env
+    assert child_env["CLAUDE_CODE_DISABLE_ATTACHMENTS"] == "1"
+    assert child_env["CLAUDE_CODE_DISABLE_CLAUDE_MDS"] == "1"
+    assert child_env["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] == "1"
+    assert child_env["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "false"
+    assert child_env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
+    assert (
+        child_env["WORK_BUDDY_SESSION_ID"]
+        == "claude-generation-cowork"
+    )
+
+
+def test_claude_worker_rejects_unsafe_direct_identity() -> None:
+    assert (
+        run_claude_worker(
+            model="sonnet",
+            prompt="brief",
+            session_id="unsafe\nheader",
+            max_budget_usd=1.0,
+            command_runner=lambda *_args, **_kwargs: pytest.fail(
+                "Claude must not start"
+            ),
+        )
+        == 2
+    )
+
+
+class _FakeCodexProbeClient:
+    def __init__(
+        self,
+        *,
+        account_type: str = "chatgpt",
+        requires_auth: bool = False,
+        fail: Exception | None = None,
+    ) -> None:
+        self._account_type = account_type
+        self._requires_auth = requires_auth
+        self._fail = fail
+
+    def __enter__(self) -> "_FakeCodexProbeClient":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def account(self, *, refresh_token: bool) -> object:
+        assert refresh_token is False
+        if self._fail is not None:
+            raise self._fail
+        account = SimpleNamespace(
+            type=self._account_type,
+            email="private@example.test",
+        )
+        return SimpleNamespace(
+            account=SimpleNamespace(root=account),
+            requires_openai_auth=self._requires_auth,
+        )
+
+    def models(self, *, include_hidden: bool) -> object:
+        assert include_hidden is False
+        return SimpleNamespace(
+            data=[
+                SimpleNamespace(
+                    model="gpt-visible",
+                    display_name="GPT Visible",
+                    hidden=False,
+                    is_default=True,
+                    description="Visible model",
+                ),
+                SimpleNamespace(
+                    model="gpt-hidden",
+                    display_name="GPT Hidden",
+                    hidden=True,
+                    is_default=False,
+                    description="Hidden model",
+                ),
+            ]
+        )
+
+
+def test_codex_sdk_probe_projects_only_chatgpt_and_model_fields() -> None:
+    payload = collect_redacted_probe(
+        lambda: _FakeCodexProbeClient(requires_auth=True)
+    )
+
+    assert payload["availability"] == "ready"
+    assert payload["auth_mode"] == "chatgpt"
+    assert payload["models"] == [
+        {
+            "id": "gpt-visible",
+            "label": "GPT Visible",
+            "available": True,
+            "description": "Visible model",
+            "unavailable_reason": "",
+            "is_default": True,
+        }
+    ]
+    assert "private@example.test" not in json.dumps(payload)
+
+
+def test_codex_sdk_probe_rejects_api_key_without_leaking_details() -> None:
+    payload = collect_redacted_probe(
+        lambda: _FakeCodexProbeClient(account_type="apiKey")
+    )
+    failed = collect_redacted_probe(
+        lambda: _FakeCodexProbeClient(
+            fail=RuntimeError("secret-token-and-private-path")
+        )
+    )
+
+    assert payload["availability"] == "unavailable"
+    assert payload["auth_mode"] == "chatgpt"
+    assert "API" not in payload["unavailable_reason"]
+    assert "secret-token-and-private-path" not in json.dumps(failed)
+    assert failed["availability"] == "unknown"
+
+
+def test_codex_provider_parses_redacted_probe_and_caches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "not-in-probe")
+    monkeypatch.setenv("CODEX_API_KEY", "also-not-in-probe")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.example.test")
+    monkeypatch.setenv("CODEX_MODEL_PROVIDER", "custom-provider")
+    calls: list[list[str]] = []
+    payload = {
+        "availability": "ready",
+        "auth_mode": "chatgpt",
+        "models": [
+            {
+                "id": "gpt-5.6-sol",
+                "label": "GPT-5.6 Sol",
+                "available": True,
+                "description": "Frontier",
+                "is_default": True,
+            }
+        ],
+        "unavailable_reason": "",
+        "state_key": "safe-key",
+    }
+
+    def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        assert kwargs["shell"] is False
+        child_env = kwargs["env"]
+        assert isinstance(child_env, dict)
+        assert "OPENAI_API_KEY" not in child_env
+        assert "CODEX_API_KEY" not in child_env
+        assert "OPENAI_BASE_URL" not in child_env
+        assert "CODEX_MODEL_PROVIDER" not in child_env
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(payload),
+            stderr="account@example.test",
+        )
+
+    provider = CodexProvider(command_runner=run)
+    descriptor = provider.probe()
+    assert provider.probe() is descriptor
+
+    assert calls == [
+        [
+            sys.executable,
+            "-m",
+            "work_buddy.agent_execution.codex_probe_worker",
+        ]
+    ]
+    assert descriptor.available
+    assert descriptor.state_key == "safe-key"
+    validated = provider.validate_selection(
+        AgentExecutionSelection("codex", "gpt-5.6-sol")
+    )
+    assert validated.to_dict() == {
+        "provider_id": "codex",
+        "model_id": "gpt-5.6-sol",
+        "provider_label": "Codex",
+        "model_label": "GPT-5.6 Sol",
+    }
+    assert "account@example.test" not in json.dumps(descriptor.to_dict())
+
+
+def test_codex_start_uses_worker_stdin_exact_model_and_no_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "not-in-child")
+    monkeypatch.setenv("CODEX_API_KEY", "also-not-in-child")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.example.test")
+    monkeypatch.setenv("CODEX_MODEL_PROVIDER", "custom-provider")
+    monkeypatch.setenv("WORK_BUDDY_SESSION_ID", "inherited-bootstrap-id")
+    probe_payload = {
+        "availability": "ready",
+        "models": [
+            {
+                "id": "gpt-selected",
+                "label": "GPT Selected",
+                "available": True,
+            }
+        ],
+    }
+
+    def run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(probe_payload),
+            stderr="",
+        )
+
+    captured: dict[str, object] = {}
+
+    def spawn(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"status": "ok", "pid": 84}
+
+    monkeypatch.setattr(
+        "work_buddy.sidecar.dispatch.executor.spawn_detached_process_authorized",
+        spawn,
+    )
+    provider = CodexProvider(command_runner=run)
+    outcome = provider.start_detached(
+        AgentSpawnRequest(
+            name="document",
+            prompt="private brief",
+            selection=AgentExecutionSelection("codex", "gpt-selected"),
+            working_directory=tmp_path,
+            session_id="work-buddy-session",
+        )
+    )
+
+    argv = captured["argv"]
+    assert isinstance(argv, list)
+    assert argv[:3] == [
+        sys.executable,
+        "-m",
+        "work_buddy.agent_execution.codex_worker",
+    ]
+    assert argv[argv.index("--model") + 1] == "gpt-selected"
+    assert captured["session_name"] == "work-buddy-session"
+    assert "private brief" not in argv
+    assert str(tmp_path.resolve()) not in argv
+    stdin_text = captured["stdin_text"]
+    assert isinstance(stdin_text, str)
+    assert '`session_id="work-buddy-session"`' in stdin_text
+    assert '`harness_id="codexcli"`' in stdin_text
+    assert "`workspace=" not in stdin_text
+    assert str(tmp_path.resolve()) not in stdin_text
+    assert "inherited-bootstrap-id" not in stdin_text
+    assert stdin_text.endswith("private brief")
+    child_env = captured["env"]
+    assert isinstance(child_env, dict)
+    assert "OPENAI_API_KEY" not in child_env
+    assert "CODEX_API_KEY" not in child_env
+    assert "OPENAI_BASE_URL" not in child_env
+    assert "CODEX_MODEL_PROVIDER" not in child_env
+    assert child_env["WORK_BUDDY_SESSION_ID"] == "work-buddy-session"
+    assert outcome.ok and outcome.session_id == "work-buddy-session"
+
+
+def test_codex_worker_uses_read_only_ephemeral_exact_model(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("WORK_BUDDY_SESSION_ID", "before-worker-test")
+    calls: dict[str, object] = {}
+    instances: list[object] = []
+
+    discovered_config = _isolated_effective_codex_config(
+        "node_repl",
+        "work-buddy",
+        plugin_ids=("personal@example",),
+    )
+    isolated_config = _isolated_effective_codex_config(
+        "node_repl",
+        "work-buddy",
+        plugin_ids=("personal@example",),
+    )
+    for entry in isolated_config["mcp_servers"].values():  # type: ignore[union-attr]
+        entry["enabled"] = False
+    for entry in isolated_config["plugins"].values():  # type: ignore[union-attr]
+        entry["enabled"] = False
+
+    class FakeThread:
+        def run(self, prompt: str, **kwargs: object) -> object:
+            calls["run"] = (prompt, kwargs)
+            return SimpleNamespace(final_response="done")
+
+    class FakeCodex:
+        def __init__(self) -> None:
+            instance_index = len(instances)
+            instances.append(self)
+            effective_config = (
+                discovered_config
+                if instance_index == 0
+                else isolated_config
+            )
+            self._client = SimpleNamespace(
+                _request_raw=lambda method, params: {
+                    "config": effective_config
+                }
+            )
+
+        def __enter__(self) -> "FakeCodex":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def thread_start(self, **kwargs: object) -> FakeThread:
+            calls["thread_start"] = kwargs
+            return FakeThread()
+
+    result = run_worker(
+        model="gpt-exact",
+        prompt="agent brief",
+        session_id="generation-cowork",
+        mcp_url="http://localhost:5126/mcp",
+        codex_factory=FakeCodex,
+    )
+
+    assert result == 0
+    assert len(instances) == 2
+    assert calls["thread_start"]["model"] == "gpt-exact"  # type: ignore[index]
+    assert calls["thread_start"]["model_provider"] == "openai"  # type: ignore[index]
+    assert calls["thread_start"]["ephemeral"] is True  # type: ignore[index]
+    assert calls["thread_start"]["sandbox"].value == "read-only"  # type: ignore[index]
+    assert calls["run"][0] == "agent brief"  # type: ignore[index]
+    assert calls["run"][1]["model"] == "gpt-exact"  # type: ignore[index]
+    assert calls["run"][1]["sandbox"].value == "read-only"  # type: ignore[index]
+    assert calls["thread_start"]["config"] == build_thread_config(  # type: ignore[index]
+        mcp_url="http://localhost:5126/mcp",
+        session_id="generation-cowork",
+        inherited_mcp_server_names=("node_repl", "work-buddy"),
+    )
+    assert calls["thread_start"]["config"]["mcp_servers"].keys() == {  # type: ignore[index]
+        "node_repl",
+        "work-buddy",
+    }
+    assert (
+        calls["thread_start"]["config"]["mcp_servers"]["work-buddy"][  # type: ignore[index]
+            "default_tools_approval_mode"
+        ]
+        == "approve"
+    )
+    assert (
+        calls["thread_start"]["config"]["mcp_servers"]["node_repl"][  # type: ignore[index]
+            "enabled"
+        ]
+        is False
+    )
+    assert (
+        calls["thread_start"]["config"]["mcp_servers"]["work-buddy"][  # type: ignore[index]
+            "http_headers"
+        ]
+        == {"X-Work-Buddy-Session": "generation-cowork"}
+    )
+    thread_cwd = Path(calls["thread_start"]["cwd"])  # type: ignore[index]
+    assert thread_cwd != tmp_path.resolve()
+    assert not thread_cwd.exists()
+    assert str(tmp_path.resolve()) not in calls["thread_start"][  # type: ignore[operator]
+        "base_instructions"
+    ]
+    assert "Work Buddy MCP server" in calls["thread_start"][  # type: ignore[operator]
+        "base_instructions"
+    ]
+    assert "not as permission" in calls["thread_start"][  # type: ignore[operator]
+        "developer_instructions"
+    ]
+
+
+def test_codex_worker_rejects_nonlocal_mcp_endpoint() -> None:
+    with pytest.raises(ValueError):
+        _local_mcp_url("https://example.com/mcp")
+    with pytest.raises(ValueError):
+        _local_mcp_url("http://localhost:5126/not-mcp")
+    with pytest.raises(ValueError):
+        _local_mcp_url("http://localhost:5126/mcp?redirect=elsewhere")
+
+
+class _FakeProvider:
+    def __init__(self, provider_id: str, label: str, model_id: str) -> None:
+        self.provider_id = provider_id
+        self.label = label
+        self.auth_mode = "test"
+        self.default_model_id = model_id
+        self.model_id = model_id
+        self.probe_count = 0
+        self.start_requests: list[AgentSpawnRequest] = []
+
+    def probe(self, *, refresh: bool = False) -> ProviderDescriptor:
+        self.probe_count += 1
+        return ProviderDescriptor(
+            id=self.provider_id,
+            label=self.label,
+            availability=ProviderAvailability.READY,
+            auth_mode=self.auth_mode,
+            models=(
+                ModelDescriptor(
+                    id=self.model_id,
+                    label=f"{self.label} Model",
+                    is_default=True,
+                ),
+            ),
+        )
+
+    def validate_selection(
+        self,
+        selection: AgentExecutionSelection,
+        *,
+        refresh: bool = False,
+    ) -> AgentExecutionSelection:
+        self.probe(refresh=refresh)
+        if selection.model_id != self.model_id:
+            raise UnknownModelError(selection.model_id)
+        return AgentExecutionSelection(
+            provider_id=self.provider_id,
+            model_id=self.model_id,
+            provider_label=self.label,
+            model_label=f"{self.label} Model",
+        )
+
+    def start_detached(self, request: AgentSpawnRequest) -> object:
+        self.start_requests.append(request)
+        return SimpleNamespace(selection=request.selection)
+
+
+def test_registry_default_is_deterministic_without_probe_and_dispatches_validated(
+    tmp_path: Path,
+) -> None:
+    provider = _FakeProvider("test", "Test", "model")
+    default = AgentExecutionSelection(
+        "test",
+        "model",
+        "Test",
+        "Test Model",
+    )
+    registry = ProviderRegistry([provider], default_selection=default)
+
+    assert registry.default_selection is default
+    assert provider.probe_count == 0
+    assert registry.get_catalog().default_selection is default
+    assert provider.probe_count == 1
+    outcome = registry.start_detached(
+        AgentSpawnRequest(
+            name="document",
+            prompt="brief",
+            selection=AgentExecutionSelection("test", "model"),
+            session_id="registry-session",
+            working_directory=tmp_path,
+        )
+    )
+    assert outcome.selection.provider_label == "Test"
+    assert provider.start_requests[0].selection.model_label == "Test Model"
+    with pytest.raises(UnknownProviderError):
+        registry.validate_selection(
+            AgentExecutionSelection("missing", "model")
+        )
+
+
+def test_global_registry_preserves_configured_supported_claude_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        execution_registry,
+        "load_config",
+        lambda: {
+            "sidecar": {
+                "agent_spawn": {
+                    "model": "opus",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(execution_registry, "_registry", None)
+
+    selected = execution_registry.default_selection()
+
+    assert selected == AgentExecutionSelection(
+        provider_id="claude-code",
+        model_id="opus",
+        provider_label="Claude Code",
+        model_label="Opus",
+    )
+
+
+def test_spawn_request_requires_safe_caller_supplied_session_id() -> None:
+    with pytest.raises(ValueError, match="session_id"):
+        AgentSpawnRequest(
+            name="document",
+            prompt="brief",
+            selection=AgentExecutionSelection("claude-code", "sonnet"),
+            session_id="",
+        )
+    with pytest.raises(ValueError, match="session_id"):
+        AgentSpawnRequest(
+            name="document",
+            prompt="brief",
+            selection=AgentExecutionSelection("claude-code", "sonnet"),
+            session_id="unsafe\ninjection",
+        )
+
+
+def test_registry_catalog_probes_concurrently_preserves_order_and_isolates_failure(
+) -> None:
+    barrier = threading.Barrier(2)
+
+    class ConcurrentProvider(_FakeProvider):
+        def probe(self, *, refresh: bool = False) -> ProviderDescriptor:
+            barrier.wait(timeout=2)
+            return super().probe(refresh=refresh)
+
+    class FailingProvider(_FakeProvider):
+        def probe(self, *, refresh: bool = False) -> ProviderDescriptor:
+            barrier.wait(timeout=2)
+            raise RuntimeError("private-account-and-runtime-detail")
+
+    first = ConcurrentProvider("first", "First", "model-1")
+    second = FailingProvider("second", "Second", "model-2")
+    registry = ProviderRegistry(
+        [first, second],
+        default_selection=AgentExecutionSelection(
+            "first",
+            "model-1",
+            "First",
+            "First Model",
+        ),
+    )
+
+    catalog = registry.get_catalog(refresh=True)
+
+    assert [provider.id for provider in catalog.providers] == [
+        "first",
+        "second",
+    ]
+    assert catalog.providers[0].availability is ProviderAvailability.READY
+    assert catalog.providers[1].availability is ProviderAvailability.UNKNOWN
+    assert catalog.providers[1].unavailable_reason == (
+        "Second couldn't be checked."
+    )
+    assert "private-account" not in json.dumps(catalog.to_dict())
+
+
+def test_codex_subscription_config_forces_minimal_chatgpt_host(
+    tmp_path: Path,
+) -> None:
+    config = codex_subscription_config(
+        cwd=tmp_path,
+        env={
+            "OPENAI_API_KEY": "secret",
+            "CODEX_API_KEY": "secret",
+            "KEEP": "yes",
+        },
+    )
+
+    assert config.cwd == str(tmp_path.resolve())
+    assert config.env == {"KEEP": "yes"}
+    overrides = set(config.config_overrides)
+    assert {
+        'forced_login_method="chatgpt"',
+        'model_provider="openai"',
+        'chatgpt_base_url="https://chatgpt.com/backend-api/"',
+        'openai_base_url="https://api.openai.com/v1"',
+        'approval_policy="never"',
+        'sandbox_mode="read-only"',
+        "allow_login_shell=false",
+        "features.hooks=false",
+        "features.apps=false",
+        "features.plugins=false",
+        "features.plugin_sharing=false",
+        "features.multi_agent=false",
+        "features.shell_tool=false",
+        "features.shell_snapshot=false",
+        "features.unified_exec=false",
+        "features.network_proxy=false",
+        "features.browser_use=false",
+        "features.computer_use=false",
+        "features.code_mode=false",
+        "features.workspace_dependencies=false",
+        "features.tool_suggest=false",
+        'web_search="disabled"',
+        "tools.web_search=false",
+        "tools.view_image=false",
+        "apps._default.enabled=false",
+        "developer_instructions=\"\"",
+        "instructions=\"\"",
+        "compact_prompt=\"\"",
+        "project_doc_max_bytes=0",
+        "include_apps_instructions=false",
+        "skills.include_instructions=false",
+        "include_environment_context=false",
+        "include_permissions_instructions=false",
+        "include_collaboration_mode_instructions=false",
+        "notify=[]",
+        'history.persistence="none"',
+        "check_for_update_on_startup=false",
+        "feedback.enabled=false",
+        "analytics.enabled=false",
+        "orchestrator.skills.enabled=false",
+        "orchestrator.mcp.enabled=false",
+        'otel.exporter="none"',
+        'otel.trace_exporter="none"',
+        'otel.metrics_exporter="none"',
+        "otel.log_user_prompt=false",
+    } <= overrides
+    assert not any(
+        override.startswith(("mcp_servers.", "plugins."))
+        for override in overrides
+    )
+
+
+def test_codex_config_read_enumerates_inherited_mcps_and_fails_closed(
+    tmp_path: Path,
+) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+    effective = _isolated_effective_codex_config(
+        "z-user-server",
+        "a-project-server",
+    )
+
+    def request_raw(
+        method: str,
+        params: dict[str, object],
+    ) -> dict[str, object]:
+        calls.append((method, params))
+        return {"config": effective}
+
+    codex = SimpleNamespace(
+        _client=SimpleNamespace(_request_raw=request_raw)
+    )
+    config = read_effective_codex_config(codex, cwd=tmp_path)
+    validate_subscription_codex_config(config)
+
+    assert effective_mcp_server_names(config) == (
+        "a-project-server",
+        "z-user-server",
+    )
+    assert calls == [
+        (
+            "config/read",
+            {
+                "cwd": str(tmp_path.resolve()),
+                "includeLayers": False,
+            },
+        )
+    ]
+    with pytest.raises(CodexConfigIsolationError):
+        read_effective_codex_config(SimpleNamespace(), cwd=tmp_path)
+    with pytest.raises(CodexConfigIsolationError):
+        validate_subscription_codex_config(
+            {
+                **effective,
+                "model_provider": "custom",
+            }
+        )
+    with pytest.raises(CodexConfigIsolationError):
+        validate_subscription_codex_config(
+            {
+                **effective,
+                "model_instructions_file": "private-instructions.md",
+            }
+        )
+    with pytest.raises(CodexConfigIsolationError):
+        validate_subscription_codex_config(
+            {
+                **effective,
+                "model_catalog_json": "private-models.json",
+            }
+        )
+    with pytest.raises(CodexConfigIsolationError):
+        effective_mcp_server_names(
+            {
+                **effective,
+                "mcp_servers": ["not", "a", "mapping"],
+            }
+        )
+
+
+def test_codex_entry_isolation_replaces_transports_and_verifies_every_entry(
+) -> None:
+    discovered = _isolated_effective_codex_config(
+        "command.server",
+        plugin_ids=("plugin@example",),
+    )
+    discovered["mcp_servers"]["url/server"] = {  # type: ignore[index]
+        "url": "https://untrusted.example.test/mcp",
+        "enabled": True,
+    }
+
+    overrides = codex_entry_isolation_overrides(
+        effective_config=discovered,
+        plugin_ids=effective_plugin_ids(discovered),
+    )
+
+    assert len(overrides) == 2
+    assert overrides[0].startswith("mcp_servers={")
+    assert '"command.server"=' in overrides[0]
+    assert f"command={json.dumps(sys.executable)}" in overrides[0]
+    assert 'args=["-c","pass"]' in overrides[0]
+    assert '"url/server"=' in overrides[0]
+    assert 'url="http://127.0.0.1:9/work-buddy-disabled"' in overrides[0]
+    assert overrides[0].count("enabled=false") == 2
+    assert overrides[1] == 'plugins={"plugin@example"={enabled=false}}'
+
+    isolated = _isolated_effective_codex_config(
+        "command.server",
+        plugin_ids=("plugin@example",),
+    )
+    isolated["mcp_servers"]["url/server"] = {  # type: ignore[index]
+        "url": "http://127.0.0.1:9/work-buddy-disabled",
+        "enabled": False,
+    }
+    isolated["mcp_servers"]["command.server"]["enabled"] = False  # type: ignore[index]
+    isolated["plugins"]["plugin@example"]["enabled"] = False  # type: ignore[index]
+    validate_entry_isolation(
+        isolated,
+        mcp_server_names=("command.server", "url/server"),
+        plugin_ids=("plugin@example",),
+    )
+
+    isolated["plugins"]["late-plugin"] = {"enabled": False}  # type: ignore[index]
+    with pytest.raises(CodexConfigIsolationError):
+        validate_entry_isolation(
+            isolated,
+            mcp_server_names=("command.server", "url/server"),
+            plugin_ids=("plugin@example",),
+        )
+
+
+def test_codex_worker_fails_closed_without_config_read(
+    tmp_path: Path,
+) -> None:
+    thread_started = False
+
+    class FakeCodex:
+        def __enter__(self) -> "FakeCodex":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def thread_start(self, **_kwargs: object) -> object:
+            nonlocal thread_started
+            thread_started = True
+            raise AssertionError("thread must not start")
+
+    assert (
+        run_worker(
+            model="gpt-exact",
+            prompt="agent brief",
+            session_id="generated-session",
+            mcp_url="http://localhost:5126/mcp",
+            codex_factory=FakeCodex,
+        )
+        == 1
+    )
+    assert thread_started is False
+
+
+def test_codex_worker_rejects_unsafe_direct_session_identity(
+    tmp_path: Path,
+) -> None:
+    assert (
+        run_worker(
+            model="gpt-exact",
+            prompt="agent brief",
+            session_id="unsafe\nheader",
+            mcp_url="http://localhost:5126/mcp",
+            codex_factory=lambda: object(),
+        )
+        == 2
+    )
+
+
+def test_environment_sanitizers_are_case_insensitive() -> None:
+    assert claude_account_environment(
+        {
+            "Anthropic_Api_Key": "secret",
+            "ANTHROPIC_MODEL": "claude-rerouted",
+            "aNtHrOpIc_Future_Credential": "future-secret",
+            "SUBAGENT_ANTHROPIC_API_KEY": "secret",
+            "SubAgent_Anthropic_Future_Route": "future-route",
+            "ANTHROPIC_AUTH_TOKEN": "secret",
+            "ANTHROPIC_BASE_URL": "https://gateway.example.test",
+            "Claude_Code_OAuth_Token": "different-account",
+            "CLAUDE_CODE_OAUTH_REFRESH_TOKEN": "refresh",
+            "claude_code_oauth_scopes": "user:profile",
+            "CLAUDE_CODE_USE_BEDROCK": "1",
+            "CLAUDE_CODE_USE_VERTEX": "1",
+            "CLAUDE_CODE_USE_FOUNDRY": "1",
+            "CLAUDE_CODE_USE_MANTLE": "1",
+            "CLAUDE_CODE_USE_GATEWAY": "1",
+            "CLAUDE_CODE_SKIP_PLUGIN_MCP_SERVERS": "1",
+            "ANTHROPIC_BEDROCK_BASE_URL": "https://bedrock.example.test",
+            "ANTHROPIC_VERTEX_BASE_URL": "https://vertex.example.test",
+            "ANTHROPIC_FOUNDRY_BASE_URL": "https://foundry.example.test",
+            "CLAUDE_CODE_SKIP_BEDROCK_AUTH": "1",
+            "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "500",
+            "Claude_Code_Enable_Telemetry": "1",
+            "cLaUdE_CoDe_EnHaNcEd_TeLeMeTrY_BeTa": "1",
+            "Enable_Enhanced_Telemetry_Beta": "1",
+            "oTeL_LoGs_ExPoRtEr": "otlp",
+            "OTEL_EXPORTER_OTLP_ENDPOINT": "https://collector.example.test",
+            "otel_log_raw_api_bodies": "1",
+            "OtEl_LoG_UsEr_PrOmPtS": "1",
+            "TraceParent": "00-secret-parent",
+            "TRACESTATE": "vendor=secret",
+            "Claude_Code_Disable_Nonessential_Traffic": "0",
+            "Disable_Telemetry": "0",
+            "DISABLE_ERROR_REPORTING": "0",
+            "Do_Not_Track": "0",
+            "Claude_Code_Auto_Connect_Ide": "true",
+            "Claude_Code_Disable_Attachments": "0",
+            "Claude_Code_Disable_Auto_Memory": "0",
+            "Claude_Code_Disable_Claude_Mds": "0",
+            "claude_code_ide_skip_auto_install": "0",
+            "DEBUG": "claude:*",
+            "Claude_Debug": "1",
+            "DEBUG_CLAUDE_AGENT_SDK": "1",
+            "DEBUG_SDK": "1",
+            "Claude_Code_Debug_Logs_Dir": "C:/private/debug",
+            "CLAUDE_CODE_SYNC_PLUGINS": "1",
+            "CLAUDE_CODE_SYNC_PLUGIN_INSTALL": "1",
+            "CLAUDE_CODE_SYNC_SKILLS": "1",
+            "CLAUDE_CODE_ENABLE_BACKGROUND_PLUGIN_REFRESH": "1",
+            "CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL": "0",
+            "FORCE_AUTOUPDATE_PLUGINS": "1",
+            "CLAUDE_CODE_MANAGED_SETTINGS_PATH": "C:/untrusted/policy.json",
+            "HTTPS_PROXY": "https://proxy.example.test",
+            "SSL_CERT_FILE": "certificate.pem",
+            "KEEP": "yes",
+        }
+    ) == {
+        "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
+        "CLAUDE_CODE_ENHANCED_TELEMETRY_BETA": "0",
+        "ENABLE_ENHANCED_TELEMETRY_BETA": "0",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+        "CLAUDE_CODE_AUTO_CONNECT_IDE": "false",
+        "CLAUDE_CODE_DISABLE_ATTACHMENTS": "1",
+        "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
+        "CLAUDE_CODE_DISABLE_CLAUDE_MDS": "1",
+        "CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL": "1",
+        "CLAUDE_CODE_SYNC_PLUGINS": "0",
+        "CLAUDE_CODE_SYNC_PLUGIN_INSTALL": "0",
+        "CLAUDE_CODE_SYNC_SKILLS": "0",
+        "CLAUDE_CODE_ENABLE_BACKGROUND_PLUGIN_REFRESH": "0",
+        "CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL": "1",
+        "HTTPS_PROXY": "https://proxy.example.test",
+        "SSL_CERT_FILE": "certificate.pem",
+        "KEEP": "yes",
+    }
+    assert codex_chatgpt_environment(
+        {
+            "OpenAI_Api_Key": "secret",
+            "AZURE_OPENAI_API_KEY": "secret",
+            "CODEX_API_KEY": "not-managed-session-plumbing",
+            "OPENAI_BASE_URL": "https://api.example.test",
+            "CODEX_BASE_URL": "https://codex.example.test",
+            "OPENAI_MODEL_PROVIDER": "custom",
+            "CODEX_MODEL_PROVIDER": "custom",
+            "CODEX_HOME": "C:/safe/auth-location",
+            "HTTPS_PROXY": "https://proxy.example.test",
+            "KEEP": "yes",
+        }
+    ) == {
+        "CODEX_HOME": "C:/safe/auth-location",
+        "HTTPS_PROXY": "https://proxy.example.test",
+        "KEEP": "yes",
+    }

--- a/tests/unit/test_agent_execution_executor.py
+++ b/tests/unit/test_agent_execution_executor.py
@@ -1,0 +1,478 @@
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from work_buddy.sidecar.dispatch import executor
+
+
+class _Input:
+    def __init__(self) -> None:
+        self.value = ""
+        self.closed = False
+
+    def write(self, value: str) -> None:
+        self.value += value
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _Process:
+    def __init__(self, pid: int = 123, returncode: int | None = None) -> None:
+        self.pid = pid
+        self.returncode = returncode
+        self.stdin = _Input()
+        self.killed = False
+
+    def kill(self) -> None:
+        self.killed = True
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.killed = True
+
+
+class _TerminableProcess(_Process):
+    def wait(self, timeout: float | None = None) -> int:
+        if self.returncode is None:
+            raise executor.subprocess.TimeoutExpired(
+                cmd="detached-test-process",
+                timeout=timeout,
+            )
+        return self.returncode
+
+
+class _WaitableProcess(_Process):
+    def __init__(self, pid: int = 123) -> None:
+        super().__init__(pid=pid)
+        self.exited = threading.Event()
+
+    def wait(self) -> int:
+        self.exited.wait(1)
+        self.returncode = 0
+        return 0
+
+
+@pytest.fixture(autouse=True)
+def _clear_owned_processes():
+    executor._OWNED_DETACHED_PROCESSES.clear()
+    yield
+    executor._OWNED_DETACHED_PROCESSES.clear()
+
+
+def test_generic_detached_spawn_uses_fixed_argv_no_shell_and_stdin(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+    process = _Process()
+
+    def popen(command: list[str], **kwargs: object) -> _Process:
+        captured["command"] = command
+        captured.update(kwargs)
+        return process
+
+    monkeypatch.setattr(executor.subprocess, "Popen", popen)
+    result = executor._spawn_detached_process_unchecked(
+        name="codex-worker",
+        argv=["python", "-m", "worker", "--model", "exact"],
+        cwd=tmp_path,
+        env={"SAFE": "yes"},
+        stdin_text="private prompt",
+        session_name="daemon:codex-worker",
+    )
+
+    assert result == {
+        "status": "ok",
+        "pid": 123,
+        "session_name": "daemon:codex-worker",
+        "process_owner": "daemon:codex-worker",
+    }
+    assert captured["command"] == [
+        "python",
+        "-m",
+        "worker",
+        "--model",
+        "exact",
+    ]
+    assert captured["shell"] is False
+    assert captured["start_new_session"] is (executor.os.name != "nt")
+    assert captured["cwd"] == str(tmp_path)
+    assert captured["env"] == {"SAFE": "yes"}
+    assert process.stdin.value == "private prompt"
+    assert process.stdin.closed
+    assert (
+        executor._owned_detached_process(123, "daemon:codex-worker")
+        is process
+    )
+
+
+def test_generic_detached_spawn_bounds_stdin_delivery(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    release = threading.Event()
+    process = _Process(pid=456)
+    terminated: list[int] = []
+
+    def blocked_write(_value: str) -> None:
+        release.wait(1)
+
+    process.stdin.write = blocked_write
+    monkeypatch.setattr(
+        executor.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: process,
+    )
+    monkeypatch.setattr(
+        executor,
+        "_DETACHED_STDIN_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    def terminate(proc: _Process, owner_token: str) -> bool:
+        terminated.append(proc.pid)
+        executor._forget_owned_detached_process(
+            proc.pid,
+            owner_token,
+            proc,
+        )
+        return True
+
+    monkeypatch.setattr(executor, "_terminate_owned_process_handle", terminate)
+    result = executor._spawn_detached_process_unchecked(
+        name="blocked-worker",
+        argv=["python", "-m", "worker"],
+        cwd=tmp_path,
+        stdin_text="private prompt",
+        session_name="blocked-owner",
+    )
+    release.set()
+
+    assert result == {
+        "status": "error",
+        "error_code": "spawn_input_timeout",
+        "error": "Agent process could not start.",
+    }
+    assert terminated == [456]
+    assert executor._owned_detached_process(456, "blocked-owner") is None
+
+
+def test_failed_stdin_delivery_keeps_reaper_and_cleanup_retry(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    release = threading.Event()
+    process = _Process(pid=457)
+    reaped: list[tuple[int, str]] = []
+    retried: list[tuple[int, str]] = []
+
+    def blocked_write(_value: str) -> None:
+        release.wait(1)
+
+    process.stdin.write = blocked_write
+    monkeypatch.setattr(
+        executor.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: process,
+    )
+    monkeypatch.setattr(
+        executor,
+        "_DETACHED_STDIN_TIMEOUT_SECONDS",
+        0.01,
+    )
+    monkeypatch.setattr(
+        executor,
+        "_start_detached_process_reaper",
+        lambda proc, owner: reaped.append((proc.pid, owner)),
+    )
+    monkeypatch.setattr(
+        executor,
+        "_terminate_owned_process_handle",
+        lambda _proc, _owner: False,
+    )
+    monkeypatch.setattr(
+        executor,
+        "_start_detached_termination_retrier",
+        lambda proc, owner: retried.append((proc.pid, owner)),
+    )
+
+    result = executor._spawn_detached_process_unchecked(
+        name="blocked-worker",
+        argv=["python", "-m", "worker"],
+        cwd=tmp_path,
+        stdin_text="private prompt",
+        session_name="blocked-owner",
+    )
+    release.set()
+
+    assert result["status"] == "error"
+    assert result["error_code"] == "spawn_input_timeout"
+    assert reaped == [(457, "blocked-owner")]
+    assert retried == [(457, "blocked-owner")]
+    assert (
+        executor._owned_detached_process(457, "blocked-owner")
+        is process
+    )
+
+
+def test_generic_detached_spawn_returns_safe_missing_runtime_error(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    def popen(*_args: object, **_kwargs: object) -> object:
+        raise FileNotFoundError("private executable path")
+
+    monkeypatch.setattr(executor.subprocess, "Popen", popen)
+    result = executor._spawn_detached_process_unchecked(
+        name="worker",
+        argv=["missing-runtime"],
+        cwd=tmp_path,
+        missing_executable_error="Provider is not installed.",
+    )
+
+    assert result == {
+        "status": "error",
+        "error_code": "runtime_not_installed",
+        "error": "Provider is not installed.",
+    }
+
+
+def test_claude_headless_argv_uses_caller_selected_model() -> None:
+    argv = executor._build_headless_agent_argv(
+        prompt="brief",
+        session_name="daemon:document",
+        model="opus",
+        max_budget_usd=2.0,
+        persistent=True,
+    )
+
+    assert argv[argv.index("--model") + 1] == "opus"
+    assert argv[-1] == "brief"
+
+
+def test_terminate_detached_process_validates_pid_and_uses_windows_tree_kill(
+    monkeypatch,
+) -> None:
+    killed: list[int] = []
+    process = _TerminableProcess(pid=9876)
+    executor._OWNED_DETACHED_PROCESSES[(process.pid, "generation-a")] = process
+    monkeypatch.setattr(executor.os, "name", "nt")
+
+    def _kill(pid: int) -> bool:
+        killed.append(pid)
+        process.returncode = -9
+        return True
+
+    monkeypatch.setattr(
+        "work_buddy.compat._force_kill_pid",
+        _kill,
+    )
+
+    assert executor.terminate_detached_process(
+        True,
+        owner_token="generation-a",
+    ) is False
+    assert executor.terminate_detached_process(
+        0,
+        owner_token="generation-a",
+    ) is False
+    assert executor.terminate_detached_process(
+        -4,
+        owner_token="generation-a",
+    ) is False
+    assert executor.terminate_detached_process(
+        9876,
+        owner_token="generation-a",
+    ) is True
+    assert killed == [9876]
+    assert executor._owned_detached_process(9876, "generation-a") is None
+
+
+def test_terminate_detached_process_refuses_live_unowned_pid(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "work_buddy.utils.process.is_process_alive",
+        lambda pid: True,
+    )
+    assert executor.terminate_detached_process(
+        9876,
+        owner_token="generation-a",
+    ) is False
+
+
+def test_terminate_detached_process_treats_gone_process_as_stopped(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "work_buddy.utils.process.is_process_alive",
+        lambda pid: False,
+    )
+    assert executor.terminate_detached_process(
+        9876,
+        owner_token="generation-a",
+    ) is True
+
+
+def test_natural_process_exit_releases_only_its_owned_handle() -> None:
+    process = _WaitableProcess(pid=9876)
+    replacement = _Process(pid=9876)
+    executor._OWNED_DETACHED_PROCESSES[(9876, "generation-old")] = process
+    executor._OWNED_DETACHED_PROCESSES[(9876, "generation-new")] = replacement
+
+    reaper = executor._start_detached_process_reaper(
+        process,
+        "generation-old",
+    )
+    assert reaper is not None
+    process.exited.set()
+    reaper.join(timeout=1)
+
+    assert not reaper.is_alive()
+    assert executor._owned_detached_process(9876, "generation-old") is None
+    assert (
+        executor._owned_detached_process(9876, "generation-new")
+        is replacement
+    )
+
+
+def test_failed_termination_retains_owned_handle_for_a_retry(
+    monkeypatch,
+) -> None:
+    process = _Process(pid=9876)
+    executor._OWNED_DETACHED_PROCESSES[(9876, "generation-a")] = process
+    monkeypatch.setattr(executor.os, "name", "nt")
+
+    def _fail_to_kill(_pid: int) -> None:
+        raise OSError("access denied")
+
+    monkeypatch.setattr("work_buddy.compat._force_kill_pid", _fail_to_kill)
+
+    assert executor.terminate_detached_process(
+        9876,
+        owner_token="generation-a",
+    ) is False
+    assert (
+        executor._owned_detached_process(9876, "generation-a")
+        is process
+    )
+
+
+def test_taskkill_nonzero_retains_owned_handle_for_a_retry(
+    monkeypatch,
+) -> None:
+    from work_buddy import compat
+
+    process = _Process(pid=9876)
+    executor._OWNED_DETACHED_PROCESSES[(9876, "generation-a")] = process
+    monkeypatch.setattr(executor.os, "name", "nt")
+    monkeypatch.setattr(compat, "IS_WINDOWS", True)
+
+    class _TaskkillFailure:
+        returncode = 5
+
+    monkeypatch.setattr(
+        compat.subprocess,
+        "run",
+        lambda *_args, **_kwargs: _TaskkillFailure(),
+    )
+
+    assert executor.terminate_detached_process(
+        9876,
+        owner_token="generation-a",
+    ) is False
+    assert (
+        executor._owned_detached_process(9876, "generation-a")
+        is process
+    )
+
+
+def test_taskkill_success_without_observed_exit_retains_owned_handle(
+    monkeypatch,
+) -> None:
+    process = _TerminableProcess(pid=9876)
+    executor._OWNED_DETACHED_PROCESSES[(9876, "generation-a")] = process
+    monkeypatch.setattr(executor.os, "name", "nt")
+    monkeypatch.setattr(
+        "work_buddy.compat._force_kill_pid",
+        lambda _pid: True,
+    )
+
+    assert executor.terminate_detached_process(
+        9876,
+        owner_token="generation-a",
+    ) is False
+    assert (
+        executor._owned_detached_process(9876, "generation-a")
+        is process
+    )
+
+
+def test_unix_signal_without_observed_exit_retains_owned_handle(
+    monkeypatch,
+) -> None:
+    process = _TerminableProcess(pid=9876)
+    executor._OWNED_DETACHED_PROCESSES[(9876, "generation-a")] = process
+    signalled: list[tuple[int, int]] = []
+    # os is the process-global module. Restore os.name before pytest constructs
+    # any Windows pathlib objects for reporting and cache cleanup.
+    with monkeypatch.context() as platform:
+        platform.setattr(executor.os, "name", "posix")
+        platform.setattr(
+            executor.os,
+            "killpg",
+            lambda pid, sig: signalled.append((pid, sig)),
+            raising=False,
+        )
+        assert executor.terminate_detached_process(
+            9876,
+            owner_token="generation-a",
+        ) is False
+    assert signalled == [(9876, executor.signal.SIGTERM)]
+    assert (
+        executor._owned_detached_process(9876, "generation-a")
+        is process
+    )
+
+
+def test_stale_owner_token_cannot_kill_reused_pid(
+    monkeypatch,
+) -> None:
+    killed: list[int] = []
+    exited = _Process(pid=9876, returncode=0)
+    replacement = _TerminableProcess(pid=9876)
+    executor._OWNED_DETACHED_PROCESSES[(9876, "generation-old")] = exited
+    executor._OWNED_DETACHED_PROCESSES[(9876, "generation-new")] = replacement
+    monkeypatch.setattr(executor.os, "name", "nt")
+
+    def _kill(pid: int) -> bool:
+        killed.append(pid)
+        replacement.returncode = -9
+        return True
+
+    monkeypatch.setattr(
+        "work_buddy.compat._force_kill_pid",
+        _kill,
+    )
+
+    assert executor.terminate_detached_process(
+        9876,
+        owner_token="generation-old",
+    ) is True
+    assert killed == []
+    assert (
+        executor._owned_detached_process(9876, "generation-new")
+        is replacement
+    )
+
+    assert executor.terminate_detached_process(
+        9876,
+        owner_token="generation-new",
+    ) is True
+    assert killed == [9876]

--- a/tests/unit/test_compat_port_cleanup.py
+++ b/tests/unit/test_compat_port_cleanup.py
@@ -183,7 +183,7 @@ def test_force_kill_windows_uses_taskkill_slash_F(monkeypatch):
         return _R()
 
     monkeypatch.setattr(compat.subprocess, "run", fake_run)
-    compat._force_kill_pid(12345)
+    assert compat._force_kill_pid(12345) is True
 
     assert len(recorded) == 1
     cmd = recorded[0]
@@ -203,7 +203,7 @@ def test_force_kill_unix_uses_sigkill(monkeypatch):
         killed.append((pid, sig))
 
     monkeypatch.setattr(compat.os, "kill", fake_kill)
-    compat._force_kill_pid(12345)
+    assert compat._force_kill_pid(12345) is True
 
     expected_sig = getattr(signal, "SIGKILL", signal.SIGTERM)
     assert killed == [(12345, expected_sig)]
@@ -217,8 +217,23 @@ def test_force_kill_tolerates_dead_process(monkeypatch):
         raise ProcessLookupError
 
     monkeypatch.setattr(compat.os, "kill", fake_kill)
-    # Should not raise
-    compat._force_kill_pid(12345)
+    assert compat._force_kill_pid(12345) is True
+
+
+def test_force_kill_windows_reports_taskkill_nonzero(monkeypatch):
+    """A rejected taskkill request must not be reported as successful."""
+    monkeypatch.setattr(compat, "IS_WINDOWS", True)
+
+    class _Result:
+        returncode = 5
+
+    monkeypatch.setattr(
+        compat.subprocess,
+        "run",
+        lambda *_args, **_kwargs: _Result(),
+    )
+
+    assert compat._force_kill_pid(12345) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_consent_per_invocation.py
+++ b/tests/unit/test_consent_per_invocation.py
@@ -594,6 +594,21 @@ def test_invoke_injects_session_and_binds_authorization():
     }
 
 
+def test_invoke_overrides_caller_asserted_agent_session_id():
+    from work_buddy.mcp_server.tools.gateway import _invoke_with_session
+
+    def operation(*, agent_session_id: str | None = None):
+        return agent_session_id
+
+    result = _invoke_with_session(
+        operation,
+        "trusted-transport-session",
+        agent_session_id="caller-forged-session",
+    )
+
+    assert result == "trusted-transport-session"
+
+
 def test_reload_generations_share_one_consumed_authorization():
     import importlib
     import sys

--- a/tests/unit/test_conversation_execution.py
+++ b/tests/unit/test_conversation_execution.py
@@ -1,0 +1,748 @@
+"""Conversation-scoped execution persistence and producer provenance."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from work_buddy.conversations import store
+from work_buddy.conversations.execution import (
+    ConversationExecutionConflict,
+    ConversationExecutionCorrupt,
+    EXECUTION_METADATA_KEY,
+    projected_execution,
+    set_execution,
+)
+
+
+@pytest.fixture
+def isolated_conversations(tmp_path, monkeypatch):
+    database = tmp_path / "conversation-execution.db"
+    monkeypatch.setattr(store, "_DB_PATH", database)
+    conn = store.get_connection()
+    try:
+        store._ensure_schema(conn)
+    finally:
+        conn.close()
+    return database
+
+
+def _selection(
+    provider_id: str = "claude-code",
+    model_id: str = "sonnet",
+) -> dict[str, str]:
+    provider_label = "Claude Code" if provider_id == "claude-code" else "Codex"
+    model_label = "Sonnet" if model_id == "sonnet" else "GPT-5.6 Sol"
+    return {
+        "provider_id": provider_id,
+        "model_id": model_id,
+        "provider_label": provider_label,
+        "model_label": model_label,
+    }
+
+
+def test_projected_default_is_read_only_and_pin_preserves_binding_metadata(
+    isolated_conversations,
+) -> None:
+    conversation = store.create_conversation(
+        "Document chat",
+        source="cowork_document",
+        metadata={
+            "cowork_document_id": "doc-a",
+            "cowork_store_id": "store-a",
+        },
+    )
+    projected = projected_execution(conversation.conversation_id, _selection())
+    assert projected.persisted is False
+    assert projected.revision is None
+    unchanged = store.get_conversation(conversation.conversation_id)
+    assert unchanged is not None
+    assert EXECUTION_METADATA_KEY not in unchanged.metadata
+
+    pinned = set_execution(
+        conversation.conversation_id,
+        _selection(),
+        expected_revision=None,
+    )
+    assert pinned.persisted is True
+    assert pinned.revision
+    saved = store.get_conversation(conversation.conversation_id)
+    assert saved is not None
+    assert saved.metadata["cowork_document_id"] == "doc-a"
+    assert saved.metadata["cowork_store_id"] == "store-a"
+    assert (
+        saved.metadata[EXECUTION_METADATA_KEY]["revision"]
+        == pinned.revision
+    )
+
+
+def test_execution_compare_and_swap_rejects_stale_picker(
+    isolated_conversations,
+) -> None:
+    conversation = store.create_conversation("Document chat")
+    first = set_execution(
+        conversation.conversation_id,
+        _selection(),
+        expected_revision=None,
+    )
+    changed = set_execution(
+        conversation.conversation_id,
+        _selection("codex", "gpt-5.6-sol"),
+        expected_revision=first.revision,
+    )
+    assert changed.revision != first.revision
+    with pytest.raises(
+        ConversationExecutionConflict,
+        match="execution_selection_changed",
+    ):
+        set_execution(
+            conversation.conversation_id,
+            _selection(),
+            expected_revision=first.revision,
+        )
+
+
+def test_execution_same_pair_retry_is_idempotent_after_response_loss(
+    isolated_conversations,
+) -> None:
+    conversation = store.create_conversation("Document chat")
+    first = set_execution(
+        conversation.conversation_id,
+        _selection(),
+        expected_revision=None,
+    )
+    changed = set_execution(
+        conversation.conversation_id,
+        _selection("codex", "gpt-5.6-sol"),
+        expected_revision=first.revision,
+    )
+    relabeled = _selection("codex", "gpt-5.6-sol")
+    relabeled["provider_label"] = "Codex (renamed)"
+    relabeled["model_label"] = "GPT-5.6 Sol (renamed)"
+
+    replayed = set_execution(
+        conversation.conversation_id,
+        relabeled,
+        expected_revision=first.revision,
+    )
+
+    assert replayed == changed
+
+
+@pytest.mark.parametrize(
+    "saved_execution",
+    [
+        {"schema_version": 999},
+        {"schema_version": True, **_selection()},
+        _selection(),
+    ],
+)
+def test_corrupt_saved_execution_fails_closed_instead_of_defaulting(
+    isolated_conversations,
+    saved_execution: dict[str, object],
+) -> None:
+    conversation = store.create_conversation(
+        "Document chat",
+        metadata={EXECUTION_METADATA_KEY: saved_execution},
+    )
+
+    with pytest.raises(ConversationExecutionCorrupt):
+        projected_execution(conversation.conversation_id, _selection())
+    with pytest.raises(ConversationExecutionCorrupt):
+        set_execution(
+            conversation.conversation_id,
+            _selection(),
+            expected_revision=None,
+        )
+
+
+def test_malformed_conversation_metadata_is_not_overwritten(
+    isolated_conversations,
+) -> None:
+    conversation = store.create_conversation(
+        "Document chat",
+        metadata={
+            "cowork_document_id": "doc-a",
+            "cowork_store_id": "store-a",
+        },
+    )
+    malformed = '{"cowork_document_id":"doc-a"'
+    conn = store.get_connection()
+    try:
+        conn.execute(
+            "UPDATE conversations SET metadata = ? WHERE conversation_id = ?",
+            (malformed, conversation.conversation_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(ConversationExecutionCorrupt):
+        set_execution(
+            conversation.conversation_id,
+            _selection(),
+            expected_revision=None,
+        )
+
+    conn = store.get_connection()
+    try:
+        row = conn.execute(
+            "SELECT metadata FROM conversations WHERE conversation_id = ?",
+            (conversation.conversation_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    assert row["metadata"] == malformed
+
+
+def test_projected_execution_rejects_malformed_outer_metadata(
+    isolated_conversations,
+) -> None:
+    conversation = store.create_conversation("Document chat")
+    conn = store.get_connection()
+    try:
+        conn.execute(
+            "UPDATE conversations SET metadata = ? WHERE conversation_id = ?",
+            ('{"broken"', conversation.conversation_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(
+        ConversationExecutionCorrupt,
+        match="Saved conversation metadata is invalid",
+    ):
+        projected_execution(conversation.conversation_id, _selection())
+
+
+def test_additive_execution_schema_migrates_a_legacy_conversation_db(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    database = tmp_path / "legacy-conversations.db"
+    legacy = sqlite3.connect(database)
+    try:
+        legacy.executescript(
+            """
+            CREATE TABLE conversations (
+                conversation_id TEXT PRIMARY KEY,
+                title           TEXT NOT NULL DEFAULT '',
+                status          TEXT NOT NULL DEFAULT 'open',
+                created_at      TEXT NOT NULL,
+                updated_at      TEXT NOT NULL,
+                source          TEXT NOT NULL DEFAULT '',
+                metadata        TEXT NOT NULL DEFAULT '{}'
+            );
+            CREATE TABLE messages (
+                message_id      TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL,
+                role            TEXT NOT NULL DEFAULT 'agent',
+                content         TEXT NOT NULL DEFAULT '',
+                created_at      TEXT NOT NULL,
+                message_type    TEXT NOT NULL DEFAULT 'text',
+                response_type   TEXT NOT NULL DEFAULT 'none',
+                choices         TEXT,
+                response        TEXT,
+                status          TEXT NOT NULL DEFAULT 'sent',
+                FOREIGN KEY (conversation_id)
+                    REFERENCES conversations(conversation_id)
+            );
+            CREATE TABLE conversation_agent_leases (
+                conversation_id TEXT NOT NULL,
+                consumer        TEXT NOT NULL,
+                generation      TEXT NOT NULL,
+                status          TEXT NOT NULL,
+                pid             INTEGER,
+                started_at      TEXT NOT NULL,
+                heartbeat_at    TEXT,
+                updated_at      TEXT NOT NULL,
+                error           TEXT,
+                PRIMARY KEY (conversation_id, consumer),
+                FOREIGN KEY (conversation_id)
+                    REFERENCES conversations(conversation_id)
+            );
+            """
+        )
+        now = "2026-07-28T12:00:00+00:00"
+        legacy.execute(
+            """INSERT INTO conversations
+                   (conversation_id, title, status, created_at, updated_at,
+                    source, metadata)
+               VALUES (?, ?, 'open', ?, ?, ?, ?)""",
+            (
+                "legacy-conversation",
+                "Legacy document chat",
+                now,
+                now,
+                "cowork_document",
+                json.dumps(
+                    {
+                        "cowork_document_id": "legacy-doc",
+                        "cowork_store_id": "legacy-store",
+                    }
+                ),
+            ),
+        )
+        legacy.execute(
+            """INSERT INTO messages
+                   (message_id, conversation_id, role, content, created_at)
+               VALUES (?, ?, 'agent', ?, ?)""",
+            (
+                "legacy-message",
+                "legacy-conversation",
+                "A message from before execution profiles.",
+                now,
+            ),
+        )
+        legacy.execute(
+            """INSERT INTO conversation_agent_leases
+                   (conversation_id, consumer, generation, status, pid,
+                    started_at, heartbeat_at, updated_at, error)
+               VALUES (?, ?, ?, 'running', ?, ?, ?, ?, NULL)""",
+            (
+                "legacy-conversation",
+                "cowork-document:legacy-store:legacy-doc",
+                "legacy-generation",
+                43210,
+                now,
+                now,
+                now,
+            ),
+        )
+        legacy.commit()
+    finally:
+        legacy.close()
+
+    monkeypatch.setattr(store, "_DB_PATH", database)
+    migrated = store.get_connection()
+    try:
+        store._ensure_schema(migrated)
+        message_columns = {
+            row["name"]
+            for row in migrated.execute("PRAGMA table_info(messages)").fetchall()
+        }
+        lease_columns = {
+            row["name"]
+            for row in migrated.execute(
+                "PRAGMA table_info(conversation_agent_leases)"
+            ).fetchall()
+        }
+    finally:
+        migrated.close()
+
+    assert "producer" in message_columns
+    assert "execution_json" in lease_columns
+    bundle = store.get_conversation_with_messages("legacy-conversation")
+    assert bundle is not None
+    assert bundle["messages"][0]["producer"] is None
+    lease = store.get_agent_lease(
+        "legacy-conversation",
+        "cowork-document:legacy-store:legacy-doc",
+    )
+    assert lease is not None
+    assert lease["execution"] is None
+
+
+def test_lease_snapshots_execution_and_does_not_reuse_a_different_target(
+    isolated_conversations,
+) -> None:
+    conversation = store.create_conversation("Document chat")
+    consumer = "cowork-document:store-a:doc-a"
+    claude = _selection()
+    first = store.claim_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        "generation-claude",
+        execution=claude,
+    )
+    assert first is not None and first["claimed"] is True
+    assert store.activate_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        "generation-claude",
+        701,
+    )
+    codex = _selection("codex", "gpt-5.6-sol")
+    rotated = store.claim_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        "generation-codex",
+        execution=codex,
+    )
+    assert rotated is not None and rotated["claimed"] is True
+    assert rotated["execution"] == codex
+    persisted = store.get_agent_lease(conversation.conversation_id, consumer)
+    assert persisted is not None
+    assert persisted["generation"] == "generation-codex"
+    assert persisted["execution"] == codex
+
+
+def test_agent_message_producer_comes_from_exact_lease(
+    isolated_conversations,
+) -> None:
+    from work_buddy.mcp_server import op_registry
+
+    op_registry.load_builtin_ops()
+    send = op_registry.get_op("op.wb.conversation_send")
+    assert send is not None
+    conversation = store.create_conversation("Document chat")
+    consumer = "cowork-document:store-a:doc-a"
+    generation = "generation-codex"
+    execution = {
+        "schema_version": 1,
+        **_selection("codex", "gpt-5.6-sol"),
+    }
+    lease = store.claim_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        generation,
+        execution=execution,
+    )
+    assert lease is not None and lease["claimed"] is True
+    assert store.activate_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        generation,
+        702,
+    )
+    result = send(
+        conversation.conversation_id,
+        "Generated through Codex.",
+        "reply-codex-1",
+        consumer,
+        generation,
+    )
+    assert result["created"] is True
+
+    bundle = store.get_conversation_with_messages(conversation.conversation_id)
+    assert bundle is not None
+    [message] = bundle["messages"]
+    assert message["producer"] == execution
+    conn = store.get_connection()
+    try:
+        raw = conn.execute(
+            "SELECT producer FROM messages WHERE message_id = ?",
+            ("reply-codex-1",),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert raw is not None
+    assert json.loads(raw["producer"]) == execution
+
+
+@pytest.mark.parametrize("operation_name", ["conversation_send", "conversation_ask"])
+@pytest.mark.parametrize(
+    "corrupt_execution_json",
+    [
+        "not-json",
+        json.dumps(_selection()),
+        json.dumps({"schema_version": 2, **_selection()}),
+        json.dumps({"schema_version": True, **_selection()}),
+    ],
+)
+def test_cowork_agent_message_fails_closed_without_valid_lease_provenance(
+    isolated_conversations,
+    operation_name: str,
+    corrupt_execution_json: str,
+) -> None:
+    from work_buddy.mcp_server import op_registry
+
+    op_registry.load_builtin_ops()
+    operation = op_registry.get_op(f"op.wb.{operation_name}")
+    assert operation is not None
+    conversation = store.create_conversation("Document chat")
+    consumer = "cowork-document:store-a:doc-a"
+    generation = "generation-corrupt-provenance"
+    claimed = store.claim_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        generation,
+        execution={"schema_version": 1, **_selection()},
+    )
+    assert claimed is not None and claimed["claimed"] is True
+    assert store.activate_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        generation,
+        702,
+    )
+    conn = store.get_connection()
+    try:
+        conn.execute(
+            """UPDATE conversation_agent_leases
+               SET execution_json = ?
+               WHERE conversation_id = ? AND consumer = ? AND generation = ?""",
+            (
+                corrupt_execution_json,
+                conversation.conversation_id,
+                consumer,
+                generation,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    common = {
+        "conversation_id": conversation.conversation_id,
+        "consumer": consumer,
+        "generation": generation,
+        "agent_session_id": f"{generation}-cowork",
+    }
+    result = (
+        operation(message="Must not land.", **common)
+        if operation_name == "conversation_send"
+        else operation(question="Must not land?", **common)
+    )
+
+    assert result["status"] == "lease_lost"
+    bundle = store.get_conversation_with_messages(conversation.conversation_id)
+    assert bundle is not None
+    assert bundle["messages"] == []
+
+
+def test_cowork_execution_session_cannot_omit_or_swap_its_write_fence(
+    isolated_conversations,
+) -> None:
+    from work_buddy.mcp_server import op_registry
+
+    op_registry.load_builtin_ops()
+    send = op_registry.get_op("op.wb.conversation_send")
+    assert send is not None
+    conversation = store.create_conversation("Document chat")
+    consumer = "cowork-document:store-a:doc-a"
+    generation = "generation-bound"
+    lease = store.claim_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        generation,
+        execution={
+            "schema_version": 1,
+            **_selection(),
+        },
+    )
+    assert lease is not None
+    assert store.activate_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        generation,
+        703,
+    )
+    session_id = f"{generation}-cowork"
+
+    omitted = send(
+        conversation.conversation_id,
+        "Must not land.",
+        agent_session_id=session_id,
+    )
+    swapped = send(
+        conversation.conversation_id,
+        "Must not land either.",
+        consumer=consumer,
+        generation="different-generation",
+        agent_session_id=session_id,
+    )
+
+    assert omitted["status"] == "invalid_request"
+    assert swapped["status"] == "lease_lost"
+    bundle = store.get_conversation_with_messages(
+        conversation.conversation_id
+    )
+    assert bundle is not None
+    assert bundle["messages"] == []
+
+
+def test_cowork_execution_session_cannot_read_or_ack_another_lease(
+    isolated_conversations,
+) -> None:
+    from work_buddy.mcp_server import op_registry
+
+    op_registry.load_builtin_ops()
+    poll = op_registry.get_op("op.wb.conversation_poll")
+    receive = op_registry.get_op("op.wb.conversation_receive")
+    acknowledge = op_registry.get_op("op.wb.conversation_ack")
+    assert poll is not None
+    assert receive is not None
+    assert acknowledge is not None
+
+    own = store.create_conversation("Own document chat")
+    other = store.create_conversation("Other document chat")
+    own_consumer = "cowork-document:store-a:doc-a"
+    other_consumer = "cowork-document:store-b:doc-b"
+    own_generation = "generation-own"
+    other_generation = "generation-other"
+    for conversation, consumer, generation, pid in (
+        (own, own_consumer, own_generation, 704),
+        (other, other_consumer, other_generation, 705),
+    ):
+        claimed = store.claim_agent_lease(
+            conversation.conversation_id,
+            consumer,
+            generation,
+            execution={"schema_version": 1, **_selection()},
+        )
+        assert claimed is not None and claimed["claimed"] is True
+        assert store.activate_agent_lease(
+            conversation.conversation_id,
+            consumer,
+            generation,
+            pid,
+        )
+
+    session_id = f"{own_generation}-cowork"
+    for result in (
+        poll(
+            other.conversation_id,
+            consumer=other_consumer,
+            generation=other_generation,
+            agent_session_id=session_id,
+        ),
+        receive(
+            other.conversation_id,
+            other_consumer,
+            other_generation,
+            agent_session_id=session_id,
+        ),
+        acknowledge(
+            other.conversation_id,
+            other_consumer,
+            other_generation,
+            "unknown-message",
+            agent_session_id=session_id,
+        ),
+        poll(
+            other.conversation_id,
+            consumer=own_consumer,
+            generation=own_generation,
+            agent_session_id=session_id,
+        ),
+    ):
+        assert result["status"] == "lease_lost"
+
+
+@pytest.mark.parametrize(
+    "operation_name",
+    ["conversation_ask", "conversation_poll"],
+)
+def test_cowork_long_wait_stops_reading_after_generation_fence(
+    isolated_conversations,
+    monkeypatch,
+    operation_name: str,
+) -> None:
+    import time
+
+    from work_buddy.mcp_server import op_registry
+
+    op_registry.load_builtin_ops()
+    operation = op_registry.get_op(f"op.wb.{operation_name}")
+    assert operation is not None
+    conversation = store.create_conversation("Document chat")
+    consumer = "cowork-document:store-a:doc-a"
+    generation = "generation-long-wait"
+    claimed = store.claim_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        generation,
+        execution={"schema_version": 1, **_selection()},
+    )
+    assert claimed is not None and claimed["claimed"] is True
+    assert store.activate_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        generation,
+        706,
+    )
+    if operation_name == "conversation_poll":
+        assert store.add_message(
+            conversation.conversation_id,
+            "agent",
+            "Choose one?",
+            message_type="question",
+            response_type="choice",
+            choices=[{"key": "a", "label": "A"}],
+        ) is not None
+
+    sleeps = 0
+
+    def fence_on_wait(_seconds: float) -> None:
+        nonlocal sleeps
+        sleeps += 1
+        if sleeps == 1:
+            assert store.stop_agent_lease(
+                conversation.conversation_id,
+                consumer,
+                generation,
+            )
+            pending = store.get_pending_question(conversation.conversation_id)
+            assert pending is not None
+            assert store.respond_to_message(
+                pending.message_id,
+                "Arrived after the old driver was fenced.",
+            ) is not None
+
+    monkeypatch.setattr(time, "sleep", fence_on_wait)
+    common = {
+        "conversation_id": conversation.conversation_id,
+        "consumer": consumer,
+        "generation": generation,
+        "timeout_seconds": 1,
+        "agent_session_id": f"{generation}-cowork",
+    }
+    result = (
+        operation(question="Continue?", **common)
+        if operation_name == "conversation_ask"
+        else operation(**common)
+    )
+
+    assert result["status"] == "lease_lost"
+    assert "response" not in result
+    assert sleeps == 1
+
+
+def test_receive_cannot_observe_turn_committed_after_generation_fence(
+    isolated_conversations,
+) -> None:
+    conversation = store.create_conversation("Document chat")
+    consumer = "cowork-document:store-a:doc-a"
+    generation = "generation-receive-race"
+    claimed = store.claim_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        generation,
+        execution={"schema_version": 1, **_selection()},
+    )
+    assert claimed is not None and claimed["claimed"] is True
+    assert store.activate_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        generation,
+        707,
+    )
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        receiving = pool.submit(
+            store.receive_user_message,
+            conversation.conversation_id,
+            consumer,
+            generation,
+            timeout_seconds=0.5,
+            poll_interval_seconds=0.01,
+        )
+        assert store.stop_agent_lease(
+            conversation.conversation_id,
+            consumer,
+            generation,
+        )
+        assert store.add_message(
+            conversation.conversation_id,
+            "user",
+            "Arrived after the old driver was fenced.",
+        ) is not None
+        result = receiving.result(timeout=2)
+
+    assert result["status"] == "lease_lost"

--- a/tests/unit/test_cowork_document_agent.py
+++ b/tests/unit/test_cowork_document_agent.py
@@ -349,23 +349,168 @@ def test_live_pid_has_headroom_for_long_in_flight_work(
     assert stale.alive is False
 
 
+def test_stale_live_generation_is_terminated_before_retry(
+    document_agent_store,
+    monkeypatch,
+) -> None:
+    conversation = _conversation()
+    consumer = document_agent.document_agent_consumer("store-a", "doc-a")
+    generation = "generation-stale"
+    claimed = conversation_store.claim_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        generation,
+    )
+    assert claimed is not None and claimed["claimed"] is True
+    assert conversation_store.activate_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        generation,
+        61001,
+    )
+    stale_at = (datetime.now().astimezone() - timedelta(minutes=20)).isoformat()
+    conn = conversation_store.get_connection()
+    try:
+        conn.execute(
+            """UPDATE conversation_agent_leases
+               SET started_at = ?, heartbeat_at = ?, updated_at = ?
+               WHERE conversation_id = ? AND consumer = ?""",
+            (
+                stale_at,
+                stale_at,
+                stale_at,
+                conversation.conversation_id,
+                consumer,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    terminated: list[int] = []
+    monkeypatch.setattr(
+        document_agent,
+        "_terminate_spawned_driver",
+        lambda pid, **_kwargs: terminated.append(pid),
+    )
+    status = document_agent.ensure_document_agent(
+        store_id="store-a",
+        document_id="doc-a",
+        conversation_id=conversation.conversation_id,
+        process_alive=lambda _pid: True,
+        register_agent=lambda *_args: None,
+        spawn_agent=lambda **_kwargs: {"status": "ok", "pid": 61002},
+    )
+
+    assert status.status == "running"
+    assert terminated == [61001]
+
+
+def test_activation_failure_terminates_newly_spawned_process(
+    document_agent_store,
+    monkeypatch,
+) -> None:
+    conversation = _conversation()
+    terminated: list[int] = []
+    monkeypatch.setattr(
+        document_agent,
+        "activate_agent_lease",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        document_agent,
+        "_terminate_spawned_driver",
+        lambda pid, **_kwargs: terminated.append(pid),
+    )
+
+    status = document_agent.ensure_document_agent(
+        store_id="store-a",
+        document_id="doc-a",
+        conversation_id=conversation.conversation_id,
+        process_alive=lambda _pid: True,
+        register_agent=lambda *_args: None,
+        spawn_agent=lambda **_kwargs: {"status": "ok", "pid": 62001},
+    )
+
+    assert status.status == "stopped"
+    assert terminated == [62001]
+
+
+def test_process_check_error_fences_and_terminates_before_retry(
+    document_agent_store,
+    monkeypatch,
+) -> None:
+    conversation = _conversation()
+    consumer = document_agent.document_agent_consumer("store-a", "doc-a")
+    generation = "generation-check-error"
+    claimed = conversation_store.claim_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        generation,
+    )
+    assert claimed is not None and claimed["claimed"] is True
+    assert conversation_store.activate_agent_lease(
+        conversation.conversation_id,
+        consumer,
+        generation,
+        63001,
+    )
+    checks = 0
+
+    def process_alive(_pid: int) -> bool:
+        nonlocal checks
+        checks += 1
+        if checks == 1:
+            raise OSError("transient process lookup failure")
+        return True
+
+    terminated: list[int] = []
+    monkeypatch.setattr(
+        document_agent,
+        "_terminate_spawned_driver",
+        lambda pid, **_kwargs: terminated.append(pid),
+    )
+    status = document_agent.ensure_document_agent(
+        store_id="store-a",
+        document_id="doc-a",
+        conversation_id=conversation.conversation_id,
+        process_alive=process_alive,
+        register_agent=lambda *_args: None,
+        spawn_agent=lambda **_kwargs: {"status": "ok", "pid": 63002},
+    )
+
+    assert status.status == "running"
+    assert terminated == [63001]
+
+
 def test_spawn_session_uses_explicit_model_and_authorized_executor(
     document_agent_store,
     monkeypatch,
 ) -> None:
     observed: dict[str, Any] = {}
 
-    def _authorized(**kwargs):
-        observed.update(kwargs)
-        return {"status": "ok", "pid": 70123}
-
-    from work_buddy.sidecar.dispatch import executor
-
-    monkeypatch.setattr(
-        executor,
-        "spawn_headless_agent_detached_authorized",
-        _authorized,
+    from work_buddy.agent_execution.models import (
+        AgentExecutionSelection,
+        AgentSpawnOutcome,
     )
+    from work_buddy.agent_execution import registry
+
+    selection = AgentExecutionSelection(
+        provider_id="claude-code",
+        model_id="configured-model",
+        provider_label="Claude Code",
+        model_label="Configured model",
+    )
+
+    def _start_detached(request):
+        observed["request"] = request
+        return AgentSpawnOutcome(
+            status="ok",
+            selection=request.selection,
+            pid=70123,
+        )
+
+    monkeypatch.setattr(registry, "start_detached", _start_detached)
     result = document_agent.spawn_document_agent_session(
         store_id="store-a",
         document_id="doc-a",
@@ -373,9 +518,14 @@ def test_spawn_session_uses_explicit_model_and_authorized_executor(
         consumer="cowork-document:store-a:doc-a",
         generation="generation-a",
         producer_model="configured-model",
+        execution=selection,
         history_loader=lambda _conversation_id: {"messages": []},
     )
-    assert result == {"status": "ok", "pid": 70123}
-    assert observed["name"].startswith("cowork-doc-a-conversation-a")
-    assert "producer_model: configured-model" in observed["prompt"]
-    assert observed["max_budget_usd"] == 2.0
+    assert result["status"] == "ok"
+    assert result["pid"] == 70123
+    request = observed["request"]
+    assert request.name.startswith("cowork-doc-a-conversation-a")
+    assert "producer_model: configured-model" in request.prompt
+    assert request.max_budget_usd == 2.0
+    assert request.selection == selection
+    assert request.session_id == "generation-a-cowork"

--- a/tests/unit/test_gateway_constrained_top_level.py
+++ b/tests/unit/test_gateway_constrained_top_level.py
@@ -1,0 +1,75 @@
+"""Constrained MCP sessions cannot bypass their capability ACL."""
+
+from __future__ import annotations
+
+import asyncio
+import weakref
+
+import pytest
+
+from work_buddy.mcp_server.tools import gateway
+
+
+class _FakeMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, object] = {}
+
+    def tool(self):
+        def register(function):
+            self.tools[function.__name__] = function
+            return function
+
+        return register
+
+
+class _FakeSession:
+    pass
+
+
+class _FakeContext:
+    def __init__(self, session: _FakeSession) -> None:
+        self.session = session
+
+
+@pytest.fixture
+def registered_gateway(monkeypatch):
+    monkeypatch.setattr(
+        gateway,
+        "_SESSION_REGISTRY",
+        weakref.WeakKeyDictionary(),
+    )
+    monkeypatch.setattr(gateway, "ensure_listeners_registered", lambda: None)
+    mcp = _FakeMCP()
+    gateway.register_tools(mcp)
+    return mcp
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "args"),
+    [
+        ("wb_advance", ("wf_other",)),
+        ("wb_status", ()),
+        ("wb_step_result", ("wf_other", "step-a")),
+        ("wb_capability_result", ("op_other",)),
+    ],
+)
+def test_cowork_session_cannot_call_top_level_acl_bypasses(
+    registered_gateway,
+    tool_name,
+    args,
+) -> None:
+    session = _FakeSession()
+    context = _FakeContext(session)
+    gateway._SESSION_REGISTRY[session] = "generation-123-cowork"
+
+    result = asyncio.run(
+        registered_gateway.tools[tool_name](*args, ctx=context)
+    )
+
+    assert result == {
+        "error": (
+            f"{tool_name} is not permitted for this constrained "
+            "execution session."
+        ),
+        "denied_by": "session_acl",
+    }

--- a/tests/unit/test_session_acl_escape_block.py
+++ b/tests/unit/test_session_acl_escape_block.py
@@ -64,6 +64,24 @@ def test_acl_bound_session_is_detectable():
     assert session_acl.get_session_acl(sid) is None
 
 
+def test_cowork_execution_session_has_non_overridable_builtin_acl():
+    sid = "generation-abc-cowork"
+    acl = session_acl.get_session_acl(sid)
+    assert acl is not None
+    assert "cowork_doc_get" in acl
+    assert "conversation_send" in acl
+    assert "task_toggle" not in acl
+    assert "wb_init" not in acl
+
+    session_acl.set_session_acl(
+        sid,
+        ["cowork_doc_get", "task_toggle"],
+    )
+    assert session_acl.get_session_acl(sid) == frozenset(
+        {"cowork_doc_get"}
+    )
+
+
 # ---------------------------------------------------------------------------
 # Fail-closed behavior when session cannot be resolved
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -2506,6 +2506,34 @@ wheels = [
 ]
 
 [[package]]
+name = "openai-codex"
+version = "0.144.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openai-codex-cli-bin" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/7d/4b999b0ddd05c22d83cc2e879c95e1e92e3b7808b58ac561c4ea91fca1c4/openai_codex-0.144.4.tar.gz", hash = "sha256:91c63a7cb213441569f130e593386b34657ab9e726ae88af255f0ecb8de08ea5", size = 68324, upload-time = "2026-07-17T23:42:17.013Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/35/5d2a13e38d91278019f18757ac10426d2649b7ec6f031818c792f64559e9/openai_codex-0.144.4-py3-none-any.whl", hash = "sha256:de1513a6e94b9a8d7728a3b74298bc1469428ade10ba0ef2d5db47dd1cb606f5", size = 76244, upload-time = "2026-07-17T23:42:15.658Z" },
+]
+
+[[package]]
+name = "openai-codex-cli-bin"
+version = "0.144.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/30/7e457c007a32aa7333a78438a9f532504c3b77a1ea57e7808855712c2c0f/openai_codex_cli_bin-0.144.4-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:4d587d152d5f0aa25f21ded4d08aac5150da48639b29fc3e57b2a8b413d06903", size = 126851183, upload-time = "2026-07-15T00:14:00.171Z" },
+    { url = "https://files.pythonhosted.org/packages/65/eb/64c180514a2cc3e2500e486813f5a8d7f7e349342e9bebd78d99ddd9791a/openai_codex_cli_bin-0.144.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:05db505a9c7f020f58b70837a94e00d32a50086986c267bcc44ea97b573d4a05", size = 116474758, upload-time = "2026-07-15T00:14:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/85/34/921ab692c7ed140941a91e39b84c6deafddb45072793f3a5f6dcbf86f59a/openai_codex_cli_bin-0.144.4-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:cd4bb31b8a477a3adba22139c8c493693fa5292ba21e86eef08ace3e96c41294", size = 119437596, upload-time = "2026-07-15T00:14:17.418Z" },
+    { url = "https://files.pythonhosted.org/packages/25/62/39e630cf8b7b2e2444a5a6669235a6cd88004869a25bb7f3f629ed35638c/openai_codex_cli_bin-0.144.4-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:4106229c38f37245c3eea8d904426afd45b8bf19831765715647f5402f757c06", size = 128817757, upload-time = "2026-07-15T00:14:30.539Z" },
+    { url = "https://files.pythonhosted.org/packages/23/24/318f91a95baaff845307e529d138d42a7202e6bd0e626556058eab3dead5/openai_codex_cli_bin-0.144.4-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:d2d3fada11731938e3d3e3660819d5324b7f92e825a0ed5aede63100b36ffc9a", size = 119437594, upload-time = "2026-07-15T00:14:39.327Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a0/65e6fd3a6fba52639937801d9ce517b0c48026458723bb9f08eb07a1dd35/openai_codex_cli_bin-0.144.4-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:70fb62ed7755e332dd8b00ed48e22ee16df10f4a977335039e237cd330490df3", size = 128817755, upload-time = "2026-07-15T00:14:47.849Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/8a/3ab5fc97352e8f780d472c8dd6d7504d6a670cd7dede106d461ac1171999/openai_codex_cli_bin-0.144.4-py3-none-win_amd64.whl", hash = "sha256:56e142974467332f1f669b89f2636e06b3ada09413512abb2f24c33b4a4f59fc", size = 140595092, upload-time = "2026-07-15T00:14:58.484Z" },
+    { url = "https://files.pythonhosted.org/packages/70/1a/3aa52ab8f89e0f596b6eea835e3f3494697da51917d3231f5f48f92e2bcb/openai_codex_cli_bin-0.144.4-py3-none-win_arm64.whl", hash = "sha256:2ad01058db7181323ae7c6217e560702e38c4f107595b99ab1d0abc9f184890a", size = 130665105, upload-time = "2026-07-15T00:15:08.861Z" },
+]
+
+[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4283,6 +4311,7 @@ dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "networkx" },
     { name = "omegaconf" },
+    { name = "openai-codex" },
     { name = "pathspec" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
     { name = "pyside6-essentials", marker = "sys_platform == 'win32'" },
@@ -4346,6 +4375,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.0,<2" },
     { name = "networkx", specifier = ">=3.0,<4.0" },
     { name = "omegaconf", specifier = ">=2.3.0,<3" },
+    { name = "openai-codex", specifier = ">=0.144.4,<0.145" },
     { name = "pathspec", specifier = ">=1.1.1,<2" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'", specifier = ">=0.7.0,<0.8" },
     { name = "pyside6-essentials", marker = "sys_platform == 'win32'", specifier = ">=6.8,<7" },

--- a/work_buddy/agent_execution/__init__.py
+++ b/work_buddy/agent_execution/__init__.py
@@ -1,0 +1,49 @@
+"""Long-running local agent execution providers."""
+
+from .models import (
+    AgentExecutionCatalog,
+    AgentExecutionError,
+    AgentExecutionSelection,
+    AgentSpawnOutcome,
+    AgentSpawnRequest,
+    ModelDescriptor,
+    ProviderAvailability,
+    ProviderDescriptor,
+    ProviderUnavailableError,
+    UnknownModelError,
+    UnknownProviderError,
+    default_working_directory,
+)
+from .identity import prompt_with_execution_identity
+from .registry import (
+    ProviderRegistry,
+    clear_probe_cache,
+    default_selection,
+    get_catalog,
+    get_registry,
+    start_detached,
+    validate_selection,
+)
+
+__all__ = [
+    "AgentExecutionCatalog",
+    "AgentExecutionError",
+    "AgentExecutionSelection",
+    "AgentSpawnOutcome",
+    "AgentSpawnRequest",
+    "ModelDescriptor",
+    "ProviderAvailability",
+    "ProviderDescriptor",
+    "ProviderRegistry",
+    "ProviderUnavailableError",
+    "UnknownModelError",
+    "UnknownProviderError",
+    "clear_probe_cache",
+    "default_selection",
+    "default_working_directory",
+    "get_catalog",
+    "get_registry",
+    "prompt_with_execution_identity",
+    "start_detached",
+    "validate_selection",
+]

--- a/work_buddy/agent_execution/base.py
+++ b/work_buddy/agent_execution/base.py
@@ -1,0 +1,35 @@
+"""Provider protocol shared by the execution registry."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from .models import (
+    AgentExecutionSelection,
+    AgentSpawnOutcome,
+    AgentSpawnRequest,
+    ProviderDescriptor,
+)
+
+
+class AgentExecutionProvider(Protocol):
+    """Authentication/runtime route for one family of agent models."""
+
+    provider_id: str
+    label: str
+    auth_mode: str
+    default_model_id: str
+
+    def probe(self, *, refresh: bool = False) -> ProviderDescriptor:
+        """Return a redacted installation, auth, and model projection."""
+
+    def validate_selection(
+        self,
+        selection: AgentExecutionSelection,
+        *,
+        refresh: bool = False,
+    ) -> AgentExecutionSelection:
+        """Validate IDs and return trusted labels."""
+
+    def start_detached(self, request: AgentSpawnRequest) -> AgentSpawnOutcome:
+        """Start one already-validated detached driver."""

--- a/work_buddy/agent_execution/cache.py
+++ b/work_buddy/agent_execution/cache.py
@@ -1,0 +1,61 @@
+"""Small thread-safe TTL cache used by provider probes."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Generic, TypeVar
+
+ValueT = TypeVar("ValueT")
+
+
+@dataclass(slots=True)
+class _Entry(Generic[ValueT]):
+    value: ValueT
+    expires_at: float
+
+
+class ProbeCache(Generic[ValueT]):
+    """Cache slow installation/auth/model probes for a short bounded window."""
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = 30.0,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        self._ttl_seconds = float(ttl_seconds)
+        self._clock = clock
+        self._entries: dict[str, _Entry[ValueT]] = {}
+        self._lock = threading.RLock()
+
+    def get_or_load(
+        self,
+        key: str,
+        loader: Callable[[], ValueT],
+        *,
+        refresh: bool = False,
+    ) -> ValueT:
+        """Return a live entry or load exactly once under the cache lock."""
+
+        with self._lock:
+            now = self._clock()
+            current = self._entries.get(key)
+            if not refresh and current is not None and current.expires_at > now:
+                return current.value
+            value = loader()
+            self._entries[key] = _Entry(
+                value=value,
+                expires_at=now + self._ttl_seconds,
+            )
+            return value
+
+    def clear(self, key: str | None = None) -> None:
+        with self._lock:
+            if key is None:
+                self._entries.clear()
+            else:
+                self._entries.pop(key, None)

--- a/work_buddy/agent_execution/claude_code.py
+++ b/work_buddy/agent_execution/claude_code.py
@@ -1,0 +1,450 @@
+"""Claude Code account-backed execution provider."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from work_buddy.config import load_config
+
+from .cache import ProbeCache
+from .identity import prompt_with_execution_identity
+from .models import (
+    AgentExecutionSelection,
+    AgentSpawnOutcome,
+    AgentSpawnRequest,
+    ModelDescriptor,
+    ProviderAvailability,
+    ProviderDescriptor,
+    ProviderUnavailableError,
+    UnknownModelError,
+)
+
+_CLAUDE_ACCOUNT_ROUTING_ENV_KEYS = frozenset(
+    {
+        "aws_bearer_token_bedrock",
+        "claude_bg_auth_snapshot_path",
+        "claude_code_api_base_url",
+        "claude_code_api_key_file_descriptor",
+        "claude_code_api_key_helper_ttl_ms",
+        "claude_code_assume_first_party_base_url",
+        "claude_code_custom_oauth_url",
+        "claude_code_force_windows_credman",
+        "claude_code_host_auth_env_var",
+        "claude_code_host_creds_file",
+        "claude_code_managed_settings_path",
+        "claude_code_provider_managed_by_host",
+        "claude_config_dir",
+    }
+)
+
+_CLAUDE_ACCOUNT_ROUTING_ENV_PREFIXES = (
+    "anthropic_",
+    "subagent_anthropic_",
+    "claude_code_oauth_",
+    "claude_code_skip_",
+    "claude_code_use_",
+)
+
+_CLAUDE_TELEMETRY_ENV_KEYS = frozenset(
+    {
+        "claude_code_enable_telemetry",
+        "claude_code_enhanced_telemetry_beta",
+        "claude_code_disable_nonessential_traffic",
+        "enable_enhanced_telemetry_beta",
+        "claude_code_otel_content_max_length",
+        "claude_code_otel_headers_helper_debounce_ms",
+        "claude_code_propagate_traceparent",
+        "disable_telemetry",
+        "disable_error_reporting",
+        "do_not_track",
+        "traceparent",
+        "tracestate",
+    }
+)
+
+_CLAUDE_DEBUG_ENV_KEYS = frozenset(
+    {
+        "claude_debug",
+        "debug",
+        "debug_claude_agent_sdk",
+        "debug_sdk",
+    }
+)
+
+_CLAUDE_CUSTOMIZATION_ENV_KEYS = frozenset(
+    {
+        "claude_code_disable_official_marketplace_autoinstall",
+        "claude_code_enable_background_plugin_refresh",
+        "claude_code_sync_plugin_install",
+        "claude_code_sync_plugins",
+        "claude_code_sync_skills",
+        "force_autoupdate_plugins",
+    }
+)
+
+_CLAUDE_IDE_ENV_KEYS = frozenset(
+    {
+        "claude_code_auto_connect_ide",
+        "claude_code_disable_attachments",
+        "claude_code_disable_auto_memory",
+        "claude_code_disable_claude_mds",
+        "claude_code_ide_skip_auto_install",
+    }
+)
+
+_CLAUDE_MODELS = (
+    ModelDescriptor(
+        id="sonnet",
+        label="Sonnet",
+        description="Balanced Claude Code model for everyday document work.",
+        is_default=True,
+    ),
+    ModelDescriptor(
+        id="opus",
+        label="Opus",
+        description="Most capable Claude Code model for demanding review work.",
+    ),
+)
+
+
+def claude_account_environment(
+    base: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Return an environment pinned to local Claude-account execution.
+
+    Claude account authentication is read from Claude Code's normal secure
+    credential store. No inherited Anthropic credential or routing variable is
+    needed, so all such variables are removed instead of attempting to predict
+    which future names may affect billing or provider selection.
+    """
+
+    source = os.environ if base is None else base
+    sanitized = {
+        key: value
+        for key, value in source.items()
+        if (
+            key.casefold() not in _CLAUDE_ACCOUNT_ROUTING_ENV_KEYS
+            and key.casefold() not in _CLAUDE_TELEMETRY_ENV_KEYS
+            and key.casefold() not in _CLAUDE_IDE_ENV_KEYS
+            and key.casefold() not in _CLAUDE_DEBUG_ENV_KEYS
+            and key.casefold() not in _CLAUDE_CUSTOMIZATION_ENV_KEYS
+            and not key.casefold().startswith(
+                _CLAUDE_ACCOUNT_ROUTING_ENV_PREFIXES
+            )
+            and not key.casefold().startswith("claude_code_debug_")
+            and not key.casefold().startswith("otel_")
+        )
+    }
+    # Claude Code requires this flag before it collects or exports OTel data.
+    # Pinning it off protects the worker even when the parent environment used
+    # oddly-cased variables that were stripped above.
+    sanitized["CLAUDE_CODE_ENABLE_TELEMETRY"] = "0"
+    sanitized["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"] = "0"
+    sanitized["ENABLE_ENHANCED_TELEMETRY_BETA"] = "0"
+    sanitized["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1"
+    sanitized["CLAUDE_CODE_AUTO_CONNECT_IDE"] = "false"
+    sanitized["CLAUDE_CODE_DISABLE_ATTACHMENTS"] = "1"
+    sanitized["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] = "1"
+    sanitized["CLAUDE_CODE_DISABLE_CLAUDE_MDS"] = "1"
+    sanitized["CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL"] = "1"
+    sanitized["CLAUDE_CODE_SYNC_PLUGINS"] = "0"
+    sanitized["CLAUDE_CODE_SYNC_PLUGIN_INSTALL"] = "0"
+    sanitized["CLAUDE_CODE_SYNC_SKILLS"] = "0"
+    sanitized["CLAUDE_CODE_ENABLE_BACKGROUND_PLUGIN_REFRESH"] = "0"
+    sanitized["CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL"] = "1"
+    return sanitized
+
+
+def _safe_state_key(
+    availability: ProviderAvailability,
+    auth_mode: str,
+    model_ids: tuple[str, ...],
+) -> str:
+    material = "\0".join(
+        ("claude-code", availability.value, auth_mode, *model_ids)
+    )
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()[:20]
+
+
+def _models_for_probe(
+    availability: ProviderAvailability,
+    unavailable_reason: str,
+) -> tuple[ModelDescriptor, ...]:
+    ready = availability is ProviderAvailability.READY
+    return tuple(
+        ModelDescriptor(
+            id=model.id,
+            label=model.label,
+            available=ready,
+            description=model.description,
+            unavailable_reason="" if ready else unavailable_reason,
+            is_default=model.is_default,
+        )
+        for model in _CLAUDE_MODELS
+    )
+
+
+def _isolated_setting_args() -> tuple[str, ...]:
+    """Ignore user, project, and local settings for this invocation.
+
+    Claude Code can still enforce administrator-managed policy settings. Those
+    settings are part of the host's administrative trust boundary and cannot
+    be bypassed by this process-level isolation.
+    """
+
+    return (
+        "--setting-sources",
+        "",
+        "--settings",
+        "{}",
+    )
+
+
+def _work_buddy_mcp_config(session_id: str) -> str:
+    cfg = load_config()
+    port = (
+        cfg.get("sidecar", {})
+        .get("services", {})
+        .get("mcp_gateway", {})
+        .get("port", 5126)
+    )
+    payload = {
+        "mcpServers": {
+            "work-buddy": {
+                "type": "http",
+                "url": f"http://localhost:{int(port)}/mcp",
+                "headers": {
+                    "X-Work-Buddy-Session": session_id,
+                },
+            }
+        }
+    }
+    return json.dumps(payload, separators=(",", ":"), ensure_ascii=True)
+
+
+class ClaudeCodeProvider:
+    """Local Claude CLI authenticated through the user's Claude account."""
+
+    provider_id = "claude-code"
+    label = "Claude Code"
+    auth_mode = "claude_account"
+    default_model_id = "sonnet"
+
+    def __init__(
+        self,
+        *,
+        command_runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+        timeout_seconds: float = 15.0,
+        cache: ProbeCache[ProviderDescriptor] | None = None,
+    ) -> None:
+        self._run = command_runner
+        self._timeout_seconds = timeout_seconds
+        self._cache = cache or ProbeCache(ttl_seconds=30.0)
+
+    def probe(self, *, refresh: bool = False) -> ProviderDescriptor:
+        return self._cache.get_or_load(
+            self.provider_id,
+            self._probe_uncached,
+            refresh=refresh,
+        )
+
+    def clear_probe_cache(self) -> None:
+        self._cache.clear(self.provider_id)
+
+    def _probe_uncached(self) -> ProviderDescriptor:
+        availability = ProviderAvailability.UNKNOWN
+        reason = "Claude Code couldn't be checked."
+        try:
+            from work_buddy.compat import subprocess_creation_flags
+
+            result = self._run(
+                [
+                    "claude",
+                    *_isolated_setting_args(),
+                    "auth",
+                    "status",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=self._timeout_seconds,
+                check=False,
+                env=claude_account_environment(),
+                creationflags=subprocess_creation_flags(),
+                shell=False,
+            )
+        except FileNotFoundError:
+            availability = ProviderAvailability.UNAVAILABLE
+            reason = "Claude Code is not installed."
+        except subprocess.TimeoutExpired:
+            availability = ProviderAvailability.UNKNOWN
+            reason = "Claude Code didn't respond in time."
+        except (PermissionError, OSError):
+            availability = ProviderAvailability.UNAVAILABLE
+            reason = "Claude Code couldn't be opened."
+        else:
+            availability, reason = self._classify_auth_status(result)
+
+        models = _models_for_probe(availability, reason)
+        return ProviderDescriptor(
+            id=self.provider_id,
+            label=self.label,
+            availability=availability,
+            auth_mode=self.auth_mode,
+            models=models,
+            description="Uses your signed-in Claude account.",
+            unavailable_reason="" if availability is ProviderAvailability.READY else reason,
+            state_key=_safe_state_key(
+                availability,
+                self.auth_mode,
+                tuple(model.id for model in models),
+            ),
+        )
+
+    @staticmethod
+    def _classify_auth_status(
+        result: subprocess.CompletedProcess[str],
+    ) -> tuple[ProviderAvailability, str]:
+        output = (result.stdout or "").strip()
+        payload: dict[str, Any] | None = None
+        if output:
+            try:
+                candidate = json.loads(output)
+                if isinstance(candidate, dict):
+                    payload = candidate
+            except (TypeError, ValueError):
+                payload = None
+
+        if payload is not None:
+            logged_in = payload.get("loggedIn", payload.get("logged_in"))
+            if logged_in is True:
+                auth_method = str(
+                    payload.get("authMethod", payload.get("auth_method", ""))
+                    or ""
+                ).casefold()
+                api_provider = str(
+                    payload.get("apiProvider", payload.get("api_provider", ""))
+                    or ""
+                ).casefold()
+                subscription_type = str(
+                    payload.get(
+                        "subscriptionType",
+                        payload.get("subscription_type", ""),
+                    )
+                    or ""
+                ).strip()
+                if (
+                    auth_method == "claude.ai"
+                    and api_provider == "firstparty"
+                    and subscription_type
+                ):
+                    return ProviderAvailability.READY, ""
+                return (
+                    ProviderAvailability.UNAVAILABLE,
+                    "Sign in to Claude Code with your Claude account.",
+                )
+            if logged_in is False:
+                return (
+                    ProviderAvailability.AUTH_REQUIRED,
+                    "Sign in to Claude Code with your Claude account.",
+                )
+
+        combined = f"{result.stdout or ''}\n{result.stderr or ''}".casefold()
+        if (
+            "not logged in" in combined
+            or "not authenticated" in combined
+            or "sign in" in combined
+            or "login" in combined
+        ):
+            return (
+                ProviderAvailability.AUTH_REQUIRED,
+                "Sign in to Claude Code with your Claude account.",
+            )
+        return ProviderAvailability.UNKNOWN, "Claude Code couldn't be checked."
+
+    def validate_selection(
+        self,
+        selection: AgentExecutionSelection,
+        *,
+        refresh: bool = False,
+    ) -> AgentExecutionSelection:
+        if selection.provider_id != self.provider_id:
+            raise ValueError("Selection belongs to a different provider")
+        descriptor = self.probe(refresh=refresh)
+        if not descriptor.available:
+            raise ProviderUnavailableError(
+                descriptor.unavailable_reason or "Claude Code is unavailable."
+            )
+        model = next(
+            (item for item in descriptor.models if item.id == selection.model_id),
+            None,
+        )
+        if model is None or not model.available:
+            raise UnknownModelError(
+                f"Model '{selection.model_id}' is not available for Claude Code."
+            )
+        return AgentExecutionSelection(
+            provider_id=self.provider_id,
+            model_id=model.id,
+            provider_label=self.label,
+            model_label=model.label,
+        )
+
+    def start_detached(self, request: AgentSpawnRequest) -> AgentSpawnOutcome:
+        """Start Claude with the exact validated alias and account-only env."""
+
+        selection = self.validate_selection(request.selection)
+        session_id = request.session_id
+        cfg = load_config()
+        agent_cfg = cfg.get("sidecar", {}).get("agent_spawn", {})
+        budget = (
+            request.max_budget_usd
+            if request.max_budget_usd is not None
+            else float(agent_cfg.get("max_budget_usd", 1.0))
+        )
+        process_owner = session_id
+
+        from work_buddy.sidecar.dispatch.executor import (
+            spawn_detached_process_authorized,
+        )
+
+        argv = [
+            sys.executable,
+            "-m",
+            "work_buddy.agent_execution.claude_worker",
+            "--model",
+            selection.model_id,
+            "--session-id",
+            session_id,
+            "--max-budget-usd",
+            str(budget),
+        ]
+        child_env = claude_account_environment()
+        child_env["WORK_BUDDY_SESSION_ID"] = session_id
+        result = spawn_detached_process_authorized(
+            name=request.name,
+            argv=argv,
+            cwd=Path(__file__).resolve().parents[2],
+            env=child_env,
+            stdin_text=prompt_with_execution_identity(
+                request,
+                harness_id="claudecode",
+            ),
+            session_name=process_owner,
+            missing_executable_error="Claude Code is not installed.",
+            spawn_error="Claude Code couldn't start.",
+        )
+        return AgentSpawnOutcome(
+            status=str(result.get("status") or "error"),
+            selection=selection,
+            pid=result.get("pid") if isinstance(result.get("pid"), int) else None,
+            session_id=session_id,
+            error_code=str(result.get("error_code") or ""),
+            error=str(result.get("error") or ""),
+        )

--- a/work_buddy/agent_execution/claude_worker.py
+++ b/work_buddy/agent_execution/claude_worker.py
@@ -1,0 +1,119 @@
+"""Isolated Claude Code worker for one Co-work document-agent brief."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from work_buddy.compat import subprocess_creation_flags
+from work_buddy.logging_config import get_logger
+from work_buddy.sidecar.dispatch.executor import _build_headless_agent_argv
+
+from .claude_code import (
+    _isolated_setting_args,
+    _work_buddy_mcp_config,
+    claude_account_environment,
+)
+from .models import is_safe_session_id
+
+logger = get_logger(__name__)
+
+_MAX_PROMPT_CHARS = 1_000_000
+_SUPPORTED_MODELS = frozenset({"sonnet", "opus"})
+_SESSION_NAME = "daemon:work-buddy-cowork"
+
+
+def run_worker(
+    *,
+    model: str,
+    prompt: str,
+    session_id: str,
+    max_budget_usd: float,
+    command_runner: Callable[..., Any] = subprocess.run,
+) -> int:
+    """Run Claude with user customizations disabled in a neutral directory.
+
+    Administrator-managed Claude Code policy remains effective as part of the
+    host's administrative trust boundary.
+    """
+
+    if (
+        model not in _SUPPORTED_MODELS
+        or not prompt
+        or not is_safe_session_id(session_id)
+        or max_budget_usd <= 0
+    ):
+        return 2
+
+    child_env = claude_account_environment(os.environ)
+    child_env["WORK_BUDDY_SESSION_ID"] = session_id
+    argv = _build_headless_agent_argv(
+        prompt=None,
+        session_name=_SESSION_NAME,
+        model=model,
+        max_budget_usd=max_budget_usd,
+        persistent=False,
+        extra_args=(
+            *_isolated_setting_args(),
+            "--mcp-config",
+            _work_buddy_mcp_config(session_id),
+            "--strict-mcp-config",
+            "--tools",
+            "",
+            "--disable-slash-commands",
+            "--no-chrome",
+        ),
+    )
+
+    try:
+        with TemporaryDirectory(
+            prefix="work-buddy-claude-host-",
+            ignore_cleanup_errors=True,
+        ) as host_directory:
+            result = command_runner(
+                argv,
+                cwd=str(Path(host_directory).resolve()),
+                env=child_env,
+                input=prompt,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                check=False,
+                shell=False,
+                creationflags=subprocess_creation_flags(),
+            )
+        return 0 if int(getattr(result, "returncode", 1)) == 0 else 1
+    except (FileNotFoundError, PermissionError, OSError):
+        logger.error("Claude document worker could not open the runtime")
+        return 1
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--model", required=True, choices=sorted(_SUPPORTED_MODELS))
+    parser.add_argument("--session-id", required=True)
+    parser.add_argument("--max-budget-usd", required=True, type=float)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    prompt = sys.stdin.read(_MAX_PROMPT_CHARS + 1)
+    if len(prompt) > _MAX_PROMPT_CHARS:
+        return 2
+    return run_worker(
+        model=args.model,
+        prompt=prompt,
+        session_id=args.session_id,
+        max_budget_usd=args.max_budget_usd,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/work_buddy/agent_execution/codex.py
+++ b/work_buddy/agent_execution/codex.py
@@ -1,0 +1,677 @@
+"""ChatGPT-account-backed Codex execution provider."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from work_buddy.config import load_config
+
+from .cache import ProbeCache
+from .identity import prompt_with_execution_identity
+from .models import (
+    AgentExecutionSelection,
+    AgentSpawnOutcome,
+    AgentSpawnRequest,
+    ModelDescriptor,
+    ProviderAvailability,
+    ProviderDescriptor,
+    ProviderUnavailableError,
+    UnknownModelError,
+)
+
+_CODEX_ROUTE_ENV_KEYS = frozenset(
+    {
+        "codex_api_key",
+        "codex_base_url",
+        "codex_model",
+        "codex_model_provider",
+        "codex_provider",
+        "openai_api_key",
+        "openai_api_base",
+        "openai_base_url",
+        "openai_model_provider",
+        "openai_organization",
+        "openai_org_id",
+        "openai_project",
+        "openai_project_id",
+        "openai_provider",
+        "azure_openai_api_key",
+        "azure_openai_ad_token",
+        "azure_openai_api_version",
+        "azure_openai_base_url",
+        "azure_openai_endpoint",
+    }
+)
+_MAX_PROBE_OUTPUT_CHARS = 256_000
+_MAX_EFFECTIVE_NAMED_ENTRIES = 512
+_MAX_EFFECTIVE_ENTRY_NAME_CHARS = 512
+_CHATGPT_BACKEND_URL = "https://chatgpt.com/backend-api/"
+_OPENAI_API_BASE_URL = "https://api.openai.com/v1"
+_CODEX_SUBSCRIPTION_CONFIG_OVERRIDES = (
+    'forced_login_method="chatgpt"',
+    'model_provider="openai"',
+    f'chatgpt_base_url="{_CHATGPT_BACKEND_URL}"',
+    f'openai_base_url="{_OPENAI_API_BASE_URL}"',
+    'approval_policy="never"',
+    'sandbox_mode="read-only"',
+    "allow_login_shell=false",
+    "features.hooks=false",
+    "features.apps=false",
+    "features.plugins=false",
+    "features.plugin_sharing=false",
+    "features.remote_plugin=false",
+    "features.multi_agent=false",
+    "features.shell_tool=false",
+    "features.shell_snapshot=false",
+    "features.unified_exec=false",
+    "features.skill_mcp_dependency_install=false",
+    "features.browser_use=false",
+    "features.browser_use_external=false",
+    "features.browser_use_full_cdp_access=false",
+    "features.computer_use=false",
+    "features.in_app_browser=false",
+    "features.code_mode=false",
+    "features.code_mode_host=false",
+    "features.enable_mcp_apps=false",
+    "features.image_generation=false",
+    "features.workspace_dependencies=false",
+    "features.tool_suggest=false",
+    "features.auth_elicitation=false",
+    "features.tool_call_mcp_elicitation=false",
+    "features.goals=false",
+    "features.memories=false",
+    "features.external_migration=false",
+    "features.mentions_v2=false",
+    "features.personality=false",
+    "features.realtime_conversation=false",
+    "features.artifact=false",
+    "features.request_permissions_tool=false",
+    "features.remote_control=false",
+    "features.network_proxy=false",
+    'web_search="disabled"',
+    "tools.web_search=false",
+    "tools.view_image=false",
+    "apps._default.enabled=false",
+    "apps._default.destructive_enabled=false",
+    "apps._default.open_world_enabled=false",
+    "developer_instructions=\"\"",
+    "instructions=\"\"",
+    "compact_prompt=\"\"",
+    "project_doc_max_bytes=0",
+    "project_doc_fallback_filenames=[]",
+    "include_apps_instructions=false",
+    "skills.include_instructions=false",
+    "include_environment_context=false",
+    "include_permissions_instructions=false",
+    "include_collaboration_mode_instructions=false",
+    "notify=[]",
+    'history.persistence="none"',
+    "check_for_update_on_startup=false",
+    "feedback.enabled=false",
+    "analytics.enabled=false",
+    "orchestrator.skills.enabled=false",
+    "orchestrator.mcp.enabled=false",
+    'otel.exporter="none"',
+    'otel.trace_exporter="none"',
+    'otel.metrics_exporter="none"',
+    "otel.log_user_prompt=false",
+)
+
+
+class CodexConfigIsolationError(RuntimeError):
+    """The pinned Codex runtime did not expose a safe effective config."""
+
+
+def codex_chatgpt_environment(
+    base: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Remove API-key, endpoint, and provider overrides.
+
+    The Codex provider is intentionally subscription-only.  Its authority is
+    the ChatGPT account in Codex's ``auth.json``; inherited environment
+    variables must not silently switch the SDK/App Server to API billing or a
+    different endpoint/provider.  ``CODEX_HOME`` remains available so the
+    official runtime can find that account.
+    """
+
+    source = os.environ if base is None else base
+    return {
+        key: value
+        for key, value in source.items()
+        if key.casefold() not in _CODEX_ROUTE_ENV_KEYS
+    }
+
+
+def codex_subscription_config(
+    *,
+    cwd: str | Path | None = None,
+    env: Mapping[str, str] | None = None,
+    extra_overrides: tuple[str, ...] = (),
+) -> Any:
+    """Build the pinned SDK launch config for subscription-only execution."""
+
+    from openai_codex import CodexConfig
+
+    return CodexConfig(
+        config_overrides=(
+            *_CODEX_SUBSCRIPTION_CONFIG_OVERRIDES,
+            *extra_overrides,
+        ),
+        cwd=str(Path(cwd).resolve()) if cwd is not None else None,
+        env=codex_chatgpt_environment(env),
+    )
+
+
+def read_effective_codex_config(
+    codex: Any,
+    *,
+    cwd: str | Path,
+) -> dict[str, Any]:
+    """Read effective config through the pinned 0.144.x SDK seam.
+
+    The public Python surface does not currently expose ``config/read`` and
+    the generated response model omits several host keys, including
+    ``mcp_servers``.  Use the pinned client's raw request only after checking
+    its shape, and fail closed on any SDK or response-contract drift.
+    """
+
+    client = getattr(codex, "_client", None)
+    request_raw = getattr(client, "_request_raw", None)
+    if not callable(request_raw):
+        raise CodexConfigIsolationError("Codex config inspection is unavailable")
+    try:
+        payload = request_raw(
+            "config/read",
+            {
+                "cwd": str(Path(cwd).resolve()),
+                "includeLayers": False,
+            },
+        )
+    except Exception as exc:
+        raise CodexConfigIsolationError(
+            "Codex config inspection failed"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise CodexConfigIsolationError("Codex config response was invalid")
+    config = payload.get("config")
+    if not isinstance(config, dict):
+        raise CodexConfigIsolationError("Codex effective config was unavailable")
+    return config
+
+
+def validate_subscription_codex_config(config: Mapping[str, Any]) -> None:
+    """Fail closed unless the requested minimal ChatGPT route is effective."""
+
+    expected_paths: tuple[tuple[tuple[str, ...], Any], ...] = (
+        (("forced_login_method",), "chatgpt"),
+        (("model_provider",), "openai"),
+        (("chatgpt_base_url",), _CHATGPT_BACKEND_URL),
+        (("openai_base_url",), _OPENAI_API_BASE_URL),
+        (("approval_policy",), "never"),
+        (("sandbox_mode",), "read-only"),
+        (("allow_login_shell",), False),
+        (("features", "hooks"), False),
+        (("features", "apps"), False),
+        (("features", "plugins"), False),
+        (("features", "plugin_sharing"), False),
+        (("features", "remote_plugin"), False),
+        (("features", "multi_agent"), False),
+        (("features", "shell_tool"), False),
+        (("features", "shell_snapshot"), False),
+        (("features", "unified_exec"), False),
+        (("features", "skill_mcp_dependency_install"), False),
+        (("features", "browser_use"), False),
+        (("features", "browser_use_external"), False),
+        (("features", "browser_use_full_cdp_access"), False),
+        (("features", "computer_use"), False),
+        (("features", "in_app_browser"), False),
+        (("features", "code_mode"), False),
+        (("features", "code_mode_host"), False),
+        (("features", "enable_mcp_apps"), False),
+        (("features", "image_generation"), False),
+        (("features", "workspace_dependencies"), False),
+        (("features", "tool_suggest"), False),
+        (("features", "auth_elicitation"), False),
+        (("features", "tool_call_mcp_elicitation"), False),
+        (("features", "goals"), False),
+        (("features", "memories"), False),
+        (("features", "external_migration"), False),
+        (("features", "mentions_v2"), False),
+        (("features", "personality"), False),
+        (("features", "realtime_conversation"), False),
+        (("features", "artifact"), False),
+        (("features", "request_permissions_tool"), False),
+        (("features", "remote_control"), False),
+        (("features", "network_proxy"), False),
+        (("web_search",), "disabled"),
+        (("apps", "_default", "enabled"), False),
+        (("apps", "_default", "destructive_enabled"), False),
+        (("apps", "_default", "open_world_enabled"), False),
+        (("developer_instructions",), ""),
+        (("instructions",), ""),
+        (("compact_prompt",), ""),
+        (("project_doc_max_bytes",), 0),
+        (("project_doc_fallback_filenames",), []),
+        (("include_apps_instructions",), False),
+        (("skills", "include_instructions"), False),
+        (("include_environment_context",), False),
+        (("include_permissions_instructions",), False),
+        (("include_collaboration_mode_instructions",), False),
+        (("notify",), []),
+        (("history", "persistence"), "none"),
+        (("check_for_update_on_startup",), False),
+        (("feedback", "enabled"), False),
+        (("analytics", "enabled"), False),
+        (("orchestrator", "skills", "enabled"), False),
+        (("orchestrator", "mcp", "enabled"), False),
+        (("otel", "exporter"), "none"),
+        (("otel", "trace_exporter"), "none"),
+        (("otel", "metrics_exporter"), "none"),
+        (("otel", "log_user_prompt"), False),
+    )
+    for path, expected in expected_paths:
+        value: Any = config
+        for key in path:
+            if not isinstance(value, Mapping) or key not in value:
+                raise CodexConfigIsolationError(
+                    "Codex effective config did not preserve isolation"
+                )
+            value = value[key]
+        if value != expected:
+            raise CodexConfigIsolationError(
+                "Codex effective config did not preserve isolation"
+            )
+    tools = config.get("tools")
+    if not isinstance(tools, Mapping):
+        raise CodexConfigIsolationError(
+            "Codex effective tool config was unavailable"
+        )
+    if tools.get("web_search") not in (None, False):
+        raise CodexConfigIsolationError(
+            "Codex web search tool was not isolated"
+        )
+    if tools.get("view_image") not in (None, False):
+        raise CodexConfigIsolationError(
+            "Codex image tool was not isolated"
+        )
+    for path_key in (
+        "experimental_compact_prompt_file",
+        "experimental_instructions_file",
+        "model_catalog_json",
+        "model_instructions_file",
+    ):
+        if config.get(path_key) not in (None, ""):
+            raise CodexConfigIsolationError(
+                "Codex external model configuration was not isolated"
+            )
+
+
+def _effective_named_table_entries(
+    config: Mapping[str, Any],
+    *,
+    table_name: str,
+) -> tuple[str, ...]:
+    raw_entries = config.get(table_name)
+    if raw_entries is None:
+        return ()
+    if not isinstance(raw_entries, Mapping):
+        raise CodexConfigIsolationError("Codex named config table was invalid")
+    if len(raw_entries) > _MAX_EFFECTIVE_NAMED_ENTRIES:
+        raise CodexConfigIsolationError("Codex named config table was too large")
+    names: list[str] = []
+    for raw_name in raw_entries:
+        if (
+            not isinstance(raw_name, str)
+            or not raw_name
+            or len(raw_name) > _MAX_EFFECTIVE_ENTRY_NAME_CHARS
+        ):
+            raise CodexConfigIsolationError("Codex config entry name was invalid")
+        names.append(raw_name)
+    return tuple(sorted(names))
+
+
+def effective_mcp_server_names(config: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return inherited MCP names from a validated effective config."""
+
+    return _effective_named_table_entries(
+        config,
+        table_name="mcp_servers",
+    )
+
+
+def effective_plugin_ids(config: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return installed/configured plugin ids from effective config."""
+
+    return _effective_named_table_entries(
+        config,
+        table_name="plugins",
+    )
+
+
+def _toml_key_segment(value: str) -> str:
+    return json.dumps(value, ensure_ascii=True)
+
+
+def codex_entry_isolation_overrides(
+    *,
+    effective_config: Mapping[str, Any],
+    plugin_ids: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Disable discovered executable integrations before execution startup."""
+
+    raw_servers = effective_config.get("mcp_servers")
+    if raw_servers is None:
+        raw_servers = {}
+    if not isinstance(raw_servers, Mapping):
+        raise CodexConfigIsolationError("Codex MCP config was invalid")
+    mcp_entries: list[str] = []
+    for name in effective_mcp_server_names(effective_config):
+        raw_server = raw_servers.get(name)
+        if not isinstance(raw_server, Mapping):
+            raise CodexConfigIsolationError("Codex MCP transport was invalid")
+        command = raw_server.get("command")
+        url = raw_server.get("url")
+        if isinstance(command, str) and command and url is None:
+            # A launch override containing only ``enabled=false`` is rejected
+            # by 0.144.x before layers merge because that layer has no
+            # transport.  Supply an inert transport of the same kind so the
+            # layer validates, while ensuring the inherited executable and
+            # arguments cannot be selected even if merge behavior changes.
+            inert_command = _toml_key_segment(sys.executable)
+            value = (
+                f'{{command={inert_command},args=["-c","pass"],enabled=false}}'
+            )
+        elif isinstance(url, str) and url and command is None:
+            value = (
+                '{url="http://127.0.0.1:9/work-buddy-disabled",'
+                "enabled=false}"
+            )
+        else:
+            raise CodexConfigIsolationError("Codex MCP transport was invalid")
+        mcp_entries.append(f"{_toml_key_segment(name)}={value}")
+
+    overrides: list[str] = []
+    if mcp_entries:
+        # The 0.144.x CLI override parser treats quotes in dotted key paths as
+        # literal key characters.  Put quoted names inside one inline table so
+        # punctuation-bearing MCP names address the inherited entries exactly.
+        overrides.append(f"mcp_servers={{{','.join(mcp_entries)}}}")
+    if plugin_ids:
+        plugin_entries = ",".join(
+            f"{_toml_key_segment(plugin_id)}={{enabled=false}}"
+            for plugin_id in plugin_ids
+        )
+        overrides.append(f"plugins={{{plugin_entries}}}")
+    return tuple(overrides)
+
+
+def validate_entry_isolation(
+    config: Mapping[str, Any],
+    *,
+    mcp_server_names: tuple[str, ...],
+    plugin_ids: tuple[str, ...],
+) -> None:
+    """Verify every discovered executable integration is launch-disabled."""
+
+    expected_tables = (
+        ("mcp_servers", tuple(sorted(mcp_server_names))),
+        ("plugins", tuple(sorted(plugin_ids))),
+    )
+    actual_tables = (
+        ("mcp_servers", effective_mcp_server_names(config)),
+        ("plugins", effective_plugin_ids(config)),
+    )
+    if actual_tables != expected_tables:
+        raise CodexConfigIsolationError(
+            "Codex executable integration config changed during isolation"
+        )
+
+    for table_name, names in expected_tables:
+        if not names:
+            continue
+        table = config.get(table_name)
+        if not isinstance(table, Mapping):
+            raise CodexConfigIsolationError(
+                "Codex executable integration config was unavailable"
+            )
+        for name in names:
+            entry = table.get(name)
+            if not isinstance(entry, Mapping) or entry.get("enabled") is not False:
+                raise CodexConfigIsolationError(
+                    "Codex executable integration was not isolated"
+                )
+
+
+def _mcp_endpoint() -> str:
+    cfg = load_config()
+    port = (
+        cfg.get("sidecar", {})
+        .get("services", {})
+        .get("mcp_gateway", {})
+        .get("port", 5126)
+    )
+    return f"http://localhost:{int(port)}/mcp"
+
+
+class CodexProvider:
+    """Official Python SDK plus its pinned local Codex runtime."""
+
+    provider_id = "codex"
+    label = "Codex"
+    auth_mode = "chatgpt"
+    default_model_id = ""
+
+    def __init__(
+        self,
+        *,
+        command_runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+        timeout_seconds: float = 12.0,
+        cache: ProbeCache[ProviderDescriptor] | None = None,
+    ) -> None:
+        self._run = command_runner
+        self._timeout_seconds = timeout_seconds
+        self._cache = cache or ProbeCache(ttl_seconds=30.0)
+
+    def probe(self, *, refresh: bool = False) -> ProviderDescriptor:
+        return self._cache.get_or_load(
+            self.provider_id,
+            self._probe_uncached,
+            refresh=refresh,
+        )
+
+    def clear_probe_cache(self) -> None:
+        self._cache.clear(self.provider_id)
+
+    def _probe_uncached(self) -> ProviderDescriptor:
+        try:
+            from work_buddy.compat import subprocess_creation_flags
+
+            result = self._run(
+                [
+                    sys.executable,
+                    "-m",
+                    "work_buddy.agent_execution.codex_probe_worker",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=self._timeout_seconds,
+                check=False,
+                env=codex_chatgpt_environment(),
+                creationflags=subprocess_creation_flags(),
+                shell=False,
+            )
+        except subprocess.TimeoutExpired:
+            return self._unavailable(
+                ProviderAvailability.UNKNOWN,
+                "Codex didn't respond in time.",
+            )
+        except (FileNotFoundError, PermissionError, OSError):
+            return self._unavailable(
+                ProviderAvailability.UNAVAILABLE,
+                "Codex support couldn't be opened.",
+            )
+
+        stdout = (result.stdout or "")[:_MAX_PROBE_OUTPUT_CHARS]
+        if result.returncode != 0 or not stdout:
+            return self._unavailable(
+                ProviderAvailability.UNKNOWN,
+                "Codex couldn't be checked.",
+            )
+        try:
+            payload = json.loads(stdout)
+        except (TypeError, ValueError):
+            return self._unavailable(
+                ProviderAvailability.UNKNOWN,
+                "Codex couldn't be checked.",
+            )
+        if not isinstance(payload, dict):
+            return self._unavailable(
+                ProviderAvailability.UNKNOWN,
+                "Codex couldn't be checked.",
+            )
+        return self._descriptor_from_redacted_payload(payload)
+
+    def _descriptor_from_redacted_payload(
+        self,
+        payload: dict[str, Any],
+    ) -> ProviderDescriptor:
+        try:
+            availability = ProviderAvailability(
+                str(payload.get("availability") or "unknown")
+            )
+        except ValueError:
+            availability = ProviderAvailability.UNKNOWN
+
+        models: list[ModelDescriptor] = []
+        raw_models = payload.get("models")
+        if isinstance(raw_models, list):
+            seen: set[str] = set()
+            for raw in raw_models:
+                if not isinstance(raw, dict):
+                    continue
+                model_id = str(raw.get("id") or "").strip()
+                label = str(raw.get("label") or model_id).strip()
+                if not model_id or model_id in seen:
+                    continue
+                seen.add(model_id)
+                models.append(
+                    ModelDescriptor(
+                        id=model_id,
+                        label=label,
+                        available=(
+                            availability is ProviderAvailability.READY
+                            and bool(raw.get("available", True))
+                        ),
+                        description=str(raw.get("description") or ""),
+                        unavailable_reason=str(
+                            raw.get("unavailable_reason") or ""
+                        ),
+                        is_default=bool(raw.get("is_default", False)),
+                    )
+                )
+
+        reason = str(payload.get("unavailable_reason") or "")
+        if availability is ProviderAvailability.READY and not models:
+            availability = ProviderAvailability.UNAVAILABLE
+            reason = "Codex didn't report any available models."
+        return ProviderDescriptor(
+            id=self.provider_id,
+            label=self.label,
+            availability=availability,
+            auth_mode=self.auth_mode,
+            models=tuple(models),
+            description="Uses your signed-in ChatGPT account.",
+            unavailable_reason=reason,
+            state_key=str(payload.get("state_key") or ""),
+        )
+
+    def _unavailable(
+        self,
+        availability: ProviderAvailability,
+        reason: str,
+    ) -> ProviderDescriptor:
+        return ProviderDescriptor(
+            id=self.provider_id,
+            label=self.label,
+            availability=availability,
+            auth_mode=self.auth_mode,
+            description="Uses your signed-in ChatGPT account.",
+            unavailable_reason=reason,
+        )
+
+    def validate_selection(
+        self,
+        selection: AgentExecutionSelection,
+        *,
+        refresh: bool = False,
+    ) -> AgentExecutionSelection:
+        if selection.provider_id != self.provider_id:
+            raise ValueError("Selection belongs to a different provider")
+        descriptor = self.probe(refresh=refresh)
+        if not descriptor.available:
+            raise ProviderUnavailableError(
+                descriptor.unavailable_reason or "Codex is unavailable."
+            )
+        model = next(
+            (item for item in descriptor.models if item.id == selection.model_id),
+            None,
+        )
+        if model is None or not model.available:
+            raise UnknownModelError(
+                f"Model '{selection.model_id}' is not available for Codex."
+            )
+        return AgentExecutionSelection(
+            provider_id=self.provider_id,
+            model_id=model.id,
+            provider_label=self.label,
+            model_label=model.label,
+        )
+
+    def start_detached(self, request: AgentSpawnRequest) -> AgentSpawnOutcome:
+        selection = self.validate_selection(request.selection)
+        session_id = request.session_id
+
+        from work_buddy.sidecar.dispatch.executor import (
+            spawn_detached_process_authorized,
+        )
+
+        argv = [
+            sys.executable,
+            "-m",
+            "work_buddy.agent_execution.codex_worker",
+            "--model",
+            selection.model_id,
+            "--session-id",
+            session_id,
+            "--mcp-url",
+            _mcp_endpoint(),
+        ]
+        child_env = codex_chatgpt_environment()
+        child_env["WORK_BUDDY_SESSION_ID"] = session_id
+        result = spawn_detached_process_authorized(
+            name=request.name,
+            argv=argv,
+            cwd=Path(__file__).resolve().parents[2],
+            env=child_env,
+            stdin_text=prompt_with_execution_identity(
+                request,
+                harness_id="codexcli",
+            ),
+            session_name=session_id,
+            missing_executable_error="Codex support is not installed.",
+            spawn_error="Codex couldn't start.",
+        )
+        return AgentSpawnOutcome(
+            status=str(result.get("status") or "error"),
+            selection=selection,
+            pid=result.get("pid") if isinstance(result.get("pid"), int) else None,
+            session_id=session_id,
+            error_code=str(result.get("error_code") or ""),
+            error=str(result.get("error") or ""),
+        )

--- a/work_buddy/agent_execution/codex_probe_worker.py
+++ b/work_buddy/agent_execution/codex_probe_worker.py
@@ -1,0 +1,180 @@
+"""Redacted Codex SDK account/model probe.
+
+This module runs in a short-lived child process so a stuck local App Server can
+be bounded by the caller's timeout.  Its stdout contract contains only safe
+provider state and model catalog fields; account identifiers are never read
+into the projection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from .codex import (
+    codex_subscription_config,
+    read_effective_codex_config,
+    validate_subscription_codex_config,
+)
+
+
+def _state_key(
+    *,
+    availability: str,
+    runtime_version: str,
+    model_ids: tuple[str, ...],
+) -> str:
+    material = "\0".join(
+        ("codex", availability, "chatgpt", runtime_version, *sorted(model_ids))
+    )
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()[:20]
+
+
+def _unavailable(
+    *,
+    availability: str,
+    reason: str,
+    runtime_version: str = "",
+) -> dict[str, Any]:
+    return {
+        "availability": availability,
+        "auth_mode": "chatgpt",
+        "models": [],
+        "unavailable_reason": reason,
+        "state_key": _state_key(
+            availability=availability,
+            runtime_version=runtime_version,
+            model_ids=(),
+        ),
+    }
+
+
+def collect_redacted_probe(
+    client_factory: Callable[[], Any] | None = None,
+) -> dict[str, Any]:
+    """Query ``account/read`` and ``model/list`` without projecting identity."""
+
+    try:
+        import openai_codex
+        from openai_codex import Codex
+    except ImportError:
+        return _unavailable(
+            availability="unavailable",
+            reason="Codex support is not installed.",
+        )
+
+    runtime_version = str(getattr(openai_codex, "__version__", ""))
+    require_effective_config = client_factory is None
+
+    try:
+        with TemporaryDirectory(
+            prefix="work-buddy-codex-probe-",
+            ignore_cleanup_errors=True,
+        ) as host_directory:
+            host_cwd = Path(host_directory).resolve()
+            factory = client_factory or (
+                lambda: Codex(
+                    config=codex_subscription_config(
+                        cwd=host_cwd,
+                        env=os.environ,
+                    )
+                )
+            )
+            with factory() as codex:
+                if require_effective_config:
+                    effective_config = read_effective_codex_config(
+                        codex,
+                        cwd=host_cwd,
+                    )
+                    validate_subscription_codex_config(effective_config)
+                account_response = codex.account(refresh_token=False)
+                account_container = getattr(account_response, "account", None)
+                account = getattr(account_container, "root", account_container)
+                account_type = str(getattr(account, "type", "") or "")
+
+                if account is None:
+                    return _unavailable(
+                        availability="auth_required",
+                        reason="Sign in to Codex with ChatGPT.",
+                        runtime_version=runtime_version,
+                    )
+                if account_type.casefold() != "chatgpt":
+                    return _unavailable(
+                        availability="unavailable",
+                        reason=(
+                            "Codex is not using a ChatGPT account. "
+                            "Sign in to Codex with ChatGPT."
+                        ),
+                        runtime_version=runtime_version,
+                    )
+
+                response = codex.models(include_hidden=False)
+            models: list[dict[str, Any]] = []
+            seen: set[str] = set()
+            for raw in getattr(response, "data", ()):
+                if bool(getattr(raw, "hidden", False)):
+                    continue
+                model_id = str(getattr(raw, "model", "") or "").strip()
+                if not model_id or model_id in seen:
+                    continue
+                seen.add(model_id)
+                label = str(
+                    getattr(raw, "display_name", "") or model_id
+                ).strip()
+                models.append(
+                    {
+                        "id": model_id,
+                        "label": label,
+                        "available": True,
+                        "description": str(
+                            getattr(raw, "description", "") or ""
+                        ),
+                        "unavailable_reason": "",
+                        "is_default": bool(
+                            getattr(raw, "is_default", False)
+                        ),
+                    }
+                )
+
+            if not models:
+                return _unavailable(
+                    availability="unavailable",
+                    reason="Codex didn't report any available models.",
+                    runtime_version=runtime_version,
+                )
+
+            return {
+                "availability": "ready",
+                "auth_mode": "chatgpt",
+                "models": models,
+                "unavailable_reason": "",
+                "state_key": _state_key(
+                    availability="ready",
+                    runtime_version=runtime_version,
+                    model_ids=tuple(model["id"] for model in models),
+                ),
+            }
+    except Exception:
+        # SDK/RPC exceptions may contain paths, process diagnostics, or account
+        # details.  The parent receives only this fixed safe projection.
+        return _unavailable(
+            availability="unknown",
+            reason="Codex couldn't be checked.",
+            runtime_version=runtime_version,
+        )
+
+
+def main() -> int:
+    payload = collect_redacted_probe()
+    sys.stdout.write(json.dumps(payload, separators=(",", ":"), ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/work_buddy/agent_execution/codex_worker.py
+++ b/work_buddy/agent_execution/codex_worker.py
@@ -1,0 +1,224 @@
+"""Isolated long-running Codex SDK worker for a document-agent brief."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+from urllib.parse import urlsplit
+
+from work_buddy.logging_config import get_logger
+
+from .codex import (
+    codex_chatgpt_environment,
+    codex_entry_isolation_overrides,
+    codex_subscription_config,
+    effective_mcp_server_names,
+    effective_plugin_ids,
+    read_effective_codex_config,
+    validate_entry_isolation,
+    validate_subscription_codex_config,
+)
+from .models import is_safe_session_id
+
+logger = get_logger(__name__)
+
+_MAX_PROMPT_CHARS = 1_000_000
+_COWORK_BASE_INSTRUCTIONS = (
+    "You are the Work Buddy Co-work document agent. Work only through the "
+    "Work Buddy MCP server exposed to this thread. Do not use or request "
+    "filesystem, shell, browser, computer-use, app, plugin, skill, web-search, "
+    "image, or other MCP access."
+)
+_COWORK_DEVELOPER_INSTRUCTIONS = (
+    "Initialize Work Buddy with the exact session identity in the user brief, "
+    "then complete that brief through Work Buddy capabilities. Treat the "
+    "workspace path in the brief as data for Work Buddy, not as permission to "
+    "read it directly."
+)
+
+
+def _local_mcp_url(value: str) -> str:
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in {"localhost", "127.0.0.1", "::1"}
+        or parsed.path != "/mcp"
+        or parsed.query
+        or parsed.fragment
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise ValueError("mcp-url must be the local Work Buddy MCP endpoint")
+    return value
+
+
+def build_thread_config(
+    *,
+    mcp_url: str,
+    session_id: str,
+    inherited_mcp_server_names: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Disable inherited MCPs, then register only the local Work Buddy."""
+
+    if not is_safe_session_id(session_id):
+        raise ValueError("session_id must be a safe backend identity")
+
+    mcp_servers: dict[str, dict[str, Any]] = {
+        name: {"enabled": False}
+        for name in inherited_mcp_server_names
+    }
+    mcp_servers["work-buddy"] = {
+        "url": _local_mcp_url(mcp_url),
+        "enabled": True,
+        "http_headers": {
+            "X-Work-Buddy-Session": session_id,
+        },
+        "default_tools_approval_mode": "approve",
+        "tools": {
+            "wb_init": {
+                "approval_mode": "approve",
+            }
+        },
+    }
+
+    return {"mcp_servers": mcp_servers}
+
+
+def run_worker(
+    *,
+    model: str,
+    prompt: str,
+    session_id: str,
+    mcp_url: str,
+    codex_factory: Any | None = None,
+) -> int:
+    """Run one ephemeral read-only Codex thread until the brief completes."""
+
+    if not model or not is_safe_session_id(session_id) or not prompt:
+        return 2
+    os.environ["WORK_BUDDY_SESSION_ID"] = session_id
+    try:
+        from openai_codex import ApprovalMode, Codex, Sandbox
+
+        with TemporaryDirectory(
+            prefix="work-buddy-codex-host-",
+            ignore_cleanup_errors=True,
+        ) as host_directory:
+            host_cwd = Path(host_directory).resolve()
+
+            if codex_factory is None:
+                # The first App Server only reads effective config.  Codex
+                # creates MCP connection managers per thread, so no inherited
+                # MCP process is started during this discovery pass.
+                discovery_factory = lambda: Codex(
+                    config=codex_subscription_config(
+                        cwd=host_cwd,
+                        env=codex_chatgpt_environment(os.environ),
+                    )
+                )
+            else:
+                discovery_factory = codex_factory
+
+            with discovery_factory() as discovery:
+                discovered_config = read_effective_codex_config(
+                    discovery,
+                    cwd=host_cwd,
+                )
+                validate_subscription_codex_config(discovered_config)
+                inherited_mcp_server_names = effective_mcp_server_names(
+                    discovered_config
+                )
+                inherited_plugin_ids = effective_plugin_ids(discovered_config)
+
+            launch_isolation = codex_entry_isolation_overrides(
+                effective_config=discovered_config,
+                plugin_ids=inherited_plugin_ids,
+            )
+            if codex_factory is None:
+                execution_factory = lambda: Codex(
+                    config=codex_subscription_config(
+                        cwd=host_cwd,
+                        env=codex_chatgpt_environment(os.environ),
+                        extra_overrides=launch_isolation,
+                    )
+                )
+            else:
+                execution_factory = codex_factory
+
+            with execution_factory() as codex:
+                effective_config = read_effective_codex_config(
+                    codex,
+                    cwd=host_cwd,
+                )
+                validate_subscription_codex_config(effective_config)
+                validate_entry_isolation(
+                    effective_config,
+                    mcp_server_names=inherited_mcp_server_names,
+                    plugin_ids=inherited_plugin_ids,
+                )
+                config = build_thread_config(
+                    mcp_url=mcp_url,
+                    session_id=session_id,
+                    inherited_mcp_server_names=inherited_mcp_server_names,
+                )
+                thread = codex.thread_start(
+                    approval_mode=ApprovalMode.deny_all,
+                    base_instructions=_COWORK_BASE_INSTRUCTIONS,
+                    config=config,
+                    cwd=str(host_cwd),
+                    developer_instructions=_COWORK_DEVELOPER_INSTRUCTIONS,
+                    ephemeral=True,
+                    model=model,
+                    model_provider="openai",
+                    sandbox=Sandbox.read_only,
+                    service_name="work-buddy-cowork",
+                )
+                result = thread.run(
+                    prompt,
+                    approval_mode=ApprovalMode.deny_all,
+                    model=model,
+                    sandbox=Sandbox.read_only,
+                )
+        logger.info(
+            "Codex document worker completed: model=%s, response_len=%d",
+            model,
+            len(str(getattr(result, "final_response", "") or "")),
+        )
+        return 0
+    except Exception as exc:
+        # Do not log exception text: RPC/auth failures can contain account or
+        # filesystem details.  Conversation responses never receive this log.
+        logger.error(
+            "Codex document worker failed: error_type=%s",
+            type(exc).__name__,
+        )
+        return 1
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--session-id", required=True)
+    parser.add_argument("--mcp-url", required=True, type=_local_mcp_url)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    prompt = sys.stdin.read(_MAX_PROMPT_CHARS + 1)
+    if len(prompt) > _MAX_PROMPT_CHARS:
+        return 2
+    return run_worker(
+        model=args.model,
+        prompt=prompt,
+        session_id=args.session_id,
+        mcp_url=args.mcp_url,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/work_buddy/agent_execution/identity.py
+++ b/work_buddy/agent_execution/identity.py
@@ -1,0 +1,35 @@
+"""Provider-independent execution identity prompt plumbing."""
+
+from __future__ import annotations
+
+import json
+
+from .models import AgentSpawnRequest
+
+
+def prompt_with_execution_identity(
+    request: AgentSpawnRequest,
+    *,
+    harness_id: str,
+) -> str:
+    """Prepend the exact Work Buddy identity the hosted agent must initialize.
+
+    Providers isolate ``WORK_BUDDY_SESSION_ID`` to the same caller-supplied
+    value.  The explicit prompt contract avoids relying on lifecycle hooks or
+    a native harness thread ID, neither of which is the durable Co-work lease
+    identity.
+    """
+
+    session_json = json.dumps(request.session_id, ensure_ascii=True)
+    harness_json = json.dumps(harness_id, ensure_ascii=True)
+    return (
+        "## Work Buddy execution identity\n\n"
+        "Before calling any other Work Buddy tool, call `wb_init` exactly once "
+        "with these exact arguments:\n"
+        f"- `session_id={session_json}`\n"
+        f"- `harness_id={harness_json}`\n"
+        "Do not substitute an inherited bootstrap ID or a native harness "
+        "thread ID for this execution identity.\n\n"
+        "## Document-agent brief\n\n"
+        f"{request.prompt}"
+    )

--- a/work_buddy/agent_execution/models.py
+++ b/work_buddy/agent_execution/models.py
@@ -1,0 +1,206 @@
+"""Typed contracts for long-running agent execution providers.
+
+The execution profile is intentionally distinct from ``LLMRunner``.  It
+selects a local authenticated agent host (Claude Code or Codex) and one model
+that host advertised, rather than a one-shot completion backend.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field, replace
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$")
+
+
+def is_safe_session_id(value: str) -> bool:
+    """Return whether ``value`` is safe for env, CLI, and HTTP-header use."""
+
+    return bool(_SESSION_ID_RE.fullmatch(value))
+
+
+class ProviderAvailability(str, Enum):
+    """User-safe provider readiness states."""
+
+    READY = "ready"
+    AUTH_REQUIRED = "auth_required"
+    UNAVAILABLE = "unavailable"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class AgentExecutionSelection:
+    """One server-validated provider/model pair.
+
+    Labels are projections from the trusted provider catalog.  Callers may
+    construct an ID-only value as input, but must use
+    :func:`ProviderRegistry.validate_selection` before persisting or spawning
+    it.
+    """
+
+    provider_id: str
+    model_id: str
+    provider_label: str = ""
+    model_label: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.provider_id.strip():
+            raise ValueError("provider_id must not be empty")
+        if not self.model_id.strip():
+            raise ValueError("model_id must not be empty")
+
+    def to_dict(self) -> dict[str, str]:
+        """Return the stable public JSON projection."""
+
+        return {
+            "provider_id": self.provider_id,
+            "model_id": self.model_id,
+            "provider_label": self.provider_label,
+            "model_label": self.model_label,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ModelDescriptor:
+    """One model advertised by an execution provider."""
+
+    id: str
+    label: str
+    available: bool = True
+    description: str = ""
+    unavailable_reason: str = ""
+    is_default: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "label": self.label,
+            "available": self.available,
+            "description": self.description,
+            "unavailable_reason": self.unavailable_reason,
+            "is_default": self.is_default,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderDescriptor:
+    """Redacted provider probe and model catalog."""
+
+    id: str
+    label: str
+    availability: ProviderAvailability
+    auth_mode: str
+    models: tuple[ModelDescriptor, ...] = ()
+    description: str = ""
+    unavailable_reason: str = ""
+    state_key: str = ""
+
+    @property
+    def available(self) -> bool:
+        return self.availability is ProviderAvailability.READY
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "label": self.label,
+            "available": self.available,
+            "availability": self.availability.value,
+            "auth_mode": self.auth_mode,
+            "description": self.description,
+            "models": [model.to_dict() for model in self.models],
+            "unavailable_reason": self.unavailable_reason,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AgentExecutionCatalog:
+    """All known providers plus a deterministic default selection."""
+
+    providers: tuple[ProviderDescriptor, ...]
+    default_selection: AgentExecutionSelection
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "providers": [provider.to_dict() for provider in self.providers],
+            "default_selection": self.default_selection.to_dict(),
+        }
+
+
+def default_working_directory() -> Path:
+    """Return a neutral existing directory for provider host validation."""
+
+    from tempfile import gettempdir
+
+    return Path(gettempdir()).resolve()
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSpawnRequest:
+    """Validated input for starting one detached agent driver."""
+
+    name: str
+    prompt: str
+    selection: AgentExecutionSelection
+    session_id: str
+    working_directory: Path = field(default_factory=default_working_directory)
+    max_budget_usd: float | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise ValueError("name must not be empty")
+        if not self.prompt:
+            raise ValueError("prompt must not be empty")
+        if not is_safe_session_id(self.session_id):
+            raise ValueError("session_id must be a safe nonempty backend identity")
+
+    def with_selection(
+        self, selection: AgentExecutionSelection
+    ) -> "AgentSpawnRequest":
+        return replace(self, selection=selection)
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSpawnOutcome:
+    """Provider-neutral detached-process launch result."""
+
+    status: str
+    selection: AgentExecutionSelection
+    pid: int | None = None
+    session_id: str = ""
+    error_code: str = ""
+    error: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "ok" and self.pid is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "selection": self.selection.to_dict(),
+            "pid": self.pid,
+            "session_id": self.session_id,
+            "error_code": self.error_code,
+            "error": self.error,
+        }
+
+
+class AgentExecutionError(ValueError):
+    """Base class for safe execution-profile validation errors."""
+
+    error_code = "agent_execution_error"
+
+
+class UnknownProviderError(AgentExecutionError):
+    error_code = "unknown_provider"
+
+
+class UnknownModelError(AgentExecutionError):
+    error_code = "unknown_model"
+
+
+class ProviderUnavailableError(AgentExecutionError):
+    error_code = "provider_unavailable"

--- a/work_buddy/agent_execution/registry.py
+++ b/work_buddy/agent_execution/registry.py
@@ -1,0 +1,208 @@
+"""Server-authoritative registry for agent execution providers."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor
+
+from work_buddy.config import load_config
+
+from .base import AgentExecutionProvider
+from .claude_code import ClaudeCodeProvider
+from .codex import CodexProvider
+from .models import (
+    AgentExecutionCatalog,
+    AgentExecutionSelection,
+    AgentSpawnOutcome,
+    AgentSpawnRequest,
+    ProviderAvailability,
+    ProviderDescriptor,
+    UnknownProviderError,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_SELECTION = AgentExecutionSelection(
+    provider_id="claude-code",
+    model_id="sonnet",
+    provider_label="Claude Code",
+    model_label="Sonnet",
+)
+_CLAUDE_DEFAULT_SELECTIONS = {
+    "sonnet": _DEFAULT_SELECTION,
+    "opus": AgentExecutionSelection(
+        provider_id="claude-code",
+        model_id="opus",
+        provider_label="Claude Code",
+        model_label="Opus",
+    ),
+}
+
+
+def _configured_default_selection() -> AgentExecutionSelection:
+    """Preserve the supported Claude alias configured for legacy agent spawns."""
+
+    try:
+        configured = (
+            load_config()
+            .get("sidecar", {})
+            .get("agent_spawn", {})
+            .get("model", _DEFAULT_SELECTION.model_id)
+        )
+    except Exception:
+        logger.warning(
+            "Could not read the configured Co-work execution default; "
+            "using Claude Sonnet.",
+            exc_info=True,
+        )
+        return _DEFAULT_SELECTION
+    model_id = (
+        configured.strip().casefold()
+        if isinstance(configured, str)
+        else _DEFAULT_SELECTION.model_id
+    )
+    selected = _CLAUDE_DEFAULT_SELECTIONS.get(model_id)
+    if selected is not None:
+        return selected
+    logger.warning(
+        "Configured agent-spawn model is not a supported Co-work default; "
+        "using Claude Sonnet."
+    )
+    return _DEFAULT_SELECTION
+
+
+class ProviderRegistry:
+    """Validated provider lookup, catalog projection, and dispatch."""
+
+    def __init__(
+        self,
+        providers: Iterable[AgentExecutionProvider],
+        *,
+        default_selection: AgentExecutionSelection = _DEFAULT_SELECTION,
+    ) -> None:
+        ordered = tuple(providers)
+        by_id: dict[str, AgentExecutionProvider] = {}
+        for provider in ordered:
+            if provider.provider_id in by_id:
+                raise ValueError(
+                    f"Duplicate agent execution provider: {provider.provider_id}"
+                )
+            by_id[provider.provider_id] = provider
+        if default_selection.provider_id not in by_id:
+            raise ValueError("Default provider is not registered")
+        self._providers = ordered
+        self._by_id = by_id
+        self._default_selection = default_selection
+
+    @property
+    def default_selection(self) -> AgentExecutionSelection:
+        """Return the deterministic default without performing a probe."""
+
+        return self._default_selection
+
+    def get_provider(self, provider_id: str) -> AgentExecutionProvider:
+        try:
+            return self._by_id[provider_id]
+        except KeyError as exc:
+            raise UnknownProviderError(
+                f"Unknown agent execution provider: {provider_id}"
+            ) from exc
+
+    def get_catalog(self, *, refresh: bool = False) -> AgentExecutionCatalog:
+        def probe_safely(
+            provider: AgentExecutionProvider,
+        ) -> ProviderDescriptor:
+            try:
+                return provider.probe(refresh=refresh)
+            except Exception:
+                # Catalog reads must remain useful when one local runtime is
+                # broken. Never project exception text: SDK/CLI failures may
+                # carry paths, account data, or subprocess diagnostics.
+                return ProviderDescriptor(
+                    id=provider.provider_id,
+                    label=provider.label,
+                    availability=ProviderAvailability.UNKNOWN,
+                    auth_mode=provider.auth_mode,
+                    unavailable_reason=(
+                        f"{provider.label} couldn't be checked."
+                    ),
+                )
+
+        with ThreadPoolExecutor(
+            max_workers=len(self._providers),
+            thread_name_prefix="agent-provider-probe",
+        ) as pool:
+            # executor.map preserves the deterministic registry order while
+            # bounding cold-catalog latency to the slowest individual probe.
+            descriptors = tuple(pool.map(probe_safely, self._providers))
+        return AgentExecutionCatalog(
+            providers=descriptors,
+            default_selection=self._default_selection,
+        )
+
+    def validate_selection(
+        self,
+        selection: AgentExecutionSelection,
+        *,
+        refresh: bool = False,
+    ) -> AgentExecutionSelection:
+        provider = self.get_provider(selection.provider_id)
+        return provider.validate_selection(selection, refresh=refresh)
+
+    def start_detached(self, request: AgentSpawnRequest) -> AgentSpawnOutcome:
+        """Re-probe, validate, then launch the exact confirmed pair."""
+
+        provider = self.get_provider(request.selection.provider_id)
+        selection = provider.validate_selection(
+            request.selection,
+            refresh=True,
+        )
+        return provider.start_detached(request.with_selection(selection))
+
+    def clear_probe_cache(self) -> None:
+        for provider in self._providers:
+            clear = getattr(provider, "clear_probe_cache", None)
+            if callable(clear):
+                clear()
+
+
+_registry: ProviderRegistry | None = None
+_registry_lock = threading.Lock()
+
+
+def get_registry() -> ProviderRegistry:
+    global _registry
+    if _registry is None:
+        with _registry_lock:
+            if _registry is None:
+                _registry = ProviderRegistry(
+                    (ClaudeCodeProvider(), CodexProvider()),
+                    default_selection=_configured_default_selection(),
+                )
+    return _registry
+
+
+def get_catalog(*, refresh: bool = False) -> AgentExecutionCatalog:
+    return get_registry().get_catalog(refresh=refresh)
+
+
+def default_selection() -> AgentExecutionSelection:
+    return get_registry().default_selection
+
+
+def validate_selection(
+    selection: AgentExecutionSelection,
+    *,
+    refresh: bool = False,
+) -> AgentExecutionSelection:
+    return get_registry().validate_selection(selection, refresh=refresh)
+
+
+def start_detached(request: AgentSpawnRequest) -> AgentSpawnOutcome:
+    return get_registry().start_detached(request)
+
+
+def clear_probe_cache() -> None:
+    get_registry().clear_probe_cache()

--- a/work_buddy/compat.py
+++ b/work_buddy/compat.py
@@ -236,19 +236,26 @@ def kill_process_on_port(port: int, *, wait_seconds: float = 5.0) -> bool:
     return False
 
 
-def _force_kill_pid(pid: int) -> None:
-    """Force-terminate a process using the most reliable method per OS."""
+def _force_kill_pid(pid: int) -> bool:
+    """Force-terminate a process using the most reliable method per OS.
+
+    Returns ``True`` when the force-kill request succeeded or the process was
+    already gone. Returns ``False`` when the operating system rejected the
+    request or the helper could not be invoked. Callers that own a process
+    handle should still verify that handle exited before releasing ownership.
+    """
     if IS_WINDOWS:
         try:
             # taskkill /F works cross-process on Windows where os.kill
             # often silently fails. /T kills the process tree so any
             # children spawned by the orphan also go.
-            subprocess.run(
+            completed = subprocess.run(
                 ["taskkill", "/F", "/T", "/PID", str(pid)],
                 capture_output=True, timeout=5, check=False,
             )
         except Exception:
-            pass
+            return False
+        return completed.returncode == 0
     else:
         import signal
         # SIGKILL doesn't exist on Windows; on Unix it does. Use
@@ -257,8 +264,11 @@ def _force_kill_pid(pid: int) -> None:
         sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
         try:
             os.kill(pid, sigkill)
-        except (OSError, ProcessLookupError):
-            pass
+        except ProcessLookupError:
+            return True
+        except OSError:
+            return False
+        return True
 
 
 def _is_port_listening(port: int, *, timeout: float = 0.1) -> bool:

--- a/work_buddy/conversations/execution.py
+++ b/work_buddy/conversations/execution.py
@@ -1,0 +1,304 @@
+"""Conversation-scoped agent execution selection and provenance.
+
+The conversations database is the durable authority for which execution
+provider/model owns a conversation.  Provider discovery and validation live in
+``work_buddy.agent_execution``; this module only persists a trusted, immutable
+snapshot without coupling the generic conversation store to any provider SDK.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from work_buddy.conversations.store import get_connection
+
+
+EXECUTION_METADATA_KEY = "cowork_agent_execution"
+EXECUTION_SCHEMA_VERSION = 1
+_UNSET = object()
+
+
+class ConversationExecutionConflict(RuntimeError):
+    """The caller tried to replace a selection based on a stale revision."""
+
+
+class ConversationExecutionCorrupt(RuntimeError):
+    """Persisted execution authority exists but cannot be trusted."""
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationExecution:
+    """One trusted execution snapshot and its optimistic-lock revision."""
+
+    provider_id: str
+    model_id: str
+    provider_label: str
+    model_label: str
+    revision: str | None
+    persisted: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": EXECUTION_SCHEMA_VERSION,
+            "provider_id": self.provider_id,
+            "model_id": self.model_id,
+            "provider_label": self.provider_label,
+            "model_label": self.model_label,
+            "revision": self.revision,
+            "persisted": self.persisted,
+        }
+
+    def lease_snapshot(self) -> dict[str, Any]:
+        """Return the immutable execution identity copied into an agent lease."""
+        return {
+            "schema_version": EXECUTION_SCHEMA_VERSION,
+            "provider_id": self.provider_id,
+            "model_id": self.model_id,
+            "provider_label": self.provider_label,
+            "model_label": self.model_label,
+        }
+
+    def producer_snapshot(self) -> dict[str, Any]:
+        """Return trusted provenance suitable for an assistant message."""
+        return self.lease_snapshot()
+
+
+def _require_text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a nonempty string")
+    return value.strip()
+
+
+def _selection_fields(selection: Mapping[str, Any]) -> dict[str, str]:
+    return {
+        "provider_id": _require_text(selection.get("provider_id"), "provider_id"),
+        "model_id": _require_text(selection.get("model_id"), "model_id"),
+        "provider_label": _require_text(
+            selection.get("provider_label"), "provider_label"
+        ),
+        "model_label": _require_text(selection.get("model_label"), "model_label"),
+    }
+
+
+def _decode_metadata(raw: object) -> dict[str, Any]:
+    if raw is None or raw == "":
+        return {}
+    if isinstance(raw, str):
+        try:
+            decoded = json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            raise ConversationExecutionCorrupt(
+                "Saved conversation metadata is invalid"
+            ) from exc
+    else:
+        decoded = raw
+    if not isinstance(decoded, dict):
+        raise ConversationExecutionCorrupt(
+            "Saved conversation metadata is invalid"
+        )
+    return dict(decoded)
+
+
+def _decode_persisted(value: object) -> ConversationExecution | None:
+    if not isinstance(value, dict):
+        return None
+    schema_version = value.get("schema_version")
+    if (
+        type(schema_version) is not int
+        or schema_version != EXECUTION_SCHEMA_VERSION
+    ):
+        return None
+    try:
+        fields = _selection_fields(value)
+        revision = _require_text(value.get("revision"), "revision")
+    except ValueError:
+        return None
+    return ConversationExecution(
+        **fields,
+        revision=revision,
+        persisted=True,
+    )
+
+
+def _persisted_from_metadata(
+    metadata: Mapping[str, Any],
+) -> ConversationExecution | None:
+    if EXECUTION_METADATA_KEY not in metadata:
+        return None
+    persisted = _decode_persisted(metadata.get(EXECUTION_METADATA_KEY))
+    if persisted is None:
+        raise ConversationExecutionCorrupt(
+            "Saved Co-work execution selection is invalid"
+        )
+    return persisted
+
+
+def projected_execution(
+    conversation_id: str | None,
+    default_selection: Mapping[str, Any],
+    *,
+    conn: sqlite3.Connection | None = None,
+) -> ConversationExecution:
+    """Read a persisted selection or project the server default without writing."""
+    default_fields = _selection_fields(default_selection)
+    if conversation_id is None:
+        return ConversationExecution(
+            **default_fields,
+            revision=None,
+            persisted=False,
+        )
+    own_conn = conn is None
+    active = get_connection() if own_conn else conn
+    try:
+        row = active.execute(
+            "SELECT metadata FROM conversations WHERE conversation_id = ?",
+            (conversation_id,),
+        ).fetchone()
+        if row is None:
+            raise LookupError(f"Conversation not found: {conversation_id}")
+        metadata = _decode_metadata(row["metadata"])
+        persisted = _persisted_from_metadata(metadata)
+        if persisted is not None:
+            return persisted
+        return ConversationExecution(
+            **default_fields,
+            revision=None,
+            persisted=False,
+        )
+    finally:
+        if own_conn:
+            active.close()
+
+
+def set_execution(
+    conversation_id: str,
+    selection: Mapping[str, Any],
+    *,
+    expected_revision: str | None | object = _UNSET,
+    conn: sqlite3.Connection | None = None,
+) -> ConversationExecution:
+    """Persist one trusted selection with compare-and-swap semantics.
+
+    ``expected_revision=None`` means that no selection may already be pinned.
+    Omitting ``expected_revision`` performs an unconditional trusted write.
+    Re-selecting the same provider/model is idempotent and keeps its revision.
+    """
+    fields = _selection_fields(selection)
+    own_conn = conn is None
+    active = get_connection() if own_conn else conn
+    if own_conn:
+        active.execute("BEGIN IMMEDIATE")
+    try:
+        row = active.execute(
+            "SELECT metadata FROM conversations WHERE conversation_id = ?",
+            (conversation_id,),
+        ).fetchone()
+        if row is None:
+            raise LookupError(f"Conversation not found: {conversation_id}")
+        metadata = _decode_metadata(row["metadata"])
+        current = _persisted_from_metadata(metadata)
+        current_revision = None if current is None else current.revision
+        if (
+            current is not None
+            and current.provider_id == fields["provider_id"]
+            and current.model_id == fields["model_id"]
+        ):
+            if own_conn:
+                active.commit()
+            return current
+        if (
+            expected_revision is not _UNSET
+            and expected_revision != current_revision
+        ):
+            raise ConversationExecutionConflict("execution_selection_changed")
+
+        result = ConversationExecution(
+            **fields,
+            revision=uuid.uuid4().hex,
+            persisted=True,
+        )
+        metadata[EXECUTION_METADATA_KEY] = {
+            key: value
+            for key, value in result.to_dict().items()
+            if key != "persisted"
+        }
+        active.execute(
+            """UPDATE conversations
+               SET metadata = ?, updated_at = ?
+               WHERE conversation_id = ?""",
+            (
+                json.dumps(metadata),
+                datetime.now(timezone.utc).isoformat(),
+                conversation_id,
+            ),
+        )
+        if own_conn:
+            active.commit()
+        return result
+    except Exception:
+        if own_conn and active.in_transaction:
+            active.rollback()
+        raise
+    finally:
+        if own_conn:
+            active.close()
+
+
+def producer_for_lease(
+    *,
+    conversation_id: str,
+    consumer: str,
+    generation: str,
+    conn: sqlite3.Connection,
+) -> dict[str, Any] | None:
+    """Read trusted producer provenance from the exact fenced lease."""
+    row = conn.execute(
+        """SELECT execution_json
+           FROM conversation_agent_leases
+           WHERE conversation_id = ? AND consumer = ? AND generation = ?
+             AND status IN ('starting', 'running')""",
+        (conversation_id, consumer, generation),
+    ).fetchone()
+    if row is None:
+        return None
+    raw = row["execution_json"]
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        execution = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(execution, dict):
+        return None
+    schema_version = execution.get("schema_version")
+    if (
+        type(schema_version) is not int
+        or schema_version != EXECUTION_SCHEMA_VERSION
+    ):
+        return None
+    try:
+        fields = _selection_fields(execution)
+    except ValueError:
+        return None
+    return {
+        "schema_version": EXECUTION_SCHEMA_VERSION,
+        **fields,
+    }
+
+
+__all__ = [
+    "ConversationExecution",
+    "ConversationExecutionConflict",
+    "ConversationExecutionCorrupt",
+    "EXECUTION_METADATA_KEY",
+    "EXECUTION_SCHEMA_VERSION",
+    "producer_for_lease",
+    "projected_execution",
+    "set_execution",
+]

--- a/work_buddy/conversations/models.py
+++ b/work_buddy/conversations/models.py
@@ -29,6 +29,7 @@ class ConversationMessage:
         choices: For choice questions — [{key, label, description?}].
         response: User's answer (filled when user responds).
         status: "sent" | "pending" (awaiting response) | "answered".
+        producer: Trusted execution provenance for an agent-authored message.
     """
 
     message_id: str = ""
@@ -41,6 +42,7 @@ class ConversationMessage:
     choices: list[dict] | None = None
     response: str | None = None
     status: str = "sent"
+    producer: dict[str, Any] | None = None
 
     def is_question(self) -> bool:
         return self.message_type == "question"
@@ -60,6 +62,7 @@ class ConversationMessage:
             "choices": self.choices,
             "response": self.response,
             "status": self.status,
+            "producer": self.producer,
         }
 
     @classmethod
@@ -70,6 +73,14 @@ class ConversationMessage:
         choices = row.get("choices")
         if isinstance(choices, str) and choices:
             choices = json.loads(choices)
+        producer = row.get("producer")
+        if isinstance(producer, str) and producer:
+            try:
+                producer = json.loads(producer)
+            except (TypeError, ValueError):
+                producer = None
+        if not isinstance(producer, dict):
+            producer = None
         return cls(
             message_id=row["message_id"],
             conversation_id=row["conversation_id"],
@@ -81,6 +92,7 @@ class ConversationMessage:
             choices=choices,
             response=row.get("response"),
             status=row.get("status", "sent"),
+            producer=producer,
         )
 
 

--- a/work_buddy/conversations/store.py
+++ b/work_buddy/conversations/store.py
@@ -25,7 +25,7 @@ import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from work_buddy.conversations.models import Conversation, ConversationMessage
 
@@ -154,6 +154,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
             choices         TEXT,
             response        TEXT,
             status          TEXT NOT NULL DEFAULT 'sent',
+            producer        TEXT,
             FOREIGN KEY (conversation_id) REFERENCES conversations(conversation_id)
         );
 
@@ -183,11 +184,35 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
             heartbeat_at    TEXT,
             updated_at      TEXT NOT NULL,
             error           TEXT,
+            execution_json  TEXT,
             PRIMARY KEY (conversation_id, consumer),
             FOREIGN KEY (conversation_id) REFERENCES conversations(conversation_id)
         );
         """
     )
+    _ensure_column(conn, "messages", "producer", "producer TEXT")
+    _ensure_column(
+        conn,
+        "conversation_agent_leases",
+        "execution_json",
+        "execution_json TEXT",
+    )
+    conn.commit()
+
+
+def _ensure_column(
+    conn: sqlite3.Connection,
+    table: str,
+    column: str,
+    declaration: str,
+) -> None:
+    """Add one optional column to an existing SQLite table, idempotently."""
+    columns = {
+        str(row["name"])
+        for row in conn.execute(f"PRAGMA table_info({table})").fetchall()
+    }
+    if column not in columns:
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {declaration}")
 
 
 def _maybe_migrate_legacy_db() -> None:
@@ -436,6 +461,7 @@ def add_message(
     choices: list[dict] | None = None,
     conn: sqlite3.Connection | None = None,
     message_id: str | None = None,
+    producer: Mapping[str, Any] | None = None,
 ) -> ConversationMessage | None:
     """Add a message to a conversation. Returns the message, or None if
     conversation not found.
@@ -468,12 +494,13 @@ def add_message(
             response_type=response_type,
             choices=choices,
             status=status,
+            producer=dict(producer) if producer is not None else None,
         )
         cursor = conn.execute(
             """INSERT OR IGNORE INTO messages
                (message_id, conversation_id, role, content, created_at,
-                message_type, response_type, choices, response, status)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                message_type, response_type, choices, response, status, producer)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 msg.message_id,
                 msg.conversation_id,
@@ -485,6 +512,7 @@ def add_message(
                 json.dumps(choices) if choices else None,
                 None,
                 msg.status,
+                json.dumps(msg.producer) if msg.producer is not None else None,
             ),
         )
         if cursor.rowcount == 0:
@@ -520,6 +548,7 @@ def send_agent_message_idempotent(
     content: str,
     message_id: str,
     conn: sqlite3.Connection | None = None,
+    producer: Mapping[str, Any] | None = None,
 ) -> tuple[ConversationMessage | None, bool]:
     """Send one caller-keyed agent message with first-writer-wins semantics.
 
@@ -551,13 +580,22 @@ def send_agent_message_idempotent(
             message_type="text",
             response_type="none",
             status="sent",
+            producer=dict(producer) if producer is not None else None,
         )
         cursor = conn.execute(
             """INSERT OR IGNORE INTO messages
                (message_id, conversation_id, role, content, created_at,
-                message_type, response_type, choices, response, status)
-               VALUES (?, ?, 'agent', ?, ?, 'text', 'none', NULL, NULL, 'sent')""",
-            (message_id, conversation_id, content, now),
+                message_type, response_type, choices, response, status, producer)
+               VALUES (?, ?, 'agent', ?, ?, 'text', 'none', NULL, NULL, 'sent', ?)""",
+            (
+                message_id,
+                conversation_id,
+                content,
+                now,
+                json.dumps(candidate.producer)
+                if candidate.producer is not None
+                else None,
+            ),
         )
         if cursor.rowcount == 1:
             conn.execute(
@@ -789,12 +827,25 @@ def get_agent_lease(
     try:
         row = conn.execute(
             """SELECT conversation_id, consumer, generation, status, pid,
-                      started_at, heartbeat_at, updated_at, error
+                      started_at, heartbeat_at, updated_at, error,
+                      execution_json
                FROM conversation_agent_leases
                WHERE conversation_id = ? AND consumer = ?""",
             (conversation_id, consumer),
         ).fetchone()
-        return None if row is None else dict(row)
+        if row is None:
+            return None
+        result = dict(row)
+        raw_execution = result.pop("execution_json", None)
+        if isinstance(raw_execution, str) and raw_execution:
+            try:
+                execution = json.loads(raw_execution)
+            except (TypeError, ValueError):
+                execution = None
+        else:
+            execution = None
+        result["execution"] = execution if isinstance(execution, dict) else None
+        return result
     finally:
         if own_conn:
             conn.close()
@@ -880,6 +931,7 @@ def claim_agent_lease(
     heartbeat_ttl_seconds: float = 150.0,
     now: datetime | None = None,
     conn: sqlite3.Connection | None = None,
+    execution: Mapping[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     """Atomically claim a new generation unless a recent one still owns it.
 
@@ -915,6 +967,16 @@ def claim_agent_lease(
             )
             age = _timestamp_age_seconds(reference, now=current_now)
             reusable = age is not None and age <= ttl
+        requested_execution = (
+            dict(execution) if execution is not None else None
+        )
+        if (
+            reusable
+            and requested_execution is not None
+            and existing is not None
+            and existing.get("execution") != requested_execution
+        ):
+            reusable = False
         if reusable:
             existing["claimed"] = False
             if own_conn:
@@ -924,8 +986,8 @@ def claim_agent_lease(
         conn.execute(
             """INSERT INTO conversation_agent_leases
                    (conversation_id, consumer, generation, status, pid,
-                    started_at, heartbeat_at, updated_at, error)
-               VALUES (?, ?, ?, 'starting', NULL, ?, NULL, ?, NULL)
+                    started_at, heartbeat_at, updated_at, error, execution_json)
+               VALUES (?, ?, ?, 'starting', NULL, ?, NULL, ?, NULL, ?)
                ON CONFLICT(conversation_id, consumer) DO UPDATE SET
                    generation = excluded.generation,
                    status = 'starting',
@@ -933,8 +995,18 @@ def claim_agent_lease(
                    started_at = excluded.started_at,
                    heartbeat_at = NULL,
                    updated_at = excluded.updated_at,
-                   error = NULL""",
-            (conversation_id, consumer, generation, now_text, now_text),
+                   error = NULL,
+                   execution_json = excluded.execution_json""",
+            (
+                conversation_id,
+                consumer,
+                generation,
+                now_text,
+                now_text,
+                json.dumps(requested_execution)
+                if requested_execution is not None
+                else None,
+            ),
         )
         if own_conn:
             conn.commit()
@@ -948,6 +1020,7 @@ def claim_agent_lease(
             "heartbeat_at": None,
             "updated_at": now_text,
             "error": None,
+            "execution": requested_execution,
             "claimed": True,
         }
     except Exception:
@@ -1146,6 +1219,11 @@ def receive_user_message(
     while True:
         conn = get_connection()
         try:
+            # Couple lease validation and message selection in one short
+            # transaction. A generation fence either commits first and this
+            # pass returns lease_lost, or waits until this read completes; an
+            # old process can never observe a turn committed after revocation.
+            conn.execute("BEGIN IMMEDIATE")
             monotonic_now = time.monotonic()
             if monotonic_now - last_heartbeat >= 10.0:
                 if not _touch_agent_lease(
@@ -1156,7 +1234,6 @@ def receive_user_message(
                 ):
                     conn.rollback()
                     return {"status": "lease_lost"}
-                conn.commit()
                 last_heartbeat = monotonic_now
             else:
                 lease = conn.execute(
@@ -1185,12 +1262,14 @@ def receive_user_message(
                         or starting_age > _AGENT_STARTING_GRACE_SECONDS
                     )
                 ):
+                    conn.rollback()
                     return {"status": "lease_lost"}
             row = _next_user_message(
                 conn,
                 conversation_id=conversation_id,
                 consumer=consumer,
             )
+            conn.commit()
             if row is not None:
                 return {
                     "status": "message",

--- a/work_buddy/cowork/api.py
+++ b/work_buddy/cowork/api.py
@@ -30,6 +30,7 @@ from urllib.parse import urlsplit
 
 from flask import Blueprint, Response, jsonify, request
 
+from work_buddy.conversations import execution as conversation_execution
 from work_buddy.cowork import (
     conversations,
     document_agent,
@@ -551,6 +552,295 @@ def _conversation_spawn_failure() -> document_agent.DocumentAgentStatus:
     )
 
 
+def _execution_selection_from_state(
+    state: conversation_execution.ConversationExecution,
+):
+    from work_buddy.agent_execution.models import AgentExecutionSelection
+
+    return AgentExecutionSelection(
+        provider_id=state.provider_id,
+        model_id=state.model_id,
+        provider_label=state.provider_label,
+        model_label=state.model_label,
+    )
+
+
+def _project_execution(conversation_id: str | None):
+    from work_buddy.agent_execution.registry import default_selection
+
+    return conversation_execution.projected_execution(
+        conversation_id,
+        default_selection().to_dict(),
+    )
+
+
+def _pin_projected_execution(conversation_id: str):
+    """Return the conversation target, pinning the default on first start."""
+    state = _project_execution(conversation_id)
+    if state.persisted:
+        return state
+    return conversation_execution.set_execution(
+        conversation_id,
+        state.to_dict(),
+        expected_revision=None,
+    )
+
+
+def _conversation_status(conversation_id: str) -> str | None:
+    """Read lifecycle state without parsing unrelated conversation metadata."""
+    from work_buddy.conversations.store import get_connection
+
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT status FROM conversations WHERE conversation_id = ?",
+            (conversation_id,),
+        ).fetchone()
+        return None if row is None else str(row["status"])
+    finally:
+        conn.close()
+
+
+def _execution_snapshot(
+    conversation_id: str | None,
+    *,
+    refresh_catalog: bool = False,
+) -> dict[str, object]:
+    """Project the picker catalog plus the conversation's durable selection."""
+    from work_buddy.agent_execution.registry import get_catalog
+
+    state = _project_execution(conversation_id)
+    catalog = get_catalog(refresh=refresh_catalog)
+    providers = [provider.to_dict() for provider in catalog.providers]
+
+    selected_provider = next(
+        (
+            provider
+            for provider in providers
+            if provider.get("id") == state.provider_id
+        ),
+        None,
+    )
+    if selected_provider is None:
+        providers.append(
+            {
+                "id": state.provider_id,
+                "label": state.provider_label,
+                "available": False,
+                "availability": "unavailable",
+                "auth_mode": "",
+                "models": [
+                    {
+                        "id": state.model_id,
+                        "label": state.model_label,
+                        "available": False,
+                        "description": "",
+                        "unavailable_reason": (
+                            "This saved execution provider is no longer available."
+                        ),
+                        "is_default": False,
+                    }
+                ],
+                "unavailable_reason": (
+                    "This saved execution provider is no longer available."
+                ),
+            }
+        )
+    else:
+        models = selected_provider.get("models")
+        model_list = models if isinstance(models, list) else []
+        if not any(
+            model.get("id") == state.model_id
+            for model in model_list
+            if isinstance(model, dict)
+        ):
+            model_list.append(
+                {
+                    "id": state.model_id,
+                    "label": state.model_label,
+                    "available": False,
+                    "description": "",
+                    "unavailable_reason": (
+                        "This saved model is no longer available."
+                    ),
+                    "is_default": False,
+                }
+            )
+            selected_provider["models"] = model_list
+
+    selection = state.to_dict()
+    selection["revision"] = state.revision or ""
+    return {
+        "selection": selection,
+        "providers": providers,
+        "read_only": _is_read_only(),
+    }
+
+
+def _unreadable_execution_snapshot() -> dict[str, object]:
+    """Represent known-corrupt authority after a user action already committed."""
+    reason = "This chat’s saved provider and model choice couldn’t be read."
+    provider_id = "execution-unavailable"
+    model_id = "saved-selection-unreadable"
+    return {
+        "selection": {
+            "schema_version": 1,
+            "provider_id": provider_id,
+            "model_id": model_id,
+            "provider_label": "Unavailable",
+            "model_label": "Saved selection couldn’t be read",
+            "revision": "",
+            "persisted": False,
+        },
+        "providers": [
+            {
+                "id": provider_id,
+                "label": "Unavailable",
+                "available": False,
+                "availability": "unavailable",
+                "auth_mode": "",
+                "description": "",
+                "models": [
+                    {
+                        "id": model_id,
+                        "label": "Saved selection couldn’t be read",
+                        "available": False,
+                        "description": "",
+                        "unavailable_reason": reason,
+                        "is_default": False,
+                    }
+                ],
+                "unavailable_reason": reason,
+            }
+        ],
+        "read_only": True,
+        "error": {
+            "code": "execution_selection_corrupt",
+            "message": reason,
+        },
+    }
+
+
+def _execution_snapshot_after_committed_action(
+    conversation_id: str,
+) -> dict[str, object]:
+    """Never obscure a durable user action with a later projection failure."""
+    try:
+        return _execution_snapshot(conversation_id)
+    except conversation_execution.ConversationExecutionCorrupt:
+        return _unreadable_execution_snapshot()
+
+
+def _requested_execution(
+    body: object,
+    *,
+    require_expected_revision: bool,
+):
+    """Validate one UI-supplied pair and return trusted labels plus its CAS."""
+    from work_buddy.agent_execution.models import AgentExecutionSelection
+    from work_buddy.agent_execution.registry import validate_selection
+
+    if not isinstance(body, dict):
+        if require_expected_revision:
+            raise ValueError("A provider and model are required.")
+        return None
+    nested = body.get("execution")
+    source = nested if isinstance(nested, dict) else body
+    provider_id = source.get("provider_id")
+    model_id = source.get("model_id")
+    if provider_id is None and model_id is None and not require_expected_revision:
+        return None
+    if not isinstance(provider_id, str) or not provider_id.strip():
+        raise ValueError("provider_id is required")
+    if not isinstance(model_id, str) or not model_id.strip():
+        raise ValueError("model_id is required")
+    if require_expected_revision and "expected_revision" not in source:
+        raise ValueError("expected_revision is required")
+    raw_revision = source.get("expected_revision")
+    if raw_revision in (None, ""):
+        expected_revision = None
+    elif isinstance(raw_revision, str):
+        expected_revision = raw_revision
+    else:
+        raise ValueError("expected_revision must be a string")
+    trusted = validate_selection(
+        AgentExecutionSelection(
+            provider_id=provider_id.strip(),
+            model_id=model_id.strip(),
+        ),
+        refresh=True,
+    )
+    return trusted, expected_revision
+
+
+def _execution_error(
+    exc: Exception,
+    *,
+    status: int | None = None,
+    code: str | None = None,
+    retryable: bool | None = None,
+    conversation_id: str | None = None,
+    agent: document_agent.DocumentAgentStatus | None = None,
+):
+    from work_buddy.agent_execution.models import AgentExecutionError
+
+    if isinstance(exc, conversation_execution.ConversationExecutionConflict):
+        default_code = "execution_selection_changed"
+        message = "The model choice changed in another window. Reload and try again."
+        default_status = 409
+    elif isinstance(exc, conversation_execution.ConversationExecutionCorrupt):
+        default_code = "execution_selection_corrupt"
+        message = "This chat's saved provider and model choice could not be read."
+        default_status = 409
+    elif isinstance(exc, AgentExecutionError):
+        default_code = exc.error_code
+        message = str(exc)
+        default_status = 409
+    elif isinstance(exc, ValueError):
+        default_code = "invalid_execution_selection"
+        message = str(exc)
+        default_status = 400
+    else:
+        default_code = "execution_unavailable"
+        message = "That provider or model is unavailable right now."
+        default_status = 409
+    response_status = default_status if status is None else status
+    response_code = default_code if code is None else code
+    if isinstance(exc, conversation_execution.ConversationExecutionCorrupt):
+        response_retryable = False
+    elif retryable is None:
+        response_retryable = (
+            isinstance(
+                exc,
+                conversation_execution.ConversationExecutionConflict,
+            )
+            or response_status >= 500
+        )
+    else:
+        response_retryable = retryable
+    payload: dict[str, object] = {
+        "ok": False,
+        "error": {
+            "code": response_code,
+            "message": message,
+            "details": {},
+            "retryable": response_retryable,
+        },
+    }
+    if (
+        conversation_id is not None
+        and isinstance(
+            exc,
+            conversation_execution.ConversationExecutionConflict,
+        )
+    ):
+        payload["conversation_id"] = conversation_id
+        payload["execution"] = _execution_snapshot(conversation_id)
+        if agent is not None:
+            payload["agent"] = agent.to_dict()
+    return jsonify(payload), response_status
+
+
 @cowork_blueprint.get("/api/truth/doc/<document_id>/conversation")
 def api_doc_conversation_get(document_id: str):
     """Read the existing real binding and persisted driver status, without writes."""
@@ -566,10 +856,13 @@ def api_doc_conversation_get(document_id: str):
     if not document_surface_allowed(store, document):
         return _fail("This document is not available in Co-work for this folder.", 403)
 
-    conversation_id = conversations.find_document_conversation(
-        document_id=document.id,
-        store_id=store.store_id,
-    )
+    try:
+        conversation_id = conversations.find_document_conversation(
+            document_id=document.id,
+            store_id=store.store_id,
+        )
+    except conversation_execution.ConversationExecutionCorrupt as exc:
+        return _execution_error(exc)
     consumer = (
         None
         if conversation_id is None
@@ -584,12 +877,26 @@ def api_doc_conversation_get(document_id: str):
         document_id=document.id,
         conversation_id=conversation_id,
     )
+    try:
+        execution_snapshot = _execution_snapshot(
+            conversation_id,
+            refresh_catalog=(
+                request.args.get("refresh_execution") == "1"
+            ),
+        )
+    except conversation_execution.ConversationExecutionCorrupt as exc:
+        return _execution_error(
+            exc,
+            conversation_id=conversation_id,
+            agent=agent_status,
+        )
     return jsonify(
         {
             "ok": True,
             "conversation_id": conversation_id,
             "agent": agent_status.to_dict(),
             "feedback": feedback_payload,
+            "execution": execution_snapshot,
         }
     )
 
@@ -606,9 +913,17 @@ def api_doc_conversation_ensure(document_id: str):
     gate = _document_surface_or_403(store)
     if gate:
         return gate
+    try:
+        requested_execution = _requested_execution(
+            request.get_json(silent=True),
+            require_expected_revision=False,
+        )
+    except Exception as exc:
+        return _execution_error(exc)
 
     from work_buddy.consent import user_initiated
 
+    binding = None
     try:
         # This lock is the cross-database lifecycle boundary.  It is acquired
         # before reading the Truth document and held through conversation bind
@@ -632,13 +947,10 @@ def api_doc_conversation_ensure(document_id: str):
                     document_id=document.id,
                     store_id=store.store_id,
                 )
-                from work_buddy.conversations.store import get_conversation
+                from work_buddy.conversations.store import get_agent_lease
 
-                bound_conversation = get_conversation(binding.conversation_id)
-                if (
-                    bound_conversation is None
-                    or bound_conversation.status == "closed"
-                ):
+                bound_status = _conversation_status(binding.conversation_id)
+                if bound_status is None or bound_status == "closed":
                     return (
                         jsonify(
                             {
@@ -657,10 +969,74 @@ def api_doc_conversation_ensure(document_id: str):
                         409,
                     )
                 try:
+                    if requested_execution is None:
+                        execution_state = _pin_projected_execution(
+                            binding.conversation_id
+                        )
+                    else:
+                        selected, expected_revision = requested_execution
+                        current_execution = _project_execution(
+                            binding.conversation_id
+                        )
+                        consumer = document_agent.document_agent_consumer(
+                            store.store_id,
+                            document.id,
+                        )
+                        selection_changed = (
+                            current_execution.provider_id
+                            != selected.provider_id
+                            or current_execution.model_id != selected.model_id
+                        )
+                        if (
+                            selection_changed
+                            and get_agent_lease(
+                                binding.conversation_id,
+                                consumer,
+                            )
+                            is not None
+                        ):
+                            return (
+                                jsonify(
+                                    {
+                                        "ok": False,
+                                        "error": {
+                                            "code": "execution_switch_required",
+                                            "message": (
+                                                "Choose the provider and model "
+                                                "with Run with before restarting "
+                                                "chat."
+                                            ),
+                                            "details": {},
+                                            "retryable": False,
+                                        },
+                                        "conversation_id": (
+                                            binding.conversation_id
+                                        ),
+                                        "execution": _execution_snapshot(
+                                            binding.conversation_id
+                                        ),
+                                    }
+                                ),
+                                409,
+                            )
+                        execution_state = conversation_execution.set_execution(
+                            binding.conversation_id,
+                            selected.to_dict(),
+                            expected_revision=expected_revision,
+                        )
+                except Exception as exc:
+                    return _execution_error(
+                        exc,
+                        conversation_id=binding.conversation_id,
+                    )
+                try:
                     agent_status = document_agent.ensure_document_agent(
                         store_id=store.store_id,
                         document_id=document.id,
                         conversation_id=binding.conversation_id,
+                        execution=_execution_selection_from_state(
+                            execution_state
+                        ),
                     )
                 except Exception:
                     logger.exception(
@@ -676,6 +1052,13 @@ def api_doc_conversation_ensure(document_id: str):
                     document_id=document.id,
                     conversation_id=binding.conversation_id,
                 )
+    except conversation_execution.ConversationExecutionCorrupt as exc:
+        return _execution_error(
+            exc,
+            conversation_id=(
+                None if binding is None else binding.conversation_id
+            ),
+        )
     except InvariantViolation as exc:
         return _fail(str(exc), 400)
     return jsonify(
@@ -685,6 +1068,152 @@ def api_doc_conversation_ensure(document_id: str):
             "created": binding.created,
             "agent": agent_status.to_dict(),
             "feedback": feedback_payload,
+            "execution": _execution_snapshot(binding.conversation_id),
+        }
+    )
+
+
+@cowork_blueprint.patch("/api/truth/doc/<document_id>/conversation/execution")
+def api_doc_conversation_execution(document_id: str):
+    """Select one provider/model pair and restart only an existing driver."""
+    blocked = _reject_read_only()
+    if blocked:
+        return blocked
+    store, error = _resolve_store(request.args.get("store_id"))
+    if error:
+        return error
+    gate = _document_surface_or_403(store)
+    if gate:
+        return gate
+    try:
+        selected, expected_revision = _requested_execution(
+            request.get_json(silent=True),
+            require_expected_revision=True,
+        )
+    except Exception as exc:
+        return _execution_error(exc)
+
+    from work_buddy.consent import user_initiated
+    from work_buddy.conversations.store import get_agent_lease
+
+    binding = None
+    try:
+        with lifecycle_lock.document_lifecycle_lock(store.store_id, document_id):
+            document, doc_error = _resolve_document(store, document_id)
+            if doc_error:
+                return doc_error
+            if documents.current_lifecycle(store, document.id) != "active":
+                return _fail(
+                    "The model cannot be changed for a retired document.",
+                    409,
+                )
+            if not document_surface_allowed(store, document):
+                return _fail(
+                    "This document is not available in Co-work for this folder.",
+                    403,
+                )
+            with user_initiated("dashboard.cowork.execution_select"):
+                binding = conversations.ensure_document_conversation(
+                    document_id=document.id,
+                    store_id=store.store_id,
+                )
+                bound_status = _conversation_status(binding.conversation_id)
+                if bound_status is None or bound_status == "closed":
+                    return _execution_error(
+                        ValueError(
+                            "This document's conversation is closed and "
+                            "cannot change models."
+                        ),
+                        status=409,
+                        code="conversation_closed",
+                        retryable=False,
+                        conversation_id=binding.conversation_id,
+                    )
+                current = _project_execution(binding.conversation_id)
+                changed = (
+                    current.provider_id != selected.provider_id
+                    or current.model_id != selected.model_id
+                )
+                if changed and current.revision != expected_revision:
+                    raise conversation_execution.ConversationExecutionConflict(
+                        "execution_selection_changed"
+                    )
+                consumer = document_agent.document_agent_consumer(
+                    store.store_id,
+                    document.id,
+                )
+                previous_lease = get_agent_lease(
+                    binding.conversation_id,
+                    consumer,
+                )
+                should_restart = (
+                    changed
+                    and previous_lease is not None
+                    and previous_lease.get("status") in {"starting", "running"}
+                )
+                if should_restart:
+                    document_agent.fence_document_agent(
+                        conversation_id=binding.conversation_id,
+                        consumer=consumer,
+                    )
+                execution_state = conversation_execution.set_execution(
+                    binding.conversation_id,
+                    selected.to_dict(),
+                    expected_revision=expected_revision,
+                )
+                if should_restart:
+                    try:
+                        agent_status = document_agent.ensure_document_agent(
+                            store_id=store.store_id,
+                            document_id=document.id,
+                            conversation_id=binding.conversation_id,
+                            execution=_execution_selection_from_state(
+                                execution_state
+                            ),
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Document-agent restart failed after execution "
+                            "selection: store=%s document=%s conversation=%s",
+                            store.store_id,
+                            document.id,
+                            binding.conversation_id,
+                        )
+                        agent_status = _conversation_spawn_failure()
+                else:
+                    agent_status = document_agent.inspect_document_agent(
+                        binding.conversation_id,
+                        consumer=consumer,
+                    )
+    except conversation_execution.ConversationExecutionConflict as exc:
+        conflict_agent = document_agent.inspect_document_agent(
+            binding.conversation_id,
+            consumer=document_agent.document_agent_consumer(
+                store.store_id,
+                document.id,
+            ),
+        )
+        return _execution_error(
+            exc,
+            conversation_id=binding.conversation_id,
+            agent=conflict_agent,
+        )
+    except conversation_execution.ConversationExecutionCorrupt as exc:
+        return _execution_error(
+            exc,
+            conversation_id=(
+                None if binding is None else binding.conversation_id
+            ),
+        )
+    except InvariantViolation as exc:
+        return _fail(str(exc), 400)
+    return jsonify(
+        {
+            "ok": True,
+            "conversation_id": binding.conversation_id,
+            "created": binding.created,
+            "execution": _execution_snapshot(binding.conversation_id),
+            "agent": agent_status.to_dict(),
         }
     )
 
@@ -946,10 +1475,16 @@ def api_doc_feedback(document_id: str):
                     post_message=poster,
                 )
                 try:
+                    execution_state = _pin_projected_execution(
+                        capture.conversation_id
+                    )
                     agent_status = document_agent.ensure_document_agent(
                         store_id=store.store_id,
                         document_id=document.id,
                         conversation_id=capture.conversation_id,
+                        execution=_execution_selection_from_state(
+                            execution_state
+                        ),
                         feedback=document_agent.FeedbackPromptContext(
                             text=text,
                             exact=feedback_span["exact"],
@@ -980,6 +1515,9 @@ def api_doc_feedback(document_id: str):
             "conversation_id": capture.conversation_id,
             "message_id": capture.message_id,
             "agent": agent_status.to_dict(),
+            "execution": _execution_snapshot_after_committed_action(
+                capture.conversation_id
+            ),
         }
     )
 

--- a/work_buddy/cowork/conversations.py
+++ b/work_buddy/cowork/conversations.py
@@ -31,6 +31,7 @@ import threading
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from work_buddy.conversations.execution import ConversationExecutionCorrupt
 from work_buddy.conversations.models import ConversationMessage
 from work_buddy.conversations.store import (
     add_message,
@@ -56,6 +57,10 @@ _BINDING_LOCK = threading.RLock()
 # The two proposal decisions whose routing this module delivers. Redirect
 # carries a typed human note, endorse carries none (PRD section 6).
 ROUTING_VERBS = frozenset({"redirect", "endorse"})
+
+
+class ConversationBindingCorrupt(ConversationExecutionCorrupt):
+    """A Co-work conversation row cannot be safely matched to its document."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -115,10 +120,14 @@ def _find_bound_conversation(
         raw_meta = row["metadata"]
         try:
             meta = json.loads(raw_meta) if raw_meta else {}
-        except (TypeError, ValueError):
-            continue
+        except (TypeError, ValueError) as exc:
+            raise ConversationBindingCorrupt(
+                "Saved Co-work conversation metadata is invalid"
+            ) from exc
         if not isinstance(meta, dict):
-            continue
+            raise ConversationBindingCorrupt(
+                "Saved Co-work conversation metadata is invalid"
+            )
         if (
             meta.get(_DOCUMENT_ID_KEY) == document_id
             and meta.get(_STORE_ID_KEY) == store_id

--- a/work_buddy/cowork/document_agent.py
+++ b/work_buddy/cowork/document_agent.py
@@ -17,8 +17,9 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
-from work_buddy.config import load_config
-from work_buddy.conversations.agents import register
+from work_buddy.agent_execution.models import AgentExecutionSelection
+from work_buddy.conversations.agents import register, unregister
+from work_buddy.cowork.execution_identity import cowork_execution_session_id
 from work_buddy.conversations.store import (
     activate_agent_lease,
     claim_agent_lease,
@@ -100,16 +101,6 @@ def _age_seconds(value: object, *, now: datetime) -> float | None:
         return max(0.0, (now - parsed.astimezone(timezone.utc)).total_seconds())
     except (TypeError, ValueError):
         return None
-
-
-def _configured_spawn_model() -> str:
-    configured = (
-        load_config()
-        .get("sidecar", {})
-        .get("agent_spawn", {})
-        .get("model", "sonnet")
-    )
-    return configured if isinstance(configured, str) and configured.strip() else "sonnet"
 
 
 def _bounded_history(messages: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
@@ -203,9 +194,10 @@ Bindings:
    exact conversation message_id. Pass producer_model={producer_model!r},
    conversation_id={conversation_id!r}, consumer={consumer!r}, and
    generation={generation!r} to every proposal/comment call.
-4. First call conversation_poll without a timeout only to inspect whether a
-   legacy structured boolean/choice question is pending. Do not add a greeting
-   or duplicate structured question.
+4. First call conversation_poll without a timeout, passing the bound
+   conversation_id, consumer, and generation, only to inspect whether a legacy
+   structured boolean/choice question is pending. Do not add a greeting or
+   duplicate structured question.
 5. Receive authored user turns only with conversation_receive, always passing
    conversation_id={conversation_id!r}, consumer={consumer!r}, and
    generation={generation!r}. It returns the oldest unacked user turn and
@@ -389,6 +381,7 @@ def spawn_document_agent_session(
     generation: str,
     feedback: FeedbackPromptContext | None = None,
     producer_model: str | None = None,
+    execution: AgentExecutionSelection | None = None,
     history_loader: HistoryLoader = get_conversation_with_messages,
 ) -> Mapping[str, Any]:
     """Build the prompt and perform one authorized detached spawn attempt.
@@ -397,11 +390,17 @@ def spawn_document_agent_session(
     decorated with ``requires_consent``; the explicit POST/feedback route calls
     it from a ``user_initiated`` boundary, making that one click the authority.
     """
-    from work_buddy.sidecar.dispatch.executor import (
-        spawn_headless_agent_detached_authorized,
+    from work_buddy.agent_execution.models import (
+        AgentSpawnRequest,
+        default_working_directory,
+    )
+    from work_buddy.agent_execution.registry import (
+        default_selection,
+        start_detached,
     )
 
-    model = producer_model or _configured_spawn_model()
+    selected = execution or default_selection()
+    model = producer_model or f"{selected.provider_id}:{selected.model_id}"
     bundle = history_loader(conversation_id)
     raw_messages = [] if bundle is None else bundle.get("messages", [])
     messages = raw_messages if isinstance(raw_messages, list) else []
@@ -416,11 +415,42 @@ def spawn_document_agent_session(
         feedback=feedback,
     )
     safe_document = re.sub(r"[^A-Za-z0-9_-]", "-", document_id)[:24] or "document"
-    return spawn_headless_agent_detached_authorized(
+    session_id = cowork_execution_session_id(generation)
+    try:
+        from work_buddy.truth.registry import TruthStoreRegistry
+
+        working_directory = (
+            TruthStoreRegistry()
+            .open_store(store_id)
+            .paths.root.resolve()
+        )
+    except Exception:
+        logger.warning(
+            "Co-work folder root could not be resolved for agent identity: "
+            "store=%s",
+            store_id,
+        )
+        working_directory = default_working_directory()
+    spawn_request = AgentSpawnRequest(
         name=f"cowork-{safe_document}-{conversation_id}",
         prompt=prompt,
+        selection=selected,
+        session_id=session_id,
+        working_directory=working_directory,
         max_budget_usd=_DEFAULT_BUDGET_USD,
     )
+    from work_buddy.agent_session import update_manifest
+
+    update_manifest(
+        session_id=session_id,
+        harness_id=selected.provider_id,
+        native_session_id=session_id,
+        model=model,
+        surface="cowork",
+        workspace=str(spawn_request.working_directory.resolve()),
+    )
+    outcome = start_detached(spawn_request)
+    return outcome.to_dict()
 
 
 def _safe_spawn_error(result: Mapping[str, Any]) -> str:
@@ -434,17 +464,59 @@ def _safe_spawn_error(result: Mapping[str, Any]) -> str:
     return _SAFE_AGENT_ERROR
 
 
+def _terminate_spawned_driver(
+    pid: int,
+    *,
+    conversation_id: str,
+    generation: str,
+) -> None:
+    """Terminate only a process handle owned by this server runtime."""
+
+    try:
+        from work_buddy.sidecar.dispatch.executor import (
+            terminate_detached_process,
+        )
+
+        if not terminate_detached_process(
+            pid,
+            owner_token=cowork_execution_session_id(generation),
+        ):
+            logger.warning(
+                "Document-agent process was fenced but not owned by this "
+                "runtime: conversation=%s pid=%s",
+                conversation_id,
+                pid,
+            )
+    except Exception:
+        logger.warning(
+            "Document-agent termination failed after fencing: "
+            "conversation=%s pid=%s",
+            conversation_id,
+            pid,
+            exc_info=True,
+        )
+
+
 def ensure_document_agent(
     *,
     store_id: str,
     document_id: str,
     conversation_id: str,
     feedback: FeedbackPromptContext | None = None,
+    execution: AgentExecutionSelection | None = None,
     process_alive: ProcessAliveCheck = _process_is_alive,
     register_agent: RegisterAgent = register,
     spawn_agent: SpawnAgent = spawn_document_agent_session,
 ) -> DocumentAgentStatus:
     """Idempotently claim, spawn, and persist one generation-scoped driver."""
+    if execution is None:
+        from work_buddy.agent_execution.registry import default_selection
+
+        execution = default_selection()
+    execution_snapshot = {
+        "schema_version": 1,
+        **execution.to_dict(),
+    }
     with _SPAWN_LOCK:
         consumer = document_agent_consumer(store_id, document_id)
         current = inspect_document_agent(
@@ -452,9 +524,25 @@ def ensure_document_agent(
             consumer=consumer,
             process_alive=process_alive,
         )
-        if current.alive is True:
-            return current
         existing = get_agent_lease(conversation_id, consumer)
+        if (
+            current.alive is True
+            and existing is not None
+            and existing.get("execution") == execution_snapshot
+        ):
+            return current
+        if current.alive is True and existing is not None:
+            fence_document_agent(
+                conversation_id=conversation_id,
+                consumer=consumer,
+            )
+            current = DocumentAgentStatus(
+                status="stopped",
+                alive=False,
+                started=False,
+                error=None,
+            )
+            existing = get_agent_lease(conversation_id, consumer)
         if (
             current.status == "stopped"
             and existing is not None
@@ -465,6 +553,17 @@ def ensure_document_agent(
                 consumer,
                 str(existing["generation"]),
             )
+            old_pid = existing.get("pid")
+            if (
+                isinstance(old_pid, int)
+                and not isinstance(old_pid, bool)
+                and old_pid > 0
+            ):
+                _terminate_spawned_driver(
+                    old_pid,
+                    conversation_id=conversation_id,
+                    generation=str(existing["generation"]),
+                )
 
         generation = uuid.uuid4().hex
         lease = claim_agent_lease(
@@ -473,6 +572,7 @@ def ensure_document_agent(
             generation,
             starting_grace_seconds=_STARTING_GRACE_SECONDS,
             heartbeat_ttl_seconds=_HEARTBEAT_TTL_SECONDS,
+            execution=execution_snapshot,
         )
         if lease is None:
             return DocumentAgentStatus(
@@ -496,6 +596,7 @@ def ensure_document_agent(
                 consumer=consumer,
                 generation=generation,
                 feedback=feedback,
+                execution=execution,
             )
         except Exception:
             logger.warning(
@@ -558,6 +659,11 @@ def ensure_document_agent(
                 "Document-agent lease rotated before activation: conversation=%s",
                 conversation_id,
             )
+            _terminate_spawned_driver(
+                pid,
+                conversation_id=conversation_id,
+                generation=generation,
+            )
             return DocumentAgentStatus(
                 status="stopped",
                 alive=False,
@@ -576,6 +682,16 @@ def ensure_document_agent(
         try:
             alive = process_alive(pid)
         except Exception:
+            stop_agent_lease(
+                conversation_id,
+                consumer,
+                generation,
+            )
+            _terminate_spawned_driver(
+                pid,
+                conversation_id=conversation_id,
+                generation=generation,
+            )
             return DocumentAgentStatus(
                 status="stopped",
                 alive=None,
@@ -589,6 +705,11 @@ def ensure_document_agent(
                 generation,
                 error=_SAFE_AGENT_EXITED,
             )
+            _terminate_spawned_driver(
+                pid,
+                conversation_id=conversation_id,
+                generation=generation,
+            )
             return DocumentAgentStatus(
                 status="spawn_failed",
                 alive=False,
@@ -600,12 +721,49 @@ def ensure_document_agent(
         )
 
 
+def fence_document_agent(
+    *,
+    conversation_id: str,
+    consumer: str,
+) -> bool:
+    """Fence and best-effort terminate the lease-owned detached driver.
+
+    The persisted generation is stopped before process termination, so even a
+    process that outlives the best-effort kill can no longer mutate the
+    conversation or document through generation-fenced capabilities.
+    """
+    with _SPAWN_LOCK:
+        lease = get_agent_lease(conversation_id, consumer)
+        if lease is None:
+            return False
+        generation = lease.get("generation")
+        if not isinstance(generation, str) or not generation:
+            return False
+        fenced = stop_agent_lease(
+            conversation_id,
+            consumer,
+            generation,
+        )
+        if not fenced:
+            return False
+        unregister(conversation_id)
+        pid = lease.get("pid")
+        if isinstance(pid, int) and not isinstance(pid, bool) and pid > 0:
+            _terminate_spawned_driver(
+                pid,
+                conversation_id=conversation_id,
+                generation=generation,
+            )
+        return True
+
+
 __all__ = [
     "DocumentAgentStatus",
     "FeedbackPromptContext",
     "build_document_agent_prompt",
     "document_agent_consumer",
     "ensure_document_agent",
+    "fence_document_agent",
     "inspect_document_agent",
     "spawn_document_agent_session",
 ]

--- a/work_buddy/cowork/execution_identity.py
+++ b/work_buddy/cowork/execution_identity.py
@@ -1,0 +1,35 @@
+"""Server-owned identity shape for one generation-fenced Co-work driver."""
+
+from __future__ import annotations
+
+import re
+
+_GENERATION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_SESSION_SUFFIX = "-cowork"
+
+
+def cowork_execution_session_id(generation: str) -> str:
+    """Put generation entropy first so session-directory prefixes stay unique."""
+
+    normalized = str(generation or "").strip()
+    if not _GENERATION_RE.fullmatch(normalized):
+        raise ValueError("Co-work generation is not a safe session identity")
+    return f"{normalized}{_SESSION_SUFFIX}"
+
+
+def cowork_generation_from_session(session_id: str | None) -> str | None:
+    """Return the bound generation for a Co-work execution session."""
+
+    normalized = str(session_id or "").strip()
+    if not normalized.endswith(_SESSION_SUFFIX):
+        return None
+    generation = normalized[: -len(_SESSION_SUFFIX)]
+    if not _GENERATION_RE.fullmatch(generation):
+        return None
+    return generation
+
+
+__all__ = [
+    "cowork_execution_session_id",
+    "cowork_generation_from_session",
+]

--- a/work_buddy/cowork/ops.py
+++ b/work_buddy/cowork/ops.py
@@ -106,8 +106,23 @@ def _document_agent_write_fence(
     conversation_id: str | None,
     consumer: str | None,
     generation: str | None,
+    agent_session_id: str | None,
 ):
     """Bind an optional lease tuple to this exact store/document conversation."""
+    from work_buddy.cowork.execution_identity import (
+        cowork_generation_from_session,
+    )
+
+    session_generation = cowork_generation_from_session(agent_session_id)
+    if session_generation is not None:
+        if (
+            conversation_id is None
+            or consumer is None
+            or generation is None
+        ):
+            raise ConversationLeaseLost("lease_lost")
+        if generation != session_generation:
+            raise ConversationLeaseLost("lease_lost")
     supplied = (conversation_id, consumer, generation)
     if all(value is None for value in supplied):
         yield
@@ -339,7 +354,11 @@ def cowork_doc_list(store_id: str, profile: str | None = None) -> dict[str, Any]
     }
 
 
-def cowork_doc_get(store_id: str, document_id: str) -> dict[str, Any]:
+def cowork_doc_get(
+    store_id: str,
+    document_id: str,
+    agent_session_id: str | None = None,
+) -> dict[str, Any]:
     """Read one cowork doc's content-meta, open proposals, expressions, and drift.
 
     Content itself rides the binary Y.Doc transport, so this carries meta plus
@@ -353,31 +372,68 @@ def cowork_doc_get(store_id: str, document_id: str) -> dict[str, Any]:
         document_id=document_id,
         store_id=store.store_id,
     )
-    with store._read_connection() as conn:
-        document = documents.get_document(store, document_id, conn=conn)
-        current_file = _current_file_sha256(store, document.path)
-        state = documents.drift_state(
-            store,
-            document.id,
-            current_file_sha256=current_file,
-            conn=conn,
-        )
-        open_props = proposals.open_proposals(
-            store, document_id=document.id, conn=conn
-        )
-        open_payload = [_proposal_view(item, document, store) for item in open_props]
-        expr_payload = [
-            _expression_view(expression, conn, store)
-            for expression in expressions.expressions_for_document(
-                store, document.id, conn=conn
-            )
-        ]
-        feedback_payload = feedback.feedback_items(
-            store,
-            document_id=document.id,
-            conversation_id=conversation_id,
-            conn=conn,
-        )
+    from work_buddy.cowork.execution_identity import (
+        cowork_generation_from_session,
+    )
+
+    session_generation = cowork_generation_from_session(agent_session_id)
+    consumer = (
+        document_agent_consumer(store.store_id, document_id)
+        if session_generation is not None
+        else None
+    )
+    try:
+        with _document_agent_write_fence(
+            store_id=store.store_id,
+            document_id=document_id,
+            conversation_id=(
+                conversation_id
+                if session_generation is not None
+                else None
+            ),
+            consumer=consumer,
+            generation=session_generation,
+            agent_session_id=agent_session_id,
+        ):
+            with store._read_connection() as conn:
+                document = documents.get_document(
+                    store,
+                    document_id,
+                    conn=conn,
+                )
+                current_file = _current_file_sha256(store, document.path)
+                state = documents.drift_state(
+                    store,
+                    document.id,
+                    current_file_sha256=current_file,
+                    conn=conn,
+                )
+                open_props = proposals.open_proposals(
+                    store, document_id=document.id, conn=conn
+                )
+                open_payload = [
+                    _proposal_view(item, document, store)
+                    for item in open_props
+                ]
+                expr_payload = [
+                    _expression_view(expression, conn, store)
+                    for expression in expressions.expressions_for_document(
+                        store, document.id, conn=conn
+                    )
+                ]
+                feedback_payload = feedback.feedback_items(
+                    store,
+                    document_id=document.id,
+                    conversation_id=conversation_id,
+                    conn=conn,
+                )
+    except ConversationLeaseLost:
+        return {
+            "ok": False,
+            "status": "lease_lost",
+            "document_id": document_id,
+            "store_id": store.store_id,
+        }
     return {
         "ok": True,
         "document_id": document.id,
@@ -477,6 +533,7 @@ def cowork_doc_propose_edit(
             conversation_id=conversation_id,
             consumer=consumer,
             generation=generation,
+            agent_session_id=agent_session_id,
         ):
             with store.write_transaction() as truth_conn:
                 document = documents.get_document(
@@ -591,6 +648,7 @@ def cowork_doc_comment(
             conversation_id=conversation_id,
             consumer=consumer,
             generation=generation,
+            agent_session_id=agent_session_id,
         ):
             document = documents.get_document(store, document_id)
             if documents.current_lifecycle(store, document.id) != "active":

--- a/work_buddy/cowork/sitting_api.py
+++ b/work_buddy/cowork/sitting_api.py
@@ -88,6 +88,12 @@ def _reconcile_routing_deliveries(
         ]
         return {**receipt, "routing_deliveries": enriched}
 
+    from work_buddy.cowork.api import (
+        _execution_selection_from_state,
+        _execution_snapshot_after_committed_action,
+        _pin_projected_execution,
+    )
+
     enriched: list[dict[str, Any]] = []
     for descriptor in descriptors:
         try:
@@ -126,10 +132,14 @@ def _reconcile_routing_deliveries(
             continue
 
         try:
+            execution_state = _pin_projected_execution(
+                status.conversation_id
+            )
             agent_status = document_agent.ensure_document_agent(
                 store_id=store.store_id,
                 document_id=document_id,
                 conversation_id=status.conversation_id,
+                execution=_execution_selection_from_state(execution_state),
             )
         except Exception:
             logger.exception(
@@ -149,6 +159,9 @@ def _reconcile_routing_deliveries(
                 "message_id": status.message_id,
                 "reason": None,
                 "agent": agent_status.to_dict(),
+                "execution": _execution_snapshot_after_committed_action(
+                    status.conversation_id
+                ),
             }
         )
     return {**receipt, "routing_deliveries": enriched}

--- a/work_buddy/mcp_server/ops/conversations_ops.py
+++ b/work_buddy/mcp_server/ops/conversations_ops.py
@@ -40,13 +40,91 @@ def _register() -> None:
         list_conversations as _list_conversations,
         conversation_agent_write_guard as _agent_write_guard,
     )
+    from work_buddy.conversations.execution import (
+        producer_for_lease as _producer_for_lease,
+    )
 
-    def _write_fence(conversation_id, consumer, generation):
+    def _write_fence(
+        conversation_id,
+        consumer,
+        generation,
+        agent_session_id,
+    ):
+        from work_buddy.cowork.execution_identity import (
+            cowork_generation_from_session,
+        )
+
+        session_generation = cowork_generation_from_session(
+            agent_session_id
+        )
+        if session_generation is not None:
+            if consumer is None or generation is None:
+                raise ValueError(
+                    "Co-work execution requires consumer and generation"
+                )
+            if generation != session_generation:
+                raise ConversationLeaseLost("lease_lost")
         if consumer is None and generation is None:
             return nullcontext(None)
         if consumer is None or generation is None:
             raise ValueError("consumer and generation must be provided together")
         return _agent_write_guard(conversation_id, consumer, generation)
+
+    def _trusted_producer(
+        conversation_id,
+        consumer,
+        generation,
+        lease_conn,
+        agent_session_id,
+    ):
+        producer = None
+        if consumer is not None and generation is not None and lease_conn is not None:
+            producer = _producer_for_lease(
+                conversation_id=conversation_id,
+                consumer=consumer,
+                generation=generation,
+                conn=lease_conn,
+            )
+        from work_buddy.cowork.execution_identity import (
+            cowork_generation_from_session,
+        )
+
+        if (
+            cowork_generation_from_session(agent_session_id) is not None
+            and producer is None
+        ):
+            raise ConversationLeaseLost("lease_lost")
+        return producer
+
+    def _verify_cowork_read_scope(
+        conversation_id,
+        consumer,
+        generation,
+        agent_session_id,
+    ) -> None:
+        """Bind hosted Co-work reads to their exact active lease."""
+
+        from work_buddy.cowork.execution_identity import (
+            cowork_generation_from_session,
+        )
+
+        session_generation = cowork_generation_from_session(
+            agent_session_id
+        )
+        if session_generation is None:
+            return
+        if consumer is None or generation is None:
+            raise ValueError(
+                "Co-work execution requires consumer and generation"
+            )
+        if generation != session_generation:
+            raise ConversationLeaseLost("lease_lost")
+        with _agent_write_guard(
+            conversation_id,
+            consumer,
+            generation,
+        ):
+            pass
 
     def _notify_conversation_created(
         conversation_id: str, title: str, body: str = "",
@@ -105,19 +183,29 @@ def _register() -> None:
         message_id: str | None = None,
         consumer: str | None = None,
         generation: str | None = None,
+        agent_session_id: str | None = None,
     ) -> dict:
         try:
             with _write_fence(
                 conversation_id,
                 consumer,
                 generation,
+                agent_session_id,
             ) as lease_conn:
+                producer = _trusted_producer(
+                    conversation_id,
+                    consumer,
+                    generation,
+                    lease_conn,
+                    agent_session_id,
+                )
                 if message_id is None:
                     msg = _add_msg(
                         conversation_id,
                         "agent",
                         message,
                         conn=lease_conn,
+                        producer=producer,
                     )
                     created = msg is not None
                 else:
@@ -126,6 +214,7 @@ def _register() -> None:
                         message,
                         message_id,
                         conn=lease_conn,
+                        producer=producer,
                     )
         except ConversationLeaseLost:
             return {
@@ -154,6 +243,7 @@ def _register() -> None:
         timeout_seconds: int | None = None,
         consumer: str | None = None,
         generation: str | None = None,
+        agent_session_id: str | None = None,
     ) -> dict:
         choice_dicts = None
         if choices:
@@ -169,7 +259,15 @@ def _register() -> None:
                 conversation_id,
                 consumer,
                 generation,
+                agent_session_id,
             ) as lease_conn:
+                producer = _trusted_producer(
+                    conversation_id,
+                    consumer,
+                    generation,
+                    lease_conn,
+                    agent_session_id,
+                )
                 msg = _add_msg(
                     conversation_id,
                     "agent",
@@ -178,6 +276,7 @@ def _register() -> None:
                     response_type=response_type,
                     choices=choice_dicts,
                     conn=lease_conn,
+                    producer=producer,
                 )
         except ConversationLeaseLost:
             return {
@@ -201,9 +300,32 @@ def _register() -> None:
             timeout_seconds = min(timeout_seconds, 110)
             deadline = time.time() + timeout_seconds
             while time.time() < deadline:
-                pending = _get_pending(conversation_id)
+                try:
+                    with _write_fence(
+                        conversation_id,
+                        consumer,
+                        generation,
+                        agent_session_id,
+                    ) as lease_conn:
+                        pending = _get_pending(
+                            conversation_id,
+                            conn=lease_conn,
+                        )
+                        data = (
+                            _get_conv_msgs(
+                                conversation_id,
+                                conn=lease_conn,
+                            )
+                            if pending is None
+                            or pending.status == "answered"
+                            else None
+                        )
+                except ConversationLeaseLost:
+                    return {
+                        "status": "lease_lost",
+                        "conversation_id": conversation_id,
+                    }
                 if pending is None or pending.status == "answered":
-                    data = _get_conv_msgs(conversation_id)
                     if data:
                         for m in reversed(data["messages"]):
                             if m.get("message_id") == msg.message_id:
@@ -220,10 +342,41 @@ def _register() -> None:
     def conversation_poll(
         conversation_id: str,
         timeout_seconds: int | None = None,
+        consumer: str | None = None,
+        generation: str | None = None,
+        agent_session_id: str | None = None,
     ) -> dict:
-        pending = _get_pending(conversation_id)
+        def _scoped_snapshot():
+            with _write_fence(
+                conversation_id,
+                consumer,
+                generation,
+                agent_session_id,
+            ) as lease_conn:
+                pending_question = _get_pending(
+                    conversation_id,
+                    conn=lease_conn,
+                )
+                conversation_data = (
+                    _get_conv_msgs(
+                        conversation_id,
+                        conn=lease_conn,
+                    )
+                    if pending_question is None
+                    else None
+                )
+                return pending_question, conversation_data
+
+        try:
+            pending, data = _scoped_snapshot()
+        except ConversationLeaseLost:
+            return {
+                "status": "lease_lost",
+                "conversation_id": conversation_id,
+            }
+        except ValueError as exc:
+            return {"status": "invalid_request", "error": str(exc)}
         if pending is None:
-            data = _get_conv_msgs(conversation_id)
             if not data:
                 return {"error": f"Conversation not found: {conversation_id}"}
             answered = [m for m in data["messages"]
@@ -247,9 +400,14 @@ def _register() -> None:
         timeout_seconds = min(timeout_seconds, 110)
         deadline = time.time() + timeout_seconds
         while time.time() < deadline:
-            p = _get_pending(conversation_id)
+            try:
+                p, data = _scoped_snapshot()
+            except ConversationLeaseLost:
+                return {
+                    "status": "lease_lost",
+                    "conversation_id": conversation_id,
+                }
             if p is None:
-                data = _get_conv_msgs(conversation_id)
                 if data:
                     answered = [m for m in data["messages"]
                                 if m.get("message_id") == pending.message_id]
@@ -269,8 +427,23 @@ def _register() -> None:
         consumer: str,
         generation: str,
         timeout_seconds: int | None = None,
+        agent_session_id: str | None = None,
     ) -> dict:
         """Receive the oldest unacked user turn for one leased consumer."""
+        try:
+            _verify_cowork_read_scope(
+                conversation_id,
+                consumer,
+                generation,
+                agent_session_id,
+            )
+        except ConversationLeaseLost:
+            return {
+                "status": "lease_lost",
+                "conversation_id": conversation_id,
+            }
+        except ValueError as exc:
+            return {"status": "invalid_request", "error": str(exc)}
         return _receive_user(
             conversation_id,
             consumer,
@@ -283,8 +456,23 @@ def _register() -> None:
         consumer: str,
         generation: str,
         message_id: str,
+        agent_session_id: str | None = None,
     ) -> dict:
         """Acknowledge exactly the currently delivered oldest user turn."""
+        try:
+            _verify_cowork_read_scope(
+                conversation_id,
+                consumer,
+                generation,
+                agent_session_id,
+            )
+        except ConversationLeaseLost:
+            return {
+                "status": "lease_lost",
+                "conversation_id": conversation_id,
+            }
+        except ValueError as exc:
+            return {"status": "invalid_request", "error": str(exc)}
         return _ack_user(
             conversation_id,
             consumer,

--- a/work_buddy/mcp_server/session_acl.py
+++ b/work_buddy/mcp_server/session_acl.py
@@ -35,6 +35,30 @@ from typing import Any, Iterable
 
 
 _SESSION_ACL: dict[str, frozenset[str]] = {}
+_COWORK_EXECUTION_CAPABILITIES = frozenset(
+    {
+        "cowork_doc_get",
+        "cowork_doc_propose_edit",
+        "cowork_doc_comment",
+        "conversation_send",
+        "conversation_ask",
+        "conversation_poll",
+        "conversation_receive",
+        "conversation_ack",
+    }
+)
+
+
+def _builtin_session_acl(session_id: str | None) -> frozenset[str] | None:
+    """Return the non-overridable least-authority ACL for hosted Co-work."""
+
+    from work_buddy.cowork.execution_identity import (
+        cowork_generation_from_session,
+    )
+
+    if cowork_generation_from_session(session_id) is None:
+        return None
+    return _COWORK_EXECUTION_CAPABILITIES
 
 
 def set_session_acl(session_id: str, allowed_capabilities: Iterable[str]) -> None:
@@ -60,7 +84,13 @@ def get_session_acl(session_id: str | None) -> frozenset[str] | None:
     """
     if not session_id:
         return None
-    return _SESSION_ACL.get(session_id)
+    configured = _SESSION_ACL.get(session_id)
+    builtin = _builtin_session_acl(session_id)
+    if builtin is None:
+        return configured
+    if configured is None:
+        return builtin
+    return builtin.intersection(configured)
 
 
 def any_acl_registered() -> bool:

--- a/work_buddy/mcp_server/tools/gateway.py
+++ b/work_buddy/mcp_server/tools/gateway.py
@@ -145,6 +145,34 @@ def _require_init(ctx: Context) -> dict | None:
         ),
     })
 
+
+def _reject_constrained_top_level(
+    ctx: Context,
+    tool_name: str,
+) -> dict[str, Any] | None:
+    """Deny top-level gateway tools that bypass the capability ACL.
+
+    Constrained callers may initialize, discover their filtered capability
+    surface, and dispatch those capabilities through ``wb_run``. Workflow and
+    operation-result tools are not capability-dispatched, so allowing them
+    would bypass that whitelist and could expose or mutate another session's
+    state.
+    """
+    from work_buddy.mcp_server.session_acl import get_session_acl
+
+    session_id = _resolve_session(ctx)
+    if get_session_acl(session_id) is None:
+        return None
+    return _prepare(
+        {
+            "error": (
+                f"{tool_name} is not permitted for this constrained "
+                "execution session."
+            ),
+            "denied_by": "session_acl",
+        }
+    )
+
 # ---------------------------------------------------------------------------
 # Operation log — durable records for retry / observability
 # ---------------------------------------------------------------------------
@@ -430,7 +458,7 @@ def _invoke_with_session(
     from contextlib import ExitStack
 
     call_kwargs = dict(kwargs)
-    if session_id and "agent_session_id" not in call_kwargs:
+    if session_id:
         try:
             parameter = inspect.signature(callable_).parameters.get(
                 "agent_session_id"
@@ -441,6 +469,8 @@ def _invoke_with_session(
             inspect.Parameter.POSITIONAL_OR_KEYWORD,
             inspect.Parameter.KEYWORD_ONLY,
         ):
+            # Session identity is transport-owned. Never let capability params
+            # override the server-resolved MCP connection identity.
             call_kwargs["agent_session_id"] = session_id
 
     authorization_contexts: list[tuple[Any, Any | None]] = []
@@ -1501,6 +1531,22 @@ def register_tools(mcp: FastMCP) -> None:
                 "error": "session_id is required. Pass your WORK_BUDDY_SESSION_ID.",
             })
         session_id = session_id.strip()
+        from work_buddy.mcp_server.session_acl import get_session_acl
+
+        _auto_init_from_header(ctx)
+        current_sid = _resolve_session(ctx)
+        if (
+            current_sid is not None
+            and current_sid != session_id
+            and get_session_acl(current_sid) is not None
+        ):
+            return _prepare({
+                "error": (
+                    "wb_init is not permitted to rebind this constrained "
+                    "execution session."
+                ),
+                "denied_by": "session_acl",
+            })
         _register_session(ctx, session_id)
 
         # Ensure the agent session directory exists
@@ -1652,12 +1698,19 @@ def register_tools(mcp: FastMCP) -> None:
             # ACL check would be silently bypassed.
             _auto_init_from_header(ctx)
             current_sid = _resolve_session(ctx)
-            if current_sid is not None and get_session_acl(current_sid) is not None:
+            sid = parsed_params.get("session_id", "")
+            if not sid or not str(sid).strip():
+                return _prepare({"error": "session_id is required. Pass your WORK_BUDDY_SESSION_ID."})
+            sid = str(sid).strip()
+            if (
+                current_sid is not None
+                and current_sid != sid
+                and get_session_acl(current_sid) is not None
+            ):
                 return _prepare({
                     "error": (
-                        "wb_init is not permitted for ACL-scoped sessions. "
-                        "The caller set a capability whitelist on this "
-                        "session; re-initialization would escape the ACL."
+                        "wb_init is not permitted to rebind this constrained "
+                        "execution session."
                     ),
                     "denied_by": "session_acl",
                     "hint": (
@@ -1667,10 +1720,6 @@ def register_tools(mcp: FastMCP) -> None:
                         "opened inside an llm_with_tools run by mistake."
                     ),
                 })
-            sid = parsed_params.get("session_id", "")
-            if not sid or not str(sid).strip():
-                return _prepare({"error": "session_id is required. Pass your WORK_BUDDY_SESSION_ID."})
-            sid = str(sid).strip()
             _register_session(ctx, sid)
             from work_buddy.mcp_server.activity_ledger import record_init
             record_init(sid)
@@ -2610,6 +2659,9 @@ def register_tools(mcp: FastMCP) -> None:
         gate = _require_init(ctx)
         if gate:
             return gate
+        denied = _reject_constrained_top_level(ctx, "wb_advance")
+        if denied:
+            return denied
         parsed_result = _parse_params(step_result)
         _t0 = _time.monotonic()
         result = await asyncio.to_thread(
@@ -2644,6 +2696,9 @@ def register_tools(mcp: FastMCP) -> None:
         gate = _require_init(ctx)
         if gate:
             return gate
+        denied = _reject_constrained_top_level(ctx, "wb_status")
+        if denied:
+            return denied
         if operation_id:
             record = _load_operation(operation_id)
             if record is None:
@@ -2683,6 +2738,9 @@ def register_tools(mcp: FastMCP) -> None:
         gate = _require_init(ctx)
         if gate:
             return gate
+        denied = _reject_constrained_top_level(ctx, "wb_step_result")
+        if denied:
+            return denied
         result = await asyncio.to_thread(
             _conductor().get_step_result, workflow_run_id, step_id, key,
         )
@@ -2709,6 +2767,9 @@ def register_tools(mcp: FastMCP) -> None:
         gate = _require_init(ctx)
         if gate:
             return gate
+        denied = _reject_constrained_top_level(ctx, "wb_capability_result")
+        if denied:
+            return denied
         result = await asyncio.to_thread(
             _capability_result_payload, operation_id, key,
         )

--- a/work_buddy/sidecar/dispatch/executor.py
+++ b/work_buddy/sidecar/dispatch/executor.py
@@ -27,8 +27,12 @@ See ``dispatch/models.py`` for the full spawn type model.
 from __future__ import annotations
 
 import os
+import signal
 import subprocess
+import threading
 import time
+import uuid
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -50,6 +54,15 @@ AGENT_SPAWN_CONSENT_OP = "sidecar:agent_spawn"
 # Session name prefix for daemon-spawned agents.
 # Phase C (routing) uses this to distinguish daemon agents from user sessions.
 DAEMON_SESSION_PREFIX = "daemon:"
+
+# Detached Co-work drivers are terminated only through the exact ``Popen``
+# handle that created them. A persisted PID alone is not sufficient proof of
+# ownership because operating systems can reuse PIDs after a process exits.
+_OWNED_DETACHED_PROCESSES: dict[tuple[int, str], subprocess.Popen] = {}
+_OWNED_DETACHED_PROCESSES_LOCK = threading.RLock()
+_DETACHED_STDIN_TIMEOUT_SECONDS = 10.0
+_DETACHED_TERMINATION_VERIFY_TIMEOUT_SECONDS = 1.0
+_DETACHED_TERMINATION_RETRY_SECONDS = 1.0
 
 
 def execute_job(job: Job) -> dict[str, Any]:
@@ -350,11 +363,12 @@ def _resolve_spawn_mode(mode_str: str) -> SpawnMode:
 
 def _build_headless_agent_argv(
     *,
-    prompt: str,
+    prompt: str | None,
     session_name: str,
     model: str,
     max_budget_usd: float,
     persistent: bool,
+    extra_args: Sequence[str] = (),
 ) -> list[str]:
     """Build the ``claude --print`` argv for a headless agent spawn.
 
@@ -367,6 +381,7 @@ def _build_headless_agent_argv(
     # Note: Do NOT use --bare — it disables OAuth/keychain, causing auth failure.
     cmd = [
         "claude",
+        *extra_args,
         "--print",
         "--model", model,
         "--output-format", "json",
@@ -376,8 +391,381 @@ def _build_headless_agent_argv(
     ]
     if not persistent:
         cmd.append("--no-session-persistence")
-    cmd.append(prompt)
+    if prompt is not None:
+        cmd.append(prompt)
     return cmd
+
+
+def _spawn_detached_process_unchecked(
+    *,
+    name: str,
+    argv: Sequence[str],
+    cwd: str | Path,
+    env: Mapping[str, str] | None = None,
+    stdin_text: str | None = None,
+    session_name: str = "",
+    missing_executable_error: str = "Agent runtime is not installed.",
+    spawn_error: str = "Agent process could not start.",
+) -> dict[str, Any]:
+    """Start one fixed-argv background process without a command shell.
+
+    This is the provider-neutral process boundary used by Co-work execution
+    providers.  Provider registries construct and validate ``argv``; browser
+    requests never supply executable paths or flags directly.
+
+    ``stdin_text`` exists so workers can receive a potentially large private
+    brief without putting it in the OS process list.  The write is completed
+    before this function returns, while the worker remains detached.
+    """
+
+    command = tuple(argv)
+    if not command or any(not isinstance(arg, str) or "\x00" in arg for arg in command):
+        return {
+            "status": "error",
+            "error_code": "invalid_spawn_request",
+            "error": "Agent process request was invalid.",
+        }
+
+    logger.info(
+        "Spawning detached process: name='%s', executable='%s', argc=%d",
+        name,
+        Path(command[0]).name,
+        len(command),
+    )
+    try:
+        from work_buddy.compat import subprocess_creation_flags
+
+        proc = subprocess.Popen(
+            list(command),
+            stdin=subprocess.PIPE if stdin_text is not None else subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            cwd=str(cwd),
+            env=dict(env) if env is not None else None,
+            creationflags=subprocess_creation_flags(),
+            start_new_session=os.name != "nt",
+            close_fds=True,
+            shell=False,
+            text=stdin_text is not None,
+            encoding="utf-8" if stdin_text is not None else None,
+        )
+    except FileNotFoundError:
+        logger.error(
+            "Detached process executable was not found: name='%s'", name
+        )
+        return {
+            "status": "error",
+            "error_code": "runtime_not_installed",
+            "error": missing_executable_error,
+        }
+    except Exception as exc:
+        logger.error(
+            "Detached process spawn failed: name='%s', error_type=%s",
+            name,
+            type(exc).__name__,
+            exc_info=True,
+        )
+        return {
+            "status": "error",
+            "error_code": "spawn_failed",
+            "error": spawn_error,
+        }
+
+    owner_token = session_name.strip() or uuid.uuid4().hex
+    with _OWNED_DETACHED_PROCESSES_LOCK:
+        _OWNED_DETACHED_PROCESSES[(proc.pid, owner_token)] = proc
+    # Start the natural-exit reaper before prompt delivery. Delivery can time
+    # out while its writer thread is still blocked; that failure path must
+    # retain a way to observe and clean up the exact owned process.
+    _start_detached_process_reaper(proc, owner_token)
+
+    if stdin_text is not None and proc.stdin is not None:
+        delivered, timed_out = _deliver_detached_stdin(
+            proc,
+            stdin_text,
+            timeout_seconds=_DETACHED_STDIN_TIMEOUT_SECONDS,
+        )
+        if not delivered:
+            terminated = _terminate_owned_process_handle(proc, owner_token)
+            if not terminated:
+                _start_detached_termination_retrier(proc, owner_token)
+            logger.error(
+                "Detached process rejected its input: name='%s'", name
+            )
+            return {
+                "status": "error",
+                "error_code": (
+                    "spawn_input_timeout"
+                    if timed_out
+                    else "spawn_input_failed"
+                ),
+                "error": spawn_error,
+            }
+
+    return {
+        "status": "ok",
+        "pid": proc.pid,
+        "session_name": session_name,
+        "process_owner": owner_token,
+    }
+
+
+def _deliver_detached_stdin(
+    proc: subprocess.Popen,
+    stdin_text: str,
+    *,
+    timeout_seconds: float,
+) -> tuple[bool, bool]:
+    """Write a private prompt through stdin without blocking the request forever."""
+
+    completed = threading.Event()
+    failed = threading.Event()
+
+    def _write() -> None:
+        try:
+            if proc.stdin is None:
+                failed.set()
+                return
+            proc.stdin.write(stdin_text)
+            proc.stdin.close()
+        except (BrokenPipeError, OSError, ValueError):
+            failed.set()
+        finally:
+            completed.set()
+
+    writer = threading.Thread(
+        target=_write,
+        name=f"detached-stdin-{proc.pid}",
+        daemon=True,
+    )
+    writer.start()
+    if not completed.wait(max(0.0, timeout_seconds)):
+        return False, True
+    return not failed.is_set(), False
+
+
+def _owned_detached_process(
+    pid: int,
+    owner_token: str,
+) -> subprocess.Popen | None:
+    with _OWNED_DETACHED_PROCESSES_LOCK:
+        return _OWNED_DETACHED_PROCESSES.get((pid, owner_token))
+
+
+def _forget_owned_detached_process(
+    pid: int,
+    owner_token: str,
+    proc: subprocess.Popen | None = None,
+) -> None:
+    with _OWNED_DETACHED_PROCESSES_LOCK:
+        key = (pid, owner_token)
+        current = _OWNED_DETACHED_PROCESSES.get(key)
+        if proc is None or current is proc:
+            _OWNED_DETACHED_PROCESSES.pop(key, None)
+
+
+def _start_detached_process_reaper(
+    proc: subprocess.Popen,
+    owner_token: str,
+) -> threading.Thread | None:
+    """Release the exact owned process handle after natural worker exit."""
+
+    wait = getattr(proc, "wait", None)
+    if not callable(wait):
+        return None
+
+    def _reap() -> None:
+        try:
+            wait()
+        except (OSError, ValueError):
+            return
+        _forget_owned_detached_process(proc.pid, owner_token, proc)
+
+    reaper = threading.Thread(
+        target=_reap,
+        name=f"detached-reaper-{proc.pid}",
+        daemon=True,
+    )
+    reaper.start()
+    return reaper
+
+
+def _start_detached_termination_retrier(
+    proc: subprocess.Popen,
+    owner_token: str,
+) -> threading.Thread:
+    """Retry cleanup when a worker's private prompt was not delivered.
+
+    A timed-out stdin writer may unblock later and let the worker consume the
+    prompt. The caller has already received a failed spawn result, so this
+    runtime retains the exact process handle and retries termination until the
+    process exits or another exact-owner path removes that handle.
+    """
+
+    def _retry() -> None:
+        while _owned_detached_process(proc.pid, owner_token) is proc:
+            if _terminate_owned_process_handle(proc, owner_token):
+                return
+            time.sleep(_DETACHED_TERMINATION_RETRY_SECONDS)
+
+    retrier = threading.Thread(
+        target=_retry,
+        name=f"detached-termination-retry-{proc.pid}",
+        daemon=True,
+    )
+    retrier.start()
+    return retrier
+
+
+def _terminate_owned_process_handle(
+    proc: subprocess.Popen,
+    owner_token: str,
+) -> bool:
+    """Terminate one process proven to have been spawned by this runtime."""
+
+    pid = proc.pid
+    try:
+        return_code = proc.poll()
+    except (OSError, ValueError):
+        return_code = None
+    if return_code is not None:
+        _forget_owned_detached_process(pid, owner_token, proc)
+        return True
+
+    if os.name == "nt":
+        try:
+            from work_buddy.compat import _force_kill_pid
+
+            kill_requested = _force_kill_pid(pid)
+        except (ProcessLookupError, PermissionError, OSError):
+            kill_requested = False
+
+        # A nonzero taskkill result can race with natural process exit. Poll
+        # the exact owned handle once before deciding whether ownership must
+        # remain available for a retry.
+        if not kill_requested:
+            try:
+                exited = proc.poll() is not None
+            except (OSError, ValueError):
+                exited = False
+            if exited:
+                _forget_owned_detached_process(pid, owner_token, proc)
+            return exited
+
+        # taskkill returning zero means the request was accepted, not that
+        # this Popen handle has necessarily observed exit. Wait briefly and
+        # only forget the handle once termination is confirmed.
+        try:
+            proc.wait(timeout=_DETACHED_TERMINATION_VERIFY_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            return False
+        except (OSError, TypeError, ValueError):
+            try:
+                if proc.poll() is None:
+                    return False
+            except (OSError, ValueError):
+                return False
+        _forget_owned_detached_process(pid, owner_token, proc)
+        return True
+
+    try:
+        os.killpg(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        try:
+            exited = proc.poll() is not None
+        except (OSError, ValueError):
+            exited = False
+        if exited:
+            _forget_owned_detached_process(pid, owner_token, proc)
+        return exited
+    except (PermissionError, OSError):
+        return False
+
+    # A delivered signal is not proof that the child exited. Keep the exact
+    # handle registered when it ignores SIGTERM so a later retry can still
+    # terminate it without relying on a potentially recycled PID.
+    try:
+        proc.wait(timeout=_DETACHED_TERMINATION_VERIFY_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        return False
+    except (OSError, TypeError, ValueError):
+        try:
+            if proc.poll() is None:
+                return False
+        except (OSError, ValueError):
+            return False
+    _forget_owned_detached_process(pid, owner_token, proc)
+    return True
+
+
+@requires_consent(
+    operation=AGENT_SPAWN_CONSENT_OP,
+    reason="Start a background agent for a user-opened conversation.",
+    risk="high",
+    consent_weight="high",
+    default_ttl=0,
+)
+def spawn_detached_process_authorized(
+    *,
+    name: str,
+    argv: Sequence[str],
+    cwd: str | Path,
+    env: Mapping[str, str] | None = None,
+    stdin_text: str | None = None,
+    session_name: str = "",
+    missing_executable_error: str = "Agent runtime is not installed.",
+    spawn_error: str = "Agent process could not start.",
+) -> dict[str, Any]:
+    """Consent-gated provider-neutral detached process launch."""
+
+    return _spawn_detached_process_unchecked(
+        name=name,
+        argv=argv,
+        cwd=cwd,
+        env=env,
+        stdin_text=stdin_text,
+        session_name=session_name,
+        missing_executable_error=missing_executable_error,
+        spawn_error=spawn_error,
+    )
+
+
+def terminate_detached_process(
+    pid: int,
+    *,
+    owner_token: str,
+) -> bool:
+    """Best-effort termination for a backend-owned detached driver PID.
+
+    Callers obtain ``pid`` from the persisted agent lease after fencing that
+    lease generation. A matching live ``Popen`` handle in this runtime is also
+    required before any signal is sent, preventing PID-reuse mistakes.
+
+    Windows delegates to Work Buddy's ``taskkill /F /T`` implementation so
+    the SDK worker and its pinned App Server child are terminated together.
+    """
+
+    if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 0:
+        return False
+    if pid == os.getpid():
+        logger.error("Refusing to terminate the current sidecar process")
+        return False
+    normalized_owner = str(owner_token or "").strip()
+    if not normalized_owner:
+        return False
+    proc = _owned_detached_process(pid, normalized_owner)
+    if proc is not None:
+        return _terminate_owned_process_handle(proc, normalized_owner)
+
+    from work_buddy.utils.process import is_process_alive
+
+    if not is_process_alive(pid):
+        return True
+    logger.warning(
+        "Refusing to terminate unowned detached PID: pid=%s",
+        pid,
+    )
+    return False
 
 
 def _spawn_headless_agent_detached_unchecked(


### PR DESCRIPTION
## Summary

- Add a reusable, provider-neutral execution picker to the shared Chat widget while keeping Co-work-specific restart behavior in the Co-work integration layer.
- Add conversation-scoped, server-authoritative provider/model selection with optimistic concurrency, generation fencing, and durable provider/model provenance.
- Support account-backed Claude Code and OpenAI Codex execution without introducing direct API-key billing paths.
- Isolate both runtimes with constrained workers, strict MCP access, sanitized environments, and verified process ownership/termination.
- Document the execution architecture and the reusable Chat integration contract.

## UX and behavior

- Users can choose an available provider and model directly in Chat.
- The choice belongs to the conversation, survives reloads, and is shared consistently across clients.
- Changing an active conversation's execution profile restarts only its runtime; the transcript and unsent draft remain intact.
- Unavailable providers explain why they cannot run, and read-only conversations cannot initiate execution.

## Validation

- [x] Targeted backend suite: 182 passed
- [x] Full React test suite: 1,045 passed across 162 files
- [x] React typecheck and production build
- [x] Python compileall and `uv lock --check`
- [x] Knowledge-store rebuild and validation
- [x] `git diff --check`
- [x] Two independent adversarial release-gate reviews, followed by clean re-audits

## Manual review suggestions

- Start a Co-work chat with each signed-in provider and switch models before sending.
- Switch provider/model during an existing conversation and confirm the transcript and draft remain.
- Confirm unavailable-account and read-only states are explanatory and non-actionable.
- Confirm message provenance reflects the runtime lease that actually produced each response.
