### PR TITLE
feat(cowork): add provenance lens

### DIFF
--- a/.data/designs/co-work/provenance-surface/README.md
+++ b/.data/designs/co-work/provenance-surface/README.md
@@ -1,0 +1,368 @@
+# Co-work Provenance surface
+
+**Status:** Accepted design and implementation contract for the first
+end-to-end Provenance lens. The as-built boundary is recorded in
+[implementation-plan.md](implementation-plan.md); anything listed under
+**Deferred** is not part of this delivery.
+
+## Decision
+
+Add **Provenance** as a first-class Co-work rail beside **Review**, **Truth**,
+and **Chat**. Selecting it activates a view-only provenance lens over the open
+document. The lens answers a different question from the neighboring surfaces:
+
+| Surface | Primary question | Persistent editor lens |
+|---|---|---|
+| **Review** | What proposed document or evaluation change needs my decision? | `review` |
+| **Provenance** | Where did these words come from, who is said to have written them, and what human review is recorded? | `provenance` |
+| **Truth** | What claims does this work rest on, and what evidence and lifecycle do they have? | `truth` |
+| **Chat** | What do I want to discuss or ask the agent to do? | `neutral` |
+
+The four lens values are mutually exclusive. Temporary passage emphasis used
+by Chat, **Working on**, or an explicit navigation command remains independent.
+A rail change only replaces view decorations and compatible focus; it never
+changes the document, Y.Doc, Markdown, selection, scroll position, or undo
+history.
+
+This is a panel, not only a toolbar toggle, because provenance has durable
+state and legitimate actions. The overlay makes the document scannable; hover
+explains one passage; the stable panel owns filters, details, history, and
+human decisions. That separation keeps a transient hover card from becoming a
+fragile mutation surface.
+
+## User jobs
+
+The first slice supports four practical jobs:
+
+1. **Scan** the document for AI, human, mixed, unknown, unrecorded, or stale
+   provenance.
+2. **Understand** the source, authorship assertion, review state, attester, and
+   basis for one passage without leaving the document.
+3. **Record review** of an exactly targeted AI- or mixed-authored document or
+   passage as the currently enrolled local user without erasing its authorship
+   or source.
+4. **Repair awareness** by identifying unrecorded, unresolved, ambiguous, or
+   conflicting coverage rather than silently presenting it as human-authored.
+
+Provenance does not answer whether the prose is correct, whether a claim is a
+fact, whether an edit should be accepted, or whether a named person really
+wrote the words. Those questions remain with Truth, Review, or a future
+identity-verification boundary.
+
+## Four independent recorded axes
+
+One provenance attestation keeps these facts separate:
+
+- **Source** describes how the content entered the system and any retained
+  occurrence or format facts. A paste, file import, direct entry, and accepted
+  proposal are different sources.
+- **Authorship** is `human`, `ai`, `mixed`, or `unknown`, with contributors when
+  recorded.
+- **Human review** is `reviewed`, `not_reviewed`, `not_applicable`, or
+  `unknown`, with reviewers when recorded.
+- **Attester and basis** identify who made the assertion and why it was
+  recorded, for example user attestation, automatic short-text attribution,
+  proposal acceptance, migration, or legacy data.
+
+These dimensions must not be collapsed into a single trust badge. In
+particular:
+
+- AI-authored and human-reviewed remains AI-authored;
+- human-authored does not automatically mean reviewed;
+- a local paste gesture does not prove the clipboard text was composed by the
+  person who pasted it;
+- an attestation is a report, not authorship verification; and
+- reviewed does not mean approved, accepted, fact-checked, correct, or safe.
+
+The enrolled local dashboard principal and one-time, action-bound gesture make
+the **review action** attributable to a durable local actor. This remains a
+local authority, not a verified remote identity or authenticated multi-user
+account. A typed name for someone else remains a claimed name.
+
+## Effective state and immutable history
+
+Attestations are append-only. A correction or review transition appends a new
+record whose `supersedes_id` names the prior record; history is never updated
+in place or deleted.
+
+For a single lineage, the effective attestation is the unsuperseded leaf. A
+review action is deliberately constrained:
+
+1. the server verifies that the selected record belongs to the open document
+   and is still an effective leaf for the same frozen target;
+2. it derives a replacement from that record rather than accepting a
+   client-authored rewrite;
+3. it preserves source, authorship, contributors, and the target;
+4. it changes human review to `reviewed` and records the enrolled acting user
+   as reviewer and attester; its own basis is `user_attestation` and references
+   the predecessor, while the predecessor retains its original automatic,
+   proposal, migration, or legacy basis; and
+5. it appends the replacement with a new idempotency key and a one-time gesture
+   bound to the exact request.
+
+Thus the visible transition is:
+
+> AI-authored, not reviewed → AI-authored, reviewed by the enrolled local user
+
+It is not AI-authored → human-authored. A stale leaf, already-superseded record,
+different target, actor change, head conflict, or idempotency mismatch fails
+closed and requires a refresh or a fresh user decision. Independently effective
+overlapping attestations that disagree are a **conflict**, not an invitation to
+use last-write-wins.
+
+## Exact coverage semantics
+
+The overlay is a projection over the current editor, not a mutation of its
+content. It derives current coverage conservatively:
+
+- A document-version attestation covers the whole current document only while
+  its frozen structured-head digest equals the current structured head. Once
+  the document changes, the old version remains inspectable history but cannot
+  attribute newly edited text.
+- A span attestation carries the complete exact quote selector: `exact`,
+  `prefix`, and `suffix`. At its frozen head it is current. After unrelated
+  document change it is **reanchored** for display only when that selector
+  resolves to exactly one passage in the hydrated editor.
+- A selector with no match is **unresolved**. More than one match is
+  **ambiguous**. Both are stale-target states and receive no guessed range.
+- Text not covered by any safely projected current or uniquely reanchored
+  attestation is **unrecorded**. It must not inherit a human label merely
+  because it has no decoration.
+- A current document-level attestation is fallback coverage. Any current
+  explicit span overrides that fallback for its exact range.
+- Compatible peer explicit spans may be shown as combined coverage.
+  Incompatible independently effective peer spans produce an explicit
+  conflict state and expose every contributing attestation in the panel; time
+  and DOM order never choose a winner.
+
+An unsynchronized local-human edit invalidates the pulled provenance head
+immediately. Until persistence settles and a matching authoritative projection
+arrives, the lens withholds document-wide fallback and treats exact spans as
+requiring re-anchor. A span that still resolves uniquely may remain painted for
+inspection; text outside uniquely resolved recorded spans is unrecorded. This
+prevents newly typed text from inheriting an older document-wide attribution.
+
+Document-version and exact-span targets are different scopes. A current exact
+span overrides a current document-wide determination in its range; this
+specific-over-fallback precedence is not a conflict. A stale document-level
+record is not a fallback for a changed current head. Two overlapping records
+are compatible when their source, authorship, and human-review assertions
+agree; different attesters or bases describe independent attestations and do
+not by themselves create an assertion conflict. Conflicted coverage remains
+recorded-but-disputed rather than being counted as unrecorded.
+
+## Visual language
+
+The lens uses separate channels and always repeats the meaning in text in the
+hover card and panel:
+
+| Meaning | Document treatment | Text label |
+|---|---|---|
+| Human authorship | subtle cool-neutral wash | Human-authored |
+| AI authorship | subtle violet wash | AI-authored |
+| Mixed authorship | split or patterned wash | Mixed authorship |
+| Unknown authorship | neutral dotted/patterned treatment | Authorship unknown |
+| Unrecorded coverage | neutral hatch/dotted treatment | No provenance recorded |
+| Human reviewed | solid review underline or review mark | Human reviewed |
+| Explicitly not reviewed | amber dashed underline | Not human-reviewed |
+| Review unknown | gray dotted underline | Review unknown |
+| Not applicable | no review warning; explicit label in details | Review not applicable |
+| Unresolved, ambiguous, or conflicting | red wavy underline plus warning icon/label | Stale or conflicting provenance |
+
+Red wavy underlining is reserved for a broken or conflicting target. It must
+not mean merely “AI-authored” or “not reviewed,” because those are ordinary
+recorded states rather than errors. No state may be communicated by color
+alone. Patterns, underline styles, icons, and plain-language labels remain
+distinguishable in forced-colors mode and at browser zoom.
+
+Source and attester are intentionally not assigned additional simultaneous
+per-character colors. There are too many source kinds, and another color
+channel would make the page unreadable. They are first-class data in the hover
+and stable panel and may be filtered there.
+
+## Hover explanation
+
+Pointer hover, or moving the keyboard caret/selection through a decorated
+passage while the editor is focused, exposes a compact non-modal card
+containing:
+
+- authorship and named contributors when present;
+- human-review status and reviewers;
+- source kind and retained source reference when permitted;
+- attester and basis;
+- exact/current, unrecorded, stale, ambiguous, or conflict state; and
+- a plain-language direction to open Provenance for stable details and actions.
+
+The hover card is explanatory. It does not contain **Mark reviewed**, correction,
+delete, or any other mutation. It does not steal editor selection, move either
+pane, or persist its open state. It closes on Escape, pointer departure, focus
+departure, lens change, or document change. Keyboard users can reach the same
+information through the document-order panel list even when editor decoration
+spans themselves are not convenient tab stops.
+
+## Stable panel
+
+The Provenance panel has three progressively disclosed levels:
+
+1. **Summary** — needs-review and reviewed counts, issue count, and whether any
+   current text is unrecorded.
+2. **Document-order list** — one row per projected target or issue, with a text
+   excerpt, authorship label, review label, and target-health label.
+3. **Detail** — all four recorded axes, frozen target, effective state,
+   target-lineage history, and currently valid actions. A separate collapsed
+   **Complete provenance history** section keeps every append-only record for
+   the document inspectable, including old or malformed targets which cannot
+   safely project into the current text.
+
+Initial filters are conservative and additive: **All**, **Needs review**,
+**AI-authored**, and **Issues**. A filter changes the list, never the document
+content or what the overlay truthfully represents. If a later implementation
+adds overlay-dimension toggles, hiding a treatment must remain visibly
+disclosed; this first slice does not need them.
+
+Selecting a list row opens or closes its detail and may apply compatible focus;
+it does not scroll the editor. A uniquely resolved span exposes the explicit
+**Show in document** action, which issues one present-user reveal command and
+must not replay after refresh. An unresolved or ambiguous row opens details
+without scrolling to a guessed location. Expanding or closing inline detail
+does not replace the independently persisted list position.
+
+The **Mark reviewed** action appears only in stable detail when all of these are
+true:
+
+- the record is effective and targets either the current whole-document
+  version or a uniquely resolved span in the current document;
+- its frozen structured-head digest still equals the current document head;
+- authorship is AI or mixed;
+- review is not already `reviewed`;
+- the document and provenance surfaces are writable; and
+- the current actor and exact target can receive a fresh bound gesture.
+
+The action and nearby explanatory copy say what it does and does not assert.
+While a request is pending it is disabled and duplicate activation is
+idempotent. A successful append refreshes the authoritative read model; a
+failure keeps the previous data visible and explains whether refresh, retry, or
+a new decision is required.
+
+The editor owns a persistence barrier around this mutation. It disables
+editing, retries pending persistence when needed, flushes the Yjs outbox,
+asserts canonical editor state, compacts to a durable structured head, and
+keeps the editor locked while the Provenance provider performs a forced fresh
+document pull. The panel then re-finds the same effective leaf, rechecks the
+fresh head, eligibility, unique exact-span resolution, and incompatible peer
+overlaps before posting. The lock remains in place through the append and its
+authoritative repull; editing is restored only if the mounted document is still
+writable. Any drift fails closed and asks for a fresh inspection and gesture.
+
+## Loading, empty, error, and read-only states
+
+- First load shows a bounded loading state, not “No provenance.”
+- Background refresh retains prior data and geometry until an authoritative
+  replacement arrives.
+- A failed load offers **Retry** and is never rendered as an empty document.
+- A document with text and no current coverage says **No provenance is recorded
+  for this document** and the lens shows unrecorded coverage.
+- A genuinely empty document says **This document has no text to map yet**.
+- Read-only mode preserves scanning, hover, detail, and history while mutation
+  controls explain why they are unavailable.
+- A retired or unavailable document retains historical inspection only when
+  the surrounding Co-work lifecycle permits it.
+
+## Responsive, focus, and scroll behavior
+
+The rail tablist uses roving keyboard focus with Left/Right arrows and Home/End
+across all four tabs. The selected tab and the active lens remain synchronized.
+Adding Provenance must not make **Chat** unreachable at narrow widths; the
+tablist may scroll horizontally with a visible focus target rather than clip or
+shrink labels into ambiguity.
+
+The panel owns one scroll position per full Folder and document identity,
+separate from Review, Truth, and Chat. Summary controls remain compact; the
+document-order list receives the remaining height. Expanding or closing an
+inline detail preserves that list position. Switching tabs or refreshing data
+does not scroll the editor or rail. On narrow layouts, existing panel stacking
+or drawer behavior is preserved; the hover card is clamped to the viewport and
+must not cover the focused passage when a usable alternate placement exists.
+
+All controls have visible focus. Status icons are decorative only when their
+adjacent text already names the state. Touch has a stable panel path and never
+depends on hover. Reduced-motion mode avoids animated scanning or underline
+effects.
+
+## Architecture
+
+The implementation has four boundaries:
+
+1. **Truth provenance authority** retains append-only attestations and
+   supersession history.
+2. **Co-work read/action API** returns an authoritative provenance projection
+   alongside the open document and exposes the constrained review transition
+   behind local identity, CSRF, exact context, and one-time gesture checks.
+3. **Dedicated Provenance provider** parses typed provenance records, keeps
+   stale/error state explicit, and emits one view projection plus forced
+   refresh after action. It may share the open-document snapshot source with
+   neighboring surfaces, but it does not enlarge `ReviewRailData` into a
+   general provenance transport.
+4. **ProseMirror decoration plugin and Provenance rail** render the view-only
+   lens, re-anchor exact spans, compute uncovered text, explain hover, and own
+   stable details/actions.
+
+SSE may nudge invalidation, but the client always repulls authoritative data.
+The overlay never writes a ProseMirror transaction that changes document state.
+Raw database IDs and hashes stay out of routine copy, though advanced history
+may expose shortened identifiers where useful for diagnosis.
+
+## Acceptance contract
+
+The slice is complete only when all of these are demonstrable:
+
+1. **Review | Provenance | Truth | Chat** is keyboard-operable, and each tab
+   activates exactly its intended lens without moving or mutating the document.
+2. Current AI-authored, not-reviewed text is distinguishable from AI-authored,
+   reviewed text by more than color.
+3. Human, mixed, unknown, and unrecorded text cannot be mistaken for one
+   another in the panel, and missing data never defaults to human.
+4. Hover/focus details name all available axes and target health; mutations are
+   absent from hover.
+5. **Mark reviewed** appends a superseding record, retains AI/mixed authorship
+   and source, records the enrolled reviewer/attester under a new
+   user-attestation basis, preserves the predecessor's original basis in
+   history, and refreshes the lens.
+6. A stale, ambiguous, conflicting, already-superseded, wrong-document, or
+   actor-changed action fails closed without changing history.
+7. A changed document-version attestation does not paint newly edited text;
+   unique exact spans re-anchor for inspection and missing/ambiguous selectors
+   become issues. A reanchored changed-head span is not review-actionable in
+   this slice.
+8. Loading and failure are not rendered as empty; read-only mode keeps
+   inspection useful.
+9. Existing Review, Truth, Chat, temporary-highlight, persistence, selection,
+   scroll, and undo behavior remains intact.
+10. Backend, projection, decoration, interaction, accessibility, narrow-layout,
+    and non-regression tests cover the matrix in the implementation plan.
+11. A local edit immediately removes stale document-wide fallback; review
+    stays unavailable until the editor persistence barrier and a forced fresh
+    preflight agree on one exact current head and effective leaf.
+
+## Deferred
+
+The following are explicitly outside this delivery:
+
+- verified remote or multi-user identity and `account_ref` enrollment;
+- character-level collaborative authorship inferred from arbitrary Yjs
+  updates;
+- automatic propagation of version-wide attribution through later edits
+  without a proven changeset map;
+- durable review of a changed-head client-reanchored span; it requires a
+  trusted server/editor text-geometry proof rather than trusting browser
+  placement for an append-only assertion;
+- a general provenance correction composer or arbitrary source/authorship
+  rewriting;
+- bulk **Mark reviewed**, conversational review assent, or agent-authored
+  review decisions;
+- automatic authorship detection, plagiarism detection, factual verification,
+  or “AI detector” scoring;
+- source-content browsing that bypasses Sources access/redaction policy;
+- provenance overlays across multiple documents at once; and
+- user-configurable color themes or per-axis overlay toggles beyond the
+  accessible built-in treatment.

--- a/.data/designs/co-work/provenance-surface/implementation-plan.md
+++ b/.data/designs/co-work/provenance-surface/implementation-plan.md
@@ -1,0 +1,281 @@
+# Provenance surface implementation plan
+
+**Parent contract:** [README.md](README.md)
+
+**Delivery status:** implemented as one end-to-end vertical slice, with backend
+and frontend checkpoints that remain independently testable. This plan records
+the as-built boundary; the follow-ons under **Deferred** have not shipped.
+
+## Workstreams and sequence
+
+### 0. Freeze the contract
+
+- [x] Give Provenance a first-class rail boundary and a mutually exclusive
+  `provenance` editor lens.
+- [x] Preserve source, authorship, review, and attester/basis as independent
+  axes.
+- [x] Define current, unrecorded, unresolved, ambiguous, and conflicting
+  coverage without last-write-wins inference.
+- [x] Define **Mark reviewed** as an append-only constrained supersession.
+- [x] Reserve hover for explanation and stable detail for action.
+- [x] Record accessibility, narrow-layout, focus, scroll, loading, error, and
+  read-only behavior.
+
+### 1. Authoritative backend projection
+
+Produce a typed, additive provenance projection for the open document. The
+server projection should carry enough immutable data for the client to resolve
+exact spans and explain history without reconstructing database semantics.
+
+Required fields per attestation or effective item:
+
+- permanent attestation ID and `supersedes_id`;
+- target kind, document/version/span identity, complete quote selector for
+  spans, and frozen structured-head digest;
+- source object;
+- authorship kind and contributors;
+- human-review state and reviewers;
+- attester, basis, creation time, and canonical digest;
+- effective/superseded state and target-head relation; and
+- history or a stable way to join it.
+
+Projection rules:
+
+- identify effective leaves without deleting history;
+- reject malformed/forked supersession from mutation paths and surface any
+  pre-existing inconsistency as an issue;
+- expose document-version coverage as current only at the same structured head;
+- leave changed-head exact span re-anchoring to the hydrated editor, which owns
+  current text geometry, and mark successful client reanchors inspectable but
+  not review-actionable;
+- use a current document-level record as fallback coverage, let explicit spans
+  override it, and preserve incompatible peer-span conflicts rather than
+  selecting by time; and
+- remain additive to existing document reads so older clients can ignore it.
+
+As built, `GET /api/truth/doc/<document_id>?store_id=...` retains the legacy
+`authorship_attestations` field and adds `provenance` with schema
+`cowork-provenance-view/v1`. That view carries the current structured head, an
+optional document fallback, explicit span targets, complete document history,
+and diagnostic summary counts. Each target carries currentness, resolution,
+review eligibility, an optional issue, effective leaves, and lineage history.
+Missing or malformed target rows remain visible as issues and in complete
+history instead of breaking or disappearing from the read.
+
+### 2. Constrained review action
+
+Add or extend one document-scoped route for **Mark reviewed**. The command
+contains the selected effective attestation identity, current target/head
+precondition, and idempotency key. The server:
+
+1. authenticates the enrolled local session and CSRF boundary;
+2. consumes a one-time gesture bound to operation, Folder, document, actor,
+   target, expected head, prior attestation, and exact body;
+3. verifies the prior record is an effective leaf on the same document and
+   target;
+4. rechecks current target validity under the document/Yjs lifecycle locks;
+5. derives the new record by preserving source, authorship, contributors, and
+   frozen target;
+6. sets review to `reviewed`, reviewer to the acting enrolled principal, basis
+   to `user_attestation` with a reference to the predecessor, and
+   `supersedes_id` to the prior record; the predecessor retains its original
+   automatic, proposal, migration, or legacy basis in history;
+7. appends idempotently and emits the normal provenance invalidation event; and
+8. returns a compact receipt, after which the client repulls the authoritative
+   document projection.
+
+Before that request, the editor-owned mutation barrier disables editing,
+retries and flushes pending persistence, verifies canonical state, and compacts
+the current Y.Doc to one durable structured head. While the editor remains
+locked, the dedicated Provenance provider forces a fresh document pull. The
+panel re-finds the same effective leaf and rechecks the returned head,
+eligibility, unique span resolution, and incompatible peer overlap. The lock
+stays held through the append and the authoritative post-action repull. Any
+drift fails closed before a review attestation can be appended.
+
+No route in this slice accepts “make this human-authored” as a side effect of
+review. An actor change, stale head, stale selector, already-superseded record,
+fork attempt, wrong document, retired document, or idempotency collision gets a
+typed failure.
+
+The as-built route is
+`POST /api/truth/doc/<document_id>/authorship-attestations/<attestation_id>/human-review?store_id=...`.
+Its exact gesture-bound body contains `attestation_id`,
+`expected_structured_head_sha256`, and `idempotency_key`. A successful fresh
+append or an idempotent replay returns the portable superseding attestation;
+the client does not clear the retry key until a forced authoritative refresh
+actually contains the reviewed successor.
+
+### 3. Frontend contracts and projection
+
+- Extend the typed document payload to retain rich attestations/effective
+  provenance rather than dropping them into the older three-state trust span.
+- Use a dedicated Provenance provider and panel projection. The provider shares
+  the authoritative open-document snapshot source, including sequence-guarded
+  refresh publication, but does not turn Review's domain contract into a
+  general ledger transport.
+- Re-resolve complete quote selectors against the hydrated ProseMirror
+  document and classify current-head, uniquely reanchored, absent, and
+  ambiguous results. A unique reanchor is paintable/inspectable but is not
+  sufficient authority for a durable review action in this slice.
+- Treat current document-version coverage as a baseline only when its frozen
+  head matches the current head.
+- Compute uncovered text-node ranges as `unrecorded`; never infer human
+  authorship from the absence of a span.
+- Apply explicit spans over current document-level fallback; combine compatible
+  peer-span overlap and project incompatible peer-span overlap as conflict.
+- Treat an unsynchronized local-human edit as immediate head invalidation:
+  withhold the older document-level fallback, downgrade exact spans to
+  re-anchor-for-inspection, and restore current coverage only after a matching
+  fresh authoritative projection arrives.
+- Keep prior data during background refresh and distinguish first load, empty,
+  failure, and read-only state.
+
+### 4. Editor lens and hover
+
+- Extend `CoworkEditorLens` to `neutral | review | provenance | truth`.
+- Render provenance decorations only for the provenance lens. Remove
+  provenance treatment from the Truth lens so the two surfaces have clean
+  ownership.
+- Apply independent authorship and review classes/data attributes plus issue
+  treatment. Decorations are view-only and excluded from serialized content.
+- Expose compact hover/focus metadata through a clamped, dismissible card.
+- Make hover passive and action-free. It points people to Provenance for stable
+  details; it never performs navigation or mutation itself.
+- Preserve temporary Chat/Working-on highlights and clear incompatible
+  persistent focus on lens changes.
+- Verify no document transaction, selection rewrite, scroll, or undo entry is
+  introduced by a lens or hover change.
+
+### 5. Rail and stable panel
+
+- Insert **Provenance** between Review and Truth in the shared roving tablist.
+- Persist the selected pane and an independent Provenance list scroll per full
+  Folder/document identity.
+- Implement summary counts, filters, document-order rows, target-lineage
+  detail/history, complete document history, and empty/error/read-only states.
+- Keep list-row activation to detail and compatible focus. Reveal a uniquely
+  resolved span only from the explicit **Show in document** action and only
+  once; unresolved/ambiguous items open detail without a guessed scroll.
+- Place **Mark reviewed** only in stable detail and enable it only for an
+  effective, writable, exact-current-head AI/mixed document-version or span
+  target not already reviewed.
+  A uniquely reanchored changed-head span explains why it is inspect-only.
+- On success, retain geometry while repulling; on failure, retain the previous
+  projection and give a typed recovery path.
+- Ensure all four tabs and every action remain usable in narrow layout, at 200%
+  zoom, by touch, and by keyboard.
+
+### 6. Documentation and release evidence
+
+- Update `cowork/content-provenance` with the read/action surface and enrolled
+  local-review semantics.
+- Update `cowork/truth-surface` so provenance is a peer boundary and the Truth
+  lens owns expressions, not document-authorship treatment.
+- Validate agent knowledge and rebuild its index.
+- Run focused backend/frontend tests, TypeScript type-check, production build,
+  `git diff --check`, and the relevant existing Co-work regression lanes.
+- Record actual commands and outcomes in the PR handoff. Do not convert an
+  unrun or timed-out check into a pass.
+
+## Test matrix
+
+| Layer | Required cases |
+|---|---|
+| Provenance model | effective leaf; linear supersession; existing fork surfaced; source/authorship preserved; reviewer/attester independent |
+| Review route | success; idempotent replay; idempotency mismatch; wrong document/target; already superseded; stale head; retired/read-only; missing CSRF/session/gesture; actor change |
+| Read projection | document target at matching head; document target after head drift; span selector payload; append history; malformed/conflicting records preserved as issue |
+| Span resolution | unique exact/prefix/suffix; missing; ambiguous repeated quote; compatible overlap; incompatible overlap; Unicode and block boundaries |
+| Coverage | all text covered; partially covered complement; entirely unrecorded; empty document; version baseline plus span refinement; stale version never covers new text; local edit immediately withholds old fallback |
+| Decoration | lens exclusivity; authorship classes; independent review classes; issue override; non-color attributes; no serialization/undo/selection/scroll mutation |
+| Hover | pointer and editor caret/focus open; Escape/departure/lens/doc change close; viewport clamp; complete labels; no actions |
+| Panel | summary/filter/list/inline detail/target history/complete document history; passive row focus; explicit one-shot Show in document; unresolved no-scroll; expanding detail preserves list scroll; background refresh geometry; loading/error/empty/read-only |
+| Rail | four-tab roving focus; Home/End; persisted pane; independent pane scroll; narrow-width reachability; Chat remains neutral |
+| Action UI | editor persistence lock; forced fresh preflight; fresh-head/leaf/anchor/peer-conflict recheck; eligibility; pending dedupe; stable idempotency key across ambiguous refresh; successful authoritative repull; typed stale/actor/idempotency recovery; AI remains AI after review |
+| Regression | Review/Truth/Chat lenses; temporary highlights; proposal and claim navigation; paste provenance outbox; Yjs persistence; production build and type-check |
+| Accessibility | state names without color; forced-colors; visible focus; keyboard-only detail/action; touch path; 200% zoom; reduced motion |
+
+## End-to-end acceptance scenarios
+
+### AI passage becomes reviewed
+
+Given a uniquely resolved exact-current-head span recorded as AI-authored and
+not reviewed,
+when the enrolled user opens its stable Provenance detail and chooses **Mark
+reviewed**, then the server appends a superseding attestation, the refreshed
+overlay retains AI authorship, the review treatment changes to reviewed, and
+history shows both records and the enrolled reviewer.
+
+### Changed document-level target
+
+Given a document-version attestation and a later document head, when Provenance
+opens, then the old record remains available in history but it does not color
+the changed current document as if every word retained that attribution.
+Current text without another exact record is unrecorded.
+
+### Duplicate quote
+
+Given one changed-head span selector which now resolves to two passages, when Provenance
+opens, then neither passage is guessed. The panel reports ambiguous/stale
+targeting, red wavy issue treatment is used only where a safe issue anchor
+exists, and **Mark reviewed** is disabled until a fresh exact target is made.
+
+### Overlap conflict
+
+Given two independently effective overlapping spans with incompatible source,
+authorship, or review assertions, when the lens projects them, then the overlap
+is a conflict and detail lists both records. Creation time does not select a
+winner.
+
+### Failure is not emptiness
+
+Given prior provenance data and a failed refresh, when the request fails, then
+the prior overlay and panel geometry remain visible with an error and Retry.
+The UI never says there is no provenance merely because the server was
+unavailable.
+
+### Local edit before review
+
+Given a pulled document-wide attribution and a later local-human edit, when the
+edit has not yet settled to a matching authoritative head, then the old
+document-wide record does not paint the new text and **Mark reviewed** is
+unavailable. When the person invokes review, the editor is locked while
+persistence settles and Provenance is forcibly refreshed; the action continues
+only if the fresh head, effective leaf, unique target, and peer-conflict check
+all still agree.
+
+### Historical record without current geometry
+
+Given an append-only record whose old or malformed target cannot project into
+the current editor, when Provenance opens, then it remains inspectable under
+**Complete provenance history** without receiving a guessed range or becoming
+review-actionable.
+
+### Lens non-mutation
+
+Given an editor with selection, scroll, and undo history, when the user cycles
+Review → Provenance → Truth → Chat and opens/closes hover details, then content,
+Y.Doc, selection, scroll, and undo history are unchanged; only decorations and
+compatible persistent focus differ.
+
+## Delivery gates
+
+The PR is ready only after:
+
+- every acceptance scenario above has automated coverage or an explicitly
+  recorded manual reason;
+- backend and frontend focused suites pass;
+- TypeScript type-check and production build pass;
+- agent documentation validates and the knowledge index rebuilds;
+- `git diff --check` passes;
+- no `.claude` setting or generated document-kernel runtime artifact is staged
+  with this feature; and
+- the handoff names deferred work without implying it shipped.
+
+## Deferred follow-ons
+
+The deferred list in [README.md](README.md) is normative. The highest-value
+follow-ons are a general append-only correction ceremony, authenticated
+multi-user reviewers, proven change-map propagation, richer authorized source
+inspection, and user-configurable visual channels. None should be smuggled into
+the first review action or inferred from arbitrary editor changes.

--- a/.data/designs/co-work/truth-surface/README.md
+++ b/.data/designs/co-work/truth-surface/README.md
@@ -1,17 +1,26 @@
 # Co-work Truth surface
 
-**Status:** Accepted design and implementation contract, amended 2026-08-09
-for the AI-assisted interaction model.
+**Status:** Accepted design and implementation contract for the peer
+Provenance boundary and AI-assisted interaction model.
 
 ## Decision
 
-Co-work has three first-class rail surfaces:
+Co-work has four first-class rail surfaces:
 
 1. **Review** is the modification inbox for proposals, flags, evaluation results,
    and claims that require a decision.
-2. **Truth** is the place to observe and manage the claim ledger beneath the
+2. **Provenance** is the place to inspect document source, authorship,
+   human-review, attester, and basis records and to make constrained
+   append-only review attestations.
+3. **Truth** is the place to observe and manage the claim ledger beneath the
    work.
-3. **Chat** is the conversational interaction surface.
+4. **Chat** is the conversational interaction surface.
+
+The peer Provenance contract supersedes this document wherever older text
+placed document-authorship treatments inside Truth. See
+`../provenance-surface/README.md`. Truth still owns and explains provenance of
+Truth-domain records such as candidate preparation, evidence acquisition, and
+human claim decisions.
 
 Truth is intentionally both an observability surface and a modification
 surface. It is not a renamed Review queue. A person can inspect what the
@@ -33,7 +42,8 @@ and database rows remain implementation language rather than routine UI copy.
 
 | Term | Meaning in Co-work |
 |---|---|
-| **Truth** | The first-class rail surface for observing and managing claims, their document expressions, provenance, and lifecycle. |
+| **Provenance** | The first-class rail surface for document source, authorship, human review, attester/basis, target health, and append-only review history. |
+| **Truth** | The first-class rail surface for observing and managing claims, their document expressions, evidence, decision/acquisition provenance, and lifecycle. |
 | **Claim** | A proposition recorded in the append-only Truth ledger. A claim is not automatically a fact. |
 | **Fact** | A filter result, not a claim kind: a claim currently held as authoritative. It has confirmed base status, is current-valid, is not redacted or voided, and has no active needs-review overlay. |
 | **Expression** | A document passage where a claim is said, with a role such as quote, paraphrase, summary, or instantiation. |
@@ -93,7 +103,9 @@ evaluating an exact fetched source passage.
 
 ## Information architecture
 
-The rail tabs are **Review | Truth | Chat** on desktop and narrow layouts.
+The rail tabs are **Review | Provenance | Truth | Chat** on desktop and narrow
+layouts. The tablist keeps all four tabs keyboard- and scroll-reachable rather
+than clipping one at narrow widths.
 Truth has two independently meaningful dimensions:
 
 - Location: **This document** by default, or **Folder**.
@@ -171,13 +183,15 @@ unbounded fixed block above that body that compresses the proposal workspace.
 The editor has an explicit view-only lens state:
 
 - `review`: tracked proposals, flags, and evaluation-result anchors;
-- `truth`: expression anchors and provenance treatments; or
+- `provenance`: document source, authorship, human-review, and target-health
+  treatments;
+- `truth`: expression anchors; or
 - `neutral`: neither persistent ledger overlay.
 
 The active rail surface controls the default lens: Review selects `review`,
-Truth selects `truth`, and Chat selects `neutral`. Temporary passage highlights
-from Chat, Working on, or an explicit navigation command are independent of the
-lens.
+Provenance selects `provenance`, Truth selects `truth`, and Chat selects
+`neutral`. Temporary passage highlights from Chat, Working on, or an explicit
+navigation command are independent of the lens.
 
 Changing lens is a display operation only. It must not:
 
@@ -199,6 +213,12 @@ terminal states, and carries `base_status` separately from `needs_review`.
 Document mode joins that projection to expressions for the current document.
 Folder mode reads the whole selected ledger. SSE remains an invalidation signal;
 the client repulls authoritative state.
+
+Provenance follows the same ownership rule with its own typed provider and
+panel projection. It may share the authoritative open-document snapshot source,
+but neither Truth nor Review becomes a generic provenance transport. Its editor
+persistence barrier and forced-fresh review preflight are specified by the peer
+Provenance contract.
 
 All modifications use canonical Truth and Co-work operations. The UI does not
 write status rows, expressions, or receipts directly. Human decisions remain

--- a/chrome_extension/background.js
+++ b/chrome_extension/background.js
@@ -462,8 +462,9 @@ async function applyMutation(params) {
       }
 
       case "focus_or_create_tab": {
-        const url = params.url || "";
+        const url = (params.url || "").replace(/\/+$/, "");
         const targetHash = params.target_hash || "";
+        const preservePath = params.preserve_path === true;
         if (!url) {
           results.status = "error";
           results.details = { error: "No url provided" };
@@ -477,7 +478,15 @@ async function applyMutation(params) {
             (a, b) => (b.lastAccessed || 0) - (a.lastAccessed || 0)
           );
           const tab = sorted[0];
-          const newUrl = targetHash ? url + "/" + targetHash : undefined;
+          // Trusted app launches deliver a one-time bootstrap in the fragment.
+          // Keep the selected document route/query intact so the already-open
+          // page receives a hashchange instead of being replaced by /app/.
+          const currentUrl = (tab.url || "").split("#", 1)[0];
+          const newUrl = targetHash
+            ? preservePath && currentUrl
+              ? currentUrl + targetHash
+              : url + "/" + targetHash
+            : undefined;
           await chrome.tabs.update(tab.id, { active: true, ...(newUrl ? { url: newUrl } : {}) });
           await chrome.windows.update(tab.windowId, { focused: true });
           results.details = { created: false, tab_id: tab.id, focused: true };
@@ -485,7 +494,9 @@ async function applyMutation(params) {
           // No existing tab — create one
           const fullUrl = targetHash ? url + "/" + targetHash : url;
           const newTab = await chrome.tabs.create({ url: fullUrl });
-          results.details = { created: true, tab_id: newTab.id, url: fullUrl };
+          // The fragment may contain a one-time bearer. Do not echo it through
+          // the native-messaging result file after Chrome has accepted it.
+          results.details = { created: true, tab_id: newTab.id };
         }
         break;
       }

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.materialize.test.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.materialize.test.tsx
@@ -1,8 +1,10 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { Editor } from "@tiptap/core";
 import { ySyncPluginKey } from "@tiptap/y-tiptap";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
+
+import { resetLocalIdentityForTests } from "../../../security/localIdentity";
 
 import { bootstrapCoworkYdoc } from "../documents/bootstrapCoworkYdoc";
 import { HttpCoworkMaterializationClient } from "../materialization/HttpCoworkMaterializationClient";
@@ -20,6 +22,7 @@ import { resolveQuoteAnchor } from "../suggestions/anchor";
 import { buildEditorExtensions } from "../editor/extensions";
 import { serializeCoworkEditorMarkdown } from "../editor/serializeCoworkMarkdown";
 import { projectCoworkLedgerDecorations } from "../editor/ledgerDecorations";
+import { authenticatedHumanAuthorityFetch } from "../testSupport/authenticatedHumanAuthorityFetch";
 import {
   assertCanonicalCoworkEditorState,
   CoworkBridgeEditor,
@@ -27,6 +30,8 @@ import {
 import type { CoworkSittingWorkspace } from "./sittingWorkspace";
 
 describe("CoworkBridgeEditor explicit Markdown Save", () => {
+  beforeEach(() => resetLocalIdentityForTests());
+
   it("refuses to compact a legacy tracked-suggestion projection", async () => {
     const initialized = await bootstrapCoworkYdoc(
       new TextEncoder().encode("The quick brown fox"),
@@ -299,7 +304,10 @@ describe("CoworkBridgeEditor explicit Markdown Save", () => {
     });
 
     const requests: Record<string, unknown>[] = [];
-    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchImpl = authenticatedHumanAuthorityFetch(async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
       const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
       requests.push(body);
       if (requests.length === 1) {
@@ -471,7 +479,10 @@ describe("CoworkBridgeEditor explicit Markdown Save", () => {
     });
     const initialServerHead = (await server.pull({})).structuredHeadSha256;
     const saveRequests: Record<string, unknown>[] = [];
-    const saveFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+    const saveFetch = authenticatedHumanAuthorityFetch(async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
       const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
       saveRequests.push(body);
       return new Response(

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.pasteProvenance.test.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.pasteProvenance.test.tsx
@@ -2,8 +2,13 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Editor } from "@tiptap/core";
 import { DOMParser as ProseMirrorDOMParser } from "@tiptap/pm/model";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
+
+import {
+  refreshLocalIdentity,
+  resetLocalIdentityForTests,
+} from "../../../security/localIdentity";
 
 import { bootstrapCoworkYdoc } from "../documents/bootstrapCoworkYdoc";
 import { InMemoryCoworkYdocTransport } from "../persistence/InMemoryCoworkYdocTransport";
@@ -44,6 +49,22 @@ const ACTOR = {
   ref: "dashboard-user",
   identity_status: "local_actor_ref",
 } as const;
+const LOCAL_PRINCIPAL = {
+  actor: {
+    schema: "wb.actor-ref/v1" as const,
+    issuer_authority_id: "wia_test",
+    subject: "wactor_test",
+    kind: "human" as const,
+    tenant_scope_id: "wts_test",
+  },
+  origin: window.location.origin,
+  audience: "work-buddy-dashboard",
+  session_expires_at: 99,
+  rotation_due_at: 50,
+  assurance: "enrolled_local_session" as const,
+};
+
+beforeEach(() => resetLocalIdentityForTests());
 
 const mountPasteEditor = async (
   recorder: CoworkPasteProvenanceRecorder,
@@ -538,6 +559,17 @@ describe("CoworkBridgeEditor paste provenance", () => {
       )
       .mockResolvedValueOnce();
     const actorFetch = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input) === "/api/local-identity/session/csrf") {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            authenticated: true,
+            principal: LOCAL_PRINCIPAL,
+            csrf_token: "wbc_actor_change",
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
       expect(String(input)).toBe("/api/truth/cowork/current-actor");
       return new Response(
         JSON.stringify({
@@ -563,7 +595,14 @@ describe("CoworkBridgeEditor paste provenance", () => {
           "The active identity changed before this attribution was saved. Confirm it again for the current person.",
         ),
       ).toBeVisible();
-      await waitFor(() => expect(actorFetch).toHaveBeenCalledOnce());
+      await waitFor(() =>
+        expect(
+          actorFetch.mock.calls.filter(
+            ([input]) =>
+              String(input) === "/api/truth/cowork/current-actor",
+          ),
+        ).toHaveLength(1),
+      );
       await new Promise((resolve) => window.setTimeout(resolve, 50));
       expect(recorder).toHaveBeenCalledOnce();
       expect(mounted.editor.getText()).toBe("Before pasted after");
@@ -750,13 +789,27 @@ describe("CoworkBridgeEditor paste provenance", () => {
     );
   }, 20_000);
 
-  it("hydrates read-only when actor lookup fails and recovers on direct retry", async () => {
-    const user = userEvent.setup();
+  it("keeps editing available and durably defers paste attribution when actor lookup fails", async () => {
     const recorder = vi.fn<CoworkPasteProvenanceRecorder>().mockResolvedValue();
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `missing-actor-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
     let actorAttempts = 0;
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input) === "/api/local-identity/session/csrf") {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              authenticated: true,
+              principal: LOCAL_PRINCIPAL,
+              csrf_token: "wbc_test",
+            }),
+            { headers: { "Content-Type": "application/json" } },
+          );
+        }
         expect(String(input)).toBe("/api/truth/cowork/current-actor");
         actorAttempts += 1;
         if (actorAttempts === 1) {
@@ -789,24 +842,126 @@ describe("CoworkBridgeEditor paste provenance", () => {
     try {
       mounted = await mountPasteEditor(recorder, {
         resolveActorFromServer: true,
+        outbox,
       });
       const editorSurface = screen.getByRole("textbox", {
         name: "Document editor",
       });
-      expect(await screen.findByText("Editing is paused.")).toBeVisible();
-      expect(editorSurface).toHaveAttribute("aria-readonly", "true");
-
-      await user.click(
-        screen.getByRole("button", { name: "Retry identity" }),
-      );
-      await waitFor(() =>
-        expect(editorSurface).toHaveAttribute("aria-readonly", "false"),
-      );
-      expect(screen.queryByText("Editing is paused.")).toBeNull();
+      await waitFor(() => expect(actorAttempts).toBe(1));
+      expect(editorSurface).toHaveAttribute("aria-readonly", "false");
+      expect(
+        screen.queryByText(/Reconnect Work Buddy to edit/i),
+      ).toBeNull();
 
       dispatchSimplePaste(mounted.editor);
-      await waitFor(() => expect(recorder).toHaveBeenCalledOnce());
-      expect(actorAttempts).toBe(2);
+      await waitFor(async () => {
+        const entries = await outbox.list();
+        expect(entries).toHaveLength(1);
+        expect(entries[0]).toMatchObject({
+          substantial: false,
+          status: "awaiting_determination",
+          requiresExplicitDetermination: true,
+          determination: unknownCoworkProvenanceDetermination(),
+        });
+      });
+      expect(recorder).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await refreshLocalIdentity();
+      });
+      await waitFor(() => expect(actorAttempts).toBe(2));
+      expect(
+        await screen.findByRole("dialog", {
+          name: "Where did this text come from?",
+        }),
+      ).toBeVisible();
+      expect(editorSurface).toHaveAttribute("aria-readonly", "false");
+      expect(
+        screen.queryByText(/Reconnect Work Buddy to edit/i),
+      ).toBeNull();
+    } finally {
+      mounted?.unmount();
+      vi.unstubAllGlobals();
+    }
+  }, 20_000);
+
+  it("keeps editing available while a launcher identity is absent and reconnects silently", async () => {
+    const recorder = vi.fn<CoworkPasteProvenanceRecorder>().mockResolvedValue();
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `missing-session-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    let sessionAttempts = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/local-identity/session/csrf") {
+          sessionAttempts += 1;
+          if (sessionAttempts === 1) {
+            return new Response(
+              JSON.stringify({
+                ok: true,
+                authenticated: false,
+                human_authority_available: false,
+              }),
+              { headers: { "Content-Type": "application/json" } },
+            );
+          }
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              authenticated: true,
+              principal: LOCAL_PRINCIPAL,
+              csrf_token: "wbc_reconnected",
+            }),
+            { headers: { "Content-Type": "application/json" } },
+          );
+        }
+        expect(url).toBe("/api/truth/cowork/current-actor");
+        return new Response(
+          JSON.stringify({
+            kind: "human",
+            ref: ACTOR.ref,
+            identity_status: ACTOR.identity_status,
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+
+    let mounted: MountedPasteEditor | undefined;
+    try {
+      mounted = await mountPasteEditor(recorder, {
+        resolveActorFromServer: true,
+        outbox,
+      });
+      const editorSurface = screen.getByRole("textbox", {
+        name: "Document editor",
+      });
+      await waitFor(() => expect(sessionAttempts).toBe(1));
+      expect(editorSurface).toHaveAttribute("aria-readonly", "false");
+      expect(screen.queryByRole("alert")).toBeNull();
+
+      dispatchSimplePaste(mounted.editor);
+      await waitFor(async () =>
+        expect((await outbox.list())[0]).toMatchObject({
+          status: "awaiting_determination",
+          requiresExplicitDetermination: true,
+        }),
+      );
+
+      await act(async () => {
+        await refreshLocalIdentity();
+      });
+      expect(
+        await screen.findByRole("dialog", {
+          name: "Where did this text come from?",
+        }),
+      ).toBeVisible();
+      expect(editorSurface).toHaveAttribute("aria-readonly", "false");
+      expect(screen.queryByRole("alert")).toBeNull();
+      expect(sessionAttempts).toBeGreaterThanOrEqual(2);
     } finally {
       mounted?.unmount();
       vi.unstubAllGlobals();

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.provenanceSettlement.test.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.provenanceSettlement.test.tsx
@@ -1,0 +1,61 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import type { Editor } from "@tiptap/core";
+import { describe, expect, it, vi } from "vitest";
+import * as Y from "yjs";
+
+import { bootstrapCoworkYdoc } from "../documents/bootstrapCoworkYdoc";
+import { InMemoryCoworkYdocTransport } from "../persistence/InMemoryCoworkYdocTransport";
+import { CoworkBridgeEditor } from "./CoworkBridgeEditor";
+
+describe("CoworkBridgeEditor provenance persistence settlement", () => {
+  it("reports an unchanged generation only after normal persistence compacts it", async () => {
+    const initialized = await bootstrapCoworkYdoc(
+      new TextEncoder().encode("Initial text"),
+    );
+    if (!initialized.ok) throw new Error(initialized.message);
+    const server = new InMemoryCoworkYdocTransport();
+    const empty = await server.pull({});
+    await server.push({
+      batch: initialized.snapshot,
+      baseSha256: empty.docSha256,
+      baseStructuredHeadSha256: empty.structuredHeadSha256,
+      baseYdocGeneration: empty.ydocGeneration,
+      compaction: {
+        snapshot: initialized.snapshot,
+        snapshotSha256: initialized.snapshotSha256,
+      },
+    });
+    const document = new Y.Doc();
+    let editor: Editor | null = null;
+    const settled = vi.fn();
+    const mounted = render(
+      <CoworkBridgeEditor
+        document={document}
+        transport={server}
+        seedMarkdown=""
+        onReady={(context) => {
+          editor = context.editor;
+        }}
+        onProvenancePersistenceSettled={settled}
+      />,
+    );
+    await screen.findByRole(
+      "textbox",
+      { name: "Document editor" },
+      { timeout: 10_000 },
+    );
+    await waitFor(() => expect(editor).not.toBeNull());
+    settled.mockClear();
+
+    act(() => {
+      editor!.commands.insertContentAt(editor!.state.doc.content.size, " changed");
+    });
+
+    await waitFor(() => expect(settled).toHaveBeenCalled(), { timeout: 10_000 });
+    const serverHead = (await server.pull({})).structuredHeadSha256;
+    expect(settled).toHaveBeenLastCalledWith(serverHead);
+
+    mounted.unmount();
+    document.destroy();
+  });
+});

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.tsx
@@ -42,6 +42,7 @@ import type {
   CoworkMaterializeReceipt,
   CoworkMaterializeRequest,
 } from "../materialization/contracts";
+import type { ProvenanceMutationBarrier } from "../provenance/view/contracts";
 import type { FeedbackCapture } from "../chat";
 import {
   CoworkFeedbackAffordance,
@@ -84,6 +85,11 @@ import {
   type CoworkProvenanceActorIdentity,
   type CoworkProvenanceDetermination,
 } from "../provenance";
+import {
+  initializeLocalIdentity,
+  refreshLocalIdentity,
+  subscribeLocalIdentity,
+} from "../../../security/localIdentity";
 
 /** What the host reports up once the canonical editor is mounted. */
 export interface CoworkEditorReadyContext {
@@ -141,6 +147,19 @@ export interface CoworkBridgeEditorProps {
   ) => void;
   readonly onMaterialized?: (receipt: CoworkMaterializeReceipt) => void;
   readonly onSittingWorkspace?: (workspace: CoworkSittingWorkspace | null) => void;
+  readonly onProvenanceMutationBarrier?: (
+    barrier: ProvenanceMutationBarrier | null,
+  ) => void;
+  /** Exact local-human edit signal; foreign hydration must not invalidate attribution. */
+  readonly onLocalProvenanceEdit?: () => void;
+  /**
+   * A normal persistence cycle durably flushed and compacted one unchanged
+   * editor generation. The consumer still verifies this head against a fresh
+   * provenance projection before treating attribution as current.
+   */
+  readonly onProvenancePersistenceSettled?: (
+    structuredHeadSha256: string,
+  ) => void;
   /** Narrow editor-owned exact-action capture seam lifted to the keyed live session. */
   readonly onActionSnapshotController?: (
     controller: CoworkActionSnapshotController | null,
@@ -476,7 +495,6 @@ function MountedBridgeEditor({
         pasteRecorderRef.current === undefined ||
         documentId === undefined ||
         storeId === undefined ||
-        resolvedProvenanceActor === undefined ||
         resolvedPasteProvenanceOutbox === undefined
       ) {
         return;
@@ -504,12 +522,15 @@ function MountedBridgeEditor({
                 persistence.docSha256,
             }),
       };
-      if (capture.substantial) {
+      if (capture.substantial || resolvedProvenanceActor === undefined) {
         const pendingCapture: CoworkPasteProvenanceCapture = {
           ...captureRequest,
-          substantial: true,
+          substantial: capture.substantial,
           basisKind: "user_attestation",
           determination: unknownCoworkProvenanceDetermination(),
+          ...(resolvedProvenanceActor === undefined
+            ? { requiresExplicitDetermination: true }
+            : {}),
           status: "awaiting_determination",
         };
         void resolvedPasteProvenanceOutbox
@@ -1017,13 +1038,12 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
   const [hydration, setHydration] = useState<{ readonly wasEmpty: boolean }>();
   const [hydrationError, setHydrationError] = useState<string>();
   const [attempt, setAttempt] = useState(0);
-  const provenanceEditingBlocked =
-    provenanceEnabled && provenanceActorState !== "ready";
-  const effectiveReadOnly =
-    (props.readOnly ?? false) || provenanceEditingBlocked;
+  const effectiveReadOnly = props.readOnly ?? false;
   const persistenceReadOnly = effectiveReadOnly || hydration === undefined;
   const editorRef = useRef<Editor | null>(null);
   const editGeneration = useRef(0);
+  const lastProvenanceSettlementGeneration = useRef(0);
+  const provenanceSettlementInFlight = useRef<Promise<void> | null>(null);
   const expectedFileSha256 = useRef(props.currentFileSha256 ?? null);
   const saveInFlight = useRef<Promise<void> | null>(null);
   const retryAttempt = useRef<{
@@ -1133,9 +1153,7 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
       if (effectiveReadOnly || props.canMaterialize === false) {
         publishMaterializationState({
           kind: "read_only",
-          reason: provenanceEditingBlocked
-            ? "Editing is paused until Co-work can bind provenance to the current identity."
-            : "This document cannot publish Markdown from this session.",
+          reason: "This document cannot publish Markdown from this session.",
         });
         return;
       }
@@ -1179,7 +1197,6 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
       effectiveReadOnly,
       props.canMaterialize,
       props.document,
-      provenanceEditingBlocked,
       publishMaterializationState,
     ],
   );
@@ -1328,6 +1345,49 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
     }
   }, [persistence]);
 
+  const settleProvenancePersistence = useCallback((): void => {
+    if (
+      props.onProvenancePersistenceSettled === undefined ||
+      provenanceSettlementInFlight.current !== null ||
+      editGeneration.current <= lastProvenanceSettlementGeneration.current ||
+      persistence.status !== "clean"
+    ) {
+      return;
+    }
+    const generation = editGeneration.current;
+    let retryForNewerGeneration = false;
+    const run = (async () => {
+      try {
+        await persistence.flush();
+        const editor = editorRef.current;
+        if (editor === null) return;
+        assertCanonicalCoworkEditorState(editor);
+        const receipt = await persistence.compact();
+        if (generation !== editGeneration.current) {
+          retryForNewerGeneration = true;
+          return;
+        }
+        lastProvenanceSettlementGeneration.current = generation;
+        props.onProvenancePersistenceSettled?.(
+          receipt.structuredHeadSha256,
+        );
+      } catch {
+        // Persistence publishes the actionable failure. Provenance remains
+        // dirty until a later successful settlement and fresh R2 projection.
+      } finally {
+        provenanceSettlementInFlight.current = null;
+        if (
+          retryForNewerGeneration &&
+          persistence.status === "clean" &&
+          editGeneration.current > lastProvenanceSettlementGeneration.current
+        ) {
+          queueMicrotask(settleProvenancePersistence);
+        }
+      }
+    })();
+    provenanceSettlementInFlight.current = run;
+  }, [persistence, props.onProvenancePersistenceSettled]);
+
   const settleForLifecycle = useCallback(async (): Promise<void> => {
     const currentEditor = editorRef.current;
     if (currentEditor === null) {
@@ -1437,6 +1497,9 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
         }
         const editor = editorRef.current;
         if (editor !== null) assertCanonicalCoworkEditorState(editor);
+        props.onProvenancePersistenceSettled?.(
+          response.structured_head_sha256,
+        );
         props.onSittingServerRefreshed?.();
       },
     }),
@@ -1444,15 +1507,51 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
       persistence,
       props.document,
       props.getProposalCatalog,
+      props.onProvenancePersistenceSettled,
       props.onSittingServerRefreshed,
       publishMaterializationState,
     ],
   );
 
+  const provenanceMutationBarrier = useMemo<ProvenanceMutationBarrier>(
+    () => ({
+      runWithSynchronizedDocument: async (operation) => {
+        const liveEditor = editorRef.current;
+        if (liveEditor === null) {
+          throw new Error("The document is still loading. Try again in a moment.");
+        }
+        const wasEditable = liveEditor.isEditable;
+        liveEditor.setEditable(false);
+        try {
+          if (persistence.lastError !== null || persistence.pendingBatchCount > 0) {
+            await persistence.retry();
+          }
+          await persistence.flush();
+          assertCanonicalCoworkEditorState(liveEditor);
+          const receipt = await persistence.compact();
+          return await operation({
+            structuredHeadSha256: receipt.structuredHeadSha256,
+          });
+        } finally {
+          if (wasEditable && !readOnlyRef.current && !liveEditor.isDestroyed) {
+            liveEditor.setEditable(true);
+          }
+        }
+      },
+    }),
+    [persistence],
+  );
+
+  useEffect(() => {
+    props.onProvenanceMutationBarrier?.(provenanceMutationBarrier);
+    return () => props.onProvenanceMutationBarrier?.(null);
+  }, [props.onProvenanceMutationBarrier, provenanceMutationBarrier]);
+
   useEffect(() => {
     const onUpdate = (_update: Uint8Array, origin: unknown): void => {
       if (!isLocalHumanOrigin(origin)) return;
       editGeneration.current += 1;
+      props.onLocalProvenanceEdit?.();
       retryAttempt.current = null;
       const fileSha256 = expectedFileSha256.current;
       if (fileSha256 !== null) {
@@ -1461,7 +1560,7 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
     };
     props.document.on("update", onUpdate);
     return () => props.document.off("update", onUpdate);
-  }, [props.document, publishMaterializationState]);
+  }, [props.document, props.onLocalProvenanceEdit, publishMaterializationState]);
 
   useEffect(() => {
     props.onMaterializationController?.(materializationController);
@@ -1500,6 +1599,14 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
     if (props.onSyncStatus === undefined) return;
     return persistence.subscribeStatus(props.onSyncStatus);
   }, [persistence, props.onSyncStatus]);
+
+  useEffect(
+    () =>
+      persistence.subscribeStatus((status) => {
+        if (status === "clean") settleProvenancePersistence();
+      }),
+    [persistence, settleProvenancePersistence],
+  );
 
   useEffect(() => {
     if (hydration === undefined || editorRef.current === null) return;
@@ -1559,7 +1666,19 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
     }
     setResolvedProvenanceActor(undefined);
     setProvenanceActorState("loading");
-    void provenanceClient.currentActor().then(
+    const resolveActor = async (): Promise<CoworkProvenanceActorIdentity> => {
+      const identity = provenanceActorAttempt > 0
+        ? await refreshLocalIdentity()
+        : await initializeLocalIdentity();
+      if (!identity.authenticated) {
+        throw new Error(
+          identity.reason ??
+            "This browser does not have an authenticated local Work Buddy session.",
+        );
+      }
+      return provenanceClient.currentActor();
+    };
+    void resolveActor().then(
       (actor) => {
         if (!active) return;
         setResolvedProvenanceActor(actor);
@@ -1582,6 +1701,16 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
   ]);
 
   useEffect(
+    () =>
+      subscribeLocalIdentity((identity) => {
+        if (identity.authenticated && provenanceActorState === "error") {
+          requestProvenanceActorRefresh();
+        }
+      }),
+    [provenanceActorState, requestProvenanceActorRefresh],
+  );
+
+  useEffect(
     () => () => {
       // In-app navigation awaits the explicit registry barrier. A direct host unmount has
       // no cancellable continuation, so dispose remains a best-effort fallback and must not
@@ -1593,21 +1722,6 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
 
   return (
     <section className="wb-cowork-editor" aria-label="Editor">
-      {hydration !== undefined && provenanceActorState === "error" ? (
-        <InlineAlert tone="danger" role="alert">
-          <strong>Editing is paused.</strong>
-          <span>
-            Co-work couldn’t bind paste attribution to the current identity.
-            You can still read the document.
-          </span>
-          <Button
-            size="small"
-            onClick={requestProvenanceActorRefresh}
-          >
-            Retry identity
-          </Button>
-        </InlineAlert>
-      ) : null}
       {hydrationError !== undefined ? (
         <InlineAlert tone="danger" role="alert" className="wb-cowork-editor__hydration-error">
           <strong>Document couldn’t be opened.</strong>

--- a/dashboard-react/src/apps/cowork/bridge/DomReviewAnchorController.test.ts
+++ b/dashboard-react/src/apps/cowork/bridge/DomReviewAnchorController.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   CoworkLedgerDecorations,
   projectCoworkLedgerDecorations,
+  setCoworkEditorLens,
 } from "../editor/ledgerDecorations";
 import { DomReviewAnchorController } from "./DomReviewAnchorController";
 
@@ -138,6 +139,75 @@ describe("DomReviewAnchorController", () => {
       editor.view.dom.querySelector('[data-wb-anchor-id="flag-1"]'),
     ).toHaveClass("wb-cowork-anchor--active");
 
+    controller.detachEditor();
+    editor.destroy();
+  });
+
+  it("reveals and visibly focuses a secondary compatible provenance target", () => {
+    const editor = new Editor({
+      element: document.createElement("div"),
+      content: "<p>Shared passage.</p>",
+      extensions: [
+        StarterKit.configure({ undoRedo: false }),
+        CoworkLedgerDecorations,
+      ],
+    });
+    const base = {
+      quoteAnchor: {
+        exact: "Shared passage",
+        prefix: "",
+        suffix: ".",
+      },
+      isDocumentDefault: false,
+      authorship: "ai" as const,
+      reviewStatus: "not_reviewed" as const,
+      currentness: "current" as const,
+      resolution: "resolved" as const,
+      source: "paste",
+      sourceDetail: "Provider: clipboard",
+      contributors: "No contributors recorded",
+      reviewers: "No reviewers recorded",
+      attester: "user-1",
+      basis: "user_attestation",
+      historyCount: 1,
+      effectiveCount: 1,
+      recordState: "recorded" as const,
+      authorshipFingerprint: "ai",
+      reviewFingerprint: "not_reviewed",
+      sourceFingerprint: "paste",
+    };
+    projectCoworkLedgerDecorations(editor, {
+      edits: [],
+      flags: [],
+      expressions: [],
+      claims: [],
+      provenance: [],
+      provenanceOverlay: [
+        { ...base, targetId: "primary", recordId: "record-primary" },
+        { ...base, targetId: "secondary", recordId: "record-secondary" },
+      ],
+    });
+    setCoworkEditorLens(editor, "provenance");
+    const mark = editor.view.dom.querySelector<HTMLElement>(
+      "[data-wb-provenance-ids]",
+    );
+    expect(mark).not.toBeNull();
+    const scrollIntoView = vi.fn();
+    if (mark !== null) mark.scrollIntoView = scrollIntoView;
+    const controller = new DomReviewAnchorController({
+      getEditorRoot: () => editor.view.dom,
+      getEditor: () => editor,
+    });
+    controller.attachEditor(editor);
+
+    controller.revealAnchor("secondary", "provenance", { flash: true });
+
+    expect(scrollIntoView).toHaveBeenCalledOnce();
+    const focused = editor.view.dom.querySelector<HTMLElement>(
+      "[data-wb-provenance-ids]",
+    );
+    expect(focused).toHaveClass("wb-cowork-anchor--active");
+    expect(focused).toHaveClass("wb-cowork-anchor--flash");
     controller.detachEditor();
     editor.destroy();
   });

--- a/dashboard-react/src/apps/cowork/bridge/DomReviewAnchorController.ts
+++ b/dashboard-react/src/apps/cowork/bridge/DomReviewAnchorController.ts
@@ -6,8 +6,9 @@
  * refresh cannot snap the editor back to a formerly activated passage.
  *
  * Every current anchor renders `data-wb-anchor-kind` plus
- * `data-wb-anchor-id`; old suggestion marks retain their JSON `data-id` for
- * adapter compatibility.
+ * `data-wb-anchor-id`; atomized compatible provenance overlaps additionally
+ * carry every target in `data-wb-provenance-ids`. Old suggestion marks retain
+ * their JSON `data-id` for adapter compatibility.
  */
 
 import type { Editor } from "@tiptap/core";
@@ -104,6 +105,19 @@ export class DomReviewAnchorController implements ReviewAnchorController {
         "[data-wb-claim-ids]",
       )) {
         if (parseStringList(element.getAttribute("data-wb-claim-ids")).includes(id)) {
+          matches.add(element);
+        }
+      }
+    }
+    if (kind === "provenance") {
+      for (const element of root.querySelectorAll<HTMLElement>(
+        "[data-wb-provenance-ids]",
+      )) {
+        if (
+          parseStringList(
+            element.getAttribute("data-wb-provenance-ids"),
+          ).includes(id)
+        ) {
           matches.add(element);
         }
       }

--- a/dashboard-react/src/apps/cowork/bridge/HttpCoworkDocClient.test.ts
+++ b/dashboard-react/src/apps/cowork/bridge/HttpCoworkDocClient.test.ts
@@ -1,8 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { resetLocalIdentityForTests } from "../../../security/localIdentity";
+import {
+  applicationRequest,
+  authenticatedHumanAuthorityFetch,
+} from "../testSupport/authenticatedHumanAuthorityFetch";
 
 import { HttpCoworkDocClient } from "./HttpCoworkDocClient";
 
 describe("HttpCoworkDocClient Verify setup", () => {
+  beforeEach(() => resetLocalIdentityForTests());
+
   it("sends the exact effective activation as a compare-and-set precondition", async () => {
     const configuration = {
       schema: "work-buddy.cowork-verify-configuration/v1",
@@ -18,7 +26,7 @@ describe("HttpCoworkDocClient Verify setup", () => {
       },
       criteria: [],
     };
-    const fetchImpl = vi.fn<typeof fetch>(async () =>
+    const fetchImpl = authenticatedHumanAuthorityFetch(async () =>
       new Response(JSON.stringify({ ok: true, configuration }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -38,11 +46,15 @@ describe("HttpCoworkDocClient Verify setup", () => {
       ),
     ).resolves.toEqual(configuration);
 
-    const [url, init] = fetchImpl.mock.calls[0];
+    const [url, init] = applicationRequest(fetchImpl) ?? [];
     expect(url).toBe(
       "/api/truth/doc/doc-1/verify/criteria/terminology_exact_match?store_id=store-1",
     );
     expect(init?.method).toBe("PATCH");
+    expect(init?.headers).toMatchObject({
+      "X-WB-CSRF": "test-csrf-token",
+      "X-WB-Gesture": "test-gesture-1",
+    });
     expect(JSON.parse(String(init?.body))).toEqual({
       enabled: false,
       expected_activation_id: "activation-1",
@@ -50,7 +62,7 @@ describe("HttpCoworkDocClient Verify setup", () => {
   });
 
   it("keeps a Co-think lifecycle action bound to the exact item hash", async () => {
-    const fetchImpl = vi.fn<typeof fetch>(async () =>
+    const fetchImpl = authenticatedHumanAuthorityFetch(async () =>
       new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -64,7 +76,7 @@ describe("HttpCoworkDocClient Verify setup", () => {
 
     await client.actOnCothink("item-1", "park", "item-sha");
 
-    const [url, init] = fetchImpl.mock.calls[0];
+    const [url, init] = applicationRequest(fetchImpl) ?? [];
     expect(url).toBe(
       "/api/truth/doc/doc-1/cothink/items/item-1/actions?store_id=store-1",
     );
@@ -75,7 +87,7 @@ describe("HttpCoworkDocClient Verify setup", () => {
   });
 
   it("routes Discuss with the exact Co-think item hash into Chat", async () => {
-    const fetchImpl = vi.fn<typeof fetch>(async () =>
+    const fetchImpl = authenticatedHumanAuthorityFetch(async () =>
       new Response(
         JSON.stringify({
           ok: true,
@@ -100,7 +112,7 @@ describe("HttpCoworkDocClient Verify setup", () => {
       conversationId: "conversation-1",
       messageId: "message-1",
     });
-    const [url, init] = fetchImpl.mock.calls[0];
+    const [url, init] = applicationRequest(fetchImpl) ?? [];
     expect(url).toBe(
       "/api/truth/doc/doc-1/cothink/items/item-1/actions?store_id=store-1",
     );
@@ -111,7 +123,7 @@ describe("HttpCoworkDocClient Verify setup", () => {
   });
 
   it("maps only the typed safe Verify inspection projection", async () => {
-    const fetchImpl = vi.fn<typeof fetch>(async () =>
+    const fetchImpl = authenticatedHumanAuthorityFetch(async () =>
       new Response(
         JSON.stringify({
           ok: true,
@@ -257,7 +269,7 @@ describe("HttpCoworkDocClient Verify setup", () => {
       },
       criteria: [],
     };
-    const fetchImpl = vi.fn<typeof fetch>(async () =>
+    const fetchImpl = authenticatedHumanAuthorityFetch(async () =>
       new Response(JSON.stringify({ ok: true, configuration }), {
         status: 201,
         headers: { "Content-Type": "application/json" },
@@ -276,7 +288,7 @@ describe("HttpCoworkDocClient Verify setup", () => {
       limitations: ["Negation can be necessary."],
     });
 
-    const [url, init] = fetchImpl.mock.calls[0] ?? [];
+    const [url, init] = applicationRequest(fetchImpl) ?? [];
     expect(url).toBe(
       "/api/truth/doc/doc-1/verify/criteria/drafts?store_id=store-1",
     );
@@ -303,7 +315,7 @@ describe("HttpCoworkDocClient Verify setup", () => {
       },
       criteria: [],
     };
-    const fetchImpl = vi.fn<typeof fetch>(async () =>
+    const fetchImpl = authenticatedHumanAuthorityFetch(async () =>
       new Response(JSON.stringify({ ok: true, configuration }), {
         status: 201,
         headers: { "Content-Type": "application/json" },
@@ -324,7 +336,7 @@ describe("HttpCoworkDocClient Verify setup", () => {
       }),
     ).resolves.toEqual(configuration);
 
-    const [url, init] = fetchImpl.mock.calls[0] ?? [];
+    const [url, init] = applicationRequest(fetchImpl) ?? [];
     expect(url).toBe(
       "/api/truth/doc/doc-1/verify/checks?store_id=store-1",
     );

--- a/dashboard-react/src/apps/cowork/bridge/HttpCoworkDocClient.ts
+++ b/dashboard-react/src/apps/cowork/bridge/HttpCoworkDocClient.ts
@@ -20,6 +20,10 @@ import type {
   VerifyRunInspection,
 } from "../rail/contracts";
 import { coworkHumanAuthorityHeaders } from "../../../security/humanAuthority";
+import {
+  CoworkHttpError,
+  normalizeCoworkError,
+} from "../providers/errors";
 
 type JsonObject = Record<string, unknown>;
 
@@ -66,6 +70,11 @@ export interface CoworkDocClient {
   createVerifyCheck?(
     check: VerifyCheckInput,
   ): Promise<R2VerificationConfiguration>;
+  markProvenanceReviewed?(
+    attestationId: string,
+    expectedStructuredHeadSha256: string,
+    idempotencyKey: string,
+  ): Promise<void>;
 }
 
 export interface HttpCoworkDocClientOptions {
@@ -111,6 +120,50 @@ export class HttpCoworkDocClient implements CoworkDocClient {
       throw new Error(`doc read failed with status ${String(response.status)}`);
     }
     return (await response.json()) as R2DocPayload;
+  }
+
+  async markProvenanceReviewed(
+    attestationId: string,
+    expectedStructuredHeadSha256: string,
+    idempotencyKey: string,
+  ): Promise<void> {
+    const body = {
+      attestation_id: attestationId,
+      expected_structured_head_sha256: expectedStructuredHeadSha256,
+      idempotency_key: idempotencyKey,
+    };
+    const authorityHeaders = await this.#authority("provenance.review", body);
+    const response = await this.#fetch(
+      `/api/truth/doc/${encodeURIComponent(this.#documentId)}/authorship-attestations/${encodeURIComponent(attestationId)}/human-review?store_id=${encodeURIComponent(this.#storeId)}`,
+      {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json", ...authorityHeaders },
+        body: JSON.stringify(body),
+      },
+    );
+    const payload = objectValue(await response.json().catch(() => ({})));
+    if (!response.ok) {
+      throw new CoworkHttpError(
+        normalizeCoworkError(
+          payload,
+          response.status,
+          "This passage could not be marked reviewed.",
+        ),
+      );
+    }
+    const receipt = objectValue(payload.attestation);
+    const scope = objectValue(receipt.scope);
+    const review = objectValue(receipt.human_review);
+    if (
+      payload.ok !== true ||
+      stringValue(receipt.attestation_id).length === 0 ||
+      stringValue(receipt.supersedes_id) !== attestationId ||
+      stringValue(scope.structured_head_sha256) !== expectedStructuredHeadSha256 ||
+      stringValue(review.status) !== "reviewed"
+    ) {
+      throw new Error("The provenance review returned an invalid receipt.");
+    }
   }
 
   async setVerifyCriterionEnabled(

--- a/dashboard-react/src/apps/cowork/bridge/LiveReviewRailProvider.test.ts
+++ b/dashboard-react/src/apps/cowork/bridge/LiveReviewRailProvider.test.ts
@@ -195,6 +195,9 @@ describe("LiveReviewRailProvider", () => {
     expect(proposals.mock.calls[0]?.[0]).toEqual([
       expect.objectContaining({ proposal_id: "newer" }),
     ]);
+    await expect(provider.loadPayload()).resolves.toMatchObject({
+      open_proposals: [expect.objectContaining({ proposal_id: "newer" })],
+    });
   });
 
   it("does not publish an older pull that resolves before the newer pull", async () => {

--- a/dashboard-react/src/apps/cowork/bridge/LiveReviewRailProvider.ts
+++ b/dashboard-react/src/apps/cowork/bridge/LiveReviewRailProvider.ts
@@ -66,11 +66,13 @@ export class LiveReviewRailProvider implements ReviewRailProvider {
   readonly #invalidationListeners = new Set<ReviewInvalidationListener>();
   readonly #proposalsListeners = new Set<ProposalsListener>();
   readonly #dataListeners = new Set<ReviewDataListener>();
+  readonly #payloadListeners = new Set<() => void>();
   #lastProposals: readonly ProposalInput[] | null = null;
   #lastData: ReviewRailData | null = null;
   #pendingKey: { readonly fingerprint: string; readonly key: string } | null = null;
   #loadSequence = 0;
   #latestLoad: Promise<ReviewRailData> | null = null;
+  #lastPayload: Awaited<ReturnType<CoworkDocClient["fetchDoc"]>> | null = null;
 
   constructor(options: LiveReviewRailProviderOptions) {
     this.#options = options;
@@ -97,8 +99,10 @@ export class LiveReviewRailProvider implements ReviewRailProvider {
 
     this.#lastProposals = mapped.proposalInputs;
     this.#lastData = mapped.railData;
+    this.#lastPayload = payload;
     for (const listener of this.#proposalsListeners) listener(mapped.proposalInputs);
     for (const listener of this.#dataListeners) listener(mapped.railData);
+    for (const listener of this.#payloadListeners) listener();
     return mapped.railData;
   }
 
@@ -280,5 +284,26 @@ export class LiveReviewRailProvider implements ReviewRailProvider {
     return () => {
       this.#dataListeners.delete(listener);
     };
+  }
+
+  /** Shared raw R2 snapshot for independent bounded-context projections. */
+  async loadPayload(): Promise<Awaited<ReturnType<CoworkDocClient["fetchDoc"]>>> {
+    if (this.#lastPayload !== null) return this.#lastPayload;
+    if (this.#latestLoad !== null) await this.#latestLoad;
+    else await this.load();
+    if (this.#lastPayload === null) throw new Error("The document snapshot could not be loaded.");
+    return this.#lastPayload;
+  }
+
+  async refreshPayload(): Promise<Awaited<ReturnType<CoworkDocClient["fetchDoc"]>>> {
+    await this.load();
+    if (this.#lastPayload === null) throw new Error("The document snapshot could not be loaded.");
+    return this.#lastPayload;
+  }
+
+  subscribePayload(listener: () => void): ReviewUnsubscribe {
+    this.#payloadListeners.add(listener);
+    if (this.#lastPayload !== null) listener();
+    return () => this.#payloadListeners.delete(listener);
   }
 }

--- a/dashboard-react/src/apps/cowork/bridge/ledgerDecorationProjector.test.ts
+++ b/dashboard-react/src/apps/cowork/bridge/ledgerDecorationProjector.test.ts
@@ -4,6 +4,11 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { CoworkLedgerDecorations } from "../editor/ledgerDecorations";
 import type { ReviewRailData } from "../rail/contracts";
+import type {
+  ProvenanceAttestation,
+  ProvenanceData,
+  ProvenanceTarget,
+} from "../provenance/view/contracts";
 import {
   LedgerDecorationProjector,
   ledgerDecorationProjectionFromReview,
@@ -130,6 +135,77 @@ const data: ReviewRailData = {
   ],
 };
 
+const provenanceRecord = (
+  id: string,
+  kind: "document_version" | "document_span",
+  spanId: string | null,
+): ProvenanceAttestation => ({
+  attestationId: id,
+  at: "2026-08-12T12:00:00Z",
+  assertedBy: { kind: "human", ref: "user-1", meta: null },
+  scope: {
+    kind,
+    documentVersionId: kind === "document_version" ? "version-1" : null,
+    documentSpanId: spanId,
+    structuredHeadSha256: "a".repeat(64),
+  },
+  authorship: { kind: "ai", contributors: [] },
+  humanReview: { status: "not_reviewed", reviewers: [] },
+  source: { kind: "paste" },
+  basis: { kind: "user_attestation", ref: null },
+  supersedesId: null,
+  canonicalSha256: "b".repeat(64),
+});
+
+const provenanceTarget = (
+  id: string,
+  record: ProvenanceAttestation,
+  span: ProvenanceTarget["span"],
+): ProvenanceTarget => ({
+  projectionId: id,
+  target: {
+    kind: record.scope.kind,
+    documentVersionId: record.scope.documentVersionId,
+    documentSpanId: record.scope.documentSpanId,
+    structuredHeadSha256: record.scope.structuredHeadSha256,
+    currentness: "current",
+  },
+  span,
+  effectiveAttestations: [record],
+  effectiveAttestation: record,
+  resolution: "resolved",
+  reviewEligibility: "eligible",
+  issue: null,
+  history: [record],
+});
+
+const provenanceData = (): ProvenanceData => {
+  const defaultRecord = provenanceRecord("default-record", "document_version", null);
+  const spanRecord = provenanceRecord("span-record", "document_span", "span-1");
+  return {
+    schema: "cowork-provenance-view/v1",
+    currentStructuredHeadSha256: "a".repeat(64),
+    documentDefault: provenanceTarget("default-target", defaultRecord, null),
+    spans: [
+      provenanceTarget("span-target", spanRecord, {
+        exact: "AI passage",
+        prefix: "",
+        suffix: " and",
+      }),
+    ],
+    history: [defaultRecord, spanRecord],
+    summary: {
+      totalTargets: 2,
+      currentSpanCount: 1,
+      aiUnreviewedCount: 2,
+      reviewedCount: 0,
+      conflictedCount: 0,
+      staleCount: 0,
+      unrecorded: false,
+    },
+  };
+};
+
 let editor: Editor | null = null;
 
 afterEach(() => {
@@ -218,12 +294,64 @@ describe("ledgerDecorationProjectionFromReview", () => {
     ).toHaveClass(
       "wb-cowork-expression-mark",
       "wb-cowork-claim-anchor",
-      "wb-cowork-provenance-tint",
     );
 
     projector.clear();
     expect(
       editor.view.dom.querySelector(".wb-cowork-ledger-decoration"),
     ).toBeNull();
+  });
+
+  it("suppresses whole-document attribution and re-resolves exact spans while locally dirty", () => {
+    const projector = new LedgerDecorationProjector();
+    projector.setData({ ...data, provenanceSpans: [] });
+    projector.setProvenanceData(provenanceData());
+    editor = new Editor({
+      element: document.createElement("div"),
+      content: "<p>AI passage and default words.</p>",
+      extensions: [
+        StarterKit.configure({ undoRedo: false }),
+        CoworkLedgerDecorations,
+      ],
+    });
+    projector.attach(editor);
+    projector.setLens("provenance");
+    expect(
+      editor.view.dom.querySelectorAll(
+        '[data-wb-provenance-id="default-target"]',
+      ).length,
+    ).toBeGreaterThan(0);
+
+    projector.setProvenanceDirty(true);
+    expect(
+      editor.view.dom.querySelector(
+        '[data-wb-provenance-id="default-target"]',
+      ),
+    ).toBeNull();
+    expect(
+      editor.view.dom.querySelector(
+        '[data-wb-provenance-id="span-target"]',
+      ),
+    ).toHaveAttribute("data-wb-provenance-currentness", "requires_reanchor");
+
+    editor.commands.setContent("<p>The passage was replaced.</p>");
+    expect(
+      editor.view.dom.querySelector(
+        '[data-wb-provenance-id="span-target"]',
+      ),
+    ).toBeNull();
+    expect(
+      editor.view.dom.querySelector(
+        '[data-wb-provenance-record-state="unrecorded"]',
+      ),
+    ).not.toBeNull();
+
+    projector.setProvenanceDirty(false);
+    projector.setProvenanceData(provenanceData());
+    expect(
+      editor.view.dom.querySelector(
+        '[data-wb-provenance-id="default-target"]',
+      ),
+    ).not.toBeNull();
   });
 });

--- a/dashboard-react/src/apps/cowork/bridge/ledgerDecorationProjector.ts
+++ b/dashboard-react/src/apps/cowork/bridge/ledgerDecorationProjector.ts
@@ -7,6 +7,18 @@ import {
   type CoworkLedgerDecorationProjection,
 } from "../editor/ledgerDecorations";
 import type { ReviewRailData } from "../rail/contracts";
+import type {
+  ProvenanceAttestation,
+  ProvenanceData,
+  ProvenanceTarget,
+} from "../provenance/view/contracts";
+import {
+  provenanceAuthorshipFingerprint,
+  provenancePersonDetail,
+  provenanceReviewFingerprint,
+  provenanceSourceDetails,
+  provenanceSourceFingerprint,
+} from "../provenance/view/semantics";
 import { claimRefMatchesId } from "../rail/items";
 
 const EMPTY_LEDGER_PROJECTION: CoworkLedgerDecorationProjection = {
@@ -107,6 +119,62 @@ export const ledgerDecorationProjectionFromReview = (
   ),
 });
 
+const provenanceTargetId = (target: ProvenanceTarget): string =>
+  target.projectionId;
+
+const provenanceOverlayRecord = (
+  target: ProvenanceTarget,
+  record: ProvenanceAttestation,
+  isDocumentDefault: boolean,
+) => {
+  const personList = (
+    people: ProvenanceAttestation["authorship"]["contributors"],
+    empty: string,
+  ): string =>
+    people.map(provenancePersonDetail).join(", ") || empty;
+  const sourceDetail = provenanceSourceDetails(record).map(
+    (detail) => `${detail.label}: ${detail.value}`,
+  );
+  return ({
+  targetId:
+    provenanceTargetId(target),
+  recordId: record.attestationId,
+  quoteAnchor: target.span,
+  isDocumentDefault,
+  authorship: record.authorship.kind,
+  reviewStatus: record.humanReview.status,
+  currentness: target.target.currentness,
+  resolution: target.resolution,
+  source:
+    typeof record.source.kind === "string" ? record.source.kind : "unknown",
+  sourceDetail:
+    sourceDetail.length === 0
+      ? "No additional source detail"
+      : [...new Set(sourceDetail)].join(" · "),
+  contributors: personList(record.authorship.contributors, "No contributors recorded"),
+  reviewers: personList(record.humanReview.reviewers, "No reviewers recorded"),
+  attester: record.assertedBy.ref ?? record.assertedBy.kind,
+  basis: record.basis.kind,
+  historyCount: target.history.length,
+  effectiveCount: target.effectiveAttestations.length,
+  recordState: "recorded" as const,
+  authorshipFingerprint: provenanceAuthorshipFingerprint(record),
+  reviewFingerprint: provenanceReviewFingerprint(record),
+  sourceFingerprint: provenanceSourceFingerprint(record),
+  });
+};
+
+export const ledgerProvenanceProjection = (data: ProvenanceData) => {
+  const project = (target: ProvenanceTarget, isDocumentDefault: boolean) =>
+    target.effectiveAttestations.map((record) =>
+      provenanceOverlayRecord(target, record, isDocumentDefault),
+    );
+  return [
+    ...(data.documentDefault === null ? [] : project(data.documentDefault, true)),
+    ...data.spans.flatMap((target) => project(target, false)),
+  ];
+};
+
 /**
  * R2 may resolve before or after the editor mounts. This coordinator retains the
  * latest projection and dispatches it whenever both halves are present, without putting
@@ -115,6 +183,9 @@ export const ledgerDecorationProjectionFromReview = (
 export class LedgerDecorationProjector {
   #editor: Editor | null = null;
   #projection: CoworkLedgerDecorationProjection | null = null;
+  #provenanceOverlay: CoworkLedgerDecorationProjection["provenanceOverlay"] =
+    undefined;
+  #provenanceDirty = false;
   #lens: CoworkEditorLens = "review";
 
   attach(editor: Editor): void {
@@ -131,6 +202,22 @@ export class LedgerDecorationProjector {
     this.#flush();
   }
 
+  setProvenanceData(data: ProvenanceData | null): void {
+    this.#provenanceOverlay =
+      data === null ? undefined : ledgerProvenanceProjection(data);
+    this.#flush();
+  }
+
+  /**
+   * A local edit makes the last server head non-current immediately. Whole-document
+   * attribution is therefore withheld; exact spans may only reanchor for inspection.
+   */
+  setProvenanceDirty(dirty: boolean): void {
+    if (this.#provenanceDirty === dirty) return;
+    this.#provenanceDirty = dirty;
+    this.#flush();
+  }
+
   /** Retain the active rail lens across editor remounts and data refreshes. */
   setLens(lens: CoworkEditorLens): void {
     this.#lens = lens;
@@ -139,6 +226,8 @@ export class LedgerDecorationProjector {
 
   clear(): void {
     this.#projection = null;
+    this.#provenanceOverlay = undefined;
+    this.#provenanceDirty = false;
     if (this.#editor !== null) {
       projectCoworkLedgerDecorations(this.#editor, EMPTY_LEDGER_PROJECTION);
     }
@@ -146,7 +235,31 @@ export class LedgerDecorationProjector {
 
   #flush(): void {
     if (this.#editor === null || this.#projection === null) return;
-    projectCoworkLedgerDecorations(this.#editor, this.#projection);
+    const provenanceOverlay = this.#provenanceOverlay;
+    const projectedProvenance =
+      provenanceOverlay === undefined
+        ? undefined
+        : this.#provenanceDirty
+          ? provenanceOverlay.flatMap((target) =>
+              target.isDocumentDefault
+                ? []
+                : [
+                    {
+                      ...target,
+                      currentness:
+                        target.currentness === "current"
+                          ? "requires_reanchor" as const
+                          : target.currentness,
+                    },
+                  ],
+            )
+          : provenanceOverlay;
+    projectCoworkLedgerDecorations(this.#editor, {
+      ...this.#projection,
+      ...(projectedProvenance === undefined
+        ? {}
+        : { provenanceOverlay: projectedProvenance }),
+    });
     setCoworkEditorLens(this.#editor, this.#lens);
   }
 }

--- a/dashboard-react/src/apps/cowork/bridge/types.ts
+++ b/dashboard-react/src/apps/cowork/bridge/types.ts
@@ -95,6 +95,9 @@ export interface R2ProvenanceSpan {
   readonly approval_gesture_id: string | null;
 }
 
+/** Rich provenance is parsed from unknown at the bridge boundary. */
+export type R2ProvenanceView = Readonly<Record<string, unknown>>;
+
 /** The R2 hashes block (section 1.3). */
 export interface R2Hashes {
   readonly ydoc_snapshot_sha256: string | null;
@@ -407,5 +410,7 @@ export interface R2DocPayload {
   readonly open_proposals: readonly R2Proposal[];
   readonly expressions: readonly R2Expression[];
   readonly provenance_spans: readonly R2ProvenanceSpan[];
+  /** Additive v1 projection. The mapper validates every field before use. */
+  readonly provenance?: R2ProvenanceView;
   readonly events_cursor: string;
 }

--- a/dashboard-react/src/apps/cowork/bridge/useCoworkBridge.provenance.test.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/useCoworkBridge.provenance.test.tsx
@@ -1,0 +1,290 @@
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CoworkLedgerDecorations } from "../editor/ledgerDecorations";
+import { InMemoryCoworkYdocTransport } from "../persistence/InMemoryCoworkYdocTransport";
+import type { R2DocPayload } from "./types";
+import { useCoworkBridge } from "./useCoworkBridge";
+
+const headA = "a".repeat(64);
+const headB = "b".repeat(64);
+
+const provenancePayload = (head: string): R2DocPayload => {
+  const record = {
+    attestation_id: `attestation-${head[0]}`,
+    at: "2026-08-12T12:00:00Z",
+    asserted_by: { kind: "human", ref: "user-1", meta: null },
+    scope: {
+      kind: "document_version",
+      document_version_id: `version-${head[0]}`,
+      document_span_id: null,
+      structured_head_sha256: head,
+    },
+    authorship: { kind: "ai", contributors: [] },
+    human_review: { status: "not_reviewed", reviewers: [] },
+    source: { kind: "generation", model: "test-model" },
+    basis: { kind: "system_observation", ref: null },
+    supersedes_id: null,
+    canonical_sha256: "c".repeat(64),
+  };
+  return {
+    document_id: "doc-1",
+    store_id: "store-1",
+    path: "docs/demo.md",
+    title: "demo.md",
+    profile: "co_authored",
+    hashes: {
+      ydoc_snapshot_sha256: null,
+      last_materialized_sha256: null,
+      current_file_sha256: null,
+    },
+    drift: { state: "clean", diff_available: false },
+    open_proposals: [],
+    expressions: [],
+    provenance_spans: [],
+    events_cursor: "cursor-1",
+    provenance: {
+      schema: "cowork-provenance-view/v1",
+      current_structured_head_sha256: head,
+      document_default: {
+        projection_id: `document_version:version-${head[0]}`,
+        target: {
+          kind: "document_version",
+          document_version_id: `version-${head[0]}`,
+          document_span_id: null,
+          structured_head_sha256: head,
+          currentness: "current",
+        },
+        span: null,
+        resolution: "resolved",
+        review_eligibility: "eligible",
+        issue: null,
+        effective_attestation: record,
+        effective_attestations: [record],
+        history: [record],
+      },
+      spans: [],
+      history: [record],
+      summary: {
+        total_targets: 1,
+        current_span_count: 0,
+        ai_unreviewed_count: 1,
+        reviewed_count: 0,
+        conflicted_count: 0,
+        stale_count: 0,
+        unrecorded: false,
+      },
+    },
+  };
+};
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+describe("useCoworkBridge provenance freshness", () => {
+  it("fails closed without an overlay when the initial provenance load rejects", async () => {
+    const fetchDoc = vi.fn(async (): Promise<R2DocPayload> => {
+      throw new Error("provenance transport unavailable");
+    });
+    const hook = renderHook(() =>
+      useCoworkBridge({
+        documentId: "doc-1",
+        storeId: "store-1",
+        docClient: { fetchDoc },
+        ydocTransport: new InMemoryCoworkYdocTransport(),
+      }),
+    );
+    editor = new Editor({
+      element: document.createElement("div"),
+      content: "<p>AI-authored text.</p>",
+      extensions: [
+        StarterKit.configure({ undoRedo: false }),
+        CoworkLedgerDecorations,
+      ],
+    });
+
+    act(() => {
+      hook.result.current.editorProps.onReady({
+        editor: editor!,
+        dom: editor!.view.dom,
+      });
+      hook.result.current.setEditorLens("provenance");
+    });
+    await waitFor(() => expect(fetchDoc).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(hook.result.current.provenanceEditor.isLocallyDirty()).toBe(false);
+    expect(
+      editor.view.dom.querySelector("[data-wb-provenance-record-state]"),
+    ).toBeNull();
+
+    act(() => hook.result.current.editorProps.onTeardown());
+    hook.unmount();
+  });
+
+  it("retains dirty settlement state when its authoritative refresh rejects", async () => {
+    let requestCount = 0;
+    const fetchDoc = vi.fn(async (): Promise<R2DocPayload> => {
+      requestCount += 1;
+      if (requestCount === 2) {
+        throw new Error("settlement refresh unavailable");
+      }
+      return provenancePayload(requestCount === 1 ? headA : headB);
+    });
+    const hook = renderHook(() =>
+      useCoworkBridge({
+        documentId: "doc-1",
+        storeId: "store-1",
+        docClient: { fetchDoc },
+        ydocTransport: new InMemoryCoworkYdocTransport(),
+      }),
+    );
+    editor = new Editor({
+      element: document.createElement("div"),
+      content: "<p>AI-authored text.</p>",
+      extensions: [
+        StarterKit.configure({ undoRedo: false }),
+        CoworkLedgerDecorations,
+      ],
+    });
+    act(() => {
+      hook.result.current.editorProps.onReady({
+        editor: editor!,
+        dom: editor!.view.dom,
+      });
+      hook.result.current.setEditorLens("provenance");
+    });
+    await waitFor(() =>
+      expect(
+        editor!.view.dom.querySelector(
+          '[data-wb-provenance-record-state="recorded"]',
+        ),
+      ).not.toBeNull(),
+    );
+
+    act(() => hook.result.current.editorProps.onLocalProvenanceEdit?.());
+    await act(async () => {
+      hook.result.current.editorProps.onProvenancePersistenceSettled?.(headB);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(fetchDoc).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(hook.result.current.provenanceEditor.isLocallyDirty()).toBe(true);
+    expect(
+      editor.view.dom.querySelector(
+        '[data-wb-provenance-record-state="recorded"]',
+      ),
+    ).toBeNull();
+    expect(
+      editor.view.dom.querySelector(
+        '[data-wb-provenance-record-state="unrecorded"]',
+      ),
+    ).not.toBeNull();
+
+    // A later shared authoritative pull can settle the retained pending head;
+    // the user does not need to repeat the persistence notification.
+    await act(async () => {
+      await hook.result.current.reviewProvider.load();
+    });
+    await waitFor(() =>
+      expect(hook.result.current.provenanceEditor.isLocallyDirty()).toBe(false),
+    );
+    expect(fetchDoc).toHaveBeenCalledTimes(3);
+    expect(
+      editor.view.dom.querySelector(
+        '[data-wb-provenance-record-state="recorded"]',
+      ),
+    ).not.toBeNull();
+
+    act(() => hook.result.current.editorProps.onTeardown());
+    hook.unmount();
+  });
+
+  it("restores a suppressed default only after persistence settlement and a fresh matching head", async () => {
+    let authoritativeHead = headA;
+    const fetchDoc = vi.fn(async () => provenancePayload(authoritativeHead));
+    const hook = renderHook(() =>
+      useCoworkBridge({
+        documentId: "doc-1",
+        storeId: "store-1",
+        docClient: { fetchDoc },
+        ydocTransport: new InMemoryCoworkYdocTransport(),
+      }),
+    );
+    editor = new Editor({
+      element: document.createElement("div"),
+      content: "<p>AI-authored text.</p>",
+      extensions: [
+        StarterKit.configure({ undoRedo: false }),
+        CoworkLedgerDecorations,
+      ],
+    });
+    act(() => {
+      hook.result.current.editorProps.onReady({
+        editor: editor!,
+        dom: editor!.view.dom,
+      });
+      hook.result.current.setEditorLens("provenance");
+    });
+    await waitFor(() =>
+      expect(
+        editor!.view.dom.querySelector(
+          '[data-wb-provenance-record-state="recorded"]',
+        ),
+      ).not.toBeNull(),
+    );
+
+    act(() => hook.result.current.editorProps.onLocalProvenanceEdit?.());
+    expect(hook.result.current.provenanceEditor.isLocallyDirty()).toBe(true);
+    expect(
+      editor.view.dom.querySelector(
+        '[data-wb-provenance-record-state="recorded"]',
+      ),
+    ).toBeNull();
+    expect(
+      editor.view.dom.querySelector(
+        '[data-wb-provenance-record-state="unrecorded"]',
+      ),
+    ).not.toBeNull();
+
+    await act(async () => {
+      hook.result.current.editorProps.onProvenancePersistenceSettled?.(headB);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(fetchDoc).toHaveBeenCalledTimes(2));
+    expect(hook.result.current.provenanceEditor.isLocallyDirty()).toBe(true);
+    expect(
+      editor.view.dom.querySelector(
+        '[data-wb-provenance-record-state="recorded"]',
+      ),
+    ).toBeNull();
+
+    authoritativeHead = headB;
+    await act(async () => {
+      hook.result.current.editorProps.onProvenancePersistenceSettled?.(headB);
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(hook.result.current.provenanceEditor.isLocallyDirty()).toBe(false),
+    );
+    expect(
+      editor.view.dom.querySelector(
+        '[data-wb-provenance-record-state="recorded"]',
+      ),
+    ).not.toBeNull();
+
+    act(() => hook.result.current.editorProps.onTeardown());
+    hook.unmount();
+  });
+});

--- a/dashboard-react/src/apps/cowork/bridge/useCoworkBridge.ts
+++ b/dashboard-react/src/apps/cowork/bridge/useCoworkBridge.ts
@@ -15,7 +15,14 @@
  * defaults to the same-origin HTTP realizations for the live surface.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
 import type { Editor } from "@tiptap/core";
 import * as Y from "yjs";
 
@@ -62,6 +69,12 @@ import type { CoworkSittingWorkspace } from "./sittingWorkspace";
 import type { CoworkActionSnapshotController } from "../targets";
 import type { CoworkPasteProvenanceRecorder } from "../provenance";
 import type { CoworkEditorLens } from "../editor/ledgerDecorations";
+import { LiveProvenanceProvider } from "../provenance/view/LiveProvenanceProvider";
+import type { ProvenanceProvider } from "../provenance/view/contracts";
+import type { ProvenanceEditorIntegration } from "../provenance/view/contracts";
+import type { ProvenanceMutationBarrier } from "../provenance/view/contracts";
+import type { ProvenanceLoad } from "../provenance/view/contracts";
+import { resolveProvenanceQuoteAnchorDetailed } from "../suggestions/anchor";
 
 /** Registered documents are initialized by bootstrap; live hydration never fabricates text. */
 export const DEFAULT_BRIDGE_SEED_MARKDOWN = "";
@@ -139,12 +152,24 @@ export interface CoworkBridgeEditorMountProps {
   readonly onActionSnapshotController?: (
     controller: CoworkActionSnapshotController | null,
   ) => void;
+  /** Editor-owned critical section used by append-only provenance review gestures. */
+  readonly onProvenanceMutationBarrier?: (
+    barrier: ProvenanceMutationBarrier | null,
+  ) => void;
+  readonly onLocalProvenanceEdit?: () => void;
+  readonly onProvenancePersistenceSettled?: (
+    structuredHeadSha256: string,
+  ) => void;
   readonly getProposalCatalog: () => readonly ProposalInput[];
   readonly onSittingServerRefreshed?: () => void;
 }
 
 export interface CoworkBridge {
   readonly reviewProvider: LiveReviewRailProvider;
+  readonly provenanceProvider: ProvenanceProvider;
+  readonly provenanceEditor: ProvenanceEditorIntegration;
+  readonly provenanceMutationBarrier: ProvenanceMutationBarrier | undefined;
+  readonly editorRootRef: RefObject<HTMLElement | null>;
   readonly reviewAnchors: ReviewAnchorController;
   readonly editorProps: CoworkBridgeEditorMountProps;
   /** Latest live health, or null before the first pull resolves. */
@@ -205,7 +230,11 @@ export const useCoworkBridge = (
 
   const editorRef = useRef<Editor | null>(null);
   const editorDomRef = useRef<HTMLElement | null>(null);
+  const provenanceUpdateListenerRef = useRef<(() => void) | null>(null);
+  const settledProvenanceHeadRef = useRef<string | null>(null);
+  const provenanceDirtyRef = useRef(false);
   const [editorReady, setEditorReady] = useState(false);
+  const [provenanceRevision, setProvenanceRevision] = useState(0);
   const sittingWorkspaceRef = useRef<CoworkSittingWorkspace | null>(null);
   const proposalCatalogRef = useRef<readonly ProposalInput[]>([]);
   const [health, setHealth] = useState<CoworkLiveHealth | null>(null);
@@ -219,6 +248,8 @@ export const useCoworkBridge = (
     useState<readonly VerificationRecheckIntent[]>([]);
   const [actionSnapshotController, setActionSnapshotController] =
     useState<CoworkActionSnapshotController | null>(null);
+  const [provenanceMutationBarrier, setProvenanceMutationBarrier] =
+    useState<ProvenanceMutationBarrier | null>(null);
 
   // Kept in a ref so the review provider stays stable per (documentId, storeId) while always
   // routing a delivery through the surface's latest callback.
@@ -257,6 +288,14 @@ export const useCoworkBridge = (
       onSittingCommitted: (requests) =>
         onSittingCommittedRef.current?.(requests),
     });
+    const provenanceProvider = new LiveProvenanceProvider(
+      {
+        loadPayload: () => reviewProvider.loadPayload(),
+        refreshPayload: () => reviewProvider.refreshPayload(),
+        subscribe: (listener) => reviewProvider.subscribePayload(listener),
+      },
+      resolvedDocClient,
+    );
 
     const reviewAnchors = new DomReviewAnchorController({
       getEditorRoot: () => editorDomRef.current,
@@ -268,6 +307,7 @@ export const useCoworkBridge = (
       ledgerProjector,
       passageHighlighter,
       reviewProvider,
+      provenanceProvider,
       reviewAnchors,
       ydocTransport: resolvedYdocTransport,
     };
@@ -308,6 +348,55 @@ export const useCoworkBridge = (
     };
   }, [core]);
 
+  const applyProvenanceLoad = useCallback(
+    (result: ProvenanceLoad, allowSettlement: boolean): void => {
+      core.ledgerProjector.setProvenanceData(
+        result.state === "ready" ? result.data : null,
+      );
+      if (
+        allowSettlement &&
+        result.state === "ready" &&
+        settledProvenanceHeadRef.current !== null &&
+        result.data.currentStructuredHeadSha256 ===
+          settledProvenanceHeadRef.current
+      ) {
+        core.ledgerProjector.setProvenanceDirty(false);
+        provenanceDirtyRef.current = false;
+        setProvenanceRevision((value) => value + 1);
+        settledProvenanceHeadRef.current = null;
+      }
+    },
+    [core],
+  );
+
+  useEffect(() => {
+    let active = true;
+    let subscribing = true;
+    const refresh = (allowSettlement: boolean): void => {
+      void core.provenanceProvider
+        .load()
+        .then((result) => {
+          if (!active) return;
+          applyProvenanceLoad(result, allowSettlement);
+        })
+        .catch(() => {
+          if (!active) return;
+          // Transport failures have no authoritative projection to paint.
+          core.ledgerProjector.setProvenanceData(null);
+        });
+    };
+    const unsubscribe = core.provenanceProvider.subscribe(() => {
+      refresh(!subscribing);
+    });
+    subscribing = false;
+    refresh(false);
+    return () => {
+      active = false;
+      unsubscribe();
+      core.ledgerProjector.setProvenanceData(null);
+    };
+  }, [applyProvenanceLoad, core]);
+
   useEffect(
     () => () => {
       core.ledgerProjector.detach();
@@ -330,8 +419,19 @@ export const useCoworkBridge = (
         core.ledgerProjector.attach(editor);
         core.reviewAnchors.attachEditor(editor);
         setEditorReady(true);
+        const onEditorUpdate = (): void => {
+          setProvenanceRevision((value) => value + 1);
+        };
+        editor.on("update", onEditorUpdate);
+        provenanceUpdateListenerRef.current = onEditorUpdate;
       },
       onTeardown: () => {
+        const editor = editorRef.current;
+        const onEditorUpdate = provenanceUpdateListenerRef.current;
+        if (editor !== null && onEditorUpdate !== null) {
+          editor.off("update", onEditorUpdate);
+        }
+        provenanceUpdateListenerRef.current = null;
         core.passageHighlighter.clear();
         core.reviewAnchors.detachEditor();
         setEditorReady(false);
@@ -361,6 +461,25 @@ export const useCoworkBridge = (
         sittingWorkspaceRef.current = workspace;
       },
       onActionSnapshotController: setActionSnapshotController,
+      onProvenanceMutationBarrier: setProvenanceMutationBarrier,
+      onLocalProvenanceEdit: () => {
+        settledProvenanceHeadRef.current = null;
+        provenanceDirtyRef.current = true;
+        core.ledgerProjector.setProvenanceDirty(true);
+      },
+      onProvenancePersistenceSettled: (structuredHeadSha256) => {
+        if (!provenanceDirtyRef.current) return;
+        settledProvenanceHeadRef.current = structuredHeadSha256;
+        void core.provenanceProvider
+          .refresh()
+          .then((result) => {
+            applyProvenanceLoad(result, true);
+          })
+          .catch(() => {
+            // Keep both the dirty flag and pending head until a later
+            // authoritative projection proves that persistence settled.
+          });
+      },
       getProposalCatalog: () => proposalCatalogRef.current,
       onSittingServerRefreshed: () => {
         core.ledgerProjector.clear();
@@ -368,6 +487,7 @@ export const useCoworkBridge = (
     }),
     [
       core,
+      applyProvenanceLoad,
       seedMarkdown,
       documentId,
       storeId,
@@ -415,9 +535,104 @@ export const useCoworkBridge = (
     () => (lens: CoworkEditorLens): void => core.ledgerProjector.setLens(lens),
     [core],
   );
+  const provenanceEditor = useMemo<ProvenanceEditorIntegration>(
+    () => ({
+      resolveTarget: (anchor) => {
+        const editor = editorRef.current;
+        if (editor === null) {
+          return {
+            state: "missing",
+            documentOrder: null,
+            documentEnd: null,
+          };
+        }
+        const result = resolveProvenanceQuoteAnchorDetailed(
+          editor.state.doc,
+          anchor,
+        );
+        return result.state === "unique"
+          ? {
+              state: "unique",
+              documentOrder: result.from,
+              documentEnd: result.to,
+            }
+          : {
+              state: result.state,
+              documentOrder: null,
+              documentEnd: null,
+            };
+      },
+      isLocallyDirty: () => provenanceDirtyRef.current,
+      hasText: () => (editorRef.current?.state.doc.textContent.length ?? 0) > 0,
+      hasUncoveredText: (anchors) => {
+        const editor = editorRef.current;
+        if (editor === null) return true;
+        const ranges = anchors
+          .flatMap((anchor) => {
+            const result = resolveProvenanceQuoteAnchorDetailed(
+              editor.state.doc,
+              anchor,
+            );
+            return result.state === "unique"
+              ? [{ from: result.from, to: result.to }]
+              : [];
+          })
+          .sort((left, right) => left.from - right.from || left.to - right.to)
+          .reduce<Array<{ from: number; to: number }>>((merged, range) => {
+            const previous = merged[merged.length - 1];
+            if (previous === undefined || range.from > previous.to) {
+              merged.push({ ...range });
+            } else {
+              previous.to = Math.max(previous.to, range.to);
+            }
+            return merged;
+          }, []);
+        let uncovered = false;
+        editor.state.doc.descendants((node, pos) => {
+          if (!node.isText || node.nodeSize === 0) return true;
+          if (!ranges.some((range) => range.from <= pos && range.to >= pos + node.nodeSize)) {
+            uncovered = true;
+            return false;
+          }
+          return true;
+        });
+        return uncovered;
+      },
+      focusTarget: (id) => core.reviewAnchors.focusAnchor(id, "provenance"),
+      revealTarget: (id) =>
+        core.reviewAnchors.revealAnchor(id, "provenance", { flash: true }),
+    }),
+    [core, provenanceRevision],
+  );
+
+  const synchronizedProvenanceMutationBarrier = useMemo<
+    ProvenanceMutationBarrier | undefined
+  >(
+    () =>
+      provenanceMutationBarrier === null
+        ? undefined
+        : {
+            runWithSynchronizedDocument: (operation) =>
+              provenanceMutationBarrier.runWithSynchronizedDocument(
+                async (snapshot) => {
+                  settledProvenanceHeadRef.current =
+                    snapshot.structuredHeadSha256;
+                  const result = await operation(snapshot);
+                  const fresh = await core.provenanceProvider.refresh();
+                  applyProvenanceLoad(fresh, true);
+                  return result;
+                },
+              ),
+          },
+    [applyProvenanceLoad, core.provenanceProvider, provenanceMutationBarrier],
+  );
 
   return {
     reviewProvider: core.reviewProvider,
+    provenanceProvider: core.provenanceProvider,
+    provenanceEditor,
+    provenanceMutationBarrier: synchronizedProvenanceMutationBarrier,
+    editorRootRef: editorDomRef,
     reviewAnchors: core.reviewAnchors,
     editorProps,
     health,

--- a/dashboard-react/src/apps/cowork/conformance/editorDecorationStyles.test.ts
+++ b/dashboard-react/src/apps/cowork/conformance/editorDecorationStyles.test.ts
@@ -17,6 +17,13 @@ describe("Co-work editor decoration style contract", () => {
     expect(surfaceStyles).toContain("text-decoration-style: dashed");
     expect(surfaceStyles).toContain(".wb-cowork-provenance-tint::after");
     expect(surfaceStyles).toContain('content: "\\00a0\\2713"');
+    expect(surfaceStyles).toContain(".wb-cowork-provenance--ai");
+    expect(surfaceStyles).toContain(".wb-cowork-provenance--unrecorded");
+    expect(surfaceStyles).toContain(".wb-cowork-provenance--review-not-reviewed");
+    expect(surfaceStyles).toContain("underline dashed");
+    expect(surfaceStyles).toContain(".wb-cowork-provenance--review-unknown");
+    expect(surfaceStyles).toContain("underline dotted");
+    expect(surfaceStyles).toContain(".wb-cowork-provenance--conflict");
   });
 
   it("keeps focus/highlight visible for reduced-motion and forced-colors users", () => {

--- a/dashboard-react/src/apps/cowork/editor/ledgerDecorations.test.ts
+++ b/dashboard-react/src/apps/cowork/editor/ledgerDecorations.test.ts
@@ -283,12 +283,9 @@ describe("CoworkLedgerDecorations", () => {
     expect(claim).toHaveAttribute("data-wb-claim-ids", '["same-id"]');
     expect(claim).toHaveClass("wb-cowork-claim-anchor");
 
-    const provenance = current.view.dom.querySelector<HTMLElement>(
-      '[data-wb-decoration="provenance"]',
-    );
-    expect(provenance).toHaveClass("wb-cowork-provenance-tint");
-    expect(provenance).toHaveAttribute("data-wb-trust", "ai-confirmed");
-    expect(provenance).toHaveAttribute("data-approval-gesture-id", "gesture-1");
+    expect(
+      current.view.dom.querySelector('[data-wb-decoration="provenance"]'),
+    ).toBeNull();
     expect(
       current.view.dom.querySelector('[data-wb-anchor-id="span-human"]'),
     ).toBeNull();
@@ -297,6 +294,142 @@ describe("CoworkLedgerDecorations", () => {
     // editable document or its serialized Markdown/HTML projection.
     expect(current.getJSON()).toEqual(beforeJson);
     expect(current.getHTML()).toBe(beforeHtml);
+  });
+
+  it("projects independent provenance axes, unrecorded gaps, and overlap conflicts", () => {
+    const current = mountEditor("<p>AI passage and uncovered words.</p>");
+    const before = current.getJSON();
+    const base = {
+      quoteAnchor: { exact: "AI passage", prefix: "", suffix: " and" },
+      isDocumentDefault: false,
+      currentness: "current" as const,
+      source: "paste",
+      sourceDetail: "Format: plain text",
+      contributors: "No contributors recorded",
+      reviewers: "No reviewers recorded",
+      attester: "user-1",
+      basis: "user_attestation",
+      historyCount: 1,
+      effectiveCount: 1,
+      recordState: "recorded" as const,
+    };
+    projectCoworkLedgerDecorations(current, {
+      edits: [], flags: [], expressions: [], claims: [], provenance: [],
+      provenanceOverlay: [
+        {
+          ...base,
+          targetId: "target-a",
+          recordId: "record-a",
+          authorship: "ai",
+          reviewStatus: "not_reviewed",
+          resolution: "resolved",
+          authorshipFingerprint: "ai:alice",
+          reviewFingerprint: "not-reviewed",
+          sourceFingerprint: "paste:first",
+        },
+        {
+          ...base,
+          targetId: "target-b",
+          recordId: "record-b",
+          authorship: "ai",
+          reviewStatus: "not_reviewed",
+          resolution: "resolved",
+          authorshipFingerprint: "ai:bob",
+          reviewFingerprint: "not-reviewed",
+          sourceFingerprint: "paste:first",
+        },
+      ],
+    });
+    setCoworkEditorLens(current, "provenance");
+
+    const conflict = current.view.dom.querySelector<HTMLElement>(
+      '[data-wb-provenance-conflict="true"]',
+    );
+    expect(conflict).toHaveClass("wb-cowork-provenance--conflict");
+    expect(conflict).toHaveAttribute(
+      "data-wb-provenance-ids",
+      '["target-a","target-b"]',
+    );
+    const gap = current.view.dom.querySelector<HTMLElement>(
+      '[data-wb-provenance-record-state="unrecorded"]',
+    );
+    expect(gap).toHaveClass("wb-cowork-provenance--unrecorded");
+    expect(gap).not.toHaveAttribute("data-wb-anchor-kind");
+    expect(current.getJSON()).toEqual(before);
+  });
+
+  it("keeps compatible overlap target health explicit and rejects changed selector context", () => {
+    const current = mountEditor("<p>New context Shared passage and tail.</p>");
+    const base = {
+      quoteAnchor: {
+        exact: "Shared passage",
+        prefix: "New context ",
+        suffix: " and tail.",
+      },
+      isDocumentDefault: false,
+      authorship: "ai" as const,
+      reviewStatus: "not_reviewed" as const,
+      resolution: "resolved" as const,
+      source: "generation",
+      sourceDetail: "Model: test-model",
+      contributors: "No contributors recorded",
+      reviewers: "No reviewers recorded",
+      attester: "user-1",
+      basis: "system_observation",
+      historyCount: 1,
+      effectiveCount: 1,
+      recordState: "recorded" as const,
+      authorshipFingerprint: "ai",
+      reviewFingerprint: "not_reviewed",
+      sourceFingerprint: "generation:test-model",
+    };
+    projectCoworkLedgerDecorations(current, {
+      edits: [],
+      flags: [],
+      expressions: [],
+      claims: [],
+      provenance: [],
+      provenanceOverlay: [
+        {
+          ...base,
+          targetId: "current-target",
+          recordId: "current-record",
+          currentness: "current",
+        },
+        {
+          ...base,
+          targetId: "reanchored-target",
+          recordId: "reanchored-record",
+          currentness: "requires_reanchor",
+        },
+        {
+          ...base,
+          targetId: "wrong-context-target",
+          recordId: "wrong-context-record",
+          currentness: "requires_reanchor",
+          quoteAnchor: {
+            exact: "Shared passage",
+            prefix: "Old context ",
+            suffix: " and tail.",
+          },
+        },
+      ],
+    });
+    setCoworkEditorLens(current, "provenance");
+
+    const shared = current.view.dom.querySelector<HTMLElement>(
+      '[data-wb-provenance-ids*="current-target"]',
+    );
+    expect(shared).toHaveAttribute(
+      "data-wb-provenance-currentness",
+      "multiple target states",
+    );
+    expect(shared).toHaveAttribute("data-wb-provenance-conflict", "false");
+    expect(
+      current.view.dom.querySelector(
+        '[data-wb-provenance-ids*="wrong-context-target"]',
+      ),
+    ).toBeNull();
   });
 
   it("persists kind-qualified Truth focus without leaking Review marks", () => {

--- a/dashboard-react/src/apps/cowork/editor/ledgerDecorations.ts
+++ b/dashboard-react/src/apps/cowork/editor/ledgerDecorations.ts
@@ -3,7 +3,10 @@ import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { Plugin, PluginKey, type Transaction } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 
-import { resolveQuoteAnchor } from "../suggestions/anchor";
+import {
+  resolveProvenanceQuoteAnchorDetailed,
+  resolveQuoteAnchor,
+} from "../suggestions/anchor";
 import type { QuoteAnchor } from "../suggestions/types";
 
 /**
@@ -24,7 +27,7 @@ export type CoworkEditorAnchorKind =
  * view-only decorations; it never changes the ProseMirror document, Y.Doc, or
  * the independent temporary passage highlight used by Chat and Working on.
  */
-export type CoworkEditorLens = "neutral" | "review" | "truth";
+export type CoworkEditorLens = "neutral" | "review" | "truth" | "provenance";
 
 export interface CoworkFlagDecoration {
   readonly proposalId: string;
@@ -63,6 +66,29 @@ export interface CoworkProvenanceDecoration {
   readonly approvalGestureId: string | null;
 }
 
+export interface CoworkProvenanceOverlayDecoration {
+  readonly targetId: string;
+  readonly recordId: string;
+  readonly quoteAnchor: QuoteAnchor | null;
+  readonly isDocumentDefault: boolean;
+  readonly authorship: "human" | "ai" | "mixed" | "unknown";
+  readonly reviewStatus: "reviewed" | "not_reviewed" | "not_applicable" | "unknown";
+  readonly currentness: "current" | "stale" | "requires_reanchor" | "unavailable";
+  readonly resolution: "resolved" | "conflicted";
+  readonly source: string;
+  readonly sourceDetail: string;
+  readonly contributors: string;
+  readonly reviewers: string;
+  readonly attester: string;
+  readonly basis: string;
+  readonly historyCount: number;
+  readonly effectiveCount: number;
+  readonly recordState: "recorded" | "unrecorded";
+  readonly authorshipFingerprint: string;
+  readonly reviewFingerprint: string;
+  readonly sourceFingerprint: string;
+}
+
 export interface CoworkEvaluationDecoration {
   readonly resultId: string;
   readonly quoteAnchor: QuoteAnchor;
@@ -84,6 +110,8 @@ export interface CoworkLedgerDecorationProjection {
   readonly expressions: readonly CoworkExpressionDecoration[];
   readonly claims: readonly CoworkClaimDecoration[];
   readonly provenance: readonly CoworkProvenanceDecoration[];
+  /** Rich, independent provenance lens projection. */
+  readonly provenanceOverlay?: readonly CoworkProvenanceOverlayDecoration[];
   /** Additive Verify projection; absent inputs are treated as no results. */
   readonly evaluations?: readonly CoworkEvaluationDecoration[];
 }
@@ -241,6 +269,196 @@ const atomSuggestion = (
     : null;
 };
 
+interface ResolvedProvenanceOverlay {
+  readonly target: CoworkProvenanceOverlayDecoration;
+  readonly from: number;
+  readonly to: number;
+}
+
+const provenanceAxes = (target: CoworkProvenanceOverlayDecoration): string =>
+  JSON.stringify([
+    target.authorshipFingerprint,
+    target.reviewFingerprint,
+    target.sourceFingerprint,
+  ]);
+
+const provenanceClass = (
+  targets: readonly CoworkProvenanceOverlayDecoration[],
+  conflicted: boolean,
+): string => {
+  if (conflicted) return "wb-cowork-provenance--conflict";
+  const target = targets[0];
+  const classes = [
+    "wb-cowork-provenance-mark",
+    `wb-cowork-provenance--${target.authorship}`,
+    `wb-cowork-provenance--review-${target.reviewStatus.replace(/_/gu, "-")}`,
+    `wb-cowork-provenance--${target.recordState}`,
+  ];
+  return classes.join(" ");
+};
+
+/**
+ * Atomize the document's text ranges for the Provenance lens. Explicit spans
+ * override the current document default; uncovered text is visibly unrecorded.
+ * Incompatible explicit overlaps become one conflict segment instead of a
+ * last-write-wins decoration.
+ */
+const provenanceOverlayDecorations = (
+  doc: ProseMirrorNode,
+  projection: CoworkLedgerDecorationProjection,
+  focused: CoworkFocusedAnchor | null,
+  flashFocused: boolean,
+): Decoration[] => {
+  if (projection.provenanceOverlay === undefined) return [];
+  const overlays = projection.provenanceOverlay;
+  const documentDefaults = overlays.filter(
+    (item) => item.isDocumentDefault && item.currentness === "current",
+  );
+  const resolved: ResolvedProvenanceOverlay[] = overlays.flatMap((target) => {
+    if (
+      target.isDocumentDefault ||
+      target.quoteAnchor === null ||
+      target.currentness === "stale" ||
+      target.currentness === "unavailable"
+    ) {
+      return [];
+    }
+    const resolution = resolveProvenanceQuoteAnchorDetailed(
+      doc,
+      target.quoteAnchor,
+    );
+    return resolution.state !== "unique"
+      ? []
+      : [{ target, from: resolution.from, to: resolution.to }];
+  });
+  const result: Decoration[] = [];
+  doc.descendants((node, pos) => {
+    if (!node.isText || node.nodeSize === 0) return true;
+    const nodeFrom = pos;
+    const nodeTo = pos + node.nodeSize;
+    const boundaries = new Set<number>([nodeFrom, nodeTo]);
+    for (const item of resolved) {
+      if (item.to <= nodeFrom || item.from >= nodeTo) continue;
+      boundaries.add(Math.max(nodeFrom, item.from));
+      boundaries.add(Math.min(nodeTo, item.to));
+    }
+    const ordered = [...boundaries].sort((a, b) => a - b);
+    for (let index = 0; index < ordered.length - 1; index += 1) {
+      const from = ordered[index];
+      const to = ordered[index + 1];
+      const covering = resolved.filter(
+        (item) => item.from < to && item.to > from,
+      );
+      let targets: readonly CoworkProvenanceOverlayDecoration[];
+      if (covering.length > 0) {
+        targets = covering.map((item) => item.target);
+      } else if (documentDefaults.length > 0) {
+        targets = documentDefaults;
+      } else {
+        targets = [
+          {
+            targetId: `unrecorded:${String(from)}`,
+            recordId: `unrecorded:${String(from)}`,
+            quoteAnchor: null,
+            isDocumentDefault: true,
+            authorship: "unknown",
+            reviewStatus: "unknown",
+            currentness: "current",
+            resolution: "resolved",
+            source: "unrecorded",
+            sourceDetail: "No source recorded",
+            contributors: "No contributors recorded",
+            reviewers: "No reviewers recorded",
+            attester: "none",
+            basis: "none",
+            historyCount: 0,
+            effectiveCount: 0,
+            recordState: "unrecorded",
+            authorshipFingerprint: "unrecorded",
+            reviewFingerprint: "unrecorded",
+            sourceFingerprint: "unrecorded",
+          },
+        ];
+      }
+      const incompatible = new Set(targets.map(provenanceAxes)).size > 1;
+      const conflicted =
+        incompatible || targets.some((item) => item.resolution === "conflicted");
+      const ids = targets.map((item) => item.targetId);
+      const recordIds = targets.map((item) => item.recordId);
+      const primary =
+        focused?.kind === "provenance"
+          ? targets.find((item) => item.targetId === focused.id) ?? targets[0]
+          : targets[0];
+      const attester =
+        new Set(targets.map((item) => item.attester)).size > 1
+          ? "multiple"
+          : primary.attester;
+      const basis =
+        new Set(targets.map((item) => item.basis)).size > 1
+          ? "multiple"
+          : primary.basis;
+      const sourceDetail =
+        new Set(targets.map((item) => item.sourceDetail)).size > 1
+          ? "multiple sources"
+          : primary.sourceDetail;
+      const contributors =
+        new Set(targets.map((item) => item.contributors)).size > 1
+          ? "multiple contributor records"
+          : primary.contributors;
+      const reviewers =
+        new Set(targets.map((item) => item.reviewers)).size > 1
+          ? "multiple reviewer records"
+          : primary.reviewers;
+      const metadata = {
+          "data-wb-decoration": "provenance-overlay",
+          "data-wb-provenance-id": primary.targetId,
+          "data-wb-provenance-ids": JSON.stringify(ids),
+          "data-wb-provenance-record-ids": JSON.stringify(recordIds),
+          "data-wb-authorship": conflicted ? "conflict" : primary.authorship,
+          "data-wb-human-review": conflicted ? "conflict" : primary.reviewStatus,
+          "data-wb-source": conflicted ? "conflict" : primary.source,
+          "data-wb-source-detail": conflicted ? "multiple sources" : sourceDetail,
+          "data-wb-contributors": conflicted ? "multiple contributor records" : contributors,
+          "data-wb-reviewers": conflicted ? "multiple reviewer records" : reviewers,
+          "data-wb-attester": conflicted ? "multiple" : attester,
+          "data-wb-basis": conflicted ? "multiple" : basis,
+          "data-wb-history-count": String(
+            targets.reduce((count, item) => count + item.historyCount, 0),
+          ),
+          "data-wb-provenance-conflict": String(conflicted),
+          "data-wb-provenance-record-state": primary.recordState,
+          "data-wb-provenance-currentness":
+            new Set(targets.map((item) => item.currentness)).size > 1
+              ? "multiple target states"
+              : primary.currentness,
+      };
+      const attributes =
+        primary.recordState === "unrecorded"
+          ? {
+              class: `wb-cowork-ledger-decoration ${provenanceClass(targets, conflicted)}`,
+              ...metadata,
+            }
+          : anchorAttributes(
+              "provenance",
+              primary.targetId,
+              provenanceClass(targets, conflicted),
+              focused,
+              flashFocused,
+              metadata,
+            );
+      const decoration = inlineDecoration(
+        from,
+        to,
+        attributes,
+        `provenance-overlay:${ids.join(":")}:${String(from)}`,
+      );
+      if (decoration !== null) result.push(decoration);
+    }
+    return true;
+  });
+  return result;
+};
+
 function buildDecorations(
   doc: ProseMirrorNode,
   projection: CoworkLedgerDecorationProjection,
@@ -255,6 +473,16 @@ function buildDecorations(
     const claims = claimsByExpression.get(claim.expressionId) ?? [];
     claims.push(claim);
     claimsByExpression.set(claim.expressionId, claims);
+  }
+  if (lens === "provenance") {
+    decorations.push(
+      ...provenanceOverlayDecorations(
+        doc,
+        projection,
+        focused,
+        flashFocused,
+      ),
+    );
   }
 
   /*
@@ -499,45 +727,6 @@ function buildDecorations(
   // multiple claims, and exact-overlap ProseMirror decorations merge attributes, so a
   // JSON string array truthfully preserves every claim identity on the one prose range.
 
-  // Only confirmed AI provenance receives the confirmed-provenance treatment.
-  // Human text is the unadorned baseline and proposed AI text is represented by
-  // tracked-change/flag decorations.
-  for (const span of lens === "truth" ? projection.provenance : []) {
-    if (span.trustState !== "ai_confirmed") continue;
-    const range = rangeForQuote(doc, span.quote, span.quoteAnchor);
-    if (range === null) continue;
-    const attributes: Record<string, string> = {
-      "data-wb-decoration": "provenance",
-      "data-wb-trust": "ai-confirmed",
-      "data-wb-span-id": span.spanId,
-    };
-    if (span.producer !== null) attributes["data-producer"] = span.producer;
-    if (span.approvalGestureId !== null) {
-      attributes["data-approval-gesture-id"] = span.approvalGestureId;
-    }
-    const provenanceAttributes = anchorAttributes(
-      "provenance",
-      span.spanId,
-      "wb-cowork-provenance-tint",
-      focused,
-      flashFocused,
-      attributes,
-    );
-    // Provenance can cover exactly the same range as an expression. It has no rail
-    // geometry contract, so keep its identity in a dedicated attribute instead of
-    // overwriting the expression's generalized anchor identity during DOM merging.
-    delete provenanceAttributes["data-wb-anchor-kind"];
-    delete provenanceAttributes["data-wb-anchor-id"];
-    provenanceAttributes["data-wb-provenance-id"] = span.spanId;
-    const decoration = inlineDecoration(
-      range.from,
-      range.to,
-      provenanceAttributes,
-      `provenance:${span.spanId}`,
-    );
-    if (decoration !== null) decorations.push(decoration);
-  }
-
   if (
     highlight !== null &&
     highlight.from >= 0 &&
@@ -621,15 +810,26 @@ export function coworkLedgerDecorationsPlugin(): Plugin<CoworkLedgerDecorationSt
         if (meta === undefined && !transaction.docChanged) return value;
 
         /*
-         * A keystroke already supplies a precise ProseMirror mapping. Mapping the
-         * existing DecorationSet keeps every annotation attached to its passage
-         * without re-indexing the full document once per annotation. Fresh quote
-         * resolution is reserved for an R2 projection/focus/highlight change.
+         * Review and Truth annotations can follow ProseMirror's precise mapping.
+         * Provenance is different: exact selectors are the safety boundary, so a
+         * document edit must resolve them again and must drop missing/ambiguous
+         * spans instead of carrying a stale painted range forward.
          */
         if (meta === undefined) {
+          const highlight = mappedHighlight(transaction, value.highlight);
+          if (value.lens === "provenance") {
+            return createPluginState(
+              transaction.doc,
+              value.projection,
+              value.lens,
+              value.focused,
+              value.flashFocused,
+              highlight,
+            );
+          }
           return {
             ...value,
-            highlight: mappedHighlight(transaction, value.highlight),
+            highlight,
             decorations: value.decorations.map(
               transaction.mapping,
               transaction.doc,
@@ -653,9 +853,8 @@ export function coworkLedgerDecorationsPlugin(): Plugin<CoworkLedgerDecorationSt
               (focused.kind === "proposal" ||
                 focused.kind === "evaluation_result")) ||
             (lens === "truth" &&
-              (focused.kind === "claim" ||
-                focused.kind === "expression" ||
-                focused.kind === "provenance"));
+              (focused.kind === "claim" || focused.kind === "expression")) ||
+            (lens === "provenance" && focused.kind === "provenance");
           if (!visible) {
             focused = null;
             flashFocused = false;

--- a/dashboard-react/src/apps/cowork/guards/railTab.ts
+++ b/dashboard-react/src/apps/cowork/guards/railTab.ts
@@ -24,7 +24,12 @@ export function railTabStorageKey(
 
 /** Whether a stored value is a real RailTab and safe to restore. */
 function isRailTab(value: string | null): value is RailTab {
-  return value === "review" || value === "truth" || value === "chat";
+  return (
+    value === "review" ||
+    value === "truth" ||
+    value === "provenance" ||
+    value === "chat"
+  );
 }
 
 /** Read a retained rail tab, or null when none is present or it is unrecognized. */

--- a/dashboard-react/src/apps/cowork/provenance/index.ts
+++ b/dashboard-react/src/apps/cowork/provenance/index.ts
@@ -54,3 +54,4 @@ export {
   type CoworkPasteProvenanceOutboxEntry,
   type CoworkPasteProvenanceStatus,
 } from "./CoworkPasteProvenanceOutbox";
+export * from "./view";

--- a/dashboard-react/src/apps/cowork/provenance/view/LiveProvenanceProvider.test.ts
+++ b/dashboard-react/src/apps/cowork/provenance/view/LiveProvenanceProvider.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { CoworkDocClient } from "../../bridge/HttpCoworkDocClient";
+import type { R2DocPayload } from "../../bridge/types";
+import { LiveProvenanceProvider } from "./LiveProvenanceProvider";
+
+const payload = (history: readonly unknown[] = []): R2DocPayload => ({
+  document_id: "doc", store_id: "store", path: "doc.md", title: "Doc", profile: "document",
+  hashes: { ydoc_snapshot_sha256: null, last_materialized_sha256: null, current_file_sha256: null },
+  drift: { state: "clean", diff_available: false }, open_proposals: [], expressions: [], provenance_spans: [], events_cursor: "",
+  provenance: {
+    schema: "cowork-provenance-view/v1", current_structured_head_sha256: "a".repeat(64),
+    document_default: null, spans: [], history,
+    summary: { total_targets: 0, current_span_count: 0, ai_unreviewed_count: 0, reviewed_count: 0, conflicted_count: 0, stale_count: 0, unrecorded: true },
+  },
+});
+
+describe("LiveProvenanceProvider", () => {
+  it("retains one idempotency key and confirms a successor from a fresh pull", async () => {
+    const successor = {
+      attestation_id: "new", at: "2026-08-12T12:00:00Z",
+      asserted_by: { kind: "human", ref: "user", meta: null },
+      scope: { kind: "document_span", document_version_id: null, document_span_id: "span", structured_head_sha256: "a".repeat(64) },
+      authorship: { kind: "ai", contributors: [] }, human_review: { status: "reviewed", reviewers: [{ kind: "human", ref: "user" }] },
+      source: { kind: "paste" }, basis: { kind: "user_attestation", ref: "old" }, supersedes_id: "old", canonical_sha256: "b".repeat(64),
+    };
+    const mutation = vi.fn().mockResolvedValue(undefined);
+    const provider = new LiveProvenanceProvider(
+      { loadPayload: vi.fn().mockResolvedValue(payload()), refreshPayload: vi.fn().mockResolvedValue(payload([successor])), subscribe: () => () => undefined },
+      { fetchDoc: vi.fn(), markProvenanceReviewed: mutation } as unknown as CoworkDocClient,
+    );
+    await provider.markReviewed("old", "a".repeat(64));
+    expect(mutation).toHaveBeenCalledTimes(1);
+    expect(mutation.mock.calls[0]?.[2]).toMatch(/^provenance-review-/u);
+  });
+
+  it("reuses the same idempotency key when a successful write is not yet visible", async () => {
+    const mutation = vi.fn().mockResolvedValue(undefined);
+    const refreshPayload = vi.fn().mockResolvedValue(payload());
+    const provider = new LiveProvenanceProvider(
+      {
+        loadPayload: vi.fn().mockResolvedValue(payload()),
+        refreshPayload,
+        subscribe: () => () => undefined,
+      },
+      {
+        fetchDoc: vi.fn(),
+        markProvenanceReviewed: mutation,
+      } as unknown as CoworkDocClient,
+    );
+
+    await provider.markReviewed("old", "a".repeat(64));
+    await provider.markReviewed("old", "a".repeat(64));
+
+    expect(mutation).toHaveBeenCalledTimes(2);
+    expect(mutation.mock.calls[1]?.[2]).toBe(mutation.mock.calls[0]?.[2]);
+    expect(refreshPayload).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails only the provenance surface when rich wire data is malformed", async () => {
+    const bad = payload();
+    const provider = new LiveProvenanceProvider(
+      { loadPayload: vi.fn().mockResolvedValue({ ...bad, provenance: { schema: "bad" } }), refreshPayload: vi.fn(), subscribe: () => () => undefined },
+      { fetchDoc: vi.fn() } as unknown as CoworkDocClient,
+    );
+    await expect(provider.load()).resolves.toMatchObject({ state: "unavailable" });
+  });
+});

--- a/dashboard-react/src/apps/cowork/provenance/view/LiveProvenanceProvider.ts
+++ b/dashboard-react/src/apps/cowork/provenance/view/LiveProvenanceProvider.ts
@@ -1,0 +1,84 @@
+import type { CoworkDocClient } from "../../bridge/HttpCoworkDocClient";
+import type { R2DocPayload } from "../../bridge/types";
+import { mapProvenanceView } from "./provenanceMapping";
+import type { ProvenanceLoad, ProvenanceProvider } from "./contracts";
+
+export interface ProvenanceSnapshotSource {
+  loadPayload(): Promise<R2DocPayload>;
+  refreshPayload(): Promise<R2DocPayload>;
+  subscribe(listener: () => void): () => void;
+}
+
+/** Dedicated provenance seam backed by the shared document snapshot source. */
+export class LiveProvenanceProvider implements ProvenanceProvider {
+  readonly #source: ProvenanceSnapshotSource;
+  readonly #client: CoworkDocClient;
+  readonly #pendingKeys = new Map<string, string>();
+
+  constructor(source: ProvenanceSnapshotSource, client: CoworkDocClient) {
+    this.#source = source;
+    this.#client = client;
+  }
+
+  async load(): Promise<ProvenanceLoad> {
+    return this.#map(await this.#source.loadPayload());
+  }
+
+  async refresh(): Promise<ProvenanceLoad> {
+    return this.#map(await this.#source.refreshPayload());
+  }
+
+  #map(payload: R2DocPayload): ProvenanceLoad {
+    if (payload.provenance === undefined) {
+      return {
+        state: "unavailable",
+        reason: "This server did not provide the provenance view needed to explain the document safely.",
+      };
+    }
+    try {
+      return { state: "ready", data: mapProvenanceView(payload.provenance) };
+    } catch (error) {
+      return {
+        state: "unavailable",
+        reason:
+          error instanceof Error
+            ? error.message
+            : "The server returned a malformed provenance view.",
+      };
+    }
+  }
+
+  subscribe(listener: () => void): () => void {
+    return this.#source.subscribe(listener);
+  }
+
+  async markReviewed(
+    attestationId: string,
+    expectedStructuredHeadSha256: string,
+  ): Promise<void> {
+    const mutation = this.#client.markProvenanceReviewed;
+    if (mutation === undefined) throw new Error("Provenance review is unavailable.");
+    const fingerprint = `${attestationId}\u0000${expectedStructuredHeadSha256}`;
+    const idempotencyKey =
+      this.#pendingKeys.get(fingerprint) ??
+      `provenance-review-${globalThis.crypto.randomUUID()}`;
+    this.#pendingKeys.set(fingerprint, idempotencyKey);
+    await mutation.call(
+      this.#client,
+      attestationId,
+      expectedStructuredHeadSha256,
+      idempotencyKey,
+    );
+    const fresh = this.#map(await this.#source.refreshPayload());
+    if (
+      fresh.state === "ready" &&
+      fresh.data.history.some(
+        (record) =>
+          record.supersedesId === attestationId &&
+          record.humanReview.status === "reviewed",
+      )
+    ) {
+      this.#pendingKeys.delete(fingerprint);
+    }
+  }
+}

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenanceHoverCard.test.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenanceHoverCard.test.tsx
@@ -1,0 +1,64 @@
+import { createRef } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ProvenanceHoverCard } from "./ProvenanceHoverCard";
+
+describe("ProvenanceHoverCard", () => {
+  it("explains a decorated passage passively and dismisses with Escape", () => {
+    const root = document.createElement("div");
+    const passage = document.createElement("span");
+    passage.dataset.wbDecoration = "provenance-overlay";
+    passage.dataset.wbAuthorship = "ai";
+    passage.dataset.wbHumanReview = "not_reviewed";
+    passage.dataset.wbSource = "paste";
+    passage.dataset.wbSourceDetail = "plain text · source identity not verified";
+    passage.dataset.wbContributors = "model:gpt-5 · asserted identity";
+    passage.dataset.wbReviewers = "user-1 · enrolled local identity";
+    passage.dataset.wbAttester = "user-1";
+    passage.dataset.wbBasis = "user_attestation";
+    passage.dataset.wbHistoryCount = "2";
+    passage.dataset.wbProvenanceCurrentness = "multiple target states";
+    root.append(passage);
+    document.body.append(root);
+    const ref = createRef<HTMLElement>();
+    ref.current = root;
+    render(<ProvenanceHoverCard rootRef={ref} active editorReady />);
+
+    fireEvent.pointerOver(passage);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("ai authorship");
+    expect(screen.getByRole("tooltip")).toHaveTextContent("multiple target states");
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "model:gpt-5 · asserted identity",
+    );
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "user-1 · enrolled local identity",
+    );
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "plain text · source identity not verified",
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("tooltip")).toBeNull();
+    root.remove();
+  });
+
+  it("attaches after the active editor root mounts", () => {
+    const ref = { current: null as HTMLElement | null };
+    const { rerender } = render(
+      <ProvenanceHoverCard rootRef={ref} active editorReady={false} />,
+    );
+    const root = document.createElement("div");
+    const passage = document.createElement("span");
+    passage.dataset.wbDecoration = "provenance-overlay";
+    passage.dataset.wbAuthorship = "mixed";
+    root.append(passage);
+    document.body.append(root);
+    ref.current = root;
+
+    rerender(<ProvenanceHoverCard rootRef={ref} active editorReady />);
+    fireEvent.pointerOver(passage);
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent("mixed authorship");
+    root.remove();
+  });
+});

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenanceHoverCard.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenanceHoverCard.tsx
@@ -1,0 +1,159 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+import { createPortal } from "react-dom";
+
+interface HoverState {
+  readonly left: number;
+  readonly top: number;
+  readonly anchorLeft: number;
+  readonly anchorTop: number;
+  readonly anchorBottom: number;
+  readonly authorship: string;
+  readonly review: string;
+  readonly source: string;
+  readonly sourceDetail: string;
+  readonly contributors: string;
+  readonly reviewers: string;
+  readonly attester: string;
+  readonly basis: string;
+  readonly historyCount: string;
+  readonly conflicted: boolean;
+  readonly recordState: string;
+  readonly currentness: string;
+}
+
+const label = (value: string): string => value.replace(/_/gu, " ");
+
+/** Passive explanation for provenance-decorated text; all actions stay in the panel. */
+export function ProvenanceHoverCard({
+  rootRef,
+  active,
+  editorReady,
+}: {
+  readonly rootRef: RefObject<HTMLElement | null>;
+  readonly active: boolean;
+  /** Reactive mount signal for the otherwise non-reactive editor root ref. */
+  readonly editorReady: boolean;
+}) {
+  const [hover, setHover] = useState<HoverState | null>(null);
+  const cardRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!active || root === null) {
+      setHover(null);
+      return undefined;
+    }
+    const showElement = (target: Element | null): void => {
+      const element = target?.closest<HTMLElement>(
+        "[data-wb-decoration='provenance-overlay']",
+      ) ?? null;
+      if (element === null || !root.contains(element)) {
+        setHover(null);
+        return;
+      }
+      const rect = element.getBoundingClientRect();
+      setHover({
+        left: Math.max(8, rect.left),
+        top: Math.max(8, rect.bottom + 8),
+        anchorLeft: rect.left,
+        anchorTop: rect.top,
+        anchorBottom: rect.bottom,
+        authorship: element.dataset.wbAuthorship ?? "unknown",
+        review: element.dataset.wbHumanReview ?? "unknown",
+        source: element.dataset.wbSource ?? "unknown",
+        sourceDetail: element.dataset.wbSourceDetail ?? "No additional source detail",
+        contributors: element.dataset.wbContributors ?? "No contributors recorded",
+        reviewers: element.dataset.wbReviewers ?? "No reviewers recorded",
+        attester: element.dataset.wbAttester ?? "not recorded",
+        basis: element.dataset.wbBasis ?? "not recorded",
+        historyCount: element.dataset.wbHistoryCount ?? "0",
+        conflicted: element.dataset.wbProvenanceConflict === "true",
+        recordState: element.dataset.wbProvenanceRecordState ?? "recorded",
+        currentness: element.dataset.wbProvenanceCurrentness ?? "unknown",
+      });
+    };
+    const show = (event: Event): void => {
+      showElement(event.target instanceof Element ? event.target : null);
+    };
+    const showSelection = (): void => {
+      if (!root.contains(document.activeElement)) return;
+      const anchorNode = document.getSelection()?.anchorNode ?? null;
+      const element =
+        anchorNode instanceof Element ? anchorNode : anchorNode?.parentElement ?? null;
+      showElement(element);
+    };
+    const hide = (event: Event): void => {
+      if (event instanceof FocusEvent && event.relatedTarget instanceof Node && root.contains(event.relatedTarget)) return;
+      setHover(null);
+    };
+    root.addEventListener("pointerover", show);
+    root.addEventListener("focusin", show);
+    root.addEventListener("pointerleave", hide);
+    root.addEventListener("focusout", hide);
+    const escape = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") setHover(null);
+    };
+    document.addEventListener("keydown", escape);
+    document.addEventListener("selectionchange", showSelection);
+    return () => {
+      root.removeEventListener("pointerover", show);
+      root.removeEventListener("focusin", show);
+      root.removeEventListener("pointerleave", hide);
+      root.removeEventListener("focusout", hide);
+      document.removeEventListener("keydown", escape);
+      document.removeEventListener("selectionchange", showSelection);
+    };
+  }, [active, editorReady, rootRef]);
+  useLayoutEffect(() => {
+    const card = cardRef.current;
+    if (hover === null || card === null) return;
+    const gutter = 8;
+    const rect = card.getBoundingClientRect();
+    const width = Math.max(rect.width, card.offsetWidth);
+    const height = Math.max(rect.height, card.offsetHeight);
+    const left = Math.max(
+      gutter,
+      Math.min(hover.anchorLeft, window.innerWidth - width - gutter),
+    );
+    const below = hover.anchorBottom + gutter;
+    const top = Math.max(
+      gutter,
+      below + height <= window.innerHeight - gutter
+        ? below
+        : Math.min(hover.anchorTop - height - gutter, window.innerHeight - height - gutter),
+    );
+    if (left !== hover.left || top !== hover.top) {
+      setHover((current) =>
+        current === null ? null : { ...current, left, top },
+      );
+    }
+  }, [hover]);
+  if (!active || hover === null) return null;
+  return createPortal(
+    <aside
+      className="wb-cowork-provenance-hover"
+      role="tooltip"
+      ref={cardRef}
+      style={{ left: hover.left, top: hover.top }}
+    >
+      <strong>{hover.conflicted ? "Conflicting provenance" : hover.recordState === "unrecorded" ? "No provenance recorded" : `${label(hover.authorship)} authorship`}</strong>
+      <dl>
+        <div><dt>Human review</dt><dd>{label(hover.review)}</dd></div>
+        <div><dt>Contributors</dt><dd>{hover.contributors}</dd></div>
+        <div><dt>Reviewers</dt><dd>{hover.reviewers}</dd></div>
+        <div><dt>Source</dt><dd>{label(hover.source)} · {hover.sourceDetail}</dd></div>
+        <div><dt>Attested by</dt><dd>{hover.attester}</dd></div>
+        <div><dt>Basis</dt><dd>{label(hover.basis)}</dd></div>
+        <div><dt>Target</dt><dd>{label(hover.currentness)}</dd></div>
+        <div><dt>History</dt><dd>{hover.historyCount} records</dd></div>
+      </dl>
+      <p>Open Provenance for details and actions.</p>
+    </aside>,
+    document.body,
+  );
+}

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.test.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.test.tsx
@@ -1,0 +1,402 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  ProvenanceData,
+  ProvenanceEditorIntegration,
+  ProvenanceMutationBarrier,
+  ProvenanceProvider,
+} from "./contracts";
+import { ProvenancePanel } from "./ProvenancePanel";
+
+const attestation = {
+  attestationId: "attestation-1",
+  at: "2026-08-12T12:00:00Z",
+  assertedBy: { kind: "human", ref: "user-1", meta: null },
+  scope: {
+    kind: "document_span" as const,
+    documentVersionId: null,
+    documentSpanId: "span-1",
+    structuredHeadSha256: "a".repeat(64),
+  },
+  authorship: {
+    kind: "ai" as const,
+    contributors: [
+      {
+        kind: "human" as const,
+        ref: null,
+        label: "Taylor",
+        identityStatus: "claimed_name" as const,
+      },
+    ],
+  },
+  humanReview: { status: "not_reviewed" as const, reviewers: [] },
+  source: {
+    kind: "paste",
+    provider: "clipboard",
+    media_type: "text/plain",
+    path: "notes/source.txt",
+    sha256: "c".repeat(64),
+    private_metadata: { must_not_render: true },
+  },
+  basis: { kind: "user_attestation", ref: null },
+  supersedesId: null,
+  canonicalSha256: "b".repeat(64),
+};
+
+const data: ProvenanceData = {
+  schema: "cowork-provenance-view/v1",
+  currentStructuredHeadSha256: "a".repeat(64),
+  documentDefault: null,
+  spans: [
+    {
+      projectionId: "document_span:span-1",
+      target: {
+        kind: "document_span",
+        documentVersionId: null,
+        documentSpanId: "span-1",
+        structuredHeadSha256: "a".repeat(64),
+        currentness: "current",
+      },
+      span: { exact: "AI passage", prefix: "", suffix: "" },
+      effectiveAttestations: [attestation],
+      effectiveAttestation: attestation,
+      resolution: "resolved",
+      reviewEligibility: "eligible",
+      issue: null,
+      history: [attestation],
+    },
+  ],
+  history: [attestation],
+  summary: {
+    totalTargets: 1,
+    currentSpanCount: 1,
+    aiUnreviewedCount: 1,
+    reviewedCount: 0,
+    conflictedCount: 0,
+    staleCount: 0,
+    unrecorded: true,
+  },
+};
+
+const provider = (): ProvenanceProvider => ({
+  load: vi.fn().mockResolvedValue({ state: "ready", data }),
+  refresh: vi.fn().mockResolvedValue({ state: "ready", data }),
+  subscribe: () => () => undefined,
+  markReviewed: vi.fn().mockResolvedValue(undefined),
+});
+
+const editor: ProvenanceEditorIntegration = {
+  resolveTarget: () => ({ state: "unique", documentOrder: 20, documentEnd: 30 }),
+  isLocallyDirty: () => false,
+  hasText: () => true,
+  hasUncoveredText: () => true,
+  focusTarget: vi.fn(),
+  revealTarget: vi.fn(),
+};
+
+describe("ProvenancePanel", () => {
+  it("starts with the provenance controls instead of repeating tab help", async () => {
+    render(<ProvenancePanel provider={provider()} active editor={editor} />);
+
+    expect(await screen.findByLabelText("Provenance summary")).toBeVisible();
+    expect(screen.queryByText("Document provenance")).toBeNull();
+    expect(
+      screen.queryByText("How this text is attributed—and reviewed"),
+    ).toBeNull();
+    expect(
+      screen.queryByText(/Authorship and human review are separate records/u),
+    ).toBeNull();
+  });
+
+  it("subscribes once when a provider synchronously replays its retained snapshot", async () => {
+    const source = provider();
+    const load = vi.mocked(source.load);
+    source.subscribe = vi.fn((listener) => {
+      listener();
+      return () => undefined;
+    });
+
+    render(<ProvenancePanel provider={source} active editor={editor} />);
+
+    await screen.findByRole("button", { name: /AI passage/u });
+    await waitFor(() => expect(load).toHaveBeenCalledTimes(1));
+    expect(source.subscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps selection passive and reserves navigation for Show in document", async () => {
+    const source = provider();
+    render(
+      <ProvenancePanel
+        provider={source}
+        active
+        editor={editor}
+        mutationBarrier={{ runWithSynchronizedDocument: vi.fn() }}
+      />,
+    );
+    const item = await screen.findByRole("button", { name: /AI passage/u });
+    await userEvent.click(item);
+    expect(editor.focusTarget).toHaveBeenCalledWith("document_span:span-1");
+    expect(editor.revealTarget).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole("button", { name: "Show in document" }));
+    expect(editor.revealTarget).toHaveBeenCalledWith("document_span:span-1");
+    expect(screen.getByText(/no current provenance record/u)).toBeVisible();
+  });
+
+  it("holds the editor barrier across refresh, re-resolution, and mutation", async () => {
+    const source = provider();
+    let locked = false;
+    const refresh = vi.mocked(source.refresh);
+    refresh.mockImplementation(async () => {
+      expect(locked).toBe(true);
+      return { state: "ready", data };
+    });
+    vi.mocked(source.markReviewed).mockImplementation(async () => {
+      expect(locked).toBe(true);
+    });
+    const barrier: ProvenanceMutationBarrier = {
+      runWithSynchronizedDocument: async (operation) => {
+        locked = true;
+        try {
+          return await operation({ structuredHeadSha256: "a".repeat(64) });
+        } finally {
+          locked = false;
+        }
+      },
+    };
+    render(
+      <ProvenancePanel
+        provider={source}
+        active
+        editor={editor}
+        mutationBarrier={barrier}
+      />,
+    );
+    await userEvent.click(await screen.findByRole("button", { name: /AI passage/u }));
+    await userEvent.click(screen.getByRole("button", { name: "Mark reviewed" }));
+    await waitFor(() => expect(source.markReviewed).toHaveBeenCalledOnce());
+    expect(locked).toBe(false);
+  });
+
+  it("blocks the write when a fresh pull introduces an incompatible overlap", async () => {
+    const source = provider();
+    const peerRecord = {
+      ...attestation,
+      attestationId: "attestation-peer",
+      scope: { ...attestation.scope, documentSpanId: "span-peer" },
+      authorship: { kind: "human" as const, contributors: [] },
+    };
+    const peer = {
+      ...data.spans[0]!,
+      projectionId: "document_span:span-peer",
+      target: { ...data.spans[0]!.target, documentSpanId: "span-peer" },
+      span: { exact: "passage and", prefix: "AI ", suffix: " words" },
+      effectiveAttestations: [peerRecord],
+      effectiveAttestation: peerRecord,
+      reviewEligibility: "not_ai_authored" as const,
+      history: [peerRecord],
+    };
+    vi.mocked(source.refresh).mockResolvedValue({
+      state: "ready",
+      data: { ...data, spans: [data.spans[0]!, peer] },
+    });
+    const overlapEditor: ProvenanceEditorIntegration = {
+      ...editor,
+      resolveTarget: (anchor) =>
+        anchor.exact === "AI passage"
+          ? { state: "unique", documentOrder: 5, documentEnd: 20 }
+          : { state: "unique", documentOrder: 10, documentEnd: 25 },
+    };
+    render(
+      <ProvenancePanel
+        provider={source}
+        active
+        editor={overlapEditor}
+        mutationBarrier={{
+          runWithSynchronizedDocument: (operation) =>
+            operation({ structuredHeadSha256: "a".repeat(64) }),
+        }}
+      />,
+    );
+    await userEvent.click(await screen.findByRole("button", { name: /AI passage/u }));
+    await userEvent.click(screen.getByRole("button", { name: "Mark reviewed" }));
+    await screen.findByRole("alert");
+    expect(source.markReviewed).not.toHaveBeenCalled();
+  });
+
+  it("does not claim an empty editor contains unrecorded text", async () => {
+    render(
+      <ProvenancePanel
+        provider={{ ...provider(), load: vi.fn().mockResolvedValue({ state: "ready", data: { ...data, spans: [], history: [] } }) }}
+        active
+        editor={{ ...editor, hasText: () => false }}
+      />,
+    );
+    expect(await screen.findByText("There is no text to map yet.")).toBeVisible();
+    expect(screen.queryByText(/Some text has no current provenance/u)).toBeNull();
+    expect(screen.queryByText("No provenance records match this filter.")).toBeNull();
+  });
+
+  it("keeps global append-only history inspectable without a current head", async () => {
+    render(
+      <ProvenancePanel
+        provider={{
+          ...provider(),
+          load: vi.fn().mockResolvedValue({
+            state: "ready",
+            data: {
+              ...data,
+              currentStructuredHeadSha256: null,
+              spans: [],
+            },
+          }),
+        }}
+        active
+        editor={editor}
+      />,
+    );
+    const history = await screen.findByText("Complete provenance history (1)");
+    await userEvent.click(history);
+    expect(screen.getByText(/Passage · span-1/u)).toBeVisible();
+  });
+
+  it("includes a uniquely reanchored target in Issues", async () => {
+    const reanchored = {
+      ...data.spans[0]!,
+      target: {
+        ...data.spans[0]!.target,
+        currentness: "requires_reanchor" as const,
+      },
+      reviewEligibility: "stale_target" as const,
+    };
+    render(
+      <ProvenancePanel
+        provider={{
+          ...provider(),
+          load: vi.fn().mockResolvedValue({
+            state: "ready",
+            data: { ...data, spans: [reanchored] },
+          }),
+        }}
+        active
+        editor={editor}
+      />,
+    );
+    await userEvent.click(await screen.findByRole("button", { name: "Issues" }));
+    expect(screen.getByRole("button", { name: /AI passage/u })).toHaveTextContent(
+      "Reanchored for inspection",
+    );
+  });
+
+  it("labels an unavailable orphaned passage without document actions", async () => {
+    const orphaned = {
+      ...data.spans[0]!,
+      target: {
+        ...data.spans[0]!.target,
+        currentness: "unavailable" as const,
+      },
+      span: null,
+      effectiveAttestations: [attestation],
+      effectiveAttestation: null,
+      resolution: "conflicted" as const,
+      reviewEligibility: "conflicted" as const,
+      issue: {
+        code: "missing_span_target",
+        message: "The recorded provenance span is unavailable.",
+      },
+    };
+    render(
+      <ProvenancePanel
+        provider={{
+          ...provider(),
+          load: vi.fn().mockResolvedValue({
+            state: "ready",
+            data: { ...data, spans: [orphaned] },
+          }),
+        }}
+        active
+        editor={editor}
+        mutationBarrier={{ runWithSynchronizedDocument: vi.fn() }}
+      />,
+    );
+
+    const item = await screen.findByRole("button", {
+      name: /Unavailable passage/u,
+    });
+    expect(item).toHaveTextContent("Passage unavailable");
+    expect(item).not.toHaveTextContent("Whole document");
+    await userEvent.click(item);
+    expect(screen.queryByRole("button", { name: "Show in document" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Mark reviewed" })).toBeNull();
+    expect(screen.getByText(/append-only history remains inspectable/u)).toBeVisible();
+  });
+
+  it("shows bounded source fields and identity strength without dumping raw metadata", async () => {
+    render(
+      <ProvenancePanel
+        provider={provider()}
+        active
+        editor={editor}
+      />,
+    );
+    await userEvent.click(await screen.findByRole("button", { name: /AI passage/u }));
+
+    expect(
+      screen.getAllByText(
+        /Taylor \(claimed name; not account-verified\)/u,
+      ).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Provider: clipboard/u).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Media type: text\/plain/u).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Path: notes\/source\.txt/u).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/must_not_render/u)).toBeNull();
+  });
+
+  it("blocks review and explains incompatible overlapping provenance", async () => {
+    const human = {
+      ...attestation,
+      attestationId: "attestation-2",
+      scope: { ...attestation.scope, documentSpanId: "span-2" },
+      authorship: { kind: "human" as const, contributors: [] },
+    };
+    const overlapping = {
+      ...data.spans[0]!,
+      projectionId: "document_span:span-2",
+      target: { ...data.spans[0]!.target, documentSpanId: "span-2" },
+      span: { exact: "passage and", prefix: "AI ", suffix: " uncovered" },
+      effectiveAttestations: [human],
+      effectiveAttestation: human,
+      reviewEligibility: "not_ai_authored" as const,
+      history: [human],
+    };
+    const overlapEditor: ProvenanceEditorIntegration = {
+      ...editor,
+      resolveTarget: (anchor) =>
+        anchor.exact === "AI passage"
+          ? { state: "unique", documentOrder: 5, documentEnd: 20 }
+          : { state: "unique", documentOrder: 10, documentEnd: 25 },
+    };
+    render(
+      <ProvenancePanel
+        provider={{
+          ...provider(),
+          load: vi.fn().mockResolvedValue({
+            state: "ready",
+            data: { ...data, spans: [data.spans[0]!, overlapping] },
+          }),
+        }}
+        active
+        editor={overlapEditor}
+        mutationBarrier={{ runWithSynchronizedDocument: vi.fn() }}
+      />,
+    );
+    await userEvent.click(await screen.findByRole("button", { name: /AI passage/u }));
+    expect(
+      screen.getByText(/Overlapping provenance records disagree on authorship/u),
+    ).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Mark reviewed" })).toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: "Issues" }));
+    expect(screen.getAllByText("Conflicts with overlapping passage")).toHaveLength(2);
+  });
+});

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.tsx
@@ -1,0 +1,679 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefCallback,
+} from "react";
+
+import type {
+  ProvenanceAttestation, ProvenanceEditorIntegration, ProvenanceLoad,
+  ProvenanceProvider, ProvenanceTarget,
+  ProvenanceMutationBarrier,
+} from "./contracts";
+import {
+  provenanceDisplayedAxesFingerprint,
+  provenancePersonDetail,
+  provenanceSourceDetails,
+} from "./semantics";
+import {
+  asCoworkApiError,
+  coworkErrorMessage,
+} from "../../providers/errors";
+
+type ProvenanceFilter = "all" | "needs_review" | "ai_authored" | "issues";
+
+export interface ProvenancePanelProps {
+  readonly provider: ProvenanceProvider;
+  readonly active: boolean;
+  readonly scrollContainerRef?: RefCallback<HTMLElement>;
+  readonly editor?: ProvenanceEditorIntegration;
+  readonly readOnly?: boolean;
+  readonly mutationBarrier?: ProvenanceMutationBarrier;
+}
+
+const sourceLabel = (attestation: ProvenanceAttestation): string => {
+  const kind = attestation.source.kind;
+  return typeof kind === "string" ? kind.replace(/_/gu, " ") : "Unknown source";
+};
+
+const passageExcerpt = (value: string, max = 180): string =>
+  value.length <= max ? value : `${value.slice(0, max - 1)}…`;
+
+const mutationErrorMessage = (cause: unknown): string => {
+  const error = asCoworkApiError(cause);
+  if (
+    error.code.includes("stale") ||
+    error.code.includes("conflict") ||
+    error.status === 409
+  ) {
+    return "The document or provenance record changed. The latest view was requested; inspect the passage before trying again.";
+  }
+  if (error.code.includes("actor") || error.code.includes("identity")) {
+    return "Your review identity changed. Refresh Co-work, confirm your identity, and try again.";
+  }
+  return coworkErrorMessage(
+    error,
+    error.retryable
+      ? "This review was not confirmed. Retry will safely reuse the same request."
+      : "This passage could not be marked reviewed.",
+  );
+};
+
+const targetId = (target: ProvenanceTarget): string =>
+  target.projectionId;
+
+const effective = (target: ProvenanceTarget): ProvenanceAttestation | null =>
+  target.resolution === "resolved" ? target.effectiveAttestation : null;
+
+type AnchorState =
+  | "unique"
+  | "missing"
+  | "ambiguous"
+  | "document"
+  | "unavailable";
+
+interface ResolvedPanelTarget {
+  readonly target: ProvenanceTarget;
+  readonly payloadOrder: number;
+  readonly anchorResolution: {
+    readonly state: AnchorState;
+    readonly documentOrder: number | null;
+    readonly documentEnd: number | null;
+  };
+  readonly peerConflictIds: readonly string[];
+}
+
+const targetAxes = (target: ProvenanceTarget): readonly string[] =>
+  target.effectiveAttestations.map(provenanceDisplayedAxesFingerprint);
+
+const incompatibleOverlap = (
+  left: ResolvedPanelTarget,
+  right: ResolvedPanelTarget,
+): boolean => {
+  if (
+    left.target.span === null ||
+    right.target.span === null ||
+    left.target.target.currentness === "stale" ||
+    left.target.target.currentness === "unavailable" ||
+    right.target.target.currentness === "stale" ||
+    right.target.target.currentness === "unavailable" ||
+    left.anchorResolution.state !== "unique" ||
+    right.anchorResolution.state !== "unique" ||
+    left.anchorResolution.documentOrder === null ||
+    right.anchorResolution.documentOrder === null ||
+    left.anchorResolution.documentEnd === null ||
+    right.anchorResolution.documentEnd === null ||
+    left.anchorResolution.documentOrder >= right.anchorResolution.documentEnd ||
+    right.anchorResolution.documentOrder >= left.anchorResolution.documentEnd
+  ) {
+    return false;
+  }
+  return new Set([...targetAxes(left.target), ...targetAxes(right.target)]).size > 1;
+};
+
+const withPeerConflicts = (
+  items: readonly Omit<ResolvedPanelTarget, "peerConflictIds">[],
+): readonly ResolvedPanelTarget[] =>
+  items.map((item, index) => ({
+    ...item,
+    peerConflictIds: items.flatMap((candidate, candidateIndex) =>
+      candidateIndex !== index &&
+      incompatibleOverlap(
+        { ...item, peerConflictIds: [] },
+        { ...candidate, peerConflictIds: [] },
+      )
+        ? [candidate.target.projectionId]
+        : [],
+    ),
+  }));
+
+const resolvePanelTargets = (
+  view: Extract<ProvenanceLoad, { readonly state: "ready" }>["data"],
+  editor: ProvenanceEditorIntegration | undefined,
+): readonly ResolvedPanelTarget[] =>
+  [...withPeerConflicts(
+    [
+      ...(view.documentDefault === null ? [] : [view.documentDefault]),
+      ...view.spans,
+    ].map((target, payloadOrder) => {
+      const anchorResolution =
+        target.span === null && target.target.kind === "document_version"
+          ? {
+              state: "document" as const,
+              documentOrder: -1,
+              documentEnd: null,
+            }
+          : target.span === null
+            ? {
+                state: "unavailable" as const,
+                documentOrder: null,
+                documentEnd: null,
+              }
+          : editor?.resolveTarget(target.span) ?? {
+              state: "missing" as const,
+              documentOrder: null,
+              documentEnd: null,
+            };
+      return { target, payloadOrder, anchorResolution };
+    }),
+  )].sort((left, right) => {
+    const leftOrder = left.anchorResolution.documentOrder;
+    const rightOrder = right.anchorResolution.documentOrder;
+    if (leftOrder !== null && rightOrder !== null) return leftOrder - rightOrder;
+    if (leftOrder !== null) return -1;
+    if (rightOrder !== null) return 1;
+    return left.payloadOrder - right.payloadOrder;
+  });
+
+const statusLabel = (target: ProvenanceTarget, anchorState: AnchorState): string => {
+  if (anchorState === "unavailable") return "Passage unavailable";
+  if (target.resolution === "conflicted") return "Conflicting records";
+  if (anchorState === "missing") return "Passage not found";
+  if (anchorState === "ambiguous") return "Matches multiple passages";
+  if (target.target.currentness === "stale") return "Stale target";
+  if (target.target.currentness === "unavailable") return "Target unavailable";
+  if (target.target.currentness === "requires_reanchor") {
+    return anchorState === "unique" ? "Reanchored for inspection" : "Needs location check";
+  }
+  const record = effective(target);
+  if (record === null) return "Unrecorded";
+  const author = record.authorship.kind === "ai" ? "AI" : record.authorship.kind;
+  const review = record.humanReview.status.replace(/_/gu, " ");
+  return `${author} · ${review}`;
+};
+
+const canReview = (
+  target: ProvenanceTarget,
+  anchorState: AnchorState,
+  hasPeerConflict = false,
+  locallyDirty = false,
+): boolean => {
+  const record = effective(target);
+  return (
+    !locallyDirty &&
+    !hasPeerConflict &&
+    target.reviewEligibility === "eligible" &&
+    target.target.currentness === "current" &&
+    (anchorState === "unique" || anchorState === "document") &&
+    target.resolution === "resolved" &&
+    record !== null &&
+    (record.authorship.kind === "ai" || record.authorship.kind === "mixed") &&
+    (record.humanReview.status === "not_reviewed" ||
+      record.humanReview.status === "unknown")
+  );
+};
+
+const reviewBlockedReason = (target: ProvenanceTarget): string => {
+  if (target.resolution === "conflicted") {
+    return "Resolve the conflicting attestations before recording review.";
+  }
+  if (target.target.currentness === "stale") {
+    return "This record targets an older document version.";
+  }
+  if (target.target.currentness === "requires_reanchor") {
+    return "This passage is re-anchored for inspection, but recording review requires an unchanged document head.";
+  }
+  const record = effective(target);
+  if (record === null) return "No single effective attestation is available.";
+  if (record.humanReview.status === "reviewed") return "Already reviewed.";
+  if (record.authorship.kind !== "ai" && record.authorship.kind !== "mixed") {
+    return "Review attribution is available only for AI or mixed authorship.";
+  }
+  return "This provenance record is inspect-only.";
+};
+
+const matches = (
+  target: ProvenanceTarget,
+  filter: ProvenanceFilter,
+  anchorState: AnchorState,
+  hasPeerConflict = false,
+): boolean => {
+  const record = effective(target);
+  if (filter === "all") return true;
+  if (filter === "issues") {
+    return (
+      hasPeerConflict ||
+      target.resolution === "conflicted" ||
+      target.target.currentness === "stale" ||
+      target.target.currentness === "requires_reanchor" ||
+      target.target.currentness === "unavailable" ||
+      anchorState === "missing" ||
+      anchorState === "ambiguous"
+    );
+  }
+  if (filter === "needs_review") {
+    return (
+      (record?.authorship.kind === "ai" || record?.authorship.kind === "mixed") &&
+      (record.humanReview.status === "not_reviewed" || record.humanReview.status === "unknown")
+    );
+  }
+  return record?.authorship.kind === "ai" || record?.authorship.kind === "mixed";
+};
+
+const isIssue = (
+  item: ResolvedPanelTarget,
+  locallyDirty: boolean,
+): boolean =>
+  locallyDirty ||
+  matches(
+    item.target,
+    "issues",
+    item.anchorResolution.state,
+    item.peerConflictIds.length > 0,
+  );
+
+const shortIdentity = (value: string | null): string | null =>
+  value === null || value.length <= 12
+    ? value
+    : `${value.slice(0, 6)}…${value.slice(-4)}`;
+
+function RecordDetails({ record }: { readonly record: ProvenanceAttestation }) {
+  const attester = record.assertedBy.ref ?? record.assertedBy.kind;
+  const sourceDetails = provenanceSourceDetails(record);
+  return (
+    <dl className="wb-cowork-provenance-panel__facts">
+      <div><dt>Authorship</dt><dd>{record.authorship.kind}</dd></div>
+      <div><dt>Contributors</dt><dd>{record.authorship.contributors.map(provenancePersonDetail).join(", ") || "None recorded"}</dd></div>
+      <div><dt>Human review</dt><dd>{record.humanReview.status.replace(/_/gu, " ")}</dd></div>
+      <div><dt>Reviewers</dt><dd>{record.humanReview.reviewers.map(provenancePersonDetail).join(", ") || "None recorded"}</dd></div>
+      <div><dt>Source</dt><dd>{sourceLabel(record)}</dd></div>
+      {sourceDetails.length === 0 ? null : (
+        <div>
+          <dt>Source details</dt>
+          <dd>{sourceDetails.map((detail) => `${detail.label}: ${detail.value}`).join(" · ")}</dd>
+        </div>
+      )}
+      <div><dt>Attested by</dt><dd>{attester}</dd></div>
+      <div><dt>Basis</dt><dd>{record.basis.kind.replace(/_/gu, " ")}</dd></div>
+      <div><dt>Target</dt><dd>{record.scope.kind === "document_span" ? "Passage" : "Document version"}{record.scope.documentSpanId === null ? "" : ` · ${shortIdentity(record.scope.documentSpanId)}`}{record.scope.documentVersionId === null ? "" : ` · ${shortIdentity(record.scope.documentVersionId)}`}</dd></div>
+      <div><dt>Recorded</dt><dd><time dateTime={record.at}>{new Date(record.at).toLocaleString()}</time></dd></div>
+    </dl>
+  );
+}
+
+function ProvenanceDetails({ target }: { readonly target: ProvenanceTarget }) {
+  const record = effective(target);
+  if (record === null) {
+    return (
+      <div className="wb-cowork-provenance-panel__conflict">
+        <p className="wb-cowork-provenance-panel__reason">
+          {target.issue?.message ?? `${String(target.effectiveAttestations.length)} effective records disagree; none is treated as authoritative.`}
+        </p>
+        {target.effectiveAttestations.map((leaf) => (
+          <article key={leaf.attestationId}>
+            <h4>Effective record</h4>
+            <RecordDetails record={leaf} />
+          </article>
+        ))}
+      </div>
+    );
+  }
+  return (
+    <>
+      <RecordDetails record={record} />
+      <details className="wb-cowork-provenance-panel__history">
+        <summary>{target.history.length} immutable {target.history.length === 1 ? "record" : "records"}</summary>
+        <ol>
+          {target.history.map((entry) => (
+            <li key={entry.attestationId}>
+              <RecordDetails record={entry} />
+              <p>{entry.supersedesId === null ? "Original record" : "Supersedes an earlier record"}</p>
+            </li>
+          ))}
+        </ol>
+      </details>
+    </>
+  );
+}
+
+function ProvenanceContents({
+  load,
+  provider, editor, mutationBarrier,
+  readOnly,
+}: {
+  readonly load: ProvenanceLoad;
+  readonly provider: ProvenanceProvider;
+  readonly editor?: ProvenanceEditorIntegration;
+  readonly readOnly?: boolean;
+  readonly mutationBarrier?: ProvenanceMutationBarrier;
+}) {
+  const view = load.state === "ready" ? load.data : undefined;
+  const [filter, setFilter] = useState<ProvenanceFilter>("all");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const mutationLock = useRef(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  if (view === undefined) {
+    return (
+      <div className="wb-cowork-provenance-panel__unavailable" role="status">
+        <h2>Provenance view unavailable</h2>
+        <p>
+          {load.state === "unavailable" ? load.reason : "This server did not provide the provenance view needed to explain the document safely."}
+        </p>
+      </div>
+    );
+  }
+  const targets = resolvePanelTargets(view, editor);
+  const locallyDirty = editor?.isLocallyDirty() ?? false;
+  const visible = targets.filter((item) =>
+    filter === "issues"
+      ? isIssue(item, locallyDirty)
+      : matches(
+          item.target,
+          filter,
+          item.anchorResolution.state,
+          item.peerConflictIds.length > 0,
+        ),
+  );
+  const needsReviewCount = targets.filter((item) =>
+    matches(
+      item.target,
+      "needs_review",
+      item.anchorResolution.state,
+      item.peerConflictIds.length > 0,
+    ),
+  ).length;
+  const reviewedCount = targets.filter(
+    ({ target }) => effective(target)?.humanReview.status === "reviewed",
+  ).length;
+  const issueCount = targets.filter((item) => isIssue(item, locallyDirty)).length;
+  const unrecorded =
+    (editor?.hasText() ?? true) &&
+    (locallyDirty ||
+      view.documentDefault === null ||
+      view.documentDefault.target.currentness !== "current" ||
+      view.documentDefault.effectiveAttestations.length === 0) &&
+    (editor?.hasUncoveredText(
+      view.spans.flatMap((target) =>
+        target.span !== null &&
+        target.effectiveAttestations.length > 0 &&
+        target.target.currentness !== "stale" &&
+        target.target.currentness !== "unavailable"
+          ? [target.span]
+          : [],
+      ),
+    ) ?? true);
+  const selected = targets.find((item) => targetId(item.target) === selectedId)?.target ?? null;
+  const markReviewed = async (target: ProvenanceTarget): Promise<void> => {
+    if (mutationLock.current) return;
+    const record = effective(target);
+    if (record === null || view.currentStructuredHeadSha256 === null) return;
+    mutationLock.current = true;
+    setPendingId(record.attestationId);
+    setError(null);
+    setSuccess(null);
+    try {
+      if (mutationBarrier === undefined) {
+        throw new Error("The editor is not ready to record review safely.");
+      }
+      await mutationBarrier.runWithSynchronizedDocument(
+        async (synchronized) => {
+          const refreshed = await provider.refresh();
+          if (refreshed.state !== "ready") {
+            throw new Error(refreshed.reason);
+          }
+          const refreshedTarget = [
+            ...(refreshed.data.documentDefault === null
+              ? []
+              : [refreshed.data.documentDefault]),
+            ...refreshed.data.spans,
+          ].find((candidate) => candidate.projectionId === target.projectionId);
+          const refreshedRecord =
+            refreshedTarget === undefined ? null : effective(refreshedTarget);
+          const refreshedItem = resolvePanelTargets(
+            refreshed.data,
+            editor,
+          ).find((candidate) => candidate.target.projectionId === target.projectionId);
+          if (
+            refreshed.data.currentStructuredHeadSha256 === null ||
+            synchronized.structuredHeadSha256 !==
+              refreshed.data.currentStructuredHeadSha256 ||
+            refreshedTarget === undefined ||
+            refreshedTarget.reviewEligibility !== "eligible" ||
+            refreshedRecord?.attestationId !== record.attestationId ||
+            refreshedItem === undefined ||
+            refreshedItem.peerConflictIds.length > 0
+          ) {
+            throw new Error(
+              "The document changed. Provenance was refreshed; inspect the passage and try again.",
+            );
+          }
+          if (
+            refreshedTarget.span !== null &&
+            editor?.resolveTarget(refreshedTarget.span).state !== "unique"
+          ) {
+            throw new Error("The passage no longer resolves to one location.");
+          }
+          await provider.markReviewed(
+            refreshedRecord.attestationId,
+            refreshed.data.currentStructuredHeadSha256,
+          );
+          setSuccess(
+            `Human review was recorded for “${refreshedTarget.span === null ? "the whole document" : passageExcerpt(refreshedTarget.span.exact)}”.`,
+          );
+        },
+      );
+    } catch (cause) {
+      setError(mutationErrorMessage(cause));
+    } finally {
+      mutationLock.current = false;
+      setPendingId(null);
+    }
+  };
+  return (
+    <>
+      <dl className="wb-cowork-provenance-panel__summary" aria-label="Provenance summary">
+        <div><dt>Needs review</dt><dd>{needsReviewCount}</dd></div>
+        <div><dt>Reviewed</dt><dd>{reviewedCount}</dd></div>
+        <div><dt>Issues</dt><dd>{issueCount}</dd></div>
+        <div><dt>Unrecorded</dt><dd>{unrecorded ? "Yes" : "No"}</dd></div>
+      </dl>
+      <div className="wb-cowork-provenance-panel__filters" aria-label="Filter provenance" role="group">
+        {(["all", "needs_review", "ai_authored", "issues"] as const).map((item) => (
+          <button
+            key={item}
+            type="button"
+            aria-pressed={filter === item}
+            onClick={() => setFilter(item)}
+          >
+            {item.replace(/_/gu, " ").replace(/^./u, (letter: string) => letter.toUpperCase())}
+          </button>
+        ))}
+      </div>
+      {error === null ? null : <p className="wb-cowork-provenance-panel__error" role="alert">{error}</p>}
+      {locallyDirty ? (
+        <p className="wb-cowork-provenance-panel__reason" role="status">
+          Local edits are not yet represented by the latest provenance snapshot. Exact passages are reanchored for inspection; recording review waits for synchronization.
+        </p>
+      ) : null}
+      <p className="wb-cowork-provenance-panel__success" aria-live="polite">
+        {success ?? ""}
+      </p>
+      {unrecorded && filter === "all" ? (
+        <article className="wb-cowork-provenance-panel__unrecorded">
+          <h3>Some text has no current provenance record</h3>
+          <p>Unrecorded text is shown with the unknown pattern. It is not assumed to be human-authored.</p>
+        </article>
+      ) : null}
+      {!unrecorded && targets.length === 0 ? (
+        <p className="wb-cowork-provenance-panel__empty">There is no text to map yet.</p>
+      ) : null}
+      {visible.length === 0 && (editor?.hasText() ?? true) ? (
+        <p className="wb-cowork-provenance-panel__empty">No provenance records match this filter.</p>
+      ) : (
+        <ol className="wb-cowork-provenance-panel__list">
+          {visible.map(({ target, anchorResolution, peerConflictIds }, index) => {
+            const id = targetId(target);
+            const record = effective(target);
+            const quote =
+              target.span !== null
+                ? passageExcerpt(target.span.exact)
+                : target.target.kind === "document_version"
+                  ? "Whole document"
+                  : "Unavailable passage";
+            const active = selectedId === id;
+            return (
+              <li key={`${id}:${String(index)}`} data-state={peerConflictIds.length > 0 || target.resolution === "conflicted" || target.target.currentness !== "current" ? "issue" : "recorded"}>
+                <button
+                  type="button"
+                  className="wb-cowork-provenance-panel__item"
+                  aria-expanded={active}
+                  onClick={() => {
+                    setSelectedId(active ? null : id);
+                    if (anchorResolution.state === "unique") {
+                      editor?.focusTarget(id);
+                    }
+                  }}
+                >
+                  <span className="wb-cowork-provenance-panel__quote">{quote}</span>
+                  <span className="wb-cowork-provenance-panel__status">{peerConflictIds.length > 0 ? "Conflicts with overlapping passage" : locallyDirty && target.target.currentness === "current" ? target.span === null ? "Awaiting provenance refresh" : anchorResolution.state === "unique" ? "Reanchored for inspection" : statusLabel(target, anchorResolution.state) : statusLabel(target, anchorResolution.state)}</span>
+                </button>
+                {active ? (
+                  <div className="wb-cowork-provenance-panel__detail">
+                    <ProvenanceDetails target={target} />
+                    {peerConflictIds.length > 0 ? (
+                      <div className="wb-cowork-provenance-panel__conflict">
+                        <p className="wb-cowork-provenance-panel__reason">
+                          Overlapping provenance records disagree on authorship, review, or source. Review recording is blocked until that conflict is resolved.
+                        </p>
+                        <ul>
+                          {peerConflictIds.map((peerId) => {
+                            const peer = targets.find(
+                              (candidate) => candidate.target.projectionId === peerId,
+                            )?.target;
+                            return peer === undefined ? null : (
+                              <li key={peerId}>
+                                 <strong>{peer.span !== null ? passageExcerpt(peer.span.exact) : peer.target.kind === "document_version" ? "Whole document" : "Unavailable passage"}</strong>
+                                {peer.effectiveAttestations.map((leaf) => (
+                                  <RecordDetails key={leaf.attestationId} record={leaf} />
+                                ))}
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      </div>
+                    ) : null}
+                    {anchorResolution.state === "unavailable" ? (
+                      <p className="wb-cowork-provenance-panel__reason">The recorded passage target is unavailable. Its append-only history remains inspectable, but it cannot be shown or reviewed.</p>
+                    ) : anchorResolution.state === "missing" ? (
+                      <p className="wb-cowork-provenance-panel__reason">The recorded passage is no longer present in this document.</p>
+                    ) : anchorResolution.state === "ambiguous" ? (
+                      <p className="wb-cowork-provenance-panel__reason">The recorded passage matches multiple locations, so Co-work will not choose one.</p>
+                    ) : null}
+                    {target.span !== null && anchorResolution.state === "unique" ? (
+                      <button type="button" onClick={() => editor?.revealTarget(id)}>
+                        Show in document
+                      </button>
+                    ) : null}
+                    {canReview(target, anchorResolution.state, peerConflictIds.length > 0, locallyDirty) && view.currentStructuredHeadSha256 !== null && readOnly !== true && mutationBarrier !== undefined ? (
+                      <button
+                        type="button"
+                        disabled={pendingId !== null}
+                        onClick={() => void markReviewed(target)}
+                      >
+                        {pendingId === record?.attestationId ? "Recording…" : "Mark reviewed"}
+                      </button>
+                    ) : (
+                      <p className="wb-cowork-provenance-panel__reason">
+                        {peerConflictIds.length > 0
+                          ? "Overlapping provenance records disagree, so review cannot be recorded."
+                          : locallyDirty
+                            ? "Synchronize local edits and refresh provenance before recording review."
+                          : view.currentStructuredHeadSha256 === null && canReview(target, anchorResolution.state)
+                            ? "No current structured document head is available, so review cannot be recorded."
+                          : readOnly === true && canReview(target, anchorResolution.state)
+                          ? "This document is read-only, so review cannot be recorded."
+                          : mutationBarrier === undefined && canReview(target, anchorResolution.state)
+                            ? "The editor is not ready to record review safely."
+                          : reviewBlockedReason(target)}
+                      </p>
+                    )}
+                  </div>
+                ) : null}
+              </li>
+            );
+          })}
+        </ol>
+      )}
+      <details className="wb-cowork-provenance-panel__global-history">
+        <summary>
+          Complete provenance history ({view.history.length})
+        </summary>
+        {view.history.length === 0 ? (
+          <p>No immutable provenance records have been recorded.</p>
+        ) : (
+          <ol>
+            {view.history.map((entry) => (
+              <li key={entry.attestationId}>
+                <RecordDetails record={entry} />
+                <p>
+                  {entry.supersedesId === null
+                    ? "Original append-only entry"
+                    : "Supersedes a prior append-only entry"}
+                </p>
+              </li>
+            ))}
+          </ol>
+        )}
+      </details>
+      {selected === null ? null : <span className="wb-visually-hidden">Provenance target selected</span>}
+    </>
+  );
+}
+
+export function ProvenancePanel(props: ProvenancePanelProps) {
+  const [data, setData] = useState<ProvenanceLoad | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reload, setReload] = useState(0);
+  const requestSequence = useRef(0);
+  const load = useCallback((): void => {
+    const sequence = ++requestSequence.current;
+    void props.provider.load().then(
+      (next) => {
+        if (sequence === requestSequence.current) {
+          setData(next);
+          setError(null);
+        }
+      },
+      (cause) => {
+        if (sequence === requestSequence.current) {
+          setError(
+            cause instanceof Error
+              ? cause.message
+              : "Provenance could not load.",
+          );
+        }
+      },
+    );
+  }, [props.provider]);
+  useEffect(() => {
+    if (!props.active) return undefined;
+    load();
+    return undefined;
+  }, [load, props.active, reload]);
+  useEffect(() => {
+    if (!props.active) return undefined;
+    let subscribing = true;
+    const unsubscribe = props.provider.subscribe(() => {
+      // Some live providers replay their retained snapshot synchronously.
+      // The explicit initial load below already consumes it; later callbacks
+      // are genuine invalidations and reload without rebuilding the subscription.
+      if (!subscribing) load();
+    });
+    subscribing = false;
+    return () => {
+      requestSequence.current += 1;
+      unsubscribe();
+    };
+  }, [load, props.active, props.provider]);
+  const content = useMemo(() => {
+    if (error !== null && data === null) return <div className="wb-cowork-provenance-panel__unavailable" role="alert"><h2>Provenance could not load</h2><p>{error}</p><button type="button" onClick={() => setReload((value) => value + 1)}>Retry</button></div>;
+    if (data === null) return <p className="wb-cowork-provenance-panel__empty" role="status">Loading provenance…</p>;
+    if (data.state === "unavailable") return <div className="wb-cowork-provenance-panel__unavailable" role="status"><h2>Provenance view unavailable</h2><p>{data.reason}</p><button type="button" onClick={() => setReload((value) => value + 1)}>Retry</button></div>;
+    return <>{error === null ? null : <p className="wb-cowork-provenance-panel__error" role="alert">{error} <button type="button" onClick={() => setReload((value) => value + 1)}>Retry</button></p>}<ProvenanceContents load={data} provider={props.provider} editor={props.editor} readOnly={props.readOnly} mutationBarrier={props.mutationBarrier} /></>;
+  }, [data, error, props.editor, props.mutationBarrier, props.provider, props.readOnly]);
+  return <section className="wb-cowork-provenance-panel" aria-label="Document provenance" ref={props.scrollContainerRef}>{content}</section>;
+}

--- a/dashboard-react/src/apps/cowork/provenance/view/contracts.ts
+++ b/dashboard-react/src/apps/cowork/provenance/view/contracts.ts
@@ -1,0 +1,115 @@
+import type { QuoteAnchor } from "../../rail/contracts";
+
+export type ProvenanceAuthorshipKind = "human" | "ai" | "mixed" | "unknown";
+export type ProvenanceReviewStatus = "reviewed" | "not_reviewed" | "not_applicable" | "unknown";
+export type ProvenanceCurrentness = "current" | "stale" | "requires_reanchor" | "unavailable";
+export type ProvenanceResolution = "resolved" | "conflicted";
+export type ProvenanceIdentityStatus =
+  | "local_actor_ref"
+  | "account_ref"
+  | "claimed_name";
+
+export interface ProvenanceActor {
+  readonly kind: string;
+  readonly ref: string | null;
+  readonly meta: Readonly<Record<string, unknown>> | null;
+}
+export interface ProvenanceContributor {
+  readonly kind: "human";
+  readonly ref: string | null;
+  readonly label: string | null;
+  readonly identityStatus: ProvenanceIdentityStatus;
+}
+export interface ProvenanceAttestation {
+  readonly attestationId: string;
+  readonly at: string;
+  readonly assertedBy: ProvenanceActor;
+  readonly scope: {
+    readonly kind: "document_version" | "document_span";
+    readonly documentVersionId: string | null;
+    readonly documentSpanId: string | null;
+    readonly structuredHeadSha256: string;
+  };
+  readonly authorship: { readonly kind: ProvenanceAuthorshipKind; readonly contributors: readonly ProvenanceContributor[] };
+  readonly humanReview: { readonly status: ProvenanceReviewStatus; readonly reviewers: readonly ProvenanceContributor[] };
+  readonly source: Readonly<Record<string, unknown>>;
+  readonly basis: { readonly kind: string; readonly ref: string | null };
+  readonly supersedesId: string | null;
+  readonly canonicalSha256: string;
+}
+export interface ProvenanceTarget {
+  readonly projectionId: string;
+  readonly target: {
+    readonly kind: "document_version" | "document_span";
+    readonly documentVersionId: string | null;
+    readonly documentSpanId: string | null;
+    readonly structuredHeadSha256: string;
+    readonly currentness: ProvenanceCurrentness;
+  };
+  readonly span: QuoteAnchor | null;
+  readonly effectiveAttestations: readonly ProvenanceAttestation[];
+  readonly effectiveAttestation: ProvenanceAttestation | null;
+  readonly resolution: ProvenanceResolution;
+  readonly reviewEligibility:
+    | "eligible"
+    | "stale_target"
+    | "conflicted"
+    | "not_ai_authored"
+    | "already_reviewed"
+    | "not_applicable";
+  readonly issue: { readonly code: string; readonly message: string } | null;
+  readonly history: readonly ProvenanceAttestation[];
+}
+export interface ProvenanceData {
+  readonly schema: "cowork-provenance-view/v1";
+  readonly currentStructuredHeadSha256: string | null;
+  readonly documentDefault: ProvenanceTarget | null;
+  readonly spans: readonly ProvenanceTarget[];
+  readonly history: readonly ProvenanceAttestation[];
+  readonly summary: {
+    readonly totalTargets: number;
+    readonly currentSpanCount: number;
+    readonly aiUnreviewedCount: number;
+    readonly reviewedCount: number;
+    readonly conflictedCount: number;
+    readonly staleCount: number;
+    readonly unrecorded: boolean;
+  };
+}
+
+export type ProvenanceLoad =
+  | { readonly state: "ready"; readonly data: ProvenanceData }
+  | { readonly state: "unavailable"; readonly reason: string };
+
+export interface ProvenanceTargetResolution {
+  readonly state: "unique" | "missing" | "ambiguous";
+  readonly documentOrder: number | null;
+  /** Exclusive ProseMirror position; present only for a unique quote match. */
+  readonly documentEnd: number | null;
+}
+
+export interface ProvenanceEditorIntegration {
+  resolveTarget(anchor: QuoteAnchor): ProvenanceTargetResolution;
+  /** True after an unsynchronized local-human edit invalidates the pulled head. */
+  isLocallyDirty(): boolean;
+  hasText(): boolean;
+  hasUncoveredText(anchors: readonly QuoteAnchor[]): boolean;
+  focusTarget(id: string): void;
+  revealTarget(id: string): void;
+}
+
+export interface ProvenanceProvider {
+  load(): Promise<ProvenanceLoad>;
+  /** Force one fresh authoritative document pull (used by mutation preflight). */
+  refresh(): Promise<ProvenanceLoad>;
+  subscribe(listener: () => void): () => void;
+  markReviewed(attestationId: string, expectedStructuredHeadSha256: string): Promise<void>;
+}
+
+export interface ProvenanceMutationBarrier {
+  runWithSynchronizedDocument<Result>(
+    operation: (snapshot: {
+      readonly structuredHeadSha256: string;
+    }) => Promise<Result>,
+  ): Promise<Result>;
+}

--- a/dashboard-react/src/apps/cowork/provenance/view/index.ts
+++ b/dashboard-react/src/apps/cowork/provenance/view/index.ts
@@ -1,0 +1,14 @@
+export { ProvenancePanel, type ProvenancePanelProps } from "./ProvenancePanel";
+export { ProvenanceHoverCard } from "./ProvenanceHoverCard";
+export { LiveProvenanceProvider } from "./LiveProvenanceProvider";
+export { mapProvenanceView } from "./provenanceMapping";
+export type {
+  ProvenanceAttestation,
+  ProvenanceData,
+  ProvenanceEditorIntegration,
+  ProvenanceLoad,
+  ProvenanceProvider,
+  ProvenanceMutationBarrier,
+  ProvenanceTarget,
+  ProvenanceTargetResolution,
+} from "./contracts";

--- a/dashboard-react/src/apps/cowork/provenance/view/provenanceMapping.test.ts
+++ b/dashboard-react/src/apps/cowork/provenance/view/provenanceMapping.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import { mapProvenanceView } from "./provenanceMapping";
+
+const record = {
+  attestation_id: "attestation-1",
+  at: "2026-08-12T12:00:00Z",
+  asserted_by: { kind: "human", ref: "user-1", meta: null },
+  scope: {
+    kind: "document_span",
+    document_version_id: null,
+    document_span_id: "span-1",
+    structured_head_sha256: "a".repeat(64),
+  },
+  authorship: {
+    kind: "ai",
+    contributors: [
+      {
+        kind: "human",
+        display_name: "A named collaborator",
+        identity_status: "claimed_name",
+      },
+    ],
+  },
+  human_review: { status: "not_reviewed", reviewers: [] },
+  source: { kind: "paste", format: "plain_text" },
+  basis: { kind: "user_attestation", ref: null },
+  supersedes_id: null,
+  canonical_sha256: "b".repeat(64),
+};
+
+const view = (head: string | null = "a".repeat(64)): Record<string, any> => ({
+  schema: "cowork-provenance-view/v1",
+  current_structured_head_sha256: head,
+  document_default: null,
+  spans: [
+    {
+      projection_id: "document_span:span-1",
+      target: {
+        kind: "document_span",
+        document_version_id: null,
+        document_span_id: "span-1",
+        structured_head_sha256: "a".repeat(64),
+        currentness: head === null ? "unavailable" : "current",
+      },
+      span: { exact: "AI passage", prefix: "", suffix: "" },
+      resolution: "resolved",
+      review_eligibility: head === null ? "stale_target" : "eligible",
+      issue: null,
+      effective_attestation: record,
+      effective_attestations: [record],
+      history: [record],
+    },
+  ],
+  history: [record],
+  summary: {
+    total_targets: 1,
+    current_span_count: head === null ? 0 : 1,
+    ai_unreviewed_count: 1,
+    reviewed_count: 0,
+    conflicted_count: 0,
+    stale_count: head === null ? 1 : 0,
+    unrecorded: true,
+  },
+});
+
+describe("mapProvenanceView", () => {
+  it("maps rich history while preserving independent authorship and review axes", () => {
+    const mapped = mapProvenanceView(view());
+    expect(mapped.spans[0]).toMatchObject({
+      projectionId: "document_span:span-1",
+      reviewEligibility: "eligible",
+      effectiveAttestation: {
+        humanReview: { status: "not_reviewed" },
+        authorship: {
+          kind: "ai",
+          contributors: [
+            {
+              label: "A named collaborator",
+              identityStatus: "claimed_name",
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it("keeps history inspectable when the structured head is unavailable", () => {
+    const mapped = mapProvenanceView(view(null));
+    expect(mapped.currentStructuredHeadSha256).toBeNull();
+    expect(mapped.spans[0]?.target.currentness).toBe("unavailable");
+  });
+
+  it("fails closed on inconsistent target identity or effective leaves", () => {
+    const malformed = structuredClone(view());
+    malformed.spans[0].target.document_span_id = null;
+    expect(() => mapProvenanceView(malformed)).toThrow("target identity");
+
+    const conflicted = structuredClone(view());
+    conflicted.spans[0].resolution = "conflicted";
+    expect(() => mapProvenanceView(conflicted)).toThrow("inconsistent resolution");
+  });
+
+  it("keeps an orphaned span history inspectable only in its explicit unavailable issue state", () => {
+    const orphaned = structuredClone(view());
+    orphaned.spans[0].span = null;
+    orphaned.spans[0].target.currentness = "unavailable";
+    orphaned.spans[0].resolution = "conflicted";
+    orphaned.spans[0].review_eligibility = "conflicted";
+    orphaned.spans[0].effective_attestation = null;
+    orphaned.spans[0].issue = {
+      code: "missing_span_target",
+      message: "The recorded provenance span is unavailable.",
+    };
+
+    expect(mapProvenanceView(orphaned).spans[0]).toMatchObject({
+      span: null,
+      resolution: "conflicted",
+      target: { kind: "document_span", currentness: "unavailable" },
+      issue: { code: "missing_span_target" },
+    });
+
+    orphaned.spans[0].target.currentness = "current";
+    expect(() => mapProvenanceView(orphaned)).toThrow("target identity");
+  });
+
+  it("fails closed on an unknown person identity strength", () => {
+    const malformed = structuredClone(view());
+    malformed.spans[0].effective_attestation.authorship.contributors[0].identity_status =
+      "verified_somehow";
+    expect(() => mapProvenanceView(malformed)).toThrow("identity_status");
+  });
+});

--- a/dashboard-react/src/apps/cowork/provenance/view/provenanceMapping.ts
+++ b/dashboard-react/src/apps/cowork/provenance/view/provenanceMapping.ts
@@ -1,0 +1,311 @@
+import type { QuoteAnchor } from "../../rail/contracts";
+import type {
+  ProvenanceAttestation, ProvenanceAuthorshipKind, ProvenanceContributor,
+  ProvenanceReviewStatus, ProvenanceTarget, ProvenanceData,
+} from "./contracts";
+
+type JsonObject = Record<string, unknown>;
+
+const object = (value: unknown, path: string): JsonObject => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`Invalid provenance view: ${path} must be an object.`);
+  }
+  return value as JsonObject;
+};
+
+const array = (value: unknown, path: string): readonly unknown[] => {
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid provenance view: ${path} must be an array.`);
+  }
+  return value;
+};
+
+const text = (value: unknown, path: string): string => {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Invalid provenance view: ${path} must be a non-empty string.`);
+  }
+  return value;
+};
+
+const nullableText = (value: unknown, path: string): string | null => {
+  if (value === null || value === undefined) return null;
+  return text(value, path);
+};
+
+const choice = <T extends string>(
+  value: unknown,
+  choices: readonly T[],
+  path: string,
+): T => {
+  if (typeof value !== "string" || !choices.includes(value as T)) {
+    throw new Error(
+      `Invalid provenance view: ${path} must be one of ${choices.join(", ")}.`,
+    );
+  }
+  return value as T;
+};
+
+const integer = (value: unknown, path: string): number => {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new Error(`Invalid provenance view: ${path} must be a non-negative integer.`);
+  }
+  return Number(value);
+};
+
+const contributor = (value: unknown, path: string): ProvenanceContributor => {
+  const raw = object(value, path);
+  const kind = choice(raw.kind, ["human"] as const, `${path}.kind`);
+  const ref = nullableText(raw.ref, `${path}.ref`);
+  const displayName = nullableText(raw.display_name, `${path}.display_name`);
+  const identityStatus = choice(
+    raw.identity_status,
+    ["local_actor_ref", "account_ref", "claimed_name"] as const,
+    `${path}.identity_status`,
+  );
+  const label = displayName ?? ref;
+  if (label === null) {
+    throw new Error(`Invalid provenance view: ${path} must name a person.`);
+  }
+  return { kind, ref, label, identityStatus };
+};
+
+const quoteAnchor = (value: unknown, path: string): QuoteAnchor => {
+  const raw = object(value, path);
+  return {
+    exact: text(raw.exact, `${path}.exact`),
+    prefix: typeof raw.prefix === "string" ? raw.prefix : "",
+    suffix: typeof raw.suffix === "string" ? raw.suffix : "",
+  };
+};
+
+const attestation = (
+  value: unknown,
+  path: string,
+): ProvenanceAttestation => {
+  const raw = object(value, path);
+  const assertedBy = object(raw.asserted_by, `${path}.asserted_by`);
+  const scope = object(raw.scope, `${path}.scope`);
+  const authorship = object(raw.authorship, `${path}.authorship`);
+  const review = object(raw.human_review, `${path}.human_review`);
+  const basis = object(raw.basis, `${path}.basis`);
+  const source = object(raw.source, `${path}.source`);
+  text(source.kind, `${path}.source.kind`);
+  const meta = assertedBy.meta;
+  if (
+    meta !== null &&
+    meta !== undefined &&
+    (typeof meta !== "object" || Array.isArray(meta))
+  ) {
+    throw new Error(`Invalid provenance view: ${path}.asserted_by.meta must be an object.`);
+  }
+  return {
+    attestationId: text(raw.attestation_id, `${path}.attestation_id`),
+    at: text(raw.at, `${path}.at`),
+    assertedBy: {
+      kind: text(assertedBy.kind, `${path}.asserted_by.kind`),
+      ref: nullableText(assertedBy.ref, `${path}.asserted_by.ref`),
+      meta: (meta ?? null) as Readonly<Record<string, unknown>> | null,
+    },
+    scope: {
+      kind: choice(
+        scope.kind,
+        ["document_version", "document_span"] as const,
+        `${path}.scope.kind`,
+      ),
+      documentVersionId: nullableText(
+        scope.document_version_id,
+        `${path}.scope.document_version_id`,
+      ),
+      documentSpanId: nullableText(
+        scope.document_span_id,
+        `${path}.scope.document_span_id`,
+      ),
+      structuredHeadSha256: text(
+        scope.structured_head_sha256,
+        `${path}.scope.structured_head_sha256`,
+      ),
+    },
+    authorship: {
+      kind: choice(
+        authorship.kind,
+        ["human", "ai", "mixed", "unknown"] as const,
+        `${path}.authorship.kind`,
+      ) as ProvenanceAuthorshipKind,
+      contributors: array(
+        authorship.contributors,
+        `${path}.authorship.contributors`,
+      ).map((item, index) =>
+        contributor(item, `${path}.authorship.contributors[${String(index)}]`),
+      ),
+    },
+    humanReview: {
+      status: choice(
+        review.status,
+        ["reviewed", "not_reviewed", "not_applicable", "unknown"] as const,
+        `${path}.human_review.status`,
+      ) as ProvenanceReviewStatus,
+      reviewers: array(review.reviewers, `${path}.human_review.reviewers`).map(
+        (item, index) =>
+          contributor(item, `${path}.human_review.reviewers[${String(index)}]`),
+      ),
+    },
+    source,
+    basis: {
+      kind: text(basis.kind, `${path}.basis.kind`),
+      ref: nullableText(basis.ref, `${path}.basis.ref`),
+    },
+    supersedesId: nullableText(raw.supersedes_id, `${path}.supersedes_id`),
+    canonicalSha256: text(raw.canonical_sha256, `${path}.canonical_sha256`),
+  };
+};
+
+const target = (value: unknown, path: string): ProvenanceTarget => {
+  const raw = object(value, path);
+  const rawTarget = object(raw.target, `${path}.target`);
+  const effectiveAttestations = array(
+    raw.effective_attestations,
+    `${path}.effective_attestations`,
+  ).map((item, index) =>
+    attestation(item, `${path}.effective_attestations[${String(index)}]`),
+  );
+  const resolution = choice(
+    raw.resolution,
+    ["resolved", "conflicted"] as const,
+    `${path}.resolution`,
+  );
+  const effective =
+    raw.effective_attestation === null
+      ? null
+      : attestation(raw.effective_attestation, `${path}.effective_attestation`);
+  if (
+    (resolution === "resolved" &&
+      (effectiveAttestations.length !== 1 || effective === null)) ||
+    (resolution === "conflicted" &&
+      (effectiveAttestations.length < 1 || effective !== null))
+  ) {
+    throw new Error(`Invalid provenance view: ${path} has inconsistent resolution.`);
+  }
+  if (
+    effective !== null &&
+    !effectiveAttestations.some(
+      (candidate) => candidate.attestationId === effective.attestationId,
+    )
+  ) {
+    throw new Error(`Invalid provenance view: ${path} effective record is not a leaf.`);
+  }
+  const issue = raw.issue === null ? null : object(raw.issue, `${path}.issue`);
+  const kind = choice(
+    rawTarget.kind,
+    ["document_version", "document_span"] as const,
+    `${path}.target.kind`,
+  );
+  const documentVersionId = nullableText(rawTarget.document_version_id, `${path}.target.document_version_id`);
+  const documentSpanId = nullableText(rawTarget.document_span_id, `${path}.target.document_span_id`);
+  const span = raw.span === null ? null : quoteAnchor(raw.span, `${path}.span`);
+  const currentness = choice(
+    rawTarget.currentness,
+    ["current", "stale", "requires_reanchor", "unavailable"] as const,
+    `${path}.target.currentness`,
+  );
+  const reviewEligibility = choice(
+    raw.review_eligibility,
+    ["eligible", "stale_target", "conflicted", "not_ai_authored", "already_reviewed", "not_applicable"] as const,
+    `${path}.review_eligibility`,
+  );
+  const inspectableMissingSpan =
+    kind === "document_span" &&
+    documentSpanId !== null &&
+    documentVersionId === null &&
+    span === null &&
+    currentness === "unavailable" &&
+    resolution === "conflicted" &&
+    reviewEligibility === "conflicted" &&
+    issue !== null;
+  if (
+    (kind === "document_span" &&
+      (documentSpanId === null ||
+        documentVersionId !== null ||
+        (span === null && !inspectableMissingSpan))) ||
+    (kind === "document_version" && (documentSpanId !== null || span !== null))
+  ) {
+    throw new Error(`Invalid provenance view: ${path} target identity is inconsistent.`);
+  }
+  return {
+    projectionId: text(raw.projection_id, `${path}.projection_id`),
+    target: {
+      kind,
+      documentVersionId,
+      documentSpanId,
+      structuredHeadSha256: text(
+        rawTarget.structured_head_sha256,
+        `${path}.target.structured_head_sha256`,
+      ),
+      currentness,
+    },
+    span,
+    effectiveAttestations,
+    effectiveAttestation: effective,
+    resolution,
+    reviewEligibility,
+    issue:
+      issue === null
+        ? null
+        : {
+            code: text(issue.code, `${path}.issue.code`),
+            message: text(issue.message, `${path}.issue.message`),
+          },
+    history: array(raw.history, `${path}.history`).map((item, index) =>
+      attestation(item, `${path}.history[${String(index)}]`),
+    ),
+  };
+};
+
+/** Parse the additive wire projection before it reaches rail or editor rendering. */
+export function mapProvenanceView(value: unknown): ProvenanceData {
+  const raw = object(value, "provenance");
+  if (raw.schema !== "cowork-provenance-view/v1") {
+    throw new Error("Invalid provenance view: unsupported schema.");
+  }
+  const summary = object(raw.summary, "provenance.summary");
+  if (typeof summary.unrecorded !== "boolean") {
+    throw new Error("Invalid provenance view: provenance.summary.unrecorded must be boolean.");
+  }
+  return {
+    schema: "cowork-provenance-view/v1",
+    currentStructuredHeadSha256: nullableText(
+      raw.current_structured_head_sha256,
+      "provenance.current_structured_head_sha256",
+    ),
+    documentDefault:
+      raw.document_default === null
+        ? null
+        : target(raw.document_default, "provenance.document_default"),
+    spans: array(raw.spans, "provenance.spans").map((item, index) =>
+      target(item, `provenance.spans[${String(index)}]`),
+    ),
+    history: array(raw.history, "provenance.history").map((item, index) =>
+      attestation(item, `provenance.history[${String(index)}]`),
+    ),
+    summary: {
+      totalTargets: integer(summary.total_targets, "provenance.summary.total_targets"),
+      currentSpanCount: integer(
+        summary.current_span_count,
+        "provenance.summary.current_span_count",
+      ),
+      aiUnreviewedCount: integer(
+        summary.ai_unreviewed_count,
+        "provenance.summary.ai_unreviewed_count",
+      ),
+      reviewedCount: integer(
+        summary.reviewed_count,
+        "provenance.summary.reviewed_count",
+      ),
+      conflictedCount: integer(
+        summary.conflicted_count,
+        "provenance.summary.conflicted_count",
+      ),
+      staleCount: integer(summary.stale_count, "provenance.summary.stale_count"),
+      unrecorded: summary.unrecorded,
+    },
+  };
+}

--- a/dashboard-react/src/apps/cowork/provenance/view/semantics.ts
+++ b/dashboard-react/src/apps/cowork/provenance/view/semantics.ts
@@ -1,0 +1,83 @@
+import type {
+  ProvenanceAttestation,
+  ProvenanceContributor,
+  ProvenanceIdentityStatus,
+} from "./contracts";
+
+const canonicalize = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (typeof value !== "object" || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => [key, canonicalize(item)]),
+  );
+};
+
+const fingerprint = (value: unknown): string =>
+  JSON.stringify(canonicalize(value));
+
+/** Semantic display axes; attester/basis may differ while the assertion agrees. */
+export const provenanceAuthorshipFingerprint = (
+  record: ProvenanceAttestation,
+): string => fingerprint(record.authorship);
+
+export const provenanceReviewFingerprint = (
+  record: ProvenanceAttestation,
+): string => fingerprint(record.humanReview);
+
+export const provenanceSourceFingerprint = (
+  record: ProvenanceAttestation,
+): string => fingerprint(record.source);
+
+export const provenanceDisplayedAxesFingerprint = (
+  record: ProvenanceAttestation,
+): string =>
+  JSON.stringify([
+    provenanceAuthorshipFingerprint(record),
+    provenanceReviewFingerprint(record),
+    provenanceSourceFingerprint(record),
+  ]);
+
+const boundedText = (value: unknown, maximum = 160): string | null => {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().replace(/[\u0000-\u001f\u007f]/gu, " ");
+  if (normalized.length === 0) return null;
+  return normalized.length <= maximum
+    ? normalized
+    : `${normalized.slice(0, maximum - 1)}…`;
+};
+
+const SOURCE_DETAIL_FIELDS = [
+  ["label", "Label"],
+  ["provider", "Provider"],
+  ["model", "Model"],
+  ["format", "Format"],
+  ["media_type", "Media type"],
+  ["path", "Path"],
+  ["ref", "Reference"],
+  ["surface", "Surface"],
+  ["sha256", "Digest"],
+] as const;
+
+/** Whitelisted, bounded source fields only; never dumps arbitrary source metadata. */
+export const provenanceSourceDetails = (
+  record: ProvenanceAttestation,
+): readonly { readonly label: string; readonly value: string }[] =>
+  SOURCE_DETAIL_FIELDS.flatMap(([field, label]) => {
+    const value = boundedText(record.source[field]);
+    return value === null ? [] : [{ label, value }];
+  });
+
+export const provenanceIdentityStatusLabel = (
+  status: ProvenanceIdentityStatus,
+): string => {
+  if (status === "account_ref") return "account-linked identity";
+  if (status === "local_actor_ref") return "enrolled local user";
+  return "claimed name; not account-verified";
+};
+
+export const provenancePersonDetail = (
+  person: ProvenanceContributor,
+): string =>
+  `${person.label ?? person.ref ?? "Unnamed person"} (${provenanceIdentityStatusLabel(person.identityStatus)})`;

--- a/dashboard-react/src/apps/cowork/rail/CoworkRail.test.tsx
+++ b/dashboard-react/src/apps/cowork/rail/CoworkRail.test.tsx
@@ -21,7 +21,10 @@ import {
   InMemoryReviewProvider,
 } from "./InMemoryReviewProvider";
 import type { ReviewRailProvider } from "./provider";
+import type { ProvenanceProvider } from "../provenance/view";
+import surfaceStyles from "../surface/styles.css?raw";
 import { createDemoChatProvider } from "./chatFixture";
+import railStyles from "./styles.css?raw";
 
 class MemoryStorage implements Storage {
   private map = new Map<string, string>();
@@ -124,6 +127,40 @@ const chatExecution = (
 });
 
 describe("CoworkRail", () => {
+  it("keeps the rail chrome fixed while panel-owned content scrolls", () => {
+    const railShell = railStyles.match(
+      /\.wb-cowork-rail\s*\{(?<body>[^}]*)\}/u,
+    )?.groups?.body;
+    const tabs = railStyles.match(
+      /\.wb-cowork-rail__tabs\s*\{(?<body>[^}]*)\}/u,
+    )?.groups?.body;
+    const tabpanel = railStyles.match(
+      /\.wb-cowork-rail__tabpanel\s*\{(?<body>[^}]*)\}/u,
+    )?.groups?.body;
+    const panelWrappers = [
+      ...surfaceStyles.matchAll(
+        /\.wb-cowork__rail-panel\s*\{(?<body>[^}]*)\}/gu,
+      ),
+    ];
+    const panelWrapper = panelWrappers[panelWrappers.length - 1]?.groups?.body;
+
+    expect(railShell).toContain("overflow: clip");
+    expect(tabs).toContain("flex: 0 0 auto");
+    expect(tabs).toContain("overflow-y: hidden");
+    expect(tabpanel).toContain("overflow: clip");
+    expect(panelWrapper).toContain("overflow: clip !important");
+  });
+
+  it("orders the first-class tabs Review, Provenance, Truth, Chat", () => {
+    renderRail();
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent?.trim())).toEqual([
+      "Review",
+      "Provenance",
+      "Truth",
+      "Chat",
+    ]);
+  });
+
   it("frames the Review and Chat tabs with Review active", async () => {
     renderRail();
     expect(screen.getByRole("tab", { name: "Review" })).toHaveAttribute(
@@ -179,6 +216,65 @@ describe("CoworkRail", () => {
         reviewScrollRef.mock.calls.some(([element]) => element === null),
       ).toBe(true),
     );
+  });
+
+  it("reattaches Provenance scroll persistence after switching away and back", async () => {
+    const storage = new MemoryStorage();
+    saveRailTab(storage, "demo-doc", "provenance");
+    const provenanceProvider: ProvenanceProvider = {
+      load: vi.fn().mockResolvedValue({
+        state: "unavailable",
+        reason: "No fixture provenance.",
+      }),
+      refresh: vi.fn().mockResolvedValue({
+        state: "unavailable",
+        reason: "No fixture provenance.",
+      }),
+      subscribe: () => () => undefined,
+      markReviewed: vi.fn(),
+    };
+    let current: HTMLElement | null = null;
+    let storedTop = 0;
+    const attachedTops: number[] = [];
+    const provenanceScrollRef = vi.fn((element: HTMLElement | null) => {
+      current = element;
+      if (element !== null) {
+        element.scrollTop = storedTop;
+        attachedTops.push(element.scrollTop);
+      }
+    });
+    const onProvenanceScrollWillDetach = vi.fn(() => {
+      storedTop = current?.scrollTop ?? storedTop;
+    });
+    render(
+      <CoworkRail
+        documentId="demo-doc"
+        reviewProvider={new InMemoryReviewProvider()}
+        chat={{ kind: "idle", draftStorageId: "document:demo-doc" }}
+        storage={storage}
+        provenance={{ provider: provenanceProvider }}
+        provenanceScrollRef={provenanceScrollRef}
+        onProvenanceScrollWillDetach={onProvenanceScrollWillDetach}
+      />,
+    );
+    await screen.findByText("No fixture provenance.");
+    expect(current).not.toBeNull();
+    (current as HTMLElement | null)!.scrollTop = 41;
+
+    await userEvent.click(screen.getByRole("tab", { name: "Review" }));
+    expect(onProvenanceScrollWillDetach).toHaveBeenCalledOnce();
+    await waitFor(() => expect(current).toBeNull());
+    await userEvent.click(screen.getByRole("tab", { name: "Provenance" }));
+    await waitFor(() => expect(current).not.toBeNull());
+    expect((current as HTMLElement | null)?.scrollTop).toBe(41);
+
+    (current as HTMLElement | null)!.scrollTop = 93;
+    await userEvent.click(screen.getByRole("tab", { name: /Chat/u }));
+    await waitFor(() => expect(current).toBeNull());
+    await userEvent.click(screen.getByRole("tab", { name: "Provenance" }));
+    await waitFor(() => expect(current).not.toBeNull());
+    expect((current as HTMLElement | null)?.scrollTop).toBe(93);
+    expect(attachedTops).toEqual([0, 41, 93]);
   });
 
   it("does not start an agent merely because the persisted Chat tab is restored", () => {

--- a/dashboard-react/src/apps/cowork/rail/CoworkRail.truth.test.tsx
+++ b/dashboard-react/src/apps/cowork/rail/CoworkRail.truth.test.tsx
@@ -201,19 +201,27 @@ const renderTruthRail = ({ help = false }: { readonly help?: boolean } = {}) => 
 };
 
 describe("CoworkRail Truth integration", () => {
-  it("presents Review, Truth, and Chat as one roving desktop tablist", async () => {
+  it("presents Review, Provenance, Truth, and Chat as one roving desktop tablist", async () => {
     const user = userEvent.setup();
     renderTruthRail();
 
     const review = screen.getByRole("tab", { name: "Review" });
+    const provenance = screen.getByRole("tab", { name: "Provenance" });
     const truth = screen.getByRole("tab", { name: "Truth" });
     const chat = screen.getByRole("tab", { name: /Chat/ });
     expect(review).toHaveAttribute("aria-selected", "true");
     expect(review).toHaveAttribute("tabindex", "0");
+    expect(provenance).toHaveAttribute("tabindex", "-1");
     expect(truth).toHaveAttribute("tabindex", "-1");
     expect(chat).toHaveAttribute("tabindex", "-1");
 
     review.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(provenance).toHaveFocus();
+    expect(provenance).toHaveAttribute("aria-selected", "true");
+    expect(provenance).toHaveAttribute("tabindex", "0");
+    expect(review).toHaveAttribute("tabindex", "-1");
+
     await user.keyboard("{ArrowRight}");
     expect(truth).toHaveFocus();
     expect(truth).toHaveAttribute("aria-selected", "true");
@@ -225,10 +233,10 @@ describe("CoworkRail Truth integration", () => {
     expect(chat).toHaveAttribute("aria-selected", "true");
   });
 
-  it("uses the existing Review, Truth, and Chat tabs as hover-help targets", () => {
+  it("uses the existing Review, Provenance, Truth, and Chat tabs as hover-help targets", () => {
     renderTruthRail({ help: true });
 
-    for (const name of ["Review", "Truth", /Chat/]) {
+    for (const name of ["Review", "Provenance", "Truth", /Chat/]) {
       expect(screen.getByRole("tab", { name })).toHaveAttribute(
         "data-help-target",
         "true",

--- a/dashboard-react/src/apps/cowork/rail/CoworkRail.tsx
+++ b/dashboard-react/src/apps/cowork/rail/CoworkRail.tsx
@@ -1,5 +1,5 @@
 /**
- * The Review | Truth | Chat rail. This is the mount seam the view frame wires
+ * The Review | Provenance | Truth | Chat rail. This is the mount seam the view frame wires
  * in place of the rail placeholder: it owns all three tabs and their panels.
  * Every ready Chat path
  * uses the shared ConversationChat surface through a thin Co-work adapter.
@@ -36,6 +36,12 @@ import {
   type TruthStore as CoworkTruthStore,
 } from "../truth";
 import { ReviewPanel } from "./ReviewPanel";
+import {
+  ProvenancePanel,
+  type ProvenanceEditorIntegration,
+  type ProvenanceProvider,
+  type ProvenanceMutationBarrier,
+} from "../provenance/view";
 import type { VerificationRecheckIntent } from "./contracts";
 import type { ReviewAnchorController, ReviewRailProvider } from "./provider";
 import { RailStore, type RailTab } from "./store";
@@ -63,7 +69,13 @@ const TRUTH_TAB_HELP: HelpContent = {
     "Inspect claims, where the document expresses them, their evidence, provenance, and lifecycle. Truth also hosts contextual claim management.",
 };
 
-const RAIL_TABS: readonly RailTab[] = ["review", "truth", "chat"];
+const PROVENANCE_TAB_HELP: HelpContent = {
+  summary: "See how the text is attributed and whether human review is recorded.",
+  details:
+    "The editor overlay keeps authorship, source, and human review separate. These records do not say whether the text is true.",
+};
+
+const RAIL_TABS: readonly RailTab[] = ["review", "provenance", "truth", "chat"];
 
 export interface CoworkRailProps {
   readonly documentId: string;
@@ -76,6 +88,11 @@ export interface CoworkRailProps {
     readonly readOnly?: boolean;
   };
   readonly reviewProvider: ReviewRailProvider;
+  readonly provenance?: {
+    readonly provider: ProvenanceProvider;
+    readonly editor?: ProvenanceEditorIntegration;
+    readonly mutationBarrier?: ProvenanceMutationBarrier;
+  };
   readonly chat: CoworkRailChat;
   /** Fired only for a present user click on the wide Chat tab. */
   readonly onChatSelected?: () => void;
@@ -88,12 +105,16 @@ export interface CoworkRailProps {
   readonly onReviewScrollWillDetach?: () => void;
   readonly truthScrollRef?: RefCallback<HTMLElement>;
   readonly onTruthScrollWillDetach?: () => void;
+  readonly provenanceScrollRef?: RefCallback<HTMLElement>;
+  readonly onProvenanceScrollWillDetach?: () => void;
   readonly reviewAnchors?: ReviewAnchorController;
   readonly shortcutBindings?: CoworkShortcutBindings;
   readonly initialTab?: RailTab;
   /** Whether the containing workspace currently exposes the Review pane. */
   readonly reviewVisible?: boolean;
   readonly truthVisible?: boolean;
+  readonly provenanceVisible?: boolean;
+  readonly readOnly?: boolean;
   /** Narrow workspace peer tabs own Review / Truth / Chat selection when false. */
   readonly showTabs?: boolean;
   /** Optional document linkage for passage accessories and routing notices. */
@@ -200,7 +221,10 @@ export function CoworkRail(props: CoworkRailProps) {
   });
   const tab = useRailState(store, (state) => state.tab);
   const tabRefs = useRef<Partial<Record<RailTab, HTMLButtonElement | null>>>({});
+  const tabsRef = useRef<HTMLDivElement | null>(null);
   const reviewActive = tab === "review" && props.reviewVisible !== false;
+  const provenanceActive =
+    tab === "provenance" && props.provenanceVisible !== false;
   const [messages, setMessages] = useState<readonly ChatMessage[]>([]);
   const conversationId =
     props.chat.kind === "ready" ? props.chat.conversationId : null;
@@ -225,7 +249,23 @@ export function CoworkRail(props: CoworkRailProps) {
     if (tab === "truth" && next !== "truth") {
       props.onTruthScrollWillDetach?.();
     }
+    if (tab === "provenance" && next !== "provenance") {
+      props.onProvenanceScrollWillDetach?.();
+    }
     store.setTab(next);
+  };
+
+  const revealRailTabs = (): void => {
+    window.requestAnimationFrame(() => {
+      const tabs = tabsRef.current;
+      if (tabs === null) return;
+      const rail = tabs.closest<HTMLElement>(".wb-cowork-rail");
+      if (rail === null) return;
+      const bounds = rail.getBoundingClientRect();
+      if (bounds.top < 0 || bounds.bottom > window.innerHeight) {
+        tabs.scrollIntoView?.({ block: "start", inline: "nearest" });
+      }
+    });
   };
 
   const navigateTabs = (
@@ -247,18 +287,23 @@ export function CoworkRail(props: CoworkRailProps) {
     event.preventDefault();
     const next = RAIL_TABS[nextIndex];
     selectRailTab(next);
-    if (next === "chat") props.onChatSelected?.();
+    if (next === "chat") {
+      revealRailTabs();
+      props.onChatSelected?.();
+    }
     tabRefs.current[next]?.focus();
   };
 
   const continueCothinkInChat = async (): Promise<void> => {
     selectRailTab("chat");
+    revealRailTabs();
     props.onChatSelected?.();
   };
 
   return (
     <div className="wb-cowork-rail">
       {props.showTabs !== false ? <div
+        ref={tabsRef}
         className="wb-cowork-rail__tabs"
         role="tablist"
         aria-label="Co-work side panels"
@@ -279,6 +324,24 @@ export function CoworkRail(props: CoworkRailProps) {
             onKeyDown={(event) => navigateTabs(event, "review")}
           >
             Review
+          </button>
+        </HelpTarget>
+        <HelpTarget content={PROVENANCE_TAB_HELP} placement="bottom">
+          <button
+            type="button"
+            ref={(element) => {
+              tabRefs.current.provenance = element;
+            }}
+            role="tab"
+            id="wb-cowork-rail-tab-provenance"
+            className="wb-cowork-rail__tab"
+            aria-selected={tab === "provenance"}
+            tabIndex={tab === "provenance" ? 0 : -1}
+            aria-controls="wb-cowork-rail-panel-provenance"
+            onClick={() => selectRailTab("provenance")}
+            onKeyDown={(event) => navigateTabs(event, "provenance")}
+          >
+            Provenance
           </button>
         </HelpTarget>
         <HelpTarget content={TRUTH_TAB_HELP} placement="bottom">
@@ -313,6 +376,7 @@ export function CoworkRail(props: CoworkRailProps) {
             aria-controls="wb-cowork-rail-panel-chat"
             onClick={() => {
               selectRailTab("chat");
+              revealRailTabs();
               props.onChatSelected?.();
             }}
             onKeyDown={(event) => navigateTabs(event, "chat")}
@@ -366,6 +430,34 @@ export function CoworkRail(props: CoworkRailProps) {
 
       <div
         role="tabpanel"
+        id="wb-cowork-rail-panel-provenance"
+        aria-labelledby={
+          props.showTabs === false
+            ? "wb-cowork-mobile-tab-provenance"
+            : "wb-cowork-rail-tab-provenance"
+        }
+        className="wb-cowork-rail__tabpanel"
+        hidden={tab !== "provenance"}
+      >
+        {props.provenance === undefined ? (
+          <p className="wb-cowork-rail__empty">Provenance is unavailable for this document.</p>
+        ) : (
+          <ProvenancePanel
+            key={`${props.storeId ?? "unscoped"}:${props.documentId}`}
+            provider={props.provenance.provider}
+            active={provenanceActive}
+            scrollContainerRef={
+              provenanceActive ? props.provenanceScrollRef : undefined
+            }
+            editor={props.provenance.editor}
+            mutationBarrier={props.provenance.mutationBarrier}
+            readOnly={props.readOnly}
+          />
+        )}
+      </div>
+
+      <div
+        role="tabpanel"
         id="wb-cowork-rail-panel-truth"
         aria-labelledby={
           props.showTabs === false
@@ -415,6 +507,7 @@ export function CoworkRail(props: CoworkRailProps) {
         }
         className="wb-cowork-rail__tabpanel"
         hidden={tab !== "chat"}
+        onFocusCapture={revealRailTabs}
       >
         {props.chat.kind !== "ready" ? (
           <CoworkConversationGate

--- a/dashboard-react/src/apps/cowork/rail/contracts.ts
+++ b/dashboard-react/src/apps/cowork/rail/contracts.ts
@@ -129,6 +129,8 @@ export interface ProvenanceSpan {
   readonly approvalGestureId: string | null;
 }
 
+/** Authorship and review are deliberately separate provenance dimensions. */
+
 /** Claim lifecycle status shown on a claim-review card (kernel claim states). */
 export type ClaimStatus =
   | "proposed"

--- a/dashboard-react/src/apps/cowork/rail/store.ts
+++ b/dashboard-react/src/apps/cowork/rail/store.ts
@@ -9,7 +9,7 @@
 import type { StagedClaimDecision, StagedDecision } from "./contracts";
 
 /** Which first-class interaction surface is shown in the Co-work rail. */
-export type RailTab = "review" | "truth" | "chat";
+export type RailTab = "review" | "truth" | "provenance" | "chat";
 
 /** The Review-tab layout: a document-order stream or queue focus mode. */
 export type RailMode = "stream" | "queue";

--- a/dashboard-react/src/apps/cowork/rail/styles.css
+++ b/dashboard-react/src/apps/cowork/rail/styles.css
@@ -11,6 +11,7 @@
   flex-direction: column;
   block-size: 100%;
   min-block-size: 0;
+  overflow: clip;
   background: var(--wb-color-surface-workspace);
   color: var(--wb-color-text-primary);
   font-family: var(--wb-font-sans);
@@ -207,13 +208,19 @@
  */
 .wb-cowork-rail__tabs {
   display: flex;
+  flex: 0 0 auto;
   gap: var(--wb-space-2);
   padding: var(--wb-space-3) var(--wb-space-4) 0;
   border-block-end: 1px solid var(--wb-color-border-subtle);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
 }
 
 .wb-cowork-rail__tab {
   position: relative;
+  flex: none;
+  white-space: nowrap;
   display: inline-flex;
   align-items: center;
   min-block-size: var(--wb-target-size);
@@ -227,6 +234,185 @@
   cursor: pointer;
   transition: color var(--wb-motion-duration-fast) var(--wb-motion-easing-standard),
     box-shadow var(--wb-motion-duration-fast) var(--wb-motion-easing-standard);
+}
+
+/* ---------- provenance panel ---------- */
+.wb-cowork-provenance-panel {
+  display: grid;
+  align-content: start;
+  gap: var(--wb-space-4);
+  min-block-size: 0;
+  block-size: 100%;
+  overflow: auto;
+  padding: var(--wb-space-4);
+}
+
+.wb-cowork-provenance-panel :is(h2, h3, h4, p, dl, ol) {
+  margin-block: 0;
+}
+
+.wb-cowork-provenance-panel__reason,
+.wb-cowork-provenance-panel__empty {
+  color: var(--wb-color-text-secondary);
+  font-size: var(--wb-font-size-sm);
+}
+
+.wb-cowork-provenance-panel__summary,
+.wb-cowork-provenance-panel__facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--wb-space-2);
+}
+
+.wb-cowork-provenance-panel__summary > div,
+.wb-cowork-provenance-panel__facts > div {
+  min-inline-size: 0;
+  padding: var(--wb-space-2);
+  border-radius: var(--wb-radius-control);
+  background: var(--wb-color-surface-inset);
+}
+
+.wb-cowork-provenance-panel :is(dt, dd) {
+  overflow-wrap: anywhere;
+}
+
+.wb-cowork-provenance-panel dt {
+  color: var(--wb-color-text-secondary);
+  font-size: var(--wb-font-size-xs);
+}
+
+.wb-cowork-provenance-panel dd {
+  margin: 0;
+  font-weight: var(--wb-font-weight-medium);
+}
+
+.wb-cowork-provenance-panel__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--wb-space-2);
+}
+
+.wb-cowork-provenance-panel button {
+  min-block-size: var(--wb-target-size);
+  padding: var(--wb-space-1) var(--wb-space-3);
+  border: 1px solid var(--wb-color-border-strong);
+  border-radius: var(--wb-radius-control);
+  background: var(--wb-color-surface-raised);
+  color: var(--wb-color-text-primary);
+  font: inherit;
+  cursor: pointer;
+}
+
+.wb-cowork-provenance-panel button[aria-pressed="true"] {
+  border-color: var(--wb-color-accent);
+  box-shadow: inset 0 -2px 0 var(--wb-color-accent);
+}
+
+.wb-cowork-provenance-panel button:focus-visible {
+  outline: none;
+  box-shadow: var(--wb-shadow-focus);
+}
+
+.wb-cowork-provenance-panel button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.wb-cowork-provenance-panel__list,
+.wb-cowork-provenance-panel__history ol {
+  display: grid;
+  gap: var(--wb-space-3);
+  padding: 0;
+  list-style: none;
+}
+
+.wb-cowork-provenance-panel__list > li,
+.wb-cowork-provenance-panel__unrecorded,
+.wb-cowork-provenance-panel__unavailable {
+  border: 1px solid var(--wb-color-border-subtle);
+  border-inline-start: 3px solid var(--wb-color-accent);
+  border-radius: var(--wb-radius-control);
+  background: var(--wb-color-surface-raised);
+}
+
+.wb-cowork-provenance-panel__list > li[data-state="issue"] {
+  border-inline-start-color: var(--wb-color-status-danger);
+  border-inline-start-style: double;
+}
+
+.wb-cowork-provenance-panel__item {
+  display: grid;
+  inline-size: 100%;
+  gap: var(--wb-space-1);
+  border: 0 !important;
+  text-align: start;
+}
+
+.wb-cowork-provenance-panel__quote {
+  overflow: hidden;
+  font-weight: var(--wb-font-weight-medium);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wb-cowork-provenance-panel__status {
+  color: var(--wb-color-text-secondary);
+  font-size: var(--wb-font-size-xs);
+  text-transform: capitalize;
+}
+
+.wb-cowork-provenance-panel__detail,
+.wb-cowork-provenance-panel__conflict {
+  display: grid;
+  gap: var(--wb-space-3);
+  padding: 0 var(--wb-space-3) var(--wb-space-3);
+}
+
+.wb-cowork-provenance-panel__history {
+  padding: var(--wb-space-2);
+  border-block-start: 1px solid var(--wb-color-border-subtle);
+}
+
+.wb-cowork-provenance-panel__history summary {
+  cursor: pointer;
+  font-weight: var(--wb-font-weight-medium);
+}
+
+.wb-cowork-provenance-panel__history li,
+.wb-cowork-provenance-panel__conflict article {
+  padding: var(--wb-space-2);
+  border: 1px solid var(--wb-color-border-subtle);
+  border-radius: var(--wb-radius-control);
+}
+
+.wb-cowork-provenance-panel__unrecorded,
+.wb-cowork-provenance-panel__unavailable {
+  display: grid;
+  gap: var(--wb-space-2);
+  padding: var(--wb-space-3);
+  border-inline-start-style: dashed;
+}
+
+.wb-cowork-provenance-panel__error {
+  color: var(--wb-color-status-danger);
+  font-weight: var(--wb-font-weight-medium);
+}
+
+@media (max-width: 28rem) {
+  .wb-cowork-provenance-panel__summary,
+  .wb-cowork-provenance-panel__facts {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (forced-colors: active) {
+  .wb-cowork-provenance-panel__list > li,
+  .wb-cowork-provenance-panel__unrecorded {
+    border-inline-start-color: CanvasText;
+  }
+  .wb-cowork-provenance-panel__list > li[data-state="issue"] {
+    border-inline-start-color: Mark;
+  }
 }
 
 .wb-cowork-rail__tab:hover {
@@ -259,6 +445,7 @@
   flex: 1 1 auto;
   min-block-size: 0;
   display: flex;
+  overflow: clip;
 }
 
 .wb-cowork-rail__tabpanel[hidden] {

--- a/dashboard-react/src/apps/cowork/suggestions/__tests__/anchor.test.ts
+++ b/dashboard-react/src/apps/cowork/suggestions/__tests__/anchor.test.ts
@@ -1,7 +1,10 @@
 import type { Editor } from "@tiptap/core";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { resolveQuoteAnchor } from "../anchor";
+import {
+  resolveProvenanceQuoteAnchorDetailed,
+  resolveQuoteAnchor,
+} from "../anchor";
 import { makeSuggestionEditor } from "./support";
 
 let editor: Editor | undefined;
@@ -9,6 +12,37 @@ let editor: Editor | undefined;
 afterEach(() => {
   editor?.destroy();
   editor = undefined;
+});
+
+describe("resolveProvenanceQuoteAnchorDetailed", () => {
+  it("rejects a unique exact quote when its supplied context changed", () => {
+    editor = makeSuggestionEditor({ content: "<p>New context unique passage here.</p>" });
+    expect(
+      resolveProvenanceQuoteAnchorDetailed(editor.state.doc, {
+        exact: "unique passage",
+        prefix: "Old context ",
+        suffix: " here.",
+      }),
+    ).toEqual({ state: "missing" });
+  });
+
+  it("filters repeated exact matches through both context sides", () => {
+    editor = makeSuggestionEditor({
+      content: "<p>Alpha target one. Beta target two.</p>",
+    });
+    const resolution = resolveProvenanceQuoteAnchorDetailed(editor.state.doc, {
+      exact: "target",
+      prefix: "Beta ",
+      suffix: " two.",
+    });
+    expect(resolution.state).toBe("unique");
+    if (resolution.state === "unique") {
+      expect(textOf(editor, resolution)).toBe("target");
+      expect(editor.state.doc.textBetween(resolution.to, resolution.to + 5)).toBe(
+        " two.",
+      );
+    }
+  });
 });
 
 const textOf = (ed: Editor, range: { from: number; to: number }): string =>

--- a/dashboard-react/src/apps/cowork/suggestions/anchor.ts
+++ b/dashboard-react/src/apps/cowork/suggestions/anchor.ts
@@ -146,11 +146,15 @@ const rangeFor = (
  * located uniquely. A single occurrence resolves directly. Multiple occurrences resolve
  * only when exactly one satisfies both the prefix and suffix context.
  */
-export const resolveQuoteAnchor = (
+export type QuoteAnchorResolution =
+  | { readonly state: "unique"; readonly from: number; readonly to: number }
+  | { readonly state: "missing" | "ambiguous" };
+
+export const resolveQuoteAnchorDetailed = (
   doc: Node,
   anchor: QuoteAnchor,
-): { from: number; to: number } | null => {
-  if (anchor.exact.length === 0) return null;
+): QuoteAnchorResolution => {
+  if (anchor.exact.length === 0) return { state: "missing" };
 
   const index = buildTextIndex(doc);
   let exact = anchor.exact;
@@ -163,9 +167,12 @@ export const resolveQuoteAnchor = (
     suffix = visibleMarkdownText(doc, anchor.suffix);
     occurrences = textOccurrences(index.flat, exact);
   }
-  if (occurrences.length === 0) return null;
+  if (occurrences.length === 0) return { state: "missing" };
   if (occurrences.length === 1) {
-    return rangeFor(index, occurrences[0].offset, occurrences[0].length);
+    return {
+      state: "unique",
+      ...rangeFor(index, occurrences[0].offset, occurrences[0].length),
+    };
   }
 
   const contextual = occurrences.filter(
@@ -174,7 +181,51 @@ export const resolveQuoteAnchor = (
       suffixMatches(index.flat, match.offset + match.length, suffix),
   );
   if (contextual.length === 1) {
-    return rangeFor(index, contextual[0].offset, contextual[0].length);
+    return {
+      state: "unique",
+      ...rangeFor(index, contextual[0].offset, contextual[0].length),
+    };
   }
-  return null;
+  return { state: "ambiguous" };
+};
+
+/**
+ * Provenance reanchoring is stricter than legacy proposal placement: every
+ * supplied exact/prefix/suffix component must still describe the adjacent
+ * visible text, even when the exact quote occurs only once.
+ */
+export const resolveProvenanceQuoteAnchorDetailed = (
+  doc: Node,
+  anchor: QuoteAnchor,
+): QuoteAnchorResolution => {
+  if (anchor.exact.length === 0) return { state: "missing" };
+  const index = buildTextIndex(doc);
+  let exact = anchor.exact;
+  let occurrences = textOccurrences(index.flat, exact);
+  if (occurrences.length === 0) {
+    exact = visibleMarkdownText(doc, anchor.exact);
+    occurrences = textOccurrences(index.flat, exact);
+  }
+  if (occurrences.length === 0) return { state: "missing" };
+  const prefix = visibleMarkdownText(doc, anchor.prefix);
+  const suffix = visibleMarkdownText(doc, anchor.suffix);
+  const contextual = occurrences.filter(
+    (match) =>
+      prefixMatches(index.flat, match.offset, prefix) &&
+      suffixMatches(index.flat, match.offset + match.length, suffix),
+  );
+  if (contextual.length === 0) return { state: "missing" };
+  if (contextual.length > 1) return { state: "ambiguous" };
+  return {
+    state: "unique",
+    ...rangeFor(index, contextual[0].offset, contextual[0].length),
+  };
+};
+
+export const resolveQuoteAnchor = (
+  doc: Node,
+  anchor: QuoteAnchor,
+): { from: number; to: number } | null => {
+  const result = resolveQuoteAnchorDetailed(doc, anchor);
+  return result.state === "unique" ? { from: result.from, to: result.to } : null;
 };

--- a/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.test.tsx
+++ b/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.test.tsx
@@ -2663,6 +2663,7 @@ describe("CoworkWorkspaceWidget live mode", () => {
       status: "rejected" as const,
       message,
     }));
+    globalThis.fetch = liveFetch() as unknown as typeof fetch;
     renderWorkspace(
       {
         document: LIVE_DOCUMENT,
@@ -2793,7 +2794,7 @@ describe("CoworkWorkspaceWidget live mode", () => {
     expect(screen.queryByText(/This is the editor pane/)).toBeNull();
   }, 15_000);
 
-  it("uses mounted Editor, Review, Truth, and Chat peer panes with roving focus on narrow screens", async () => {
+  it("uses mounted Editor, Review, Provenance, Truth, and Chat peer panes with roving focus on narrow screens", async () => {
     vi.stubGlobal(
       "matchMedia",
       vi.fn((query: string) => ({
@@ -2813,11 +2814,13 @@ describe("CoworkWorkspaceWidget live mode", () => {
     const paneTabs = await screen.findByRole("tablist", { name: "Co-work panes" });
     const editorTab = within(paneTabs).getByRole("tab", { name: "Editor" });
     const reviewTab = within(paneTabs).getByRole("tab", { name: "Review" });
+    const provenanceTab = within(paneTabs).getByRole("tab", { name: "Provenance" });
     const truthTab = within(paneTabs).getByRole("tab", { name: "Truth" });
     const chatTab = within(paneTabs).getByRole("tab", { name: "Chat" });
     expect(editorTab).toHaveAttribute("aria-selected", "true");
     expect(editorTab).toHaveAttribute("tabindex", "0");
     expect(reviewTab).toHaveAttribute("tabindex", "-1");
+    expect(provenanceTab).toHaveAttribute("tabindex", "-1");
     expect(truthTab).toHaveAttribute("tabindex", "-1");
     expect(chatTab).toHaveAttribute("tabindex", "-1");
     expect(document.getElementById("wb-cowork-mobile-panel-editor")).toBeVisible();
@@ -2855,6 +2858,17 @@ describe("CoworkWorkspaceWidget live mode", () => {
     expect(screen.getByText("Decision: Accept")).toBeVisible();
 
     reviewTab.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(provenanceTab).toHaveFocus();
+    expect(provenanceTab).toHaveAttribute("aria-selected", "true");
+    expect(provenanceTab).toHaveAttribute("tabindex", "0");
+    expect(reviewTab).toHaveAttribute("tabindex", "-1");
+    expect(document.getElementById("wb-cowork-rail-panel-provenance")).toBeVisible();
+    expect(document.getElementById("wb-cowork-rail-panel-review")).not.toBeVisible();
+    await waitFor(() =>
+      expect(screen.getByRole("region", { name: "Document provenance" })).toBeVisible(),
+    );
+
     await user.keyboard("{ArrowRight}");
     expect(truthTab).toHaveFocus();
     expect(truthTab).toHaveAttribute("aria-selected", "true");

--- a/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.tsx
+++ b/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.tsx
@@ -74,6 +74,7 @@ import {
   CoworkRail,
   InMemoryReviewProvider,
   RailStore,
+  useRailState,
   createDemoChatProvider,
   isDirty,
   type CoworkRailChat,
@@ -96,6 +97,8 @@ import {
   type TruthPassageNavigationTarget,
   type TruthSelectionCapture,
 } from "../truth";
+import { ProvenanceHoverCard } from "../provenance";
+import type { ProvenanceEditorIntegration } from "../provenance";
 import {
   HttpCoworkVerifyClient,
   useCoworkVerifyExecution,
@@ -208,7 +211,12 @@ interface CoworkHealthView {
   readonly openProposalCount: number;
 }
 
-type CoworkWorkspacePane = "editor" | "review" | "truth" | "chat";
+type CoworkWorkspacePane =
+  | "editor"
+  | "review"
+  | "truth"
+  | "provenance"
+  | "chat";
 const NARROW_WORKSPACE_QUERY = "(max-width: 760px)";
 
 const useNarrowWorkspace = (): boolean => {
@@ -241,6 +249,7 @@ function CoworkPaneTabs({
   const panes: readonly CoworkWorkspacePane[] = [
     "editor",
     "review",
+    "provenance",
     "truth",
     "chat",
   ];
@@ -605,6 +614,9 @@ export function CoworkLiveWorkspace({
   const truthScrollRef = usePersistedScrollPosition({
     key: coworkScrollPositionStorageKey({ documentId, storeId }, "truth"),
   });
+  const provenanceScrollRef = usePersistedScrollPosition({
+    key: coworkScrollPositionStorageKey({ documentId, storeId }, "provenance"),
+  });
   const detachReviewScroll = useCallback(
     () => reviewScrollRef(null),
     [reviewScrollRef],
@@ -612,6 +624,10 @@ export function CoworkLiveWorkspace({
   const detachTruthScroll = useCallback(
     () => truthScrollRef(null),
     [truthScrollRef],
+  );
+  const detachProvenanceScroll = useCallback(
+    () => provenanceScrollRef(null),
+    [provenanceScrollRef],
   );
 
   // One document conversation linkage store per document. The submit path annotates a routing
@@ -638,6 +654,7 @@ export function CoworkLiveWorkspace({
         },
       ),
   );
+  const activeRailTab = useRailState(railStore, (state) => state.tab);
   const truthStore = useMemo(
     () =>
       createPersistedTruthStore(
@@ -836,6 +853,9 @@ export function CoworkLiveWorkspace({
       if (activePane === "truth" && pane !== "truth") {
         detachTruthScroll();
       }
+      if (activePane === "provenance" && pane !== "provenance") {
+        detachProvenanceScroll();
+      }
       setActivePane(pane);
       if (pane !== "editor") railStore.setTab(pane);
       if (pane === "chat") void prepareChat();
@@ -844,6 +864,7 @@ export function CoworkLiveWorkspace({
       activePane,
       detachReviewScroll,
       detachTruthScroll,
+      detachProvenanceScroll,
       prepareChat,
       railStore,
     ],
@@ -914,16 +935,46 @@ export function CoworkLiveWorkspace({
             if (railStore.getState().tab === "truth") {
               detachTruthScroll();
             }
+            if (railStore.getState().tab === "provenance") {
+              detachProvenanceScroll();
+            }
             railStore.setTab("chat");
           },
         }
       : {}),
   });
+  const provenanceEditor = useMemo<ProvenanceEditorIntegration>(
+    () => ({
+      resolveTarget: bridge.provenanceEditor.resolveTarget,
+      isLocallyDirty: bridge.provenanceEditor.isLocallyDirty,
+      hasText: bridge.provenanceEditor.hasText,
+      hasUncoveredText: bridge.provenanceEditor.hasUncoveredText,
+      focusTarget: bridge.provenanceEditor.focusTarget,
+      revealTarget: (id) => {
+        if (!narrowWorkspace) {
+          bridge.provenanceEditor.revealTarget(id);
+          return;
+        }
+        setActivePane("editor");
+        window.requestAnimationFrame(() => {
+          editorPaneTabRef.current?.focus();
+          bridge.provenanceEditor.revealTarget(id);
+        });
+      },
+    }),
+    [bridge.provenanceEditor, narrowWorkspace],
+  );
   useEffect(() => {
     const applyLens = (): void => {
       const tab = railStore.getState().tab;
       bridge.setEditorLens(
-        tab === "review" ? "review" : tab === "truth" ? "truth" : "neutral",
+        tab === "review"
+          ? "review"
+          : tab === "truth"
+            ? "truth"
+            : tab === "provenance"
+              ? "provenance"
+              : "neutral",
       );
     };
     applyLens();
@@ -1290,6 +1341,11 @@ export function CoworkLiveWorkspace({
           >
             {passageAnnouncement}
           </p>
+          <ProvenanceHoverCard
+            rootRef={bridge.editorRootRef}
+            active={activeRailTab === "provenance"}
+            editorReady={bridge.editorReady}
+          />
         </>
       }
       editor={<CoworkBridgeEditor {...bridge.editorProps} />}
@@ -1307,7 +1363,14 @@ export function CoworkLiveWorkspace({
             onReviewScrollWillDetach={detachReviewScroll}
             truthScrollRef={truthScrollRef}
             onTruthScrollWillDetach={detachTruthScroll}
+            provenanceScrollRef={provenanceScrollRef}
+            onProvenanceScrollWillDetach={detachProvenanceScroll}
             reviewProvider={bridge.reviewProvider}
+            provenance={{
+              provider: bridge.provenanceProvider,
+              editor: provenanceEditor,
+              mutationBarrier: bridge.provenanceMutationBarrier,
+            }}
             chat={chat}
             reviewAnchors={reviewAnchors}
             store={railStore}
@@ -1326,6 +1389,8 @@ export function CoworkLiveWorkspace({
               !narrowWorkspace || activePane === "review"
             }
             truthVisible={!narrowWorkspace || activePane === "truth"}
+            provenanceVisible={!narrowWorkspace || activePane === "provenance"}
+            readOnly={readOnly}
             showTabs={!narrowWorkspace}
             onChatSelected={() => void prepareChat()}
             onRecheckIntent={recheckIntent}

--- a/dashboard-react/src/apps/cowork/surface/styles.css
+++ b/dashboard-react/src/apps/cowork/surface/styles.css
@@ -9,6 +9,7 @@
   display: flex;
   flex-direction: column;
   block-size: 100%;
+  max-block-size: 100dvh;
   min-block-size: 0;
   container-type: inline-size;
   background: var(--wb-color-surface-canvas);
@@ -780,6 +781,8 @@
 .wb-cowork__body {
   flex: 1 1 auto;
   min-block-size: 0;
+  /* Keep the resizable group clipped without making it another vertical scroll owner. */
+  overflow: clip !important;
 }
 
 /*
@@ -792,6 +795,15 @@
   min-inline-size: 0;
   min-block-size: 0;
   block-size: 100%;
+}
+
+/*
+ * Panel writes overflow:auto as an inline style on this inner wrapper. The rail owns its
+ * scroll boundaries below (Review/Truth/Provenance bodies and the Chat transcript), so letting
+ * this wrapper scroll creates a second scrollbar that can move the tab strip out of view.
+ */
+.wb-cowork__rail-panel {
+  overflow: clip !important;
 }
 
 .wb-cowork__editor-shell {
@@ -820,6 +832,7 @@
   min-block-size: 0;
   display: flex;
   flex-direction: column;
+  overflow: clip;
   background: var(--wb-color-surface-raised);
 }
 
@@ -891,8 +904,8 @@
 }
 
 /*
- * A narrow Co-work surface is one workspace with three peer panes, not a squeezed editor
- * beside a rail. All three remain mounted so editor selection, sitting decisions, and chat
+ * A narrow Co-work surface is one workspace with peer panes, not a squeezed editor
+ * beside a rail. All remain mounted so editor selection, sitting decisions, and chat
  * drafts survive switching; the inactive panel is hidden and inert through the markup.
  */
 @media (max-width: 760px) {
@@ -903,10 +916,12 @@
     padding: var(--wb-space-2);
     border-block-end: 1px solid var(--wb-color-border-subtle);
     background: var(--wb-color-surface-raised);
+    overflow-x: auto;
+    scrollbar-width: thin;
   }
 
   .wb-cowork__pane-tab {
-    flex: 1 1 0;
+    flex: 0 0 auto;
     padding: var(--wb-space-2) var(--wb-space-3);
     border: 1px solid transparent;
     border-radius: var(--wb-radius-control);
@@ -914,6 +929,7 @@
     color: var(--wb-color-text-secondary);
     font: inherit;
     cursor: pointer;
+    white-space: nowrap;
   }
 
   .wb-cowork__pane-tab[aria-selected="true"] {
@@ -1150,6 +1166,113 @@
   color: var(--wb-color-accent);
 }
 
+/* Provenance lens: background/border conveys authorship; underline conveys review. */
+.wb-cowork-provenance-mark {
+  border-radius: var(--wb-radius-sm);
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+
+.wb-cowork-provenance--human {
+  background: color-mix(in srgb, var(--wb-color-status-success) 9%, transparent);
+  border-inline-start: 2px solid var(--wb-color-status-success);
+}
+
+.wb-cowork-provenance--ai {
+  background: color-mix(in srgb, var(--wb-color-accent) 15%, transparent);
+  border-inline-start: 2px dotted var(--wb-color-accent);
+}
+
+.wb-cowork-provenance--mixed {
+  background: color-mix(in srgb, var(--wb-color-data-4) 13%, transparent);
+  border-inline-start: 3px double var(--wb-color-data-4);
+}
+
+.wb-cowork-provenance--unknown {
+  background: repeating-linear-gradient(
+    135deg,
+    transparent 0 4px,
+    color-mix(in srgb, var(--wb-color-text-secondary) 9%, transparent) 4px 7px
+  );
+  border-inline-start: 2px dashed var(--wb-color-text-secondary);
+}
+
+.wb-cowork-provenance--unrecorded {
+  background: repeating-linear-gradient(
+    45deg,
+    transparent 0 3px,
+    color-mix(in srgb, var(--wb-color-text-secondary) 13%, transparent) 3px 5px
+  );
+  border-inline-start-style: dashed;
+}
+
+.wb-cowork-provenance--review-reviewed {
+  text-decoration: underline solid var(--wb-color-status-success) 2px;
+  text-underline-offset: 3px;
+}
+
+.wb-cowork-provenance--review-not-reviewed:is(.wb-cowork-provenance--ai, .wb-cowork-provenance--mixed) {
+  text-decoration: underline dashed var(--wb-color-status-warning) 1.5px;
+  text-underline-offset: 3px;
+}
+
+.wb-cowork-provenance--review-unknown:is(.wb-cowork-provenance--ai, .wb-cowork-provenance--mixed) {
+  text-decoration: underline dotted var(--wb-color-text-secondary) 1.5px;
+  text-underline-offset: 3px;
+}
+
+.wb-cowork-provenance--conflict {
+  background: color-mix(in srgb, var(--wb-color-status-danger) 12%, transparent);
+  border-inline-start: 3px double var(--wb-color-status-danger);
+  text-decoration: underline wavy var(--wb-color-status-danger) 2px;
+  text-underline-offset: 3px;
+}
+
+.wb-cowork-provenance-hover {
+  position: fixed;
+  z-index: 1000;
+  display: grid;
+  inline-size: min(18rem, calc(100vw - 2rem));
+  gap: var(--wb-space-2);
+  padding: var(--wb-space-3);
+  border: 1px solid var(--wb-color-border-strong);
+  border-radius: var(--wb-radius-control);
+  background: var(--wb-color-surface-overlay, var(--wb-color-surface-raised));
+  box-shadow: var(--wb-shadow-lg);
+  color: var(--wb-color-text-primary);
+  font-family: var(--wb-font-sans);
+  pointer-events: none;
+}
+
+.wb-cowork-provenance-hover :is(p, dl) {
+  margin: 0;
+}
+
+.wb-cowork-provenance-hover dl {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--wb-space-1) var(--wb-space-2);
+  font-size: var(--wb-font-size-xs);
+}
+
+.wb-cowork-provenance-hover dl > div {
+  display: contents;
+}
+
+.wb-cowork-provenance-hover dt {
+  color: var(--wb-color-text-secondary);
+}
+
+.wb-cowork-provenance-hover dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.wb-cowork-provenance-hover p {
+  color: var(--wb-color-text-secondary);
+  font-size: var(--wb-font-size-xs);
+}
+
 /*
  * Review focus is persistent until selection moves or clears. Chat passage
  * highlighting is transient and never becomes the editor's active text selection.
@@ -1192,6 +1315,12 @@
   }
   .wb-cowork-provenance-tint {
     border-inline-start: 2px solid CanvasText;
+  }
+  .wb-cowork-provenance-mark {
+    border-inline-start-color: CanvasText;
+  }
+  .wb-cowork-provenance--conflict {
+    text-decoration: underline wavy Mark;
   }
   .wb-cowork-expression-mark,
   .wb-cowork-claim-anchor {

--- a/dashboard-react/src/apps/cowork/surface/usePersistedScrollPosition.ts
+++ b/dashboard-react/src/apps/cowork/surface/usePersistedScrollPosition.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, type RefCallback } from "react";
 
-export type CoworkScrollSurface = "editor" | "review" | "truth";
+export type CoworkScrollSurface = "editor" | "review" | "truth" | "provenance";
 
 const STORAGE_PREFIX = "wb.cowork.scroll-position.v1";
 const DEFAULT_WRITE_DELAY_MS = 250;

--- a/dashboard-react/src/apps/cowork/testSupport/authenticatedHumanAuthorityFetch.ts
+++ b/dashboard-react/src/apps/cowork/testSupport/authenticatedHumanAuthorityFetch.ts
@@ -1,0 +1,72 @@
+import { vi } from "vitest";
+
+type ApplicationResponder = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Response | Promise<Response>;
+
+const jsonResponse = (value: unknown, status = 200): Response =>
+  new Response(JSON.stringify(value), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+/**
+ * Exercise production human-authority acquisition while keeping component and
+ * client tests deterministic. Application requests still reach the supplied
+ * responder; only the local-session and gesture endpoints are test fixtures.
+ */
+export const authenticatedHumanAuthorityFetch = (
+  respond: ApplicationResponder,
+): ReturnType<typeof vi.fn<typeof fetch>> => {
+  let gestureIndex = 0;
+  return vi.fn<typeof fetch>(async (input, init) => {
+    const url = String(input);
+    if (url === "/api/local-identity/session/csrf") {
+      return jsonResponse({
+        ok: true,
+        authenticated: true,
+        csrf_token: "test-csrf-token",
+        principal: {
+          actor: {
+            schema: "wb.actor-ref/v1",
+            issuer_authority_id: "test-issuer",
+            subject: "test-dashboard-user",
+            kind: "human",
+            tenant_scope_id: "test-tenant",
+          },
+          origin: window.location.origin,
+          audience: "work-buddy-dashboard",
+          session_expires_at: 9_999_999_999,
+          rotation_due_at: 9_999_999_000,
+          assurance: "enrolled_local_session",
+        },
+      });
+    }
+    if (url === "/api/local-identity/gestures") {
+      gestureIndex += 1;
+      const request = JSON.parse(String(init?.body)) as {
+        action: string;
+        context_sha256: string;
+      };
+      return jsonResponse({
+        ok: true,
+        gesture: {
+          token: `test-gesture-${gestureIndex}`,
+          action: request.action,
+          subject_sha256: "a".repeat(64),
+          context_sha256: request.context_sha256,
+          expires_at: 9_999_999_999,
+        },
+      });
+    }
+    return respond(input, init);
+  });
+};
+
+export const applicationRequest = (
+  fetchImpl: ReturnType<typeof vi.fn<typeof fetch>>,
+): Parameters<typeof fetch> | undefined =>
+  fetchImpl.mock.calls.find(
+    ([input]) => !String(input).startsWith("/api/local-identity/"),
+  );

--- a/dashboard-react/src/main.tsx
+++ b/dashboard-react/src/main.tsx
@@ -16,15 +16,30 @@ import { DashboardTemporalContextProvider } from "./dashboard/temporal/Dashboard
 import { DensityProvider } from "./theme/DensityProvider";
 import { ThemeProvider } from "./theme/ThemeProvider";
 import { TypographyScaleProvider } from "./theme/TypographyScaleProvider";
-import { initializeLocalIdentity } from "./security/localIdentity";
+import {
+  currentLocalIdentity,
+  hasLocalIdentityBootstrap,
+  initializeLocalIdentity,
+  refreshLocalIdentity,
+} from "./security/localIdentity";
 import "./theme.css";
 
 const widgetDraftRepository = createBrowserWidgetDraftRepository();
 
 // Consume a launcher-delivered bootstrap before a feature can issue a
-// human-authority mutation. Providers remain explicitly read-only if this
-// local boundary is unavailable; startup itself is never blocked.
+// human-authority mutation. Ordinary local editing does not depend on this
+// stronger boundary; focus recovery lets another trusted app tab restore it.
 void initializeLocalIdentity();
+window.addEventListener("hashchange", () => {
+  if (hasLocalIdentityBootstrap()) void refreshLocalIdentity();
+});
+const recoverFocusedLocalIdentity = (): void => {
+  if (!currentLocalIdentity().authenticated) void refreshLocalIdentity();
+};
+window.addEventListener("focus", recoverFocusedLocalIdentity);
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "visible") recoverFocusedLocalIdentity();
+});
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/dashboard-react/src/security/localIdentity.test.ts
+++ b/dashboard-react/src/security/localIdentity.test.ts
@@ -6,6 +6,7 @@ import {
   initializeLocalIdentity,
   issueHumanGesture,
   localIdentityHeaders,
+  refreshLocalIdentity,
   resetLocalIdentityForTests,
 } from "./localIdentity";
 
@@ -73,6 +74,63 @@ describe("local identity bootstrap", () => {
     expect(currentLocalIdentity()).not.toHaveProperty("csrf_token");
     expect(localIdentityHeaders()).toEqual({ "X-WB-CSRF": "wbc_secret" });
     expect(replace).toHaveBeenCalledBefore(fetchImpl);
+  });
+
+  it("recovers when a trusted launcher focuses an already-open unauthenticated tab", async () => {
+    const location = {
+      hash: "",
+      origin: principal.origin,
+      pathname: "/app/cowork",
+      search: "?store_id=store-1&document_id=doc-1",
+    };
+    const replace = vi.fn((url: string) => {
+      location.hash = new URL(url, principal.origin).hash;
+    });
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input) === "/api/local-identity/session/csrf") {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            authenticated: false,
+            human_authority_available: false,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      expect(String(input)).toBe("/api/local-identity/bootstrap/redeem");
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          authenticated: true,
+          principal,
+          csrf_token: "wbc_reconnected",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    await expect(
+      initializeLocalIdentity({ fetchImpl, location, replaceState: replace }),
+    ).resolves.toEqual({
+      authenticated: false,
+      reason: "No authenticated local session.",
+    });
+
+    location.hash = "#wb-bootstrap=wbb_reconnect";
+    await expect(
+      refreshLocalIdentity({ fetchImpl, location, replaceState: replace }),
+    ).resolves.toEqual({ authenticated: true, principal });
+
+    expect(fetchImpl.mock.calls.map(([url]) => String(url))).toEqual([
+      "/api/local-identity/session/csrf",
+      "/api/local-identity/bootstrap/redeem",
+    ]);
+    expect(replace).toHaveBeenCalledWith(
+      "/app/cowork?store_id=store-1&document_id=doc-1",
+    );
+    expect(localIdentityHeaders()).toEqual({
+      "X-WB-CSRF": "wbc_reconnected",
+    });
   });
 
   it("rotates an aging session once before issuing the bound gesture", async () => {

--- a/dashboard-react/src/security/localIdentity.ts
+++ b/dashboard-react/src/security/localIdentity.ts
@@ -54,6 +54,7 @@ type BrowserLocation = Pick<
 let state: LocalIdentityState = { authenticated: false };
 let csrfToken: string | null = null;
 let initializePromise: Promise<LocalIdentityState> | null = null;
+let refreshPromise: Promise<LocalIdentityState> | null = null;
 const listeners = new Set<(next: LocalIdentityState) => void>();
 
 function publish(next: LocalIdentityState): LocalIdentityState {
@@ -176,6 +177,36 @@ export function initializeLocalIdentity(
   return initializePromise;
 }
 
+/**
+ * Re-check the browser's local identity boundary.
+ *
+ * A trusted launcher may focus an already-open dashboard tab by adding a new
+ * one-time bootstrap to its URL fragment.  The original initialization has
+ * already settled in that case, so retry must deliberately consume the new
+ * fragment (or recover a cookie created by another trusted launch) instead of
+ * replaying the memoized unauthenticated result.
+ */
+export function refreshLocalIdentity(
+  options: InitializeLocalIdentityOptions = {},
+): Promise<LocalIdentityState> {
+  if (refreshPromise) return refreshPromise;
+  refreshPromise = (async () => {
+    if (initializePromise) await initializePromise;
+    initializePromise = null;
+    return initializeLocalIdentity(options);
+  })().finally(() => {
+    refreshPromise = null;
+  });
+  return refreshPromise;
+}
+
+export function hasLocalIdentityBootstrap(
+  location: Pick<Location, "hash"> = window.location,
+): boolean {
+  if (!location.hash.startsWith("#")) return false;
+  return new URLSearchParams(location.hash.slice(1)).has("wb-bootstrap");
+}
+
 export function currentLocalIdentity(): LocalIdentityState {
   return state;
 }
@@ -280,5 +311,6 @@ export function resetLocalIdentityForTests(): void {
   publish({ authenticated: false });
   csrfToken = null;
   initializePromise = null;
+  refreshPromise = null;
   listeners.clear();
 }

--- a/dashboard-react/tests/e2e/cowork-persistence.spec.ts
+++ b/dashboard-react/tests/e2e/cowork-persistence.spec.ts
@@ -69,6 +69,55 @@ test.describe("Co-work persistence across visits", () => {
     ).toContainText("Context bundle cache");
   });
 
+  test("keeps the side-panel tabs pinned while a long Chat transcript scrolls", async ({
+    page,
+  }) => {
+    await openCowork(page);
+    await page.getByRole("tab", { name: /Chat/u }).click();
+
+    const composer = page.getByRole("textbox", { name: "Message" });
+    const send = page.getByRole("button", { name: "Send" });
+    for (let index = 0; index < 10; index += 1) {
+      await composer.fill(
+        `Chat scroll containment ${index}: keep the side-panel tabs available while this transcript grows.`,
+      );
+      await send.click();
+    }
+
+    const metrics = await page.evaluate(() => {
+      const railWrapper = document.querySelector<HTMLElement>(
+        ".wb-cowork__rail-panel",
+      );
+      const tabs = document.querySelector<HTMLElement>(
+        ".wb-cowork-rail__tabs",
+      );
+      const transcript = document.querySelector<HTMLElement>(
+        ".wb-chat-list__scroll",
+      );
+      if (railWrapper === null || tabs === null || transcript === null) {
+        throw new Error("The Chat rail did not render its scroll boundaries.");
+      }
+      return {
+        railScrollTop: railWrapper.scrollTop,
+        railOverflowY: getComputedStyle(railWrapper).overflowY,
+        tabsHeight: tabs.getBoundingClientRect().height,
+        tabsVisible: tabs.getBoundingClientRect().bottom > 0,
+        transcriptClientHeight: transcript.clientHeight,
+        transcriptScrollHeight: transcript.scrollHeight,
+        transcriptScrollTop: transcript.scrollTop,
+      };
+    });
+
+    expect(metrics.railScrollTop).toBe(0);
+    expect(metrics.railOverflowY).toBe("clip");
+    expect(metrics.tabsHeight).toBeGreaterThan(40);
+    expect(metrics.tabsVisible).toBe(true);
+    expect(metrics.transcriptScrollHeight).toBeGreaterThan(
+      metrics.transcriptClientHeight,
+    );
+    expect(metrics.transcriptScrollTop).toBeGreaterThan(0);
+  });
+
   test("editor and Review positions survive leaving the workspace", async ({ page }) => {
     // A shorter viewport guarantees both the seeded document and its review list have a
     // meaningful scroll range. The positions are deliberately different so accidentally

--- a/knowledge/store/cowork/content-provenance.md
+++ b/knowledge/store/cowork/content-provenance.md
@@ -3,12 +3,12 @@ name: Co-work Content Provenance
 kind: concept
 description: Frozen-target, append-only attestations that keep content source, authorship, human review, and the attester distinct.
 summary: >-
-  From file records source facts and an authorship and human-review
-  determination against the imported document version. Text-bearing pastes
-  record the same dimensions against an exact span: substantial or structured
-  text asks the user, while short simple text uses an explicit
-  automatic-attribution basis. These attestations report what a person says
-  about the content. They do not verify authorship, correctness, or claims.
+  Provenance is a first-class Co-work rail and view-only editor lens for source,
+  authorship, human-review, attester, and basis records. File import targets an
+  immutable document version; text-bearing paste targets an exact span. A
+  human review action appends a user-attested superseding record while
+  preserving source and authorship. Attestations report what a person says
+  about content; they do not verify authorship, correctness, or claims.
 tags:
 - cowork
 - provenance
@@ -69,6 +69,91 @@ ambiguous response can replay only the same immutable logical request.
 The append-only record carries a canonical digest and idempotency key.
 Corrections append a replacement that names the prior attestation through
 `supersedes_id`; they do not update or delete history.
+
+## Provenance surface
+
+The Co-work rail tabs are **Review | Provenance | Truth | Chat**:
+
+- **Review** owns document-change and evaluation decisions.
+- **Provenance** answers where current document text came from, who is said to
+  have written it, and what human review is recorded.
+- **Truth** owns claims, expressions, evidence, and their lifecycle. It can
+  still show the acquisition and decision provenance of those Truth records,
+  but it does not own document-authorship treatment in the editor.
+- **Chat** remains the conversational surface.
+
+The persistent editor lenses are `review`, `provenance`, `truth`, and
+`neutral`, respectively. A lens switch replaces view-only ProseMirror
+decorations; it never changes document content, Yjs state, Markdown, selection,
+scroll, or undo history. Temporary Chat, Working-on, and one-shot passage
+highlights remain independent.
+
+The Provenance lens uses independent visual channels. Authorship receives a
+subtle tint or pattern; human-review state receives a distinct underline.
+Source, attester, and basis remain first-class textual details rather than
+competing per-character colors. Red wavy treatment is reserved for unresolved,
+ambiguous, or conflicting targets, not ordinary AI authorship or an explicit
+not-reviewed state. Every meaning is repeated as text in the hover explanation
+and stable panel so color is never the only channel.
+
+Hover is explanatory and passive. The stable Provenance panel owns summary,
+filters, document-order items, frozen target and history details, and mutation
+controls. Missing data is visible as **No provenance recorded**, never inferred
+as human. Loading and failed refresh are separate from an empty record set.
+List-row activation opens detail and may apply compatible focus, but it does not
+scroll the editor. A uniquely resolved span has a separate **Show in document**
+action for one present-user reveal. The panel also exposes **Complete provenance
+history**, so old or malformed records without safe current geometry remain
+inspectable without receiving a guessed range.
+
+Provenance has a dedicated typed provider and panel projection. It can share the
+authoritative open-document snapshot source with other rails, but it does not
+enlarge Review's domain payload into a general provenance transport. Hover and
+the editor lens consume the same projection; hover never owns an action.
+
+For the current overlay, one unsuperseded record is the effective leaf of its
+lineage. A document-version attestation covers the current whole document only
+while its target structured head equals the current head; later text is not
+silently attributed. A span record at the current frozen head is current. After
+an unrelated document change, it can be reanchored for display only when its
+complete exact, prefix, and suffix quote selector resolves uniquely in the
+hydrated editor. Missing or duplicate matches are stale. A uniquely reanchored
+changed-head span is paintable and inspectable, but this first mutation slice
+does not let browser placement authorize a durable **Mark reviewed** assertion;
+review remains exact-head-only. Independently effective overlapping
+peer span records which disagree produce a conflict rather than last-write-wins.
+A current document-level attestation is fallback coverage, and a current exact
+span overrides it in its range; that specific-over-fallback precedence is not
+a peer conflict. Different attesters or bases do not create a conflict when
+source, authorship, and review agree. A stale document-level record is not
+fallback coverage. Conflicted coverage is recorded-but-disputed; unrecorded
+means there is no current safely resolved record for that text.
+
+An unsynchronized local-human edit invalidates the pulled provenance head at
+once. The overlay withholds document-wide fallback and treats exact spans as
+requiring re-anchor, so newly typed text cannot inherit stale authorship. A
+unique span may stay paintable for inspection; review stays unavailable until
+persistence settles and a matching fresh authoritative projection arrives.
+
+**Mark reviewed** is a constrained append-only action for one effective,
+exact-current-head AI- or mixed-authored document-version or span target. The
+server derives a superseding record
+which preserves the target, source, authorship, and contributors, changes human
+review to reviewed, and records the enrolled acting user as reviewer and
+attester. The new record has a `user_attestation` basis referencing its
+predecessor; the old record keeps its own automatic, proposal, migration, or
+legacy basis in history. The transition therefore remains “AI-authored,
+human-reviewed,” not “human-authored.” Reviewed is not approval, factual
+confirmation, or acceptance.
+
+The editor owns the review mutation barrier. It disables editing, retries and
+flushes pending Yjs persistence, verifies canonical state, and compacts to one
+durable structured head. While that lock remains held, the dedicated provider
+forces a fresh document pull and the panel rechecks the same effective leaf,
+head, eligibility, unique exact-span resolution, and incompatible peer overlap.
+Only then does it post the append-only transition and repull authoritative
+state. Any drift fails closed; the editor is re-enabled only if the mounted
+document is still writable.
 
 ## From file
 
@@ -190,20 +275,26 @@ failure can be retried without remounting the page.
 
 ## Person identity
 
-**Me** first obtains the current actor binding from the server and freezes its
-ref and identity status into the determination. The server revalidates that
-binding when the import or paste is recorded; if the acting identity changed,
-the frozen determination is rejected instead of being reassigned to the new
-actor. For queued pastes, the browser refetches the current actor, clears the
-stale frozen requests, rotates their idempotency keys, and changes every pending
-determination to unknown authorship with an explicit user-attestation basis.
-Nothing is resent until the user makes a fresh determination, including a short
-paste that was originally eligible for automatic attribution.
+**Me** first obtains the enrolled local principal binding from the server and
+freezes its actor ref and identity status into the determination. Dashboard
+mutations additionally require the revocable browser session and CSRF boundary
+plus a one-time gesture bound to the exact action, subject, and request context.
+The server derives the Truth actor from that authority; it does not accept a
+client-supplied human actor.
 
-The local actor ref is durable within the local system, but the dashboard has
-no authenticated multi-user boundary. It is stored as
-`identity_status=local_actor_ref` and must not be described as a verified
-account identity.
+The server revalidates the frozen binding when an import, paste, or review
+attestation is recorded. If the acting identity changed, the determination is
+rejected instead of being reassigned. For queued pastes, the browser refetches
+the current actor, clears stale frozen requests, rotates their idempotency keys,
+and changes every pending determination to unknown authorship with an explicit
+user-attestation basis. Nothing is resent until the user makes a fresh
+determination, including a short paste originally eligible for automatic
+attribution.
+
+The enrolled local actor ref is durable within this installation and stronger
+than an arbitrary request header, but it is not a verified remote multi-user
+account. It remains `identity_status=local_actor_ref`; product copy must not
+describe it as an authenticated external identity or `account_ref`.
 
 **Someone else** stores the typed display name with
 `identity_status=claimed_name`. It is useful attribution supplied by the

--- a/knowledge/store/cowork/truth-surface.md
+++ b/knowledge/store/cowork/truth-surface.md
@@ -1,8 +1,8 @@
 ---
 name: Co-work Truth surface
 kind: system
-description: First-class Co-work rail surface for observing and managing the claims, expressions, provenance, and lifecycle beneath a document or Folder.
-summary: Truth is the AI-assisted domain workspace for discovering, grounding, deciding, and maintaining claims, expressions, evidence, provenance, and lifecycle beneath a document or Folder. Analyze passage prepares atomic claims and may perform bounded guarded web research; manual claim and connection authoring are secondary. Truth owns full domain review, Review cross-lists attention, Chat remains a peer interaction surface but does not yet start or steer Truth analysis, and Verify remains criteria evaluation.
+description: First-class Co-work rail surface for observing and managing the claims, expressions, evidence, decision provenance, and lifecycle beneath a document or Folder.
+summary: Truth is the AI-assisted domain workspace for discovering, grounding, deciding, and maintaining claims, expressions, evidence, decision provenance, and lifecycle beneath a document or Folder. Document source, authorship, and human-review attestations have their own Provenance rail and editor lens. Analyze passage prepares atomic claims and may perform bounded guarded web research; Review cross-lists attention, Chat remains a peer interaction surface, and Verify remains criteria evaluation.
 entry_points:
 - work_buddy.truth.queries
 - work_buddy.truth.expressions
@@ -39,7 +39,15 @@ dev_notes: |-
   base_status separate from the needs_review overlay. SSE is only an
   invalidation nudge followed by an authoritative repull.
 
-  A Truth lens is a ProseMirror decoration state, never document state. Lens
+  Provenance likewise owns a dedicated typed provider and panel projection. It
+  may share the authoritative open-document snapshot source, but Review and
+  Truth do not become general provenance transports. Its Mark reviewed path
+  remains behind the editor persistence barrier and a forced-fresh exact-head
+  preflight.
+
+  A Truth lens is a ProseMirror decoration state, never document state. It owns
+  expression anchors; the peer Provenance lens owns document source,
+  authorship, and human-review treatments. Lens
   changes must not write a transaction that alters the document, Y.Doc,
   Markdown, editor selection, scroll position, or undo history. A user passage
   activation is a one-shot reveal command and is never persisted or replayed.
@@ -78,10 +86,13 @@ dev_notes: |-
 # Co-work Truth surface
 
 Truth is a first-class user surface within Co-work. The rail tabs are
-**Review | Truth | Chat**:
+**Review | Provenance | Truth | Chat**:
 
 - **Review** answers “What needs my decision?” and remains the inbox for edit
   proposals, flags, evaluation results, and cross-listed claim attention.
+- **Provenance** answers “Where did these words come from, who is said to have
+  written them, and what human review is recorded?” It owns document-level and
+  exact-span source/authorship/review attestations.
 - **Truth** answers “What does this work rest on?” and owns both observation
   and the complete domain review for claim, expression, and evidence work.
 - **Chat** remains the general conversational interaction surface. Starting,
@@ -199,15 +210,33 @@ builds and maintains the claim-expression-evidence record.
 The editor lens is explicit view state:
 
 - `review` projects proposals, flags, and evaluation-result anchors;
-- `truth` projects expression and provenance anchors; and
+- `provenance` projects document source, authorship, human-review, and
+  target-health treatments;
+- `truth` projects expression anchors; and
 - `neutral` projects neither persistent ledger overlay.
 
-Review selects the review lens, Truth selects the truth lens, and Chat selects
-neutral. Temporary Working on and Chat passage highlights remain independent.
-A lens switch replaces decorations only and clears incompatible focus; it never
-changes content, selection, scroll, or persisted document state. Clicking a
-claim or one of its expressions issues one present-user navigation command.
-Refresh may restore emphasis but never replay that reveal.
+Review selects the review lens, Provenance selects the provenance lens, Truth
+selects the truth lens, and Chat selects neutral. Temporary Working on and Chat
+passage highlights remain independent. A lens switch replaces decorations only
+and clears incompatible focus; it never changes content, selection, scroll, or
+persisted document state. Clicking a claim or one of its expressions issues one
+present-user navigation command. Refresh may restore emphasis but never replay
+that reveal.
+
+Truth still explains provenance attached to Truth-domain records: who prepared
+or decided a candidate, how evidence was acquired, and what source occurrence a
+receipt retains. That does not make Truth the home for document-authorship and
+human-review attestations. Their exact coverage, supersession history, hover
+explanation, and **Mark reviewed** action belong to Provenance. The accepted
+boundary and overlay contract live at
+`.data/designs/co-work/provenance-surface/README.md`.
+
+The Provenance list is deliberately non-navigating by default: selecting a row
+opens stable detail and may focus compatible decoration, while **Show in
+document** is the explicit one-shot reveal. Hover is passive and action-free.
+A changed-head span that reanchors uniquely remains inspectable but cannot be
+used for **Mark reviewed**; review requires an editor persistence barrier, a
+forced authoritative refresh, and one exact current head.
 
 ## Modification authority and limits
 
@@ -321,8 +350,9 @@ dependency state first identify affected work; semantic re-evaluation remains
 an explicit bounded action.
 
 Distinguish no document connections, an empty Folder ledger, and no filter
-matches. The rail tablist uses roving keyboard focus with Arrow keys and
-Home/End. Claim cards retain semantic keyboard activation, nested controls do
+matches. The four-item rail tablist uses roving keyboard focus with Arrow keys
+and Home/End and keeps every tab reachable at narrow widths. Claim cards retain
+semantic keyboard activation, nested controls do
 not also select the card, and status meaning never depends on color alone.
 
 The accepted architecture and full acceptance contract live at

--- a/tests/unit/cowork/test_api_routes.py
+++ b/tests/unit/cowork/test_api_routes.py
@@ -884,6 +884,188 @@ def test_paste_authorship_attestation_rejects_stale_structured_head(
         )
 
 
+def test_ai_provenance_human_review_is_target_bound_and_idempotent(
+    client,
+    seeded,
+):
+    document = seeded["document"]
+    head = ydoc_store.current_structured_head(
+        seeded["store"],
+        document_id=document.id,
+        snapshot_sha256=seeded["snapshot_sha256"],
+    )
+    original, span_id = provenance.record_span_attestation(
+        seeded["store"],
+        document_id=document.id,
+        exact=DOC_QUOTE,
+        attestation={
+            "schema": "cowork-authorship-attestation/v1",
+            "authorship": {"kind": "ai", "contributors": []},
+            "human_review": {"status": "not_reviewed", "reviewers": []},
+        },
+        actor=HUMAN,
+        idempotency_key="review-route-origin-0001",
+        expected_structured_head_sha256=head,
+    )
+    url = _url(
+        f"/api/truth/doc/{document.id}/authorship-attestations/"
+        f"{original.id}/human-review",
+        seeded["store_id"],
+    )
+    body = {
+        "attestation_id": original.id,
+        "expected_structured_head_sha256": head,
+        "idempotency_key": "review-route-command-0001",
+    }
+    reviewed = client.post(url, json=body)
+    replay = client.post(url, json=body)
+
+    assert reviewed.status_code == replay.status_code == 201
+    first = reviewed.get_json()["attestation"]
+    assert replay.get_json()["attestation"] == first
+    assert first["scope"]["document_span_id"] == span_id
+    assert first["authorship"] == {"kind": "ai", "contributors": []}
+    assert first["human_review"]["status"] == "reviewed"
+    assert first["human_review"]["reviewers"][0]["ref"] == HUMAN.ref
+    assert first["basis"] == {
+        "kind": "user_attestation",
+        "ref": original.id,
+    }
+    assert first["supersedes_id"] == original.id
+
+    opened = client.get(
+        _url(f"/api/truth/doc/{document.id}", seeded["store_id"])
+    )
+    view = opened.get_json()["provenance"]
+    assert view["schema"] == "cowork-provenance-view/v1"
+    assert view["summary"]["reviewed_count"] == 1
+    assert view["summary"]["ai_unreviewed_count"] == 0
+    assert view["spans"][0]["effective_attestation"] == first
+    assert len(view["spans"][0]["history"]) == 2
+
+
+@pytest.mark.parametrize("damage", ["missing", "malformed_selector"])
+def test_provenance_review_route_rejects_invalid_span_target_without_append(
+    client,
+    seeded,
+    monkeypatch,
+    damage,
+):
+    document = seeded["document"]
+    head = ydoc_store.current_structured_head(
+        seeded["store"],
+        document_id=document.id,
+        snapshot_sha256=seeded["snapshot_sha256"],
+    )
+    original, span_id = provenance.record_span_attestation(
+        seeded["store"],
+        document_id=document.id,
+        exact=DOC_QUOTE,
+        attestation={
+            "schema": "cowork-authorship-attestation/v1",
+            "authorship": {"kind": "ai", "contributors": []},
+            "human_review": {"status": "not_reviewed", "reviewers": []},
+        },
+        actor=HUMAN,
+        idempotency_key=f"review-route-damaged-{damage}-origin-0001",
+        expected_structured_head_sha256=head,
+    )
+    history_before = provenance.list_attestations(
+        seeded["store"],
+        document.id,
+    )
+    with seeded["store"].connect() as conn:
+        if damage == "missing":
+            conn.execute("PRAGMA foreign_keys = OFF")
+            conn.execute("DROP TRIGGER document_spans_append_only_delete")
+            conn.execute("DELETE FROM document_spans WHERE id = ?", (span_id,))
+        else:
+            conn.execute("DROP TRIGGER document_spans_append_only_update")
+            conn.execute(
+                "UPDATE document_spans SET selector_json = ? WHERE id = ?",
+                ("{not-json", span_id),
+            )
+
+    emitted = []
+    monkeypatch.setattr(
+        api,
+        "_emit",
+        lambda *args, **kwargs: emitted.append((args, kwargs)),
+    )
+    response = client.post(
+        _url(
+            f"/api/truth/doc/{document.id}/authorship-attestations/"
+            f"{original.id}/human-review",
+            seeded["store_id"],
+        ),
+        json={
+            "attestation_id": original.id,
+            "expected_structured_head_sha256": head,
+            "idempotency_key": f"review-route-damaged-{damage}-command-0001",
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.get_json()["error"]["code"] == (
+        "provenance_review_target_mismatch"
+    )
+    assert (
+        provenance.list_attestations(seeded["store"], document.id)
+        == history_before
+    )
+    assert emitted == []
+
+
+def test_provenance_review_route_binds_path_target_into_exact_body(
+    client,
+    seeded,
+):
+    document = seeded["document"]
+    response = client.post(
+        _url(
+            f"/api/truth/doc/{document.id}/authorship-attestations/"
+            f"{'a' * 32}/human-review",
+            seeded["store_id"],
+        ),
+        json={
+            "attestation_id": "b" * 32,
+            "expected_structured_head_sha256": "0" * 64,
+            "idempotency_key": "review-target-mismatch-0001",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == (
+        "attestation_id must match the route target"
+    )
+
+
+def test_provenance_review_route_respects_dashboard_read_only_mode(
+    client,
+    seeded,
+    monkeypatch,
+):
+    monkeypatch.setattr(api, "_is_read_only", lambda: True)
+    response = client.post(
+        _url(
+            f"/api/truth/doc/{seeded['document'].id}/"
+            f"authorship-attestations/{'a' * 32}/human-review",
+            seeded["store_id"],
+        ),
+        json={
+            "attestation_id": "a" * 32,
+            "expected_structured_head_sha256": "0" * 64,
+            "idempotency_key": "review-read-only-0001",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.get_json() == {
+        "ok": False,
+        "error": "Dashboard is in read-only mode",
+    }
+
+
 @pytest.mark.parametrize(
     ("exact", "attestation", "message"),
     [

--- a/tests/unit/cowork/test_provenance_attestations.py
+++ b/tests/unit/cowork/test_provenance_attestations.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from work_buddy.cowork import bootstrap, provenance
-from work_buddy.truth import documents
+from work_buddy.truth import documents, ydoc_store
 from work_buddy.truth.contracts import Actor, InvariantViolation
 from work_buddy.truth.export import export_store, import_store
 from work_buddy.truth.identity import sha256_bytes
@@ -241,6 +241,26 @@ def _import_ready(store_ctx, *, attestation=None):
     document = documents.get_document(store, receipt["document_id"])
     version = documents.document_versions(store, document.id)[0]
     return document, version, intent, source
+
+
+def _other_document(store_ctx, *, suffix: str):
+    store = store_ctx["store"]
+    source = f"# Other provenance target {suffix}\n".encode()
+    path = f"imports/other-provenance-{suffix}.md"
+    (store_ctx["root"] / path).write_bytes(source)
+    snapshot_sha256 = ydoc_store.write_snapshot(
+        store,
+        snapshot=f"opaque-other-provenance-{suffix}".encode(),
+    )
+    return documents.register_document(
+        store,
+        path=path,
+        title=f"Other provenance target {suffix}",
+        document_class="co_authored",
+        content_sha256=sha256_bytes(source),
+        ydoc_snapshot_sha256=snapshot_sha256,
+        actor=HUMAN,
+    )
 
 
 def test_import_records_independent_authorship_review_and_attester(store_ctx):
@@ -483,6 +503,591 @@ def test_paste_idempotency_key_is_bound_to_the_exact_selector(store_ctx):
             idempotency_key="paste-selector-bound-0001",
             expected_structured_head_sha256=version.structured_head_sha256,
         )
+
+
+@pytest.mark.parametrize("authorship", ["ai", "mixed"])
+def test_human_review_supersedes_effective_ai_without_rewriting_source(
+    store_ctx,
+    authorship,
+):
+    store = store_ctx["store"]
+    document, version, _intent, _source = _import_ready(store_ctx)
+    original, span_id = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="durable provenance",
+        prefix="A ",
+        suffix=" target.",
+        attestation=_attestation(
+            authorship=authorship,
+            review="not_reviewed",
+        ),
+        actor=HUMAN,
+        idempotency_key=f"review-origin-{authorship}-0001",
+        basis_kind="automatic_short_text_attribution",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+
+    reviewed = provenance.record_human_review(
+        store,
+        document_id=document.id,
+        attestation_id=original.id,
+        actor=HUMAN,
+        idempotency_key=f"human-review-{authorship}-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    replay = provenance.record_human_review(
+        store,
+        document_id=document.id,
+        attestation_id=original.id,
+        actor=HUMAN,
+        idempotency_key=f"human-review-{authorship}-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+
+    assert replay == reviewed
+    assert reviewed.document_span_id == span_id
+    assert reviewed.target_structured_head_sha256 == original.target_structured_head_sha256
+    assert reviewed.authorship_kind == original.authorship_kind == authorship
+    assert reviewed.human_contributors_json == original.human_contributors_json
+    assert reviewed.source_json == original.source_json
+    assert reviewed.review_status == "reviewed"
+    assert json.loads(reviewed.human_reviewers_json) == [
+        {
+            "identity_status": "local_actor_ref",
+            "kind": "human",
+            "ref": HUMAN.ref,
+        }
+    ]
+    assert original.basis_kind == "automatic_short_text_attribution"
+    assert reviewed.basis_kind == "user_attestation"
+    assert reviewed.basis_ref == original.id
+    assert reviewed.supersedes_id == original.id
+
+    projection = provenance.project_attestations(
+        store,
+        document.id,
+        current_structured_head_sha256=version.structured_head_sha256,
+    )
+    target = projection["spans"][0]
+    assert target["resolution"] == "resolved"
+    assert target["effective_attestation"]["attestation_id"] == reviewed.id
+    assert target["history"][0]["basis"]["kind"] == (
+        "automatic_short_text_attribution"
+    )
+    assert target["history"][1]["basis"] == {
+        "kind": "user_attestation",
+        "ref": original.id,
+    }
+
+
+def test_human_review_rejects_non_ai_stale_and_already_superseded_targets(
+    store_ctx,
+):
+    store = store_ctx["store"]
+    document, version, _intent, _source = _import_ready(store_ctx)
+    human, _ = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="durable provenance",
+        prefix="A ",
+        suffix=" target.",
+        attestation=_attestation(authorship="human", review="not_applicable"),
+        actor=HUMAN,
+        idempotency_key="human-review-ineligible-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    with pytest.raises(provenance.ProvenanceReviewError) as ineligible:
+        provenance.record_human_review(
+            store,
+            document_id=document.id,
+            attestation_id=human.id,
+            actor=HUMAN,
+            idempotency_key="human-review-ineligible-0001",
+            expected_structured_head_sha256=version.structured_head_sha256,
+        )
+    assert ineligible.value.code == "provenance_review_ineligible"
+
+    ai, _ = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="Imported",
+        prefix="# ",
+        suffix="\n\nA",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="human-review-ai-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    other_source = b"# Other provenance target\n"
+    other_path = "imports/other-provenance.md"
+    (store_ctx["root"] / other_path).write_bytes(other_source)
+    other_snapshot = b"opaque-other-provenance-snapshot"
+    other_snapshot_sha256 = ydoc_store.write_snapshot(
+        store,
+        snapshot=other_snapshot,
+    )
+    other = documents.register_document(
+        store,
+        path=other_path,
+        title="Other provenance target",
+        document_class="co_authored",
+        content_sha256=sha256_bytes(other_source),
+        ydoc_snapshot_sha256=other_snapshot_sha256,
+        actor=HUMAN,
+    )
+    with pytest.raises(provenance.ProvenanceReviewError) as cross_document:
+        provenance.record_human_review(
+            store,
+            document_id=other.id,
+            attestation_id=ai.id,
+            actor=HUMAN,
+            idempotency_key="human-review-ai-cross-doc-0001",
+            expected_structured_head_sha256=version.structured_head_sha256,
+        )
+    assert cross_document.value.code == "provenance_review_target_mismatch"
+
+    with pytest.raises(provenance.ProvenanceReviewError) as stale:
+        provenance.record_human_review(
+            store,
+            document_id=document.id,
+            attestation_id=ai.id,
+            actor=HUMAN,
+            idempotency_key="human-review-ai-stale-0001",
+            expected_structured_head_sha256="0" * 64,
+        )
+    assert stale.value.code == "provenance_target_changed"
+
+    reviewed = provenance.record_human_review(
+        store,
+        document_id=document.id,
+        attestation_id=ai.id,
+        actor=HUMAN,
+        idempotency_key="human-review-ai-success-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    with pytest.raises(provenance.ProvenanceReviewError) as superseded:
+        provenance.record_human_review(
+            store,
+            document_id=document.id,
+            attestation_id=ai.id,
+            actor=HUMAN,
+            idempotency_key="human-review-ai-second-0001",
+            expected_structured_head_sha256=version.structured_head_sha256,
+        )
+    assert superseded.value.code == "provenance_review_conflict"
+    assert reviewed.supersedes_id == ai.id
+
+    documents.retire_document(
+        store,
+        document_id=document.id,
+        actor=HUMAN,
+    )
+    with pytest.raises(provenance.ProvenanceReviewError) as retired:
+        provenance.record_human_review(
+            store,
+            document_id=document.id,
+            attestation_id=ai.id,
+            actor=HUMAN,
+            idempotency_key="human-review-ai-retired-0001",
+            expected_structured_head_sha256=version.structured_head_sha256,
+        )
+    assert retired.value.code == "provenance_review_state_conflict"
+
+
+@pytest.mark.parametrize(
+    "damage",
+    ["missing", "wrong_document", "malformed_selector", "quote_mismatch"],
+)
+def test_human_review_rejects_damaged_span_target_before_append(
+    store_ctx,
+    damage,
+):
+    store = store_ctx["store"]
+    document, version, _intent, _source = _import_ready(store_ctx)
+    original, span_id = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="durable provenance",
+        prefix="A ",
+        suffix=" target.",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key=f"review-damaged-{damage}-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    history_before = store.list_document_provenance_attestations(document.id)
+    other = (
+        _other_document(store_ctx, suffix=damage)
+        if damage == "wrong_document"
+        else None
+    )
+
+    with store.connect() as conn:
+        if damage == "missing":
+            conn.execute("PRAGMA foreign_keys = OFF")
+            conn.execute("DROP TRIGGER document_spans_append_only_delete")
+            conn.execute("DELETE FROM document_spans WHERE id = ?", (span_id,))
+        else:
+            conn.execute("DROP TRIGGER document_spans_append_only_update")
+            if damage == "wrong_document":
+                assert other is not None
+                conn.execute(
+                    "UPDATE document_spans SET document_id = ? WHERE id = ?",
+                    (other.id, span_id),
+                )
+            elif damage == "malformed_selector":
+                conn.execute(
+                    "UPDATE document_spans SET selector_json = ? WHERE id = ?",
+                    ("{not-json", span_id),
+                )
+            else:
+                conn.execute(
+                    "UPDATE document_spans SET quote_exact = ? WHERE id = ?",
+                    ("different quote", span_id),
+                )
+
+    with pytest.raises(provenance.ProvenanceReviewError) as rejected:
+        provenance.record_human_review(
+            store,
+            document_id=document.id,
+            attestation_id=original.id,
+            actor=HUMAN,
+            idempotency_key=f"review-damaged-{damage}-command-0001",
+            expected_structured_head_sha256=version.structured_head_sha256,
+        )
+
+    assert rejected.value.code == "provenance_review_target_mismatch"
+    assert (
+        store.list_document_provenance_attestations(document.id)
+        == history_before
+    )
+
+
+def test_human_review_replay_revalidates_span_target_before_idempotent_success(
+    store_ctx,
+):
+    store = store_ctx["store"]
+    document, version, _intent, _source = _import_ready(store_ctx)
+    original, span_id = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="durable provenance",
+        prefix="A ",
+        suffix=" target.",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="review-replay-target-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    reviewed = provenance.record_human_review(
+        store,
+        document_id=document.id,
+        attestation_id=original.id,
+        actor=HUMAN,
+        idempotency_key="review-replay-target-command-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    history_before = store.list_document_provenance_attestations(document.id)
+    with store.connect() as conn:
+        conn.execute("PRAGMA foreign_keys = OFF")
+        conn.execute("DROP TRIGGER document_spans_append_only_delete")
+        conn.execute("DELETE FROM document_spans WHERE id = ?", (span_id,))
+
+    with pytest.raises(provenance.ProvenanceReviewError) as rejected:
+        provenance.record_human_review(
+            store,
+            document_id=document.id,
+            attestation_id=original.id,
+            actor=HUMAN,
+            idempotency_key="review-replay-target-command-0001",
+            expected_structured_head_sha256=version.structured_head_sha256,
+        )
+
+    assert rejected.value.code == "provenance_review_target_mismatch"
+    assert reviewed in history_before
+    assert (
+        store.list_document_provenance_attestations(document.id)
+        == history_before
+    )
+
+
+def test_human_review_rejects_document_version_moved_to_another_document(
+    store_ctx,
+):
+    store = store_ctx["store"]
+    document, version, _intent, _source = _import_ready(
+        store_ctx,
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+    )
+    original = store.list_document_provenance_attestations(document.id)[0]
+    other = _other_document(store_ctx, suffix="version-owner")
+    with store.connect() as conn:
+        conn.execute("DROP TRIGGER document_versions_append_only_update")
+        conn.execute(
+            "UPDATE document_versions SET document_id = ? WHERE id = ?",
+            (other.id, version.id),
+        )
+
+    with pytest.raises(provenance.ProvenanceReviewError) as rejected:
+        provenance.record_human_review(
+            store,
+            document_id=document.id,
+            attestation_id=original.id,
+            actor=HUMAN,
+            idempotency_key="review-version-owner-command-0001",
+            expected_structured_head_sha256=version.structured_head_sha256,
+        )
+
+    assert rejected.value.code == "provenance_review_target_mismatch"
+    assert [
+        row.id
+        for row in store.list_document_provenance_attestations(document.id)
+    ] == [original.id]
+
+
+def test_effective_projection_surfaces_peer_conflicts_without_last_write_wins(
+    store_ctx,
+):
+    store = store_ctx["store"]
+    document, version, _intent, source = _import_ready(store_ctx)
+    source_view = {
+        "kind": "file_import",
+        "path": document.path,
+        "sha256": sha256_bytes(source),
+    }
+    first = provenance.record_document_attestation(
+        store,
+        document_id=document.id,
+        document_version_id=version.id,
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        source=source_view,
+        actor=HUMAN,
+        idempotency_key="projection-peer-ai-0001",
+    )
+    second = provenance.record_document_attestation(
+        store,
+        document_id=document.id,
+        document_version_id=version.id,
+        attestation=_attestation(authorship="human", review="not_applicable"),
+        source=source_view,
+        actor=HUMAN,
+        idempotency_key="projection-peer-human-0001",
+    )
+
+    projection = provenance.project_attestations(
+        store,
+        document.id,
+        current_structured_head_sha256=version.structured_head_sha256,
+    )
+
+    default = projection["document_default"]
+    assert default["resolution"] == "conflicted"
+    assert default["effective_attestation"] is None
+    effective_ids = {
+        item["attestation_id"] for item in default["effective_attestations"]
+    }
+    assert {first.id, second.id} <= effective_ids
+    assert projection["summary"]["conflicted_count"] == 1
+
+
+def test_effective_projection_keeps_orphaned_span_targets_inspectable(
+    store_ctx,
+):
+    store = store_ctx["store"]
+    document, version, _intent, _source = _import_ready(store_ctx)
+    orphaned, orphaned_span_id = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="Imported",
+        prefix="# ",
+        suffix="\n\nA",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="projection-orphaned-span-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    _extant, extant_span_id = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="durable provenance",
+        prefix="A ",
+        suffix=" target.",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="projection-extant-span-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+
+    # Simulate a damaged or legacy store whose attestation survived the span
+    # row. Normal writes cannot create this state because the FK and append-only
+    # trigger are enforced.
+    with store.connect() as conn:
+        conn.execute("PRAGMA foreign_keys = OFF")
+        conn.execute("DROP TRIGGER document_spans_append_only_delete")
+        conn.execute(
+            "DELETE FROM document_spans WHERE id = ?",
+            (orphaned_span_id,),
+        )
+
+    projection = provenance.project_attestations(
+        store,
+        document.id,
+        current_structured_head_sha256=version.structured_head_sha256,
+    )
+
+    assert [
+        item["target"]["document_span_id"] for item in projection["spans"]
+    ] == [extant_span_id, orphaned_span_id]
+    broken = projection["spans"][-1]
+    assert broken["projection_id"] == f"document_span:{orphaned_span_id}"
+    assert broken["target"]["currentness"] == "unavailable"
+    assert broken["resolution"] == "conflicted"
+    assert broken["review_eligibility"] == "conflicted"
+    assert broken["span"] is None
+    assert broken["effective_attestation"] is None
+    assert broken["effective_attestations"][0]["attestation_id"] == orphaned.id
+    assert broken["issue"]["code"] == "missing_span_target"
+    assert projection["summary"]["conflicted_count"] == 1
+    assert projection["summary"]["stale_count"] == 1
+
+
+def test_effective_projection_keeps_malformed_span_selectors_inspectable(
+    store_ctx,
+):
+    store = store_ctx["store"]
+    document, version, _intent, _source = _import_ready(store_ctx)
+    attestation, span_id = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="durable provenance",
+        prefix="A ",
+        suffix=" target.",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="projection-malformed-selector-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+
+    # Simulate a damaged or legacy selector. The target history must remain
+    # visible, but an invalid anchor cannot be called current or actionable.
+    with store.connect() as conn:
+        conn.execute("DROP TRIGGER document_spans_append_only_update")
+        conn.execute(
+            "UPDATE document_spans SET selector_json = ? WHERE id = ?",
+            ("{not-json", span_id),
+        )
+
+    projection = provenance.project_attestations(
+        store,
+        document.id,
+        current_structured_head_sha256=version.structured_head_sha256,
+    )
+
+    assert len(projection["spans"]) == 1
+    broken = projection["spans"][0]
+    assert broken["projection_id"] == f"document_span:{span_id}"
+    assert broken["target"]["currentness"] == "unavailable"
+    assert broken["resolution"] == "conflicted"
+    assert broken["review_eligibility"] == "conflicted"
+    assert broken["span"] is None
+    assert broken["effective_attestation"] is None
+    assert broken["effective_attestations"][0]["attestation_id"] == (
+        attestation.id
+    )
+    assert broken["history"][0]["attestation_id"] == attestation.id
+    assert broken["issue"]["code"] == "invalid_span_selector"
+    assert projection["summary"]["current_span_count"] == 0
+    assert projection["summary"]["conflicted_count"] == 1
+    assert projection["summary"]["stale_count"] == 1
+
+
+def test_effective_projection_mixed_target_heads_are_order_independent(
+    store_ctx,
+    monkeypatch,
+):
+    store = store_ctx["store"]
+    document, version, _intent, _source = _import_ready(store_ctx)
+    original, span_id = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="durable provenance",
+        prefix="A ",
+        suffix=" target.",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="projection-mixed-head-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    successor = provenance.record_human_review(
+        store,
+        document_id=document.id,
+        attestation_id=original.id,
+        actor=HUMAN,
+        idempotency_key="projection-mixed-head-review-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    conflicting_head = (
+        "0" * 64
+        if version.structured_head_sha256 != "0" * 64
+        else "1" * 64
+    )
+
+    # Normal writes preserve the frozen head across supersession. Simulate a
+    # damaged legacy history in which the same stable target spans two heads.
+    with store.connect() as conn:
+        conn.execute(
+            "DROP TRIGGER document_provenance_attestations_append_only_update"
+        )
+        conn.execute(
+            "UPDATE document_provenance_attestations "
+            "SET target_structured_head_sha256 = ? WHERE id = ?",
+            (conflicting_head, successor.id),
+        )
+
+    projections = [
+        provenance.project_attestations(
+            store,
+            document.id,
+            current_structured_head_sha256=version.structured_head_sha256,
+        )
+    ]
+    original_list = type(store).list_document_provenance_attestations
+
+    def _reversed_attestations(self, document_id, *, conn=None):
+        rows = original_list(self, document_id, conn=conn)
+        return tuple(reversed(rows))
+
+    # Reversing append-order delivery must not let the first row decide the
+    # target head, currentness, eligibility, or summary.
+    monkeypatch.setattr(
+        type(store),
+        "list_document_provenance_attestations",
+        _reversed_attestations,
+    )
+    projections.append(
+        provenance.project_attestations(
+            store,
+            document.id,
+            current_structured_head_sha256=version.structured_head_sha256,
+        )
+    )
+
+    for projection in projections:
+        assert len(projection["spans"]) == 1
+        conflicted = projection["spans"][0]
+        assert conflicted["projection_id"] == f"document_span:{span_id}"
+        assert conflicted["target"]["structured_head_sha256"] == min(
+            conflicting_head,
+            version.structured_head_sha256,
+        )
+        assert conflicted["target"]["currentness"] == "unavailable"
+        assert conflicted["resolution"] == "conflicted"
+        assert conflicted["review_eligibility"] == "conflicted"
+        assert conflicted["effective_attestation"] is None
+        assert projection["summary"]["current_span_count"] == 0
+        assert projection["summary"]["stale_count"] == 1
+        assert projection["summary"]["conflicted_count"] == 1
 
 
 def test_provenance_round_trips_and_integrity_detects_canonical_tampering(

--- a/tests/unit/test_chrome_collector_mutations.py
+++ b/tests/unit/test_chrome_collector_mutations.py
@@ -1,0 +1,39 @@
+"""Focused contracts for Chrome mutation request payloads."""
+
+from __future__ import annotations
+
+from work_buddy.collectors import chrome_collector
+
+
+def test_focus_or_create_normalizes_app_base_and_requests_path_preservation(
+    monkeypatch,
+):
+    seen = {}
+
+    def fake_request(mutation, timeout_seconds=15, **params):
+        seen.update(
+            mutation=mutation,
+            timeout_seconds=timeout_seconds,
+            params=params,
+        )
+        return {"status": "ok"}
+
+    monkeypatch.setattr(chrome_collector, "_request_mutation", fake_request)
+
+    result = chrome_collector.focus_or_create_tab(
+        "http://127.0.0.1:5127/app/",
+        target_hash="#wb-bootstrap=wbb_test",
+        preserve_path=True,
+        timeout_seconds=10,
+    )
+
+    assert result == {"status": "ok"}
+    assert seen == {
+        "mutation": "focus_or_create_tab",
+        "timeout_seconds": 10,
+        "params": {
+            "url": "http://127.0.0.1:5127/app",
+            "target_hash": "#wb-bootstrap=wbb_test",
+            "preserve_path": True,
+        },
+    }

--- a/tests/unit/test_local_identity.py
+++ b/tests/unit/test_local_identity.py
@@ -496,6 +496,134 @@ def test_dashboard_routes_ignore_caller_actor_fields_and_set_strict_cookie(
     )
 
 
+@pytest.mark.parametrize("session_state", ["missing", "unavailable", "expired"])
+def test_csrf_recovery_treats_absent_session_as_normal_unauthenticated_state(
+    authority: tuple[LocalIdentityAuthority, Clock],
+    monkeypatch: pytest.MonkeyPatch,
+    session_state: str,
+) -> None:
+    service, clock = authority
+    monkeypatch.setattr(local_identity_api, "_authority", lambda: service)
+    app = Flask(f"local-identity-csrf-{session_state}")
+    local_identity_api.register_routes(app)
+    client = app.test_client()
+
+    if session_state == "unavailable":
+        client.set_cookie(
+            SESSION_COOKIE_NAME,
+            "wbs_" + "x" * 43,
+            domain="127.0.0.1",
+        )
+    elif session_state == "expired":
+        session = _session(service)
+        client.set_cookie(
+            SESSION_COOKIE_NAME,
+            session.cookie_token,
+            domain="127.0.0.1",
+        )
+        clock.advance(_policy().session_idle_ttl_seconds + 1)
+
+    response = client.post(
+        "/api/local-identity/session/csrf",
+        headers={
+            "Origin": "http://127.0.0.1:5127",
+            "Host": "127.0.0.1:5127",
+        },
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 200
+    assert response.json == {
+        "ok": True,
+        "authenticated": False,
+        "human_authority_available": False,
+    }
+    assert response.headers["Cache-Control"] == "no-store"
+    assert response.headers["Set-Cookie"].startswith(f"{SESSION_COOKIE_NAME}=;")
+
+
+@pytest.mark.parametrize(
+    ("headers", "remote_addr", "code"),
+    [
+        (
+            {"Origin": "http://127.0.0.1:5127", "Host": "127.0.0.1:5127"},
+            "100.64.0.8",
+            "loopback_required",
+        ),
+        (
+            {"Host": "127.0.0.1:5127"},
+            "127.0.0.1",
+            "origin_required",
+        ),
+        (
+            {"Origin": "http://localhost:5127", "Host": "127.0.0.1:5127"},
+            "127.0.0.1",
+            "origin_mismatch",
+        ),
+        (
+            {
+                "Origin": "http://127.0.0.1:5127",
+                "Host": "127.0.0.1:5127",
+                "X-Forwarded-For": "127.0.0.1",
+            },
+            "127.0.0.1",
+            "direct_loopback_required",
+        ),
+    ],
+)
+def test_csrf_recovery_preserves_transport_security_failures(
+    authority: tuple[LocalIdentityAuthority, Clock],
+    monkeypatch: pytest.MonkeyPatch,
+    headers: dict[str, str],
+    remote_addr: str,
+    code: str,
+) -> None:
+    service, _ = authority
+    monkeypatch.setattr(local_identity_api, "_authority", lambda: service)
+    app = Flask(f"local-identity-csrf-security-{code}")
+    local_identity_api.register_routes(app)
+    client = app.test_client()
+    session = _session(service)
+    client.set_cookie(
+        SESSION_COOKIE_NAME,
+        session.cookie_token,
+        domain="127.0.0.1",
+    )
+
+    response = client.post(
+        "/api/local-identity/session/csrf",
+        headers=headers,
+        environ_base={"REMOTE_ADDR": remote_addr},
+    )
+
+    assert response.status_code == 403
+    assert response.json["error"]["code"] == code
+
+
+def test_csrf_recovery_preserves_malformed_credential_failure(
+    authority: tuple[LocalIdentityAuthority, Clock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _ = authority
+    monkeypatch.setattr(local_identity_api, "_authority", lambda: service)
+    app = Flask("local-identity-csrf-invalid-credential")
+    local_identity_api.register_routes(app)
+    client = app.test_client()
+    client.set_cookie(SESSION_COOKIE_NAME, "not-a-session", domain="127.0.0.1")
+
+    response = client.post(
+        "/api/local-identity/session/csrf",
+        headers={
+            "Origin": "http://127.0.0.1:5127",
+            "Host": "127.0.0.1:5127",
+        },
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 401
+    assert response.json["error"]["code"] == "invalid_credential"
+
+
 def test_dashboard_human_authority_helper_fails_closed_remotely(
     authority: tuple[LocalIdentityAuthority, Clock],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_tray_actions.py
+++ b/tests/unit/test_tray_actions.py
@@ -18,9 +18,12 @@ class TestOpenDashboard:
     def test_uses_extension_when_it_responds(self, monkeypatch):
         seen = {}
 
-        def fake_focus(url, target_hash="", timeout_seconds=15):
+        def fake_focus(
+            url, target_hash="", preserve_path=False, timeout_seconds=15
+        ):
             seen["url"] = url
             seen["hash"] = target_hash
+            seen["preserve_path"] = preserve_path
             return {"created": False, "focused": True}
 
         import work_buddy.collectors.chrome_collector as cc
@@ -35,6 +38,44 @@ class TestOpenDashboard:
         assert res == {"ok": True, "via": "extension", "result": {"created": False, "focused": True}}
         assert seen["url"] == "http://127.0.0.1:5127"
         assert seen["hash"] == "#tab=settings&st=activity"
+        assert seen["preserve_path"] is False
+
+    def test_app_launch_preserves_the_existing_react_route(self, monkeypatch):
+        seen = {}
+
+        monkeypatch.setattr(
+            "work_buddy.dashboard.local_identity_launch.bootstrap_fragment_for_dashboard",
+            lambda app_url, *, next_hash="": "#wb-bootstrap=wbb_test",
+        )
+
+        def fake_focus(
+            url, target_hash="", preserve_path=False, timeout_seconds=15
+        ):
+            seen.update(
+                url=url,
+                target_hash=target_hash,
+                preserve_path=preserve_path,
+                timeout_seconds=timeout_seconds,
+            )
+            return {"created": False, "focused": True}
+
+        monkeypatch.setattr(
+            "work_buddy.collectors.chrome_collector.focus_or_create_tab",
+            fake_focus,
+        )
+        monkeypatch.setattr(
+            "webbrowser.open", lambda *a, **k: pytest.fail("fallback used")
+        )
+
+        result = actions.open_dashboard(app=True)
+
+        assert result["identity_bootstrap"] is True
+        assert seen == {
+            "url": "http://127.0.0.1:5127/app/",
+            "target_hash": "#wb-bootstrap=wbb_test",
+            "preserve_path": True,
+            "timeout_seconds": 10,
+        }
 
     def test_falls_back_when_extension_times_out(self, monkeypatch):
         import work_buddy.collectors.chrome_collector as cc

--- a/tests/unit/test_tray_qt_smoke.py
+++ b/tests/unit/test_tray_qt_smoke.py
@@ -84,6 +84,22 @@ class TestPanelConstructs:
         panel._cancel_confirm()
         assert panel._confirm_for is None
 
+    def test_open_uses_the_trusted_react_app_launch(self, qapp, monkeypatch):
+        from work_buddy.tray import qt as tray_qt
+
+        panel = self._panel(qapp)
+        opened = []
+        monkeypatch.setattr(
+            tray_qt.actions,
+            "open_dashboard",
+            lambda target_hash, *, app=False: opened.append((target_hash, app)),
+        )
+        monkeypatch.setattr(panel, "hide", lambda: None)
+
+        panel._open("#tab=settings&st=activity")
+
+        assert opened == [("#tab=settings&st=activity", True)]
+
     @staticmethod
     def _button_texts(layout):
         from PySide6.QtWidgets import QPushButton

--- a/work_buddy/collectors/chrome_collector.py
+++ b/work_buddy/collectors/chrome_collector.py
@@ -379,22 +379,32 @@ def move_tabs(
 def focus_or_create_tab(
     url: str,
     target_hash: str = "",
+    preserve_path: bool = False,
     timeout_seconds: int = 15,
 ) -> dict | None:
     """Focus an existing Chrome tab matching *url*, or create a new one.
 
     If an existing tab is found, it's activated and its window is focused.
     If *target_hash* is set, the tab is navigated to ``url/target_hash``.
+    When *preserve_path* is true, an existing tab keeps its current path and
+    query and receives only the new fragment.  This is used for trusted app
+    bootstrap delivery so an open document is not replaced by the app root.
     If no matching tab exists, a new tab is created.
 
     Args:
         url: Base URL to match (e.g. "http://127.0.0.1:5127").
         target_hash: Optional hash fragment (e.g. "#view/req_abc123").
+        preserve_path: Keep an existing matching tab's path and query.
         timeout_seconds: How long to wait for the extension.
 
     Returns:
         Result dict with created/focused status, or None if no response.
     """
+    match_url = url.rstrip("/") or url
     return _request_mutation(
-        "focus_or_create_tab", timeout_seconds, url=url, target_hash=target_hash,
+        "focus_or_create_tab",
+        timeout_seconds,
+        url=match_url,
+        target_hash=target_hash,
+        preserve_path=preserve_path,
     )

--- a/work_buddy/cowork/api.py
+++ b/work_buddy/cowork/api.py
@@ -592,6 +592,14 @@ def api_doc_get(document_id: str):
             document.id,
             conn=conn,
         )
+        provenance_view = provenance.project_attestations(
+            store,
+            document.id,
+            current_structured_head_sha256=readiness_view[
+                "structured_head_sha256"
+            ],
+            conn=conn,
+        )
     span_by_id = {row["id"]: row for row in span_rows}
     observed_source_sha256 = _current_file_sha256(store, document)
     current_file_sha256 = (
@@ -656,6 +664,7 @@ def api_doc_get(document_id: str):
         ),
         "provenance_spans": _provenance_spans(span_rows),
         "authorship_attestations": authorship_attestations,
+        "provenance": provenance_view,
         "events_cursor": events[-1].id if events else "",
     }
     # Additive capability handshake. Older dashboard bundles ignore these
@@ -1982,6 +1991,131 @@ def api_doc_authorship_attestation(document_id: str):
                 "target_structured_head_sha256": (
                     record.target_structured_head_sha256
                 ),
+            }
+        ),
+        201,
+    )
+
+
+@cowork_blueprint.post(
+    "/api/truth/doc/<document_id>/authorship-attestations/"
+    "<attestation_id>/human-review"
+)
+def api_doc_provenance_human_review(
+    document_id: str,
+    attestation_id: str,
+):
+    """Append an exact human-review successor to one effective AI record."""
+
+    blocked = _reject_read_only()
+    if blocked:
+        return blocked
+    store, error = _resolve_store(request.args.get("store_id"))
+    if error:
+        return error
+    gate = _document_surface_or_403(store)
+    if gate:
+        return gate
+    document, doc_error = _resolve_document(store, document_id)
+    if doc_error:
+        return doc_error
+    if not document_surface_allowed(store, document):
+        return _fail(
+            "This document is not available in Co-work for this folder.",
+            403,
+        )
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return _fail("request body must be a JSON object", 400)
+    if set(body) != {
+        "attestation_id",
+        "expected_structured_head_sha256",
+        "idempotency_key",
+    }:
+        return _fail(
+            "human review requires exactly attestation_id, "
+            "expected_structured_head_sha256, and idempotency_key",
+            400,
+        )
+    if body.get("attestation_id") != attestation_id:
+        return _fail("attestation_id must match the route target", 400)
+    expected_head = body.get("expected_structured_head_sha256")
+    idempotency_key = body.get("idempotency_key")
+    if not isinstance(expected_head, str) or not expected_head:
+        return _fail("expected_structured_head_sha256 is required", 400)
+    if not isinstance(idempotency_key, str) or not idempotency_key:
+        return _fail("idempotency_key is required", 400)
+
+    try:
+        _authority_context, actor = _require_human_action(
+            operation="provenance.review",
+            store_id=store.store_id,
+            document_id=document.id,
+            body=body,
+        )
+    except LocalIdentityError as exc:
+        return _local_identity_error(exc)
+    try:
+        from work_buddy.consent import user_initiated
+
+        with user_initiated("dashboard.cowork.provenance_review"):
+            record = provenance.record_human_review(
+                store,
+                document_id=document.id,
+                attestation_id=attestation_id,
+                actor=actor,
+                idempotency_key=idempotency_key,
+                expected_structured_head_sha256=expected_head,
+            )
+    except provenance.ProvenanceReviewError as exc:
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": {
+                        "code": exc.code,
+                        "message": str(exc),
+                        "details": exc.details,
+                        "retryable": exc.retryable,
+                    },
+                }
+            ),
+            exc.status,
+        )
+    except (provenance.ProvenanceConflictError, InvariantViolation) as exc:
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": {
+                        "code": "provenance_review_state_conflict",
+                        "message": str(exc),
+                        "details": {},
+                        "retryable": False,
+                    },
+                }
+            ),
+            409,
+        )
+
+    _emit(
+        "truth.doc_provenance_reviewed",
+        store.store_id,
+        {
+            "document_id": document.id,
+            "attestation_id": record.id,
+            "supersedes_id": record.supersedes_id,
+            "target_structured_head_sha256": (
+                record.target_structured_head_sha256
+            ),
+        },
+        event_id=f"truth-doc-provenance-review-{record.id}",
+    )
+    return (
+        jsonify(
+            {
+                "ok": True,
+                "attestation": provenance.portable_attestation(record),
             }
         ),
         201,

--- a/work_buddy/cowork/provenance.py
+++ b/work_buddy/cowork/provenance.py
@@ -20,6 +20,7 @@ from work_buddy.truth.provenance import (
     PROVENANCE_AUTHORSHIP_KINDS,
     PROVENANCE_BASIS_KINDS,
     PROVENANCE_REVIEW_STATUSES,
+    PROVENANCE_SOURCE_KINDS,
     attestation_canonical_sha256,
     normalize_source,
 )
@@ -34,7 +35,7 @@ from work_buddy.truth.store import (
 
 AUTHORSHIP_KINDS = PROVENANCE_AUTHORSHIP_KINDS
 REVIEW_STATUSES = PROVENANCE_REVIEW_STATUSES
-SOURCE_KINDS = frozenset({"file_import", "paste"})
+SOURCE_KINDS = PROVENANCE_SOURCE_KINDS
 _KEY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$")
 INPUT_ATTESTATION_SCHEMA = "cowork-authorship-attestation/v1"
 CURRENT_USER_IDENTITY_STATUSES = frozenset(
@@ -73,6 +74,25 @@ class ProvenanceConflictError(InvariantViolation):
         self.details = {
             "existing_attestation_id": existing_attestation_id,
         }
+
+
+class ProvenanceReviewError(InvariantViolation):
+    """A typed refusal to turn an unsafe target into a review assertion."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        status: int = 409,
+        retryable: bool = False,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status = status
+        self.retryable = retryable
+        self.details = dict(details or {})
 
 
 def _required_text(value: Any, label: str, *, maximum: int = 240) -> str:
@@ -304,6 +324,7 @@ def _record_attestation_locked(
     basis_ref: str | None,
     supersedes_id: str | None,
     at: str | None,
+    normalized_attestation: Mapping[str, Any] | None = None,
 ) -> DocumentProvenanceAttestationRecord:
     document_ref = _valid_record_id(document_id, "document_id")
     document = store._get_document_locked(conn, document_ref)
@@ -316,8 +337,32 @@ def _record_attestation_locked(
         raise InvariantViolation(
             f"basis_kind must be one of {sorted(PROVENANCE_BASIS_KINDS)}"
         )
-    normalized = normalize_attestation(attestation, actor=actor)
+    normalized = (
+        normalize_attestation(attestation, actor=actor)
+        if normalized_attestation is None
+        else normalized_attestation
+    )
     normalized_source = _source(source)
+    if supersedes_id is not None:
+        prior = store._get_document_provenance_attestation_locked(
+            conn,
+            _valid_record_id(supersedes_id, "supersedes_id"),
+        )
+        if prior is None:
+            raise InvariantViolation(
+                f"superseded attestation does not exist: {supersedes_id}"
+            )
+        if (
+            prior.document_id != document_ref
+            or prior.target_kind != target_kind
+            or prior.document_version_id != document_version_id
+            or prior.document_span_id != document_span_id
+            or prior.target_structured_head_sha256
+            != target_structured_head_sha256
+        ):
+            raise InvariantViolation(
+                "superseded attestation must describe the same frozen target"
+            )
     identifier = _attestation_id(
         store_id=store.store_id,
         document_id=document_ref,
@@ -656,6 +701,46 @@ def record_span_attestation(
                 return event, span.id
 
 
+def portable_attestation(
+    row: DocumentProvenanceAttestationRecord,
+) -> dict[str, Any]:
+    """Return the stable wire representation for one append-only record."""
+
+    return {
+        "attestation_id": row.id,
+        "at": row.created_at,
+        "asserted_by": {
+            "kind": row.attested_by_kind,
+            "ref": row.attested_by_ref,
+            "meta": (
+                json.loads(row.attested_by_meta_json)
+                if row.attested_by_meta_json
+                else None
+            ),
+        },
+        "schema": ATTESTATION_SCHEMA,
+        "scope": {
+            "kind": row.target_kind,
+            "document_version_id": row.document_version_id,
+            "document_span_id": row.document_span_id,
+            "structured_head_sha256": row.target_structured_head_sha256,
+        },
+        "authorship": {
+            "kind": row.authorship_kind,
+            "contributors": json.loads(row.human_contributors_json),
+        },
+        "human_review": {
+            "status": row.review_status,
+            "reviewers": json.loads(row.human_reviewers_json),
+        },
+        "source": json.loads(row.source_json),
+        "basis": {"kind": row.basis_kind, "ref": row.basis_ref},
+        "supersedes_id": row.supersedes_id,
+        "idempotency_key": row.idempotency_key,
+        "canonical_sha256": row.canonical_sha256,
+    }
+
+
 def list_attestations(
     store: TruthStore,
     document_id: str,
@@ -665,42 +750,592 @@ def list_attestations(
     """Return portable attestations in append order, including history."""
 
     rows = store.list_document_provenance_attestations(document_id, conn=conn)
-    return [
-        {
-            "attestation_id": row.id,
-            "at": row.created_at,
-            "asserted_by": {
-                "kind": row.attested_by_kind,
-                "ref": row.attested_by_ref,
-                "meta": (
-                    json.loads(row.attested_by_meta_json)
-                    if row.attested_by_meta_json
-                    else None
-                ),
-            },
-            "schema": ATTESTATION_SCHEMA,
-            "scope": {
-                "kind": row.target_kind,
-                "document_version_id": row.document_version_id,
-                "document_span_id": row.document_span_id,
-                "structured_head_sha256": row.target_structured_head_sha256,
-            },
-            "authorship": {
-                "kind": row.authorship_kind,
-                "contributors": json.loads(row.human_contributors_json),
-            },
-            "human_review": {
-                "status": row.review_status,
-                "reviewers": json.loads(row.human_reviewers_json),
-            },
-            "source": json.loads(row.source_json),
-            "basis": {"kind": row.basis_kind, "ref": row.basis_ref},
-            "supersedes_id": row.supersedes_id,
-            "idempotency_key": row.idempotency_key,
-            "canonical_sha256": row.canonical_sha256,
-        }
-        for row in rows
+    return [portable_attestation(row) for row in rows]
+
+
+def _target_key(
+    row: DocumentProvenanceAttestationRecord,
+) -> tuple[str, str]:
+    target_id = row.document_version_id or row.document_span_id or ""
+    return row.target_kind, target_id
+
+
+def _target_projection(
+    rows: list[DocumentProvenanceAttestationRecord],
+    *,
+    current_structured_head_sha256: str | None,
+    span_selector: CompositeSelector | None,
+) -> dict[str, Any]:
+    first = rows[0]
+    superseded_ids = {
+        row.supersedes_id for row in rows if row.supersedes_id is not None
+    }
+    leaves = [row for row in rows if row.id not in superseded_ids]
+    portable_history = [portable_attestation(row) for row in rows]
+    portable_leaves = [portable_attestation(row) for row in leaves]
+    target_heads = sorted(
+        {row.target_structured_head_sha256 for row in rows}
+    )
+    has_conflicting_heads = len(target_heads) != 1
+    representative_head = target_heads[0]
+    resolved = len(leaves) == 1 and not has_conflicting_heads
+    if has_conflicting_heads or current_structured_head_sha256 is None:
+        currentness = "unavailable"
+    elif first.target_kind == "document_version":
+        currentness = (
+            "current"
+            if representative_head == current_structured_head_sha256
+            else "stale"
+        )
+    else:
+        # Exact span selectors may survive unrelated document edits, but only
+        # the editor can prove that by uniquely resolving the complete quote
+        # anchor.  Never call a changed-head span current on the server alone.
+        currentness = (
+            "current"
+            if representative_head == current_structured_head_sha256
+            else "requires_reanchor"
+        )
+    effective = portable_leaves[0] if resolved else None
+    review_eligibility = "eligible"
+    if not resolved:
+        review_eligibility = "conflicted"
+    elif currentness != "current":
+        review_eligibility = "stale_target"
+    elif effective is None or effective["authorship"]["kind"] not in {
+        "ai",
+        "mixed",
+    }:
+        review_eligibility = "not_ai_authored"
+    elif effective["human_review"]["status"] == "reviewed":
+        review_eligibility = "already_reviewed"
+    elif effective["human_review"]["status"] == "not_applicable":
+        review_eligibility = "not_applicable"
+    target_id = first.document_version_id or first.document_span_id
+    return {
+        "projection_id": f"{first.target_kind}:{target_id}",
+        "target": {
+            "kind": first.target_kind,
+            "document_version_id": first.document_version_id,
+            "document_span_id": first.document_span_id,
+            "structured_head_sha256": representative_head,
+            "currentness": currentness,
+        },
+        "span": (
+            None
+            if span_selector is None
+            else {
+                "exact": span_selector.exact,
+                "prefix": span_selector.prefix,
+                "suffix": span_selector.suffix,
+            }
+        ),
+        "resolution": "resolved" if resolved else "conflicted",
+        "review_eligibility": review_eligibility,
+        "issue": (
+            None
+            if resolved
+            else {
+                "code": "conflicting_effective_attestations",
+                "message": "This target has incompatible effective provenance records.",
+            }
+        ),
+        "effective_attestation": effective,
+        "effective_attestations": portable_leaves,
+        "history": portable_history,
+    }
+
+
+def _project_attestations_locked(
+    store: TruthStore,
+    document_id: str,
+    *,
+    current_structured_head_sha256: str | None,
+    conn: sqlite3.Connection,
+) -> dict[str, Any]:
+    document_ref = _valid_record_id(document_id, "document_id")
+    current_head = (
+        None
+        if current_structured_head_sha256 is None
+        else _valid_digest(
+            current_structured_head_sha256,
+            "current_structured_head_sha256",
+        )
+    )
+    rows = list(
+        store.list_document_provenance_attestations(document_ref, conn=conn)
+    )
+    groups: dict[
+        tuple[str, str], list[DocumentProvenanceAttestationRecord]
+    ] = {}
+    for row in rows:
+        groups.setdefault(_target_key(row), []).append(row)
+
+    document_targets: list[dict[str, Any]] = []
+    span_targets_by_id: dict[str, list[dict[str, Any]]] = {}
+    for (_kind, target_id), target_rows in groups.items():
+        if target_rows[0].target_kind == "document_version":
+            document_targets.append(
+                _target_projection(
+                    target_rows,
+                    current_structured_head_sha256=current_head,
+                    span_selector=None,
+                )
+            )
+            continue
+        span = store._get_document_span_locked(conn, target_id)
+        selector = None
+        selector_issue: dict[str, str] | None = None
+        if span is None or span.document_id != document_ref:
+            selector_issue = {
+                "code": "missing_span_target",
+                "message": "The recorded provenance span is unavailable.",
+            }
+        else:
+            try:
+                selector = CompositeSelector.from_json(span.selector_json)
+            except Exception:  # noqa: BLE001 - corrupt provenance stays inspectable
+                selector_issue = {
+                    "code": "invalid_span_selector",
+                    "message": "The recorded provenance anchor is invalid.",
+                }
+        projection = _target_projection(
+            target_rows,
+            current_structured_head_sha256=current_head,
+            span_selector=selector,
+        )
+        if selector_issue is not None:
+            projection["span"] = None
+            projection["resolution"] = "conflicted"
+            projection["effective_attestation"] = None
+            projection["review_eligibility"] = "conflicted"
+            projection["issue"] = selector_issue
+            projection["target"]["currentness"] = "unavailable"
+        span_targets_by_id[target_id] = [projection]
+
+    # A span ID has one stable projection entry. If legacy/corrupt history
+    # carries several frozen heads, _target_projection aggregates it as an
+    # explicit conflict instead of emitting ambiguous duplicate display IDs.
+    span_rows = conn.execute(
+        "SELECT id FROM document_spans WHERE document_id = ? "
+        "ORDER BY created_at, id",
+        (document_ref,),
+    ).fetchall()
+    extant_span_ids = [str(span_row["id"]) for span_row in span_rows]
+    span_targets = [
+        projection
+        for span_id in extant_span_ids
+        for projection in span_targets_by_id.get(span_id, [])
     ]
+    orphaned_span_ids = sorted(
+        set(span_targets_by_id) - set(extant_span_ids),
+        key=lambda span_id: (
+            span_targets_by_id[span_id][0]["history"][0]["at"],
+            span_id,
+        ),
+    )
+    span_targets.extend(
+        projection
+        for span_id in orphaned_span_ids
+        for projection in span_targets_by_id[span_id]
+    )
+    current_document_targets = [
+        target
+        for target in document_targets
+        if target["target"]["currentness"] == "current"
+    ]
+    if len(current_document_targets) == 1:
+        document_default = current_document_targets[0]
+    elif len(current_document_targets) > 1:
+        effective = [
+            attestation
+            for target in current_document_targets
+            for attestation in target["effective_attestations"]
+        ]
+        history = [
+            attestation
+            for target in current_document_targets
+            for attestation in target["history"]
+        ]
+        document_default = {
+            "projection_id": "document_version:current-conflict",
+            "target": {
+                "kind": "document_version",
+                "document_version_id": None,
+                "document_span_id": None,
+                "structured_head_sha256": current_head,
+                "currentness": "current",
+            },
+            "span": None,
+            "resolution": "conflicted",
+            "review_eligibility": "conflicted",
+            "issue": {
+                "code": "conflicting_document_defaults",
+                "message": "The current document has incompatible provenance defaults.",
+            },
+            "effective_attestation": None,
+            "effective_attestations": effective,
+            "history": history,
+        }
+    else:
+        document_default = document_targets[-1] if document_targets else None
+    visible_targets = (
+        ([] if document_default is None else [document_default]) + span_targets
+    )
+
+    def _effective(target: Mapping[str, Any]) -> Mapping[str, Any] | None:
+        value = target.get("effective_attestation")
+        return value if isinstance(value, Mapping) else None
+
+    summary = {
+        "total_targets": len(visible_targets),
+        "current_span_count": sum(
+            target["target"]["currentness"] == "current"
+            for target in span_targets
+        ),
+        "ai_unreviewed_count": sum(
+            effective is not None
+            and effective["authorship"]["kind"] in {"ai", "mixed"}
+            and effective["human_review"]["status"]
+            in {"not_reviewed", "unknown"}
+            for effective in (_effective(target) for target in visible_targets)
+        ),
+        "reviewed_count": sum(
+            effective is not None
+            and effective["human_review"]["status"] == "reviewed"
+            for effective in (_effective(target) for target in visible_targets)
+        ),
+        "conflicted_count": sum(
+            target["resolution"] == "conflicted" for target in visible_targets
+        ),
+        "stale_count": sum(
+            target["target"]["currentness"] != "current"
+            for target in visible_targets
+        ),
+        "unrecorded": (
+            document_default is None
+            or document_default["target"]["currentness"] != "current"
+        ),
+    }
+    return {
+        "schema": "cowork-provenance-view/v1",
+        "current_structured_head_sha256": current_head,
+        "document_default": document_default,
+        "spans": span_targets,
+        "history": [portable_attestation(row) for row in rows],
+        "summary": summary,
+    }
+
+
+def project_attestations(
+    store: TruthStore,
+    document_id: str,
+    *,
+    current_structured_head_sha256: str | None,
+    conn: sqlite3.Connection | None = None,
+) -> dict[str, Any]:
+    """Project append-only history into safe, deterministic effective targets."""
+
+    if conn is not None:
+        return _project_attestations_locked(
+            store,
+            document_id,
+            current_structured_head_sha256=current_structured_head_sha256,
+            conn=conn,
+        )
+    with store._read_connection() as read_conn:
+        return _project_attestations_locked(
+            store,
+            document_id,
+            current_structured_head_sha256=current_structured_head_sha256,
+            conn=read_conn,
+        )
+
+
+def _validate_review_target_locked(
+    store: TruthStore,
+    conn: sqlite3.Connection,
+    *,
+    document_id: str,
+    prior: DocumentProvenanceAttestationRecord,
+) -> None:
+    """Fail closed unless the predecessor still names a valid frozen target."""
+
+    def mismatch(message: str) -> ProvenanceReviewError:
+        return ProvenanceReviewError(
+            message,
+            code="provenance_review_target_mismatch",
+            details={
+                "target_kind": prior.target_kind,
+                "document_version_id": prior.document_version_id,
+                "document_span_id": prior.document_span_id,
+            },
+        )
+
+    try:
+        target_head = _valid_digest(
+            prior.target_structured_head_sha256,
+            "target_structured_head_sha256",
+        )
+    except InvariantViolation as exc:
+        raise mismatch(
+            "The provenance attestation has an invalid frozen target."
+        ) from exc
+
+    if prior.target_kind == "document_version":
+        if prior.document_version_id is None or prior.document_span_id is not None:
+            raise mismatch(
+                "The provenance attestation has an invalid version target."
+            )
+        version = store._get_document_version_locked(
+            conn,
+            prior.document_version_id,
+        )
+        if version is None or version.document_id != document_id:
+            raise mismatch(
+                "The provenance version target is unavailable for this document."
+            )
+        if version.structured_head_sha256 != target_head:
+            raise mismatch(
+                "The provenance version no longer matches its frozen target."
+            )
+        return
+
+    if prior.target_kind != "document_span":
+        raise mismatch("The provenance attestation has an unsupported target.")
+    if prior.document_span_id is None or prior.document_version_id is not None:
+        raise mismatch("The provenance attestation has an invalid span target.")
+
+    span = store._get_document_span_locked(conn, prior.document_span_id)
+    if span is None or span.document_id != document_id:
+        raise mismatch(
+            "The provenance span target is unavailable for this document."
+        )
+    try:
+        selector = CompositeSelector.from_json(span.selector_json)
+    except Exception as exc:  # noqa: BLE001 - corrupt anchors must fail closed
+        raise mismatch("The provenance span target has an invalid anchor.") from exc
+    if (
+        span.redacted_at is not None
+        or span.quote_exact is None
+        or selector.exact != span.quote_exact
+        or span.span_sha256 != sha256_text(span.quote_exact)
+    ):
+        raise mismatch("The provenance span target has an invalid quote anchor.")
+
+
+def record_human_review(
+    store: TruthStore,
+    *,
+    document_id: str,
+    attestation_id: str,
+    actor: Actor,
+    idempotency_key: str,
+    expected_structured_head_sha256: str,
+    at: str | None = None,
+) -> DocumentProvenanceAttestationRecord:
+    """Append a human-review successor without rewriting authorship or source.
+
+    This command is intentionally narrower than a generic correction. It can
+    review only the sole effective AI/mixed leaf at the exact current document
+    head. The human click becomes the new record's basis; the predecessor keeps
+    its original automatic/proposal/import basis in append-only history.
+    """
+
+    if actor.kind != "human" or not actor.ref:
+        raise InvariantViolation("provenance review requires a human actor")
+    document_ref = _valid_record_id(document_id, "document_id")
+    prior_id = _valid_record_id(attestation_id, "attestation_id")
+    key = _idempotency_key(idempotency_key)
+    expected_head = _valid_digest(
+        expected_structured_head_sha256,
+        "expected_structured_head_sha256",
+    )
+    reviewer = actor_binding(actor)
+
+    with document_lifecycle_lock(store.store_id, document_ref):
+        with ydoc_store.document_lock(store, document_ref):
+            with store.write_transaction() as conn:
+                document = store._get_document_locked(conn, document_ref)
+                if document is None:
+                    raise ProvenanceReviewError(
+                        f"document does not exist: {document_ref}",
+                        code="provenance_review_target_mismatch",
+                        status=404,
+                    )
+                prior = store._get_document_provenance_attestation_locked(
+                    conn,
+                    prior_id,
+                )
+                if prior is None:
+                    raise ProvenanceReviewError(
+                        "That provenance attestation no longer exists.",
+                        code="provenance_attestation_not_found",
+                        status=404,
+                    )
+                if prior.document_id != document_ref:
+                    raise ProvenanceReviewError(
+                        "The attestation does not belong to this document.",
+                        code="provenance_review_target_mismatch",
+                    )
+                _validate_review_target_locked(
+                    store,
+                    conn,
+                    document_id=document_ref,
+                    prior=prior,
+                )
+
+                normalized = {
+                    "authorship": {
+                        "kind": prior.authorship_kind,
+                        "contributors": json.loads(
+                            prior.human_contributors_json
+                        ),
+                    },
+                    "human_review": {
+                        "status": "reviewed",
+                        "reviewers": [reviewer],
+                    },
+                }
+                source = json.loads(prior.source_json)
+                identifier = _attestation_id(
+                    store_id=store.store_id,
+                    document_id=document_ref,
+                    actor_ref=actor.ref,
+                    idempotency_key=key,
+                )
+                expected_canonical = attestation_canonical_sha256(
+                    document_id=document_ref,
+                    target_kind=prior.target_kind,
+                    document_version_id=prior.document_version_id,
+                    document_span_id=prior.document_span_id,
+                    target_structured_head_sha256=(
+                        prior.target_structured_head_sha256
+                    ),
+                    authorship_kind=prior.authorship_kind,
+                    human_contributors=normalized["authorship"]["contributors"],
+                    review_status="reviewed",
+                    human_reviewers=[reviewer],
+                    source_kind=prior.source_kind,
+                    source=source,
+                    basis_kind="user_attestation",
+                    basis_ref=prior.id,
+                    supersedes_id=prior.id,
+                    attested_by_kind=actor.kind,
+                    attested_by_ref=actor.ref,
+                    attested_by_meta=(dict(actor.meta) if actor.meta else None),
+                )
+                existing = store._get_document_provenance_attestation_locked(
+                    conn,
+                    identifier,
+                )
+                if existing is not None:
+                    if existing.canonical_sha256 != expected_canonical:
+                        raise InvariantViolation(
+                            "idempotency_key was already used for a different "
+                            "provenance attestation"
+                        )
+                    return existing
+
+                if documents._lifecycle_locked(
+                    store,
+                    conn,
+                    document.id,
+                ) != "active":
+                    raise ProvenanceReviewError(
+                        "provenance cannot be reviewed on a retired document",
+                        code="provenance_review_state_conflict",
+                    )
+                if not document_surface_allowed(store, document):
+                    raise ProvenanceReviewError(
+                        "This document is not available in Co-work for this folder",
+                        code="provenance_review_forbidden",
+                        status=403,
+                    )
+                if document.ydoc_snapshot_sha256 is None:
+                    raise ProvenanceReviewError(
+                        "document has no frozen structured baseline",
+                        code="provenance_review_state_conflict",
+                    )
+                current_head = ydoc_store.current_structured_head(
+                    store,
+                    document_id=document.id,
+                    snapshot_sha256=document.ydoc_snapshot_sha256,
+                )
+                if (
+                    current_head != expected_head
+                    or prior.target_structured_head_sha256 != current_head
+                ):
+                    raise ProvenanceReviewError(
+                        "The provenance target changed before review was recorded.",
+                        code="provenance_target_changed",
+                        retryable=True,
+                    )
+                if (
+                    prior.authorship_kind not in {"ai", "mixed"}
+                    or prior.review_status not in {"not_reviewed", "unknown"}
+                ):
+                    raise ProvenanceReviewError(
+                        "Only unreviewed AI or mixed-authored content can be "
+                        "marked reviewed.",
+                        code="provenance_review_ineligible",
+                        status=400,
+                    )
+
+                all_rows = store._document_provenance_attestations_locked(
+                    conn,
+                    document_ref,
+                )
+                same_target = [
+                    row
+                    for row in all_rows
+                    if row.target_kind == prior.target_kind
+                    and row.document_version_id == prior.document_version_id
+                    and row.document_span_id == prior.document_span_id
+                ]
+                if any(
+                    row.target_structured_head_sha256
+                    != prior.target_structured_head_sha256
+                    for row in same_target
+                ):
+                    raise ProvenanceReviewError(
+                        "The target has incompatible frozen provenance records.",
+                        code="provenance_review_conflict",
+                    )
+                superseded = {
+                    row.supersedes_id
+                    for row in same_target
+                    if row.supersedes_id is not None
+                }
+                leaves = [row.id for row in same_target if row.id not in superseded]
+                if leaves != [prior.id]:
+                    raise ProvenanceReviewError(
+                        "The attestation is no longer the sole effective record "
+                        "for this target.",
+                        code="provenance_review_conflict",
+                        details={"effective_attestation_ids": leaves},
+                    )
+
+                return _record_attestation_locked(
+                    store,
+                    conn,
+                    document_id=document_ref,
+                    attestation={},
+                    normalized_attestation=normalized,
+                    source=source,
+                    actor=actor,
+                    idempotency_key=key,
+                    target_kind=prior.target_kind,
+                    document_version_id=prior.document_version_id,
+                    document_span_id=prior.document_span_id,
+                    target_structured_head_sha256=(
+                        prior.target_structured_head_sha256
+                    ),
+                    basis_kind="user_attestation",
+                    basis_ref=prior.id,
+                    supersedes_id=prior.id,
+                    at=at,
+                )
 
 
 __all__ = [
@@ -709,10 +1344,14 @@ __all__ = [
     "CURRENT_USER_IDENTITY_STATUSES",
     "ProvenanceActorBindingError",
     "ProvenanceConflictError",
+    "ProvenanceReviewError",
     "REVIEW_STATUSES",
     "actor_binding",
     "list_attestations",
     "normalize_attestation",
+    "portable_attestation",
+    "project_attestations",
     "record_document_attestation",
+    "record_human_review",
     "record_span_attestation",
 ]

--- a/work_buddy/dashboard/local_identity_api.py
+++ b/work_buddy/dashboard/local_identity_api.py
@@ -30,6 +30,13 @@ from work_buddy.security.local_identity import (
 
 local_identity_blueprint = Blueprint("local_identity", __name__)
 
+_SESSION_RECOVERY_ABSENCE_CODES = frozenset(
+    {
+        "session_expired",
+        "session_unavailable",
+    }
+)
+
 
 def _authority() -> LocalIdentityAuthority:
     """Test seam and the sole default-authority lookup for this adapter."""
@@ -142,6 +149,20 @@ def _session_payload(
     return result
 
 
+def _unauthenticated_session_response() -> Response:
+    """Return the normal result when no recoverable browser session exists."""
+
+    response = jsonify(
+        {
+            "ok": True,
+            "authenticated": False,
+            "human_authority_available": False,
+        }
+    )
+    _clear_session_cookie(response, secure=request.is_secure)
+    return response
+
+
 @local_identity_blueprint.after_request
 def _never_cache_credentials(response: Response) -> Response:
     response.headers["Cache-Control"] = "no-store"
@@ -200,6 +221,8 @@ def refresh_session_csrf():
         )
         return jsonify(_session_payload(principal, csrf_token=csrf_token))
     except LocalIdentityError as exc:
+        if exc.code in _SESSION_RECOVERY_ABSENCE_CODES:
+            return _unauthenticated_session_response()
         return _error(exc)
 
 

--- a/work_buddy/tray/actions.py
+++ b/work_buddy/tray/actions.py
@@ -50,11 +50,9 @@ def open_dashboard(target_hash: str = "", *, app: bool = False) -> dict:
     absent or times out: a plain ``webbrowser.open``. Never raises; returns a
     small dict describing what happened.
 
-    NOTE: a ``target_hash`` navigates an existing tab, which could discard
-    unsaved work in the dashboard. Safe today because the current dashboard has
-    little unsaved state and the plain "Open dashboard" button passes no hash
-    (activate-only); treating unsaved input as first-class is a React-dashboard
-    concern.
+    App launches preserve an existing React route and query while delivering
+    only the one-time bootstrap fragment. Legacy dashboard deep-links retain
+    their existing navigation behavior.
     """
     from work_buddy.cli.commands import dashboard_app_url, dashboard_local_url
 
@@ -79,7 +77,12 @@ def open_dashboard(target_hash: str = "", *, app: bool = False) -> dict:
     try:
         from work_buddy.collectors.chrome_collector import focus_or_create_tab
 
-        res = focus_or_create_tab(base, target_hash=launch_hash, timeout_seconds=10)
+        res = focus_or_create_tab(
+            base,
+            target_hash=launch_hash,
+            preserve_path=app,
+            timeout_seconds=10,
+        )
         if res is not None:
             result = {
                 "ok": True,

--- a/work_buddy/tray/qt.py
+++ b/work_buddy/tray/qt.py
@@ -345,7 +345,9 @@ class TrayPanel(QWidget):
 
     def _open(self, target_hash: str) -> None:
         try:
-            actions.open_dashboard(target_hash)
+            # The tray is a trusted host launcher. Always use the React-app
+            # launch path so it mints the one-time local-identity bootstrap.
+            actions.open_dashboard(target_hash, app=True)
         except Exception:
             logger.exception("open dashboard failed")
         self.hide()


### PR DESCRIPTION
## Summary

- add a first-class **Provenance** rail and mutually exclusive editor lens alongside Review, Truth, and Chat
- project source, authorship, human-review state, target health, history, and passive hover detail without changing document content
- add an authenticated, append-only **Mark reviewed** transition with exact-head, effective-leaf, selector, overlap, and local-persistence safeguards
- centralize the accepted design and as-built implementation plan under `.data/designs/co-work/provenance-surface/`

## Why

Document authorship provenance and human-review state need their own stable interaction home. Keeping them separate from modification review and Truth avoids conflating “AI-authored, human-reviewed” with human authorship, approval, or factual confirmation.

## Validation

- [x] 157 targeted frontend tests
- [x] 79 focused backend provenance/API tests
- [x] 18-test final affected rerun after rejected-refresh hardening
- [x] TypeScript typecheck
- [x] Production dashboard build
- [x] Python compilation and diff hygiene
- [x] Knowledge-store validation: 505 units, zero failures
- [x] Local browser smoke test for rail order and stable Provenance tab switching

## Notes

Changed-head spans that uniquely reanchor are deliberately inspect-only in this slice; durable review remains exact-head-only.