### PR TITLE
feat(cowork): record direct-entry provenance

### DIFF
--- a/.data/designs/co-work/provenance-surface/README.md
+++ b/.data/designs/co-work/provenance-surface/README.md
@@ -32,7 +32,7 @@ fragile mutation surface.
 
 ## User jobs
 
-The first slice supports four practical jobs:
+The surface supports six practical jobs:
 
 1. **Scan** the document for AI, human, mixed, unknown, unrecorded, or stale
    provenance.
@@ -43,6 +43,11 @@ The first slice supports four practical jobs:
    or source.
 4. **Repair awareness** by identifying unrecorded, unresolved, ambiguous, or
    conflicting coverage rather than silently presenting it as human-authored.
+5. **Capture new writing** by recording a local typing burst as an exact
+   `direct_entry` span attributed to the enrolled inputter once the edit and
+   its frozen structured head are durable.
+6. **Repair older uncovered text** through an explicit selection-based
+   determination whose source stays honestly labeled **Untracked / legacy**.
 
 Provenance does not answer whether the prose is correct, whether a claim is a
 fact, whether an edit should be accepted, or whether a named person really
@@ -62,7 +67,8 @@ One provenance attestation keeps these facts separate:
   `unknown`, with reviewers when recorded.
 - **Attester and basis** identify who made the assertion and why it was
   recorded, for example user attestation, automatic short-text attribution,
-  proposal acceptance, migration, or legacy data.
+  automatic direct-entry attribution, proposal acceptance, migration, or
+  legacy data.
 
 These dimensions must not be collapsed into a single trust badge. In
 particular:
@@ -142,6 +148,18 @@ requiring re-anchor. A span that still resolves uniquely may remain painted for
 inspection; text outside uniquely resolved recorded spans is unrecorded. This
 prevents newly typed text from inheriting an older document-wide attribution.
 
+For ordinary local typing, that invalidation is followed by a durable
+direct-entry capture. The editor synchronously stages each evolving burst before
+the transaction can be lost, coalesces only one contiguous same-block burst,
+and updates the staged exact selector for backspace and correction. It closes
+the burst at a quiescent persistence boundary, cursor or block discontinuity,
+paste/drop, history action, blur, lens change, save, or teardown. After Yjs
+persistence settles, the browser freezes one exact current-head request and the
+server appends a human-authored, review-not-applicable span with
+`basis=automatic_direct_entry_attribution`. Remote/applied Yjs changes,
+format-only changes, seed operations, and arbitrary disjoint transactions do
+not inherit that assertion.
+
 Document-version and exact-span targets are different scopes. A current exact
 span overrides a current document-wide determination in its range; this
 specific-over-fallback precedence is not a conflict. A stale document-level
@@ -200,6 +218,16 @@ departure, lens change, or document change. Keyboard users can reach the same
 information through the document-order panel list even when editor decoration
 spans themselves are not convenient tab stops.
 
+While Provenance owns the editor lens, the generic **Give feedback** affordance
+is absent. A deliberate text selection instead gets one provenance-specific
+entry point: **Record provenance** for uncovered text, **Review provenance** for one
+exact eligible AI/mixed span, **View provenance** for one healthy recorded
+target, or **Inspect provenance** for multiple, stale, ambiguous, or conflicting
+coverage. The floating action never performs a review mutation: it opens the
+stable panel, where the target, consequences, and guarded action remain visible.
+Recording uncovered text opens the shared determination form and stores the
+source as untracked legacy content rather than claiming it was just typed.
+
 ## Stable panel
 
 The Provenance panel has three progressively disclosed levels:
@@ -227,8 +255,9 @@ must not replay after refresh. An unresolved or ambiguous row opens details
 without scrolling to a guessed location. Expanding or closing inline detail
 does not replace the independently persisted list position.
 
-The **Mark reviewed** action appears only in stable detail when all of these are
-true:
+For an AI- or mixed-authored target, stable detail always shows the **Mark
+reviewed** action. It is enabled only when all of these are true, and otherwise
+stays visible with the exact reason it is unavailable:
 
 - the record is effective and targets either the current whole-document
   version or a uniquely resolved span in the current document;
@@ -260,8 +289,10 @@ writable. Any drift fails closed and asks for a fresh inspection and gesture.
 - Background refresh retains prior data and geometry until an authoritative
   replacement arrives.
 - A failed load offers **Retry** and is never rendered as an empty document.
-- A document with text and no current coverage says **No provenance is recorded
-  for this document** and the lens shows unrecorded coverage.
+- A document with text and no current coverage says **No provenance has been
+  recorded for this document. New typing is recorded automatically; select
+  existing text to record it.** The lens shows unrecorded coverage and makes
+  clear that the earlier source remains untracked.
 - A genuinely empty document says **This document has no text to map yet**.
 - Read-only mode preserves scanning, hover, detail, and history while mutation
   controls explain why they are unavailable.
@@ -303,7 +334,11 @@ The implementation has four boundaries:
    refresh after action. It may share the open-document snapshot source with
    neighboring surfaces, but it does not enlarge `ReviewRailData` into a
    general provenance transport.
-4. **ProseMirror decoration plugin and Provenance rail** render the view-only
+4. **Durable browser input provenance outbox** stages local typing and paste
+   captures before asynchronous IndexedDB work, freezes each request only after
+   Yjs persistence, and reconciles crash/reload delivery without changing the
+   capture-time actor.
+5. **ProseMirror decoration plugin and Provenance rail** render the view-only
    lens, re-anchor exact spans, compute uncovered text, explain hover, and own
    stable details/actions.
 
@@ -343,14 +378,22 @@ The slice is complete only when all of these are demonstrable:
 11. A local edit immediately removes stale document-wide fallback; review
     stays unavailable until the editor persistence barrier and a forced fresh
     preflight agree on one exact current head and effective leaf.
+12. Typing `Test` as one ordinary local burst creates one current exact
+    `direct_entry` span for `Test` after persistence, including through ordinary
+    backspace/correction and crash recovery; it never attributes intervening,
+    remote, pasted, or pre-existing text.
+13. Provenance selections never show **Give feedback**. They offer Record,
+    Review, View, or Inspect according to exact current coverage, with
+    durable mutation confined to the stable panel or determination form.
 
 ## Deferred
 
 The following are explicitly outside this delivery:
 
 - verified remote or multi-user identity and `account_ref` enrollment;
-- character-level collaborative authorship inferred from arbitrary Yjs
-  updates;
+- character-level collaborative authorship inferred from remote, applied,
+  programmatic, or otherwise arbitrary Yjs updates (local editor direct-entry
+  transactions are captured explicitly at ingress);
 - automatic propagation of version-wide attribution through later edits
   without a proven changeset map;
 - durable review of a changed-head client-reanchored span; it requires a

--- a/.data/designs/co-work/provenance-surface/README.md
+++ b/.data/designs/co-work/provenance-surface/README.md
@@ -1,7 +1,8 @@
 # Co-work Provenance surface
 
-**Status:** Accepted design and implementation contract for the first
-end-to-end Provenance lens. The as-built boundary is recorded in
+**Status:** Accepted design and implementation contract for the end-to-end
+Provenance lens, direct-entry delivery state, and accepted-agent-proposal
+attribution. The as-built boundary is recorded in
 [implementation-plan.md](implementation-plan.md); anything listed under
 **Deferred** is not part of this delivery.
 
@@ -45,7 +46,8 @@ The surface supports six practical jobs:
    conflicting coverage rather than silently presenting it as human-authored.
 5. **Capture new writing** by recording a local typing burst as an exact
    `direct_entry` span attributed to the enrolled inputter once the edit and
-   its frozen structured head are durable.
+   its frozen structured head are durable, while showing the exact capture as
+   **Recording provenance…** until the authoritative receipt arrives.
 6. **Repair older uncovered text** through an explicit selection-based
    determination whose source stays honestly labeled **Untracked / legacy**.
 
@@ -116,6 +118,26 @@ closed and requires a refresh or a fresh user decision. Independently effective
 overlapping attestations that disagree are a **conflict**, not an invitation to
 use last-write-wins.
 
+### Accepted agent proposal provenance
+
+A confirmed agent-run edit proposal creates an authorship record as part of the
+same locked sitting commit which materializes the accepted document. Its
+authorship is `ai`, its initial human-review state is `not_reviewed`, and both
+its source and basis are `proposal_acceptance`. The source detail binds the
+proposal and accepted-replacement digests, the consumed human confirmation
+gesture, and the validated producing agent-run reference and producer metadata.
+The human confirmer is the attester; confirmation does not become a reviewer
+record and does not imply factual approval.
+
+The exact target includes only replacement text which can be attributed
+mechanically. A true replacement records the replacement passage. An insertion
+whose replacement preserves the original quote exactly once records only the
+non-whitespace segments before and/or after that quote, never the preserved
+original. A deletion records no text span. Repeated preserved text, an invalid
+anchor, or a segment which cannot be resolved uniquely in the committed
+projection aborts the whole sitting, including document materialization,
+proposal status, gesture consumption, and provenance.
+
 ## Exact coverage semantics
 
 The overlay is a projection over the current editor, not a mutation of its
@@ -160,6 +182,17 @@ server appends a human-authored, review-not-applicable span with
 format-only changes, seed operations, and arbitrary disjoint transactions do
 not inherit that assertion.
 
+Before that authoritative record arrives, a uniquely resolved browser-local
+capture is a third delivery state: **pending**, not recorded and not
+unrecorded. The overlay marks only its exact current range and the stable panel
+announces that recent typing is being recorded. Pending carries no provisional
+authorship, review, contributor, reviewer, or attester assertion. A matching
+authoritative span takes precedence immediately, even during the brief interval
+before the browser removes the delivered outbox entry. The browser removes that
+entry only after a fresh history row matches the receipt's attestation ID,
+document-span ID, and structured head; stale, misbound, or failed refreshes keep
+the exact frozen request pending for retry.
+
 Document-version and exact-span targets are different scopes. A current exact
 span overrides a current document-wide determination in its range; this
 specific-over-fallback precedence is not a conflict. A stale document-level
@@ -181,6 +214,7 @@ hover card and panel:
 | Mixed authorship | split or patterned wash | Mixed authorship |
 | Unknown authorship | neutral dotted/patterned treatment | Authorship unknown |
 | Unrecorded coverage | neutral hatch/dotted treatment | No provenance recorded |
+| Pending direct-entry delivery | subtle informational dotted outline, without authorship or review treatment | Recording provenance… |
 | Human reviewed | solid review underline or review mark | Human reviewed |
 | Explicitly not reviewed | amber dashed underline | Not human-reviewed |
 | Review unknown | gray dotted underline | Review unknown |
@@ -208,8 +242,14 @@ containing:
 - human-review status and reviewers;
 - source kind and retained source reference when permitted;
 - attester and basis;
-- exact/current, unrecorded, stale, ambiguous, or conflict state; and
+- exact/current, pending delivery, unrecorded, stale, ambiguous, or conflict
+  state; and
 - a plain-language direction to open Provenance for stable details and actions.
+
+A pending-delivery hover is intentionally smaller: it says **Recording
+provenance…** and explains that authorship and review will appear after the
+server confirms the record. It does not render placeholder provenance facts as
+if the ledger had asserted them.
 
 The hover card is explanatory. It does not contain **Mark reviewed**, correction,
 delete, or any other mutation. It does not steal editor selection, move either
@@ -289,6 +329,9 @@ writable. Any drift fails closed and asks for a fresh inspection and gesture.
 - Background refresh retains prior data and geometry until an authoritative
   replacement arrives.
 - A failed load offers **Retry** and is never rendered as an empty document.
+- Browser-local recent typing awaiting its receipt says **Recording provenance
+  for recent typing…**; it suppresses definitive empty/unrecorded copy for that
+  pending passage and changes the summary to **Updating…**.
 - A document with text and no current coverage says **No provenance has been
   recorded for this document. New typing is recorded automatically; select
   existing text to record it.** The lens shows unrecorded coverage and makes
@@ -322,7 +365,7 @@ effects.
 
 ## Architecture
 
-The implementation has four boundaries:
+The implementation has six boundaries:
 
 1. **Truth provenance authority** retains append-only attestations and
    supersession history.
@@ -338,7 +381,11 @@ The implementation has four boundaries:
    captures before asynchronous IndexedDB work, freezes each request only after
    Yjs persistence, and reconciles crash/reload delivery without changing the
    capture-time actor.
-5. **ProseMirror decoration plugin and Provenance rail** render the view-only
+5. **Sitting commit integration** appends accepted-agent-proposal provenance in
+   the same transaction as materialization, the acceptance gesture and status,
+   and the sitting receipt. It binds the producing run and paints only exact
+   text contributed by the replacement; unsafe derivation aborts the sitting.
+6. **ProseMirror decoration plugin and Provenance rail** render the view-only
    lens, re-anchor exact spans, compute uncovered text, explain hover, and own
    stable details/actions.
 
@@ -385,6 +432,14 @@ The slice is complete only when all of these are demonstrable:
 13. Provenance selections never show **Give feedback**. They offer Record,
     Review, View, or Inspect according to exact current coverage, with
     durable mutation confined to the stable panel or determination form.
+14. During delayed direct-entry delivery, only the exact pending passage says
+    **Recording provenance…**, no provisional authorship or review is shown,
+    and authoritative recorded coverage replaces pending state in place.
+15. Confirming an agent-run proposal transactionally records the replacement's
+    attributable text as AI-authored, not reviewed, with
+    `source`/`basis=proposal_acceptance`, producing-run linkage, and the consumed
+    acceptance gesture. Preserved original text is not relabeled AI-authored,
+    and an unsafe or ambiguous derived span aborts the sitting.
 
 ## Deferred
 

--- a/.data/designs/co-work/provenance-surface/implementation-plan.md
+++ b/.data/designs/co-work/provenance-surface/implementation-plan.md
@@ -2,9 +2,11 @@
 
 **Parent contract:** [README.md](README.md)
 
-**Delivery status:** implemented as one end-to-end vertical slice, with backend
-and frontend checkpoints that remain independently testable. This plan records
-the as-built boundary; the follow-ons under **Deferred** have not shipped.
+**Delivery status:** implemented as an end-to-end provenance lens plus a
+follow-up direct-entry and selection-repair slice. Backend, durable input
+delivery, and frontend checkpoints remain independently testable. This plan
+records the as-built boundary; the follow-ons under **Deferred** have not
+shipped.
 
 ## Workstreams and sequence
 
@@ -18,6 +20,10 @@ the as-built boundary; the follow-ons under **Deferred** have not shipped.
   coverage without last-write-wins inference.
 - [x] Define **Mark reviewed** as an append-only constrained supersession.
 - [x] Reserve hover for explanation and stable detail for action.
+- [x] Give ordinary local typing a durable exact-span provenance path and give
+  uncovered historical text an honest explicit repair path.
+- [x] Replace generic feedback affordances in the Provenance lens with one
+  coverage-aware provenance selection action.
 - [x] Record accessibility, narrow-layout, focus, scroll, loading, error, and
   read-only behavior.
 
@@ -131,6 +137,33 @@ actually contains the reviewed successor.
 - Keep prior data during background refresh and distinguish first load, empty,
   failure, and read-only state.
 
+### 3a. Durable direct-entry and manual-selection writes
+
+- Generalize the existing paste recovery journal and IndexedDB delivery queue
+  into a content-input provenance outbox with explicit `paste`, `direct_entry`,
+  and `legacy` source kinds.
+- Capture local inserted-text transactions synchronously before their only
+  in-memory shape can be lost. Exclude paste/drop, applied remote Yjs,
+  undo/redo, seed/system work, formatting-only changes, deletions outside an
+  open burst, and disjoint edits which cannot be represented by one honest
+  quote anchor.
+- Coalesce only a contiguous same-textblock typing burst. Map its range through
+  backspace and correction, cancel it when fully deleted, and close it only at
+  a quiescent persistence or interaction boundary.
+- Keep the capture-time determination immutable. A later identity/session must
+  never take authorship for keystrokes made under a different or unavailable
+  actor; actor changes require an honest fresh determination.
+- Reconcile the newest synchronously staged capture over an older unfrozen
+  `capturing` row after a crash, but never overwrite a ready or frozen request.
+- Flush Yjs, freeze the exact head and selector, require a unique server-bound
+  span, and retain the immutable request through ambiguous transport.
+- Let explicit selection repair use `source=legacy` and
+  `basis=user_attestation`; never relabel pre-existing uncovered text as recent
+  direct entry.
+- Add Truth schema v10 support for
+  `automatic_direct_entry_attribution`, retaining all v9 records, lineage,
+  canonical digests, idempotency, triggers, and portable export behavior.
+
 ### 4. Editor lens and hover
 
 - Extend `CoworkEditorLens` to `neutral | review | provenance | truth`.
@@ -142,6 +175,10 @@ actually contains the reviewed successor.
 - Expose compact hover/focus metadata through a clamped, dismissible card.
 - Make hover passive and action-free. It points people to Provenance for stable
   details; it never performs navigation or mutation itself.
+- Suppress the generic **Give feedback** selection affordance whenever the
+  Provenance lens owns the editor. Show one coverage-aware action instead:
+  Record, Review provenance, View, or Inspect. Review provenance routes to stable detail
+  rather than mutating from a transient bubble.
 - Preserve temporary Chat/Working-on highlights and clear incompatible
   persistent focus on lens changes.
 - Verify no document transaction, selection rewrite, scroll, or undo entry is
@@ -161,6 +198,10 @@ actually contains the reviewed successor.
   effective, writable, exact-current-head AI/mixed document-version or span
   target not already reviewed.
   A uniquely reanchored changed-head span explains why it is inspect-only.
+- Keep Mark reviewed visible but disabled with a reason for AI/mixed targets
+  which are not currently eligible. Give zero-record text one useful empty
+  state that explains new typing is automatic and existing text can be selected
+  for an explicit determination.
 - On success, retain geometry while repulling; on failure, retain the previous
   projection and give a typed recovery path.
 - Ensure all four tabs and every action remain usable in narrow layout, at 200%
@@ -182,7 +223,7 @@ actually contains the reviewed successor.
 
 | Layer | Required cases |
 |---|---|
-| Provenance model | effective leaf; linear supersession; existing fork surfaced; source/authorship preserved; reviewer/attester independent |
+| Provenance model | effective leaf; linear supersession; existing fork surfaced; source/authorship preserved; reviewer/attester independent; strict source/basis pairing; schema v9→v10 lineage preservation |
 | Review route | success; idempotent replay; idempotency mismatch; wrong document/target; already superseded; stale head; retired/read-only; missing CSRF/session/gesture; actor change |
 | Read projection | document target at matching head; document target after head drift; span selector payload; append history; malformed/conflicting records preserved as issue |
 | Span resolution | unique exact/prefix/suffix; missing; ambiguous repeated quote; compatible overlap; incompatible overlap; Unicode and block boundaries |
@@ -192,7 +233,9 @@ actually contains the reviewed successor.
 | Panel | summary/filter/list/inline detail/target history/complete document history; passive row focus; explicit one-shot Show in document; unresolved no-scroll; expanding detail preserves list scroll; background refresh geometry; loading/error/empty/read-only |
 | Rail | four-tab roving focus; Home/End; persisted pane; independent pane scroll; narrow-width reachability; Chat remains neutral |
 | Action UI | editor persistence lock; forced fresh preflight; fresh-head/leaf/anchor/peer-conflict recheck; eligibility; pending dedupe; stable idempotency key across ambiguous refresh; successful authoritative repull; typed stale/actor/idempotency recovery; AI remains AI after review |
-| Regression | Review/Truth/Chat lenses; temporary highlights; proposal and claim navigation; paste provenance outbox; Yjs persistence; production build and type-check |
+| Direct entry | one `Test` burst; idle/lens/blur close; backspace/correction; full deletion; cursor/block split; paste/drop/history/remote/format exclusion; disjoint-range rejection; capture-time actor retention; missing identity; crash after staged update; unmount/reopen; frozen request replay |
+| Selection UX | uncovered Record; exact eligible Review provenance routing; healthy View; stale/multiple/conflict Inspect; no Give feedback; manual legacy determination; narrow editor-pane reachability |
+| Regression | Review/Truth/Chat lenses; temporary highlights; proposal and claim navigation; content-input provenance outbox; Yjs persistence; production build and type-check |
 | Accessibility | state names without color; forced-colors; visible focus; keyboard-only detail/action; touch path; 200% zoom; reduced motion |
 
 ## End-to-end acceptance scenarios
@@ -257,6 +300,23 @@ Given an editor with selection, scroll, and undo history, when the user cycles
 Review → Provenance → Truth → Chat and opens/closes hover details, then content,
 Y.Doc, selection, scroll, and undo history are unchanged; only decorations and
 compatible persistent focus differ.
+
+### Newly typed text is recorded
+
+Given a current enrolled local inputter and an editable document, when the user
+types `Test` as one contiguous burst and switches to Provenance, then the edit
+is first durable in Yjs, one exact `direct_entry` span is appended at the same
+head with human authorship and review not applicable, the provider refreshes,
+and the passage no longer appears as unrecorded. Backspace and correction update
+that same burst; deleting it completely leaves no attestation.
+
+### Existing uncovered text is repaired honestly
+
+Given text created before direct-entry capture existed, when the user selects
+it in Provenance, then the transient action says **Record provenance**, the
+shared determination form names the selected passage, and the resulting exact
+span keeps `source=legacy` / **Untracked**. The system never infers that the
+current user typed historical text.
 
 ## Delivery gates
 

--- a/.data/designs/co-work/provenance-surface/implementation-plan.md
+++ b/.data/designs/co-work/provenance-surface/implementation-plan.md
@@ -2,9 +2,10 @@
 
 **Parent contract:** [README.md](README.md)
 
-**Delivery status:** implemented as an end-to-end provenance lens plus a
-follow-up direct-entry and selection-repair slice. Backend, durable input
-delivery, and frontend checkpoints remain independently testable. This plan
+**Delivery status:** implemented as an end-to-end provenance lens plus
+direct-entry capture, pending-delivery presentation, selection repair, and
+accepted-agent-proposal attribution. Backend, durable input delivery, sitting
+integration, and frontend checkpoints remain independently testable. This plan
 records the as-built boundary; the follow-ons under **Deferred** have not
 shipped.
 
@@ -26,6 +27,11 @@ shipped.
   coverage-aware provenance selection action.
 - [x] Record accessibility, narrow-layout, focus, scroll, loading, error, and
   read-only behavior.
+- [x] Present an exact local direct-entry capture as **Recording provenance…**
+  without inventing authorship or review while the ledger receipt is pending.
+- [x] Integrate accepted agent proposals into the detailed provenance ledger
+  transactionally, without treating acceptance as human review or relabeling
+  preserved original text.
 
 ### 1. Authoritative backend projection
 
@@ -112,6 +118,38 @@ append or an idempotent replay returns the portable superseding attestation;
 the client does not clear the retry key until a forced authoritative refresh
 actually contains the reviewed successor.
 
+### 2a. Accepted agent-proposal attribution
+
+Integrate accepted edit proposals into the same detailed span ledger rather
+than relying on the proposal row or an expression span as an implicit
+authorship claim. For each applied `confirm` decision on an agent-run proposal,
+the sitting commit callback:
+
+1. verifies the consumed human gesture matches the immutable proposal and its
+   applied status;
+2. validates the proposal's producing agent-run reference and producer
+   metadata;
+3. derives only text introduced by the accepted replacement: the whole
+   replacement when it does not preserve the original quote, or the
+   non-whitespace segments surrounding one uniquely preserved original quote;
+4. proves each derived exact selector resolves uniquely in the committed
+   rendered projection;
+5. appends one exact-span attestation per attributable segment with
+   `authorship=ai`, `human_review=not_reviewed`, and
+   `source`/`basis=proposal_acceptance`;
+6. binds source detail to the proposal and replacement digests, consumed
+   acceptance gesture, producing run, and segment index/count; and
+7. returns the attestation IDs in the sitting receipt and emits normal
+   provenance invalidation events.
+
+The accepting human is the attester but is not recorded as a reviewer merely
+for accepting the edit. Deletions add no text span. A repeated preserved quote,
+invalid anchor or producer metadata, mismatched gesture/status, or ambiguous
+committed selector raises `proposal_provenance_unsafe`. Because this work runs
+inside the materialization commit callback, that failure rolls back the
+document materialization, proposal status, gesture consumption, sitting
+receipt, and every provenance row together.
+
 ### 3. Frontend contracts and projection
 
 - Extend the typed document payload to retain rich attestations/effective
@@ -128,6 +166,13 @@ actually contains the reviewed successor.
   head matches the current head.
 - Compute uncovered text-node ranges as `unrecorded`; never infer human
   authorship from the absence of a span.
+- Project uniquely resolved browser-local direct-entry captures as a distinct
+  `pending` delivery state over their exact ranges. Do not attach provisional
+  authorship/review semantics, and let authoritative server coverage win any
+  overlap before local outbox cleanup finishes.
+- Retain the exact frozen request and pending treatment until a fresh history
+  entry matches the receipt's attestation ID, document-span ID, and structured
+  head. Missing, stale, misbound, or failed refreshes remain retryable.
 - Apply explicit spans over current document-level fallback; combine compatible
   peer-span overlap and project incompatible peer-span overlap as conflict.
 - Treat an unsynchronized local-human edit as immediate head invalidation:
@@ -157,6 +202,9 @@ actually contains the reviewed successor.
   `capturing` row after a crash, but never overwrite a ready or frozen request.
 - Flush Yjs, freeze the exact head and selector, require a unique server-bound
   span, and retain the immutable request through ambiguous transport.
+- Feed current `direct_entry` captures from both the durable outbox and
+  mounted-page volatile recovery state into the editor's local pending
+  projection; update the open burst before the edited frame paints.
 - Let explicit selection repair use `source=legacy` and
   `basis=user_attestation`; never relabel pre-existing uncovered text as recent
   direct entry.
@@ -172,9 +220,15 @@ actually contains the reviewed successor.
   ownership.
 - Apply independent authorship and review classes/data attributes plus issue
   treatment. Decorations are view-only and excluded from serialized content.
+- Give pending delivery its own informational treatment and
+  `recordState=pending`, without applying unknown-authorship or unknown-review
+  styling. Only a uniquely resolved exact local capture is paintable.
 - Expose compact hover/focus metadata through a clamped, dismissible card.
 - Make hover passive and action-free. It points people to Provenance for stable
   details; it never performs navigation or mutation itself.
+- For pending delivery, replace the normal facts grid with **Recording
+  provenance…** and a statement that authorship and review await the server
+  receipt; do not expose placeholder facts as assertions.
 - Suppress the generic **Give feedback** selection affordance whenever the
   Provenance lens owns the editor. Show one coverage-aware action instead:
   Record, Review provenance, View, or Inspect. Review provenance routes to stable detail
@@ -202,6 +256,10 @@ actually contains the reviewed successor.
   which are not currently eligible. Give zero-record text one useful empty
   state that explains new typing is automatic and existing text can be selected
   for an explicit determination.
+- While any local direct-entry capture is pending, show a polite
+  **Recording provenance for recent typing…** status, report unrecorded summary
+  state as **Updating…**, and suppress definitive zero/unrecorded copy for that
+  pending interval.
 - On success, retain geometry while repulling; on failure, retain the previous
   projection and give a typed recovery path.
 - Ensure all four tabs and every action remain usable in narrow layout, at 200%
@@ -224,16 +282,17 @@ actually contains the reviewed successor.
 | Layer | Required cases |
 |---|---|
 | Provenance model | effective leaf; linear supersession; existing fork surfaced; source/authorship preserved; reviewer/attester independent; strict source/basis pairing; schema v9→v10 lineage preservation |
+| Proposal acceptance | agent-run producer validation; AI/not-reviewed semantics; acceptance distinct from review; proposal/replacement/gesture/run linkage; exact replacement; insertion before/after preserved original; whitespace trimming; deletion; repeated original; ambiguous selector; transaction rollback; idempotent segments |
 | Review route | success; idempotent replay; idempotency mismatch; wrong document/target; already superseded; stale head; retired/read-only; missing CSRF/session/gesture; actor change |
 | Read projection | document target at matching head; document target after head drift; span selector payload; append history; malformed/conflicting records preserved as issue |
 | Span resolution | unique exact/prefix/suffix; missing; ambiguous repeated quote; compatible overlap; incompatible overlap; Unicode and block boundaries |
 | Coverage | all text covered; partially covered complement; entirely unrecorded; empty document; version baseline plus span refinement; stale version never covers new text; local edit immediately withholds old fallback |
-| Decoration | lens exclusivity; authorship classes; independent review classes; issue override; non-color attributes; no serialization/undo/selection/scroll mutation |
-| Hover | pointer and editor caret/focus open; Escape/departure/lens/doc change close; viewport clamp; complete labels; no actions |
-| Panel | summary/filter/list/inline detail/target history/complete document history; passive row focus; explicit one-shot Show in document; unresolved no-scroll; expanding detail preserves list scroll; background refresh geometry; loading/error/empty/read-only |
+| Decoration | lens exclusivity; authorship classes; independent review classes; exact pending range; pending carries no authorship/review classes; authoritative span wins pending overlap; issue override; non-color attributes; no serialization/undo/selection/scroll mutation |
+| Hover | pointer and editor caret/focus open; Escape/departure/lens/doc change close; viewport clamp; complete labels; pending-delivery copy without placeholder assertions; authoritative replacement in place; no actions |
+| Panel | summary/filter/list/inline detail/target history/complete document history; pending banner and Updating summary; pending suppresses definitive unrecorded copy; passive row focus; explicit one-shot Show in document; unresolved no-scroll; expanding detail preserves list scroll; background refresh geometry; loading/error/empty/read-only |
 | Rail | four-tab roving focus; Home/End; persisted pane; independent pane scroll; narrow-width reachability; Chat remains neutral |
 | Action UI | editor persistence lock; forced fresh preflight; fresh-head/leaf/anchor/peer-conflict recheck; eligibility; pending dedupe; stable idempotency key across ambiguous refresh; successful authoritative repull; typed stale/actor/idempotency recovery; AI remains AI after review |
-| Direct entry | one `Test` burst; idle/lens/blur close; backspace/correction; full deletion; cursor/block split; paste/drop/history/remote/format exclusion; disjoint-range rejection; capture-time actor retention; missing identity; crash after staged update; unmount/reopen; frozen request replay |
+| Direct entry | one `Test` burst; idle/lens/blur close; backspace/correction; full deletion; cursor/block split; paste/drop/history/remote/format exclusion; disjoint-range rejection; capture-time actor retention; missing identity; crash after staged update; unmount/reopen; frozen request replay; delayed recorder remains pending until receipt |
 | Selection UX | uncovered Record; exact eligible Review provenance routing; healthy View; stale/multiple/conflict Inspect; no Give feedback; manual legacy determination; narrow editor-pane reachability |
 | Regression | Review/Truth/Chat lenses; temporary highlights; proposal and claim navigation; content-input provenance outbox; Yjs persistence; production build and type-check |
 | Accessibility | state names without color; forced-colors; visible focus; keyboard-only detail/action; touch path; 200% zoom; reduced motion |
@@ -309,6 +368,26 @@ is first durable in Yjs, one exact `direct_entry` span is appended at the same
 head with human authorship and review not applicable, the provider refreshes,
 and the passage no longer appears as unrecorded. Backspace and correction update
 that same burst; deleting it completely leaves no attestation.
+
+### Pending delivery is not unrecorded
+
+Given a delayed direct-entry recorder, when the user types a uniquely anchored
+passage and opens Provenance before the server receipt, then only that exact
+passage shows **Recording provenance…**, hover and panel make no provisional
+authorship or review assertion, and definitive unrecorded copy is suppressed.
+When the authoritative span arrives it replaces pending treatment in place,
+even if local outbox cleanup is still finishing.
+
+### Accepted agent edit records its own text
+
+Given an agent-run proposal whose replacement inserts a generated sentence
+before one preserved original quote, when the enrolled user confirms the exact
+proposal and the sitting commits, then the inserted sentence receives an exact
+AI-authored, not-reviewed attestation with
+`source`/`basis=proposal_acceptance`, the producing run and consumed human
+gesture remain linked, and the preserved quote keeps its prior provenance.
+If the attributable segment cannot be derived and resolved without guessing,
+the sitting and document change do not commit.
 
 ### Existing uncovered text is repaired honestly
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     env:
       WORK_BUDDY_SESSION_ID: ci-test-00000000

--- a/chrome_extension/background.js
+++ b/chrome_extension/background.js
@@ -298,6 +298,7 @@ async function checkAndExport(trigger = "unknown") {
     );
     const result = await sendToHost({
       action: "export",
+      request_id: checkResult.request_id || null,
       request_action: "mutate",
       captured_at: new Date().toISOString(),
       mutation_result: mutationResult,
@@ -317,6 +318,7 @@ async function checkAndExport(trigger = "unknown") {
     const contents = await getTabContents(tabIds, maxChars);
     const result = await sendToHost({
       action: "export",
+      request_id: checkResult.request_id || null,
       request_action: "get_content",
       captured_at: new Date().toISOString(),
       tab_contents: contents,
@@ -334,6 +336,7 @@ async function checkAndExport(trigger = "unknown") {
       until: checkResult.until || null,
     });
     snapshot.action = "export";
+    snapshot.request_id = checkResult.request_id || null;
     const exportResult = await sendToHost(snapshot);
     if (exportResult && exportResult.status === "ok") {
       console.log(
@@ -498,6 +501,39 @@ async function applyMutation(params) {
           // the native-messaging result file after Chrome has accepted it.
           results.details = { created: true, tab_id: newTab.id };
         }
+        break;
+      }
+
+      case "focus_existing_tab": {
+        const url = (params.url || "").replace(/\/+$/, "");
+        const targetHash = params.target_hash || "";
+        if (!url) {
+          results.status = "error";
+          results.details = { error: "No url provided" };
+          break;
+        }
+        const matchingTabs = await chrome.tabs.query({ url: url + "/*" });
+        if (matchingTabs.length === 0) {
+          results.details = { created: false, found: false, focused: false };
+          break;
+        }
+        const sorted = matchingTabs.sort(
+          (a, b) => (b.lastAccessed || 0) - (a.lastAccessed || 0)
+        );
+        const tab = sorted[0];
+        const currentUrl = (tab.url || "").split("#", 1)[0];
+        if (!currentUrl) {
+          results.status = "error";
+          results.details = { error: "The matching tab has no navigable URL" };
+          break;
+        }
+        await chrome.tabs.update(tab.id, { url: currentUrl + targetHash });
+        results.details = {
+          created: false,
+          found: true,
+          focused: false,
+          tab_id: tab.id,
+        };
         break;
       }
 

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Work Buddy Tab Exporter",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Exports tab metadata, browsing history, session data, and on-demand page content to a local native messaging host. Read-only.",
   "permissions": [
     "tabs",

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.pasteProvenance.test.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.pasteProvenance.test.tsx
@@ -1,7 +1,10 @@
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Editor } from "@tiptap/core";
-import type { CoworkEditorLens } from "../editor/ledgerDecorations";
+import {
+  setCoworkEditorLens,
+  type CoworkEditorLens,
+} from "../editor/ledgerDecorations";
 import { DOMParser as ProseMirrorDOMParser } from "@tiptap/pm/model";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
@@ -28,8 +31,10 @@ import {
   type CoworkPasteProvenanceIntentStage,
   type CoworkPasteProvenanceOutbox,
   type CoworkPasteProvenanceOutboxBackingStore,
-  type CoworkPasteProvenanceRecorder,
+  type CoworkPasteProvenanceReceipt,
+  type CoworkPasteProvenanceRecorder as DurableCoworkPasteProvenanceRecorder,
   type CoworkPasteProvenanceRequest,
+  type ProvenanceAttestation,
   type CoworkProvenanceActorIdentity,
   type ProvenanceData,
   type ProvenanceProvider,
@@ -39,6 +44,10 @@ import {
   CoworkBridgeEditor,
   coworkPasteProvenanceOutboxKey,
 } from "./CoworkBridgeEditor";
+
+type CoworkPasteProvenanceRecorder = (
+  request: CoworkPasteProvenanceRequest,
+) => Promise<CoworkPasteProvenanceReceipt | void>;
 
 interface MountedPasteEditor {
   readonly editor: Editor;
@@ -73,6 +82,39 @@ const LOCAL_PRINCIPAL = {
   assurance: "enrolled_local_session" as const,
 };
 
+const projectedReceipts = new WeakMap<
+  ProvenanceProvider,
+  Map<string, CoworkPasteProvenanceReceipt>
+>();
+
+const testProvenanceReceipt = (
+  request: CoworkPasteProvenanceRequest,
+): CoworkPasteProvenanceReceipt => ({
+  attestationId: `attestation-${request.idempotencyKey}`,
+  documentSpanId: `span-${request.idempotencyKey}`,
+  targetStructuredHeadSha256: request.expectedStructuredHeadSha256,
+});
+
+const attestationForReceipt = (
+  receipt: CoworkPasteProvenanceReceipt,
+): ProvenanceAttestation => ({
+  attestationId: receipt.attestationId,
+  at: "2026-08-21T12:00:00.000Z",
+  assertedBy: { kind: "human", ref: ACTOR.ref, meta: null },
+  scope: {
+    kind: "document_span",
+    documentVersionId: null,
+    documentSpanId: receipt.documentSpanId,
+    structuredHeadSha256: receipt.targetStructuredHeadSha256,
+  },
+  authorship: { kind: "human", contributors: [] },
+  humanReview: { status: "not_applicable", reviewers: [] },
+  source: { kind: "direct_entry" },
+  basis: { kind: "automatic_direct_entry_attribution", ref: null },
+  supersedesId: null,
+  canonicalSha256: "a".repeat(64),
+});
+
 beforeEach(() => resetLocalIdentityForTests());
 
 const mountPasteEditor = async (
@@ -86,6 +128,7 @@ const mountPasteEditor = async (
     readonly beforePush?: () => Promise<void>;
     readonly activeLens?: CoworkEditorLens;
     readonly provenanceProvider?: ProvenanceProvider;
+    readonly onInputProvenancePendingChange?: (pending: boolean) => void;
     readonly document?: Y.Doc;
     readonly server?: InMemoryCoworkYdocTransport;
   } = {},
@@ -129,6 +172,15 @@ const mountPasteEditor = async (
   let renderedActor = options.resolveActorFromServer
     ? undefined
     : (options.provenanceActor ?? ACTOR);
+  const durableRecorder: DurableCoworkPasteProvenanceRecorder = async (
+    request,
+  ) => {
+    const receipt = (await recorder(request)) ?? testProvenanceReceipt(request);
+    projectedReceipts
+      .get(options.provenanceProvider as ProvenanceProvider)
+      ?.set(receipt.attestationId, receipt);
+    return receipt;
+  };
   const view = () => (
     <CoworkBridgeEditor
       document={document}
@@ -140,11 +192,12 @@ const mountPasteEditor = async (
       provenanceProvider={options.provenanceProvider}
       provenanceSelectionActionsActive
       onProvenanceSelectionAction={() => undefined}
+      onInputProvenancePendingChange={options.onInputProvenancePendingChange}
       provenanceActor={renderedActor}
       pasteProvenanceOutbox={options.outbox}
       onRecordPasteProvenance={async (request) => {
         events.push("record");
-        await recorder(request);
+        return durableRecorder(request);
       }}
       onReady={({ editor }) => {
         editorRef.current = editor;
@@ -194,12 +247,21 @@ const emptyProvenanceData = (): ProvenanceData => ({
 
 const provenanceProvider = (): ProvenanceProvider => {
   const data = emptyProvenanceData();
-  return {
+  const receipts = new Map<string, CoworkPasteProvenanceReceipt>();
+  const provider: ProvenanceProvider = {
     load: vi.fn().mockResolvedValue({ state: "ready", data }),
-    refresh: vi.fn().mockResolvedValue({ state: "ready", data }),
+    refresh: vi.fn().mockImplementation(async () => ({
+      state: "ready" as const,
+      data: {
+        ...data,
+        history: [...receipts.values()].map(attestationForReceipt),
+      },
+    })),
     subscribe: () => () => undefined,
     markReviewed: vi.fn().mockResolvedValue(undefined),
   };
+  projectedReceipts.set(provider, receipts);
+  return provider;
 };
 
 const dispatchSimplePaste = (editor: Editor): void => {
@@ -261,6 +323,228 @@ describe("CoworkBridgeEditor paste provenance", () => {
     expect(provider.refresh).toHaveBeenCalledOnce();
     await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
     expect(screen.queryByText(/where did this text come from/i)).toBeNull();
+  }, 30_000);
+
+  it("marks only delayed direct-entry text as pending until its receipt settles", async () => {
+    let releaseRecorder!: () => void;
+    let recorderEntered!: () => void;
+    const recorderGate = new Promise<void>((resolve) => {
+      releaseRecorder = resolve;
+    });
+    const entered = new Promise<void>((resolve) => {
+      recorderEntered = resolve;
+    });
+    const pendingChanges: boolean[] = [];
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `pending-direct-entry-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    const mounted = await mountPasteEditor(
+      async () => {
+        recorderEntered();
+        await recorderGate;
+      },
+      {
+        outbox,
+        activeLens: "neutral",
+        provenanceProvider: provenanceProvider(),
+        onInputProvenancePendingChange: (pending) =>
+          pendingChanges.push(pending),
+      },
+    );
+
+    try {
+      act(() => mounted.editor.commands.insertContentAt(1, "Pending text"));
+      expect(pendingChanges[pendingChanges.length - 1]).toBe(true);
+      act(() => {
+        setCoworkEditorLens(mounted.editor, "provenance");
+      });
+      await act(async () => Promise.resolve());
+      const pending = mounted.editor.view.dom.querySelector<HTMLElement>(
+        '[data-wb-provenance-record-state="pending"]',
+      );
+      expect(pending).not.toBeNull();
+      expect(pending).toHaveTextContent("Pending text");
+      expect(pending).toHaveClass("wb-cowork-provenance--pending");
+      expect(
+        mounted.editor.view.dom.querySelector(
+          '[data-wb-provenance-record-state="pending"]',
+        )?.textContent,
+      ).not.toContain("Before after");
+      mounted.setActiveLens("provenance");
+      await entered;
+      await waitFor(() => expect(pendingChanges).toContain(true));
+
+      releaseRecorder();
+      await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+      await waitFor(() => {
+        expect(
+          mounted.editor.view.dom.querySelector(
+            '[data-wb-provenance-record-state="pending"]',
+          ),
+        ).toBeNull();
+        expect(pendingChanges[pendingChanges.length - 1]).toBe(false);
+      });
+    } finally {
+      releaseRecorder();
+      mounted.unmount();
+    }
+  }, 30_000);
+
+  it("keeps the frozen capture pending until the refreshed projection matches the complete receipt", async () => {
+    const data = emptyProvenanceData();
+    const requests: CoworkPasteProvenanceRequest[] = [];
+    let receipt: CoworkPasteProvenanceReceipt | undefined;
+    let projectionState: "missing" | "misbound" | "exact" = "missing";
+    const provider: ProvenanceProvider = {
+      load: vi.fn().mockResolvedValue({ state: "ready", data }),
+      refresh: vi.fn().mockImplementation(async () => {
+        const projected =
+          receipt === undefined || projectionState === "missing"
+            ? []
+            : [
+                attestationForReceipt(
+                  projectionState === "exact"
+                    ? receipt
+                    : {
+                        ...receipt,
+                        documentSpanId: `wrong-${receipt.documentSpanId}`,
+                        targetStructuredHeadSha256: "f".repeat(64),
+                      },
+                ),
+              ];
+        return {
+          state: "ready" as const,
+          data: { ...data, history: projected },
+        };
+      }),
+      subscribe: () => () => undefined,
+      markReviewed: vi.fn().mockResolvedValue(undefined),
+    };
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `pending-receipt-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    const mounted = await mountPasteEditor(
+      async (request) => {
+        requests.push(request);
+        receipt ??= testProvenanceReceipt(request);
+        return receipt;
+      },
+      { outbox, activeLens: "neutral", provenanceProvider: provider },
+    );
+
+    try {
+      act(() => mounted.editor.commands.insertContentAt(1, "Pending receipt"));
+      act(() => {
+        setCoworkEditorLens(mounted.editor, "provenance");
+      });
+      mounted.setActiveLens("provenance");
+
+      await screen.findByRole("button", { name: "Retry provenance storage" });
+      expect(requests).toHaveLength(1);
+      await expect(outbox.list()).resolves.toEqual([
+        expect.objectContaining({
+          status: "retryable_failure",
+          frozenRequest: expect.objectContaining({
+            idempotencyKey: requests[0].idempotencyKey,
+          }),
+        }),
+      ]);
+      expect(
+        mounted.editor.view.dom.querySelector(
+          '[data-wb-provenance-record-state="pending"]',
+        ),
+      ).toHaveTextContent("Pending receipt");
+
+      projectionState = "misbound";
+      await userEvent.click(
+        screen.getByRole("button", { name: "Retry provenance storage" }),
+      );
+      await waitFor(() => expect(requests).toHaveLength(2));
+      await expect(outbox.list()).resolves.toEqual([
+        expect.objectContaining({ status: "retryable_failure" }),
+      ]);
+
+      projectionState = "exact";
+      await userEvent.click(
+        screen.getByRole("button", { name: "Retry provenance storage" }),
+      );
+      await waitFor(() => expect(requests).toHaveLength(3));
+      expect(requests[1]).toEqual(requests[0]);
+      expect(requests[2]).toEqual(requests[0]);
+      await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+      await waitFor(() =>
+        expect(
+          mounted.editor.view.dom.querySelector(
+            '[data-wb-provenance-record-state="pending"]',
+          ),
+        ).toBeNull(),
+      );
+    } finally {
+      mounted.unmount();
+    }
+  }, 30_000);
+
+  it("retains pending provenance when the authoritative refresh fails", async () => {
+    const data = emptyProvenanceData();
+    let receipt: CoworkPasteProvenanceReceipt | undefined;
+    let refreshFails = true;
+    const provider: ProvenanceProvider = {
+      load: vi.fn().mockResolvedValue({ state: "ready", data }),
+      refresh: vi.fn().mockImplementation(async () => {
+        if (refreshFails) throw new Error("projection unavailable");
+        return {
+          state: "ready" as const,
+          data: {
+            ...data,
+            history:
+              receipt === undefined ? [] : [attestationForReceipt(receipt)],
+          },
+        };
+      }),
+      subscribe: () => () => undefined,
+      markReviewed: vi.fn().mockResolvedValue(undefined),
+    };
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `pending-refresh-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    const mounted = await mountPasteEditor(
+      async (request) => {
+        receipt ??= testProvenanceReceipt(request);
+        return receipt;
+      },
+      { outbox, activeLens: "neutral", provenanceProvider: provider },
+    );
+
+    try {
+      act(() => mounted.editor.commands.insertContentAt(1, "Refresh pending"));
+      act(() => {
+        setCoworkEditorLens(mounted.editor, "provenance");
+      });
+      mounted.setActiveLens("provenance");
+      await screen.findByRole("button", { name: "Retry provenance storage" });
+      await expect(outbox.list()).resolves.toEqual([
+        expect.objectContaining({
+          status: "retryable_failure",
+          frozenRequest: expect.any(Object),
+        }),
+      ]);
+      expect(
+        mounted.editor.view.dom.querySelector(
+          '[data-wb-provenance-record-state="pending"]',
+        ),
+      ).toHaveTextContent("Refresh pending");
+
+      refreshFails = false;
+      await userEvent.click(
+        screen.getByRole("button", { name: "Retry provenance storage" }),
+      );
+      await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+    } finally {
+      mounted.unmount();
+    }
   }, 30_000);
 
   it("waits for the capture actor, then keeps top-block typing whole across a persistence settlement", async () => {
@@ -508,8 +792,7 @@ describe("CoworkBridgeEditor paste provenance", () => {
       sourceKind: rejectedRequest.sourceKind,
       basisKind: rejectedRequest.basisKind,
       expectedActorRef: rejectedRequest.expectedActorRef,
-      expectedActorIdentityStatus:
-        rejectedRequest.expectedActorIdentityStatus,
+      expectedActorIdentityStatus: rejectedRequest.expectedActorIdentityStatus,
       anchor: rejectedRequest.anchor,
       attestation: rejectedRequest.attestation,
     });

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.pasteProvenance.test.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.pasteProvenance.test.tsx
@@ -27,6 +27,7 @@ import {
   type CoworkPasteProvenanceCapture,
   type CoworkPasteProvenanceIntentStage,
   type CoworkPasteProvenanceOutbox,
+  type CoworkPasteProvenanceOutboxBackingStore,
   type CoworkPasteProvenanceRecorder,
   type CoworkPasteProvenanceRequest,
   type CoworkProvenanceActorIdentity,
@@ -252,6 +253,310 @@ describe("CoworkBridgeEditor paste provenance", () => {
     expect(screen.queryByText(/where did this text come from/i)).toBeNull();
   }, 30_000);
 
+  it("keeps actorless typing durable and records it explicitly after identity recovery", async () => {
+    const requests: CoworkPasteProvenanceRequest[] = [];
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `actorless-direct-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    const documentId = `actorless-direct-document-${String(Date.now())}`;
+    let sessionAttempts = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/truth/cowork/current-actor") {
+          return new Response(JSON.stringify(ACTOR), {
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        expect(url).toBe("/api/local-identity/session/csrf");
+        sessionAttempts += 1;
+        if (sessionAttempts > 1) {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              authenticated: true,
+              principal: LOCAL_PRINCIPAL,
+              csrf_token: "wbc_recovered_direct_entry",
+            }),
+            { headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            authenticated: false,
+            human_authority_available: false,
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+
+    let mounted: MountedPasteEditor | undefined;
+    try {
+      mounted = await mountPasteEditor(
+        async (request) => {
+          requests.push(request);
+        },
+        {
+          outbox,
+          documentId,
+          resolveActorFromServer: true,
+          activeLens: "neutral",
+          provenanceProvider: provenanceProvider(),
+        },
+      );
+      await waitFor(() => expect(sessionAttempts).toBe(1));
+
+      act(() => mounted!.editor.commands.insertContentAt(1, "Test"));
+      mounted.setActiveLens("provenance");
+
+      await waitFor(async () => {
+        expect((await outbox.list())[0]).toMatchObject({
+          anchor: { exact: "Test", prefix: "", suffix: "Before after" },
+          sourceKind: "direct_entry",
+          basisKind: "automatic_direct_entry_attribution",
+          status: "capturing",
+        });
+      });
+      expect(requests).toEqual([]);
+      await act(async () => {
+        await refreshLocalIdentity();
+      });
+      await waitFor(() => expect(sessionAttempts).toBeGreaterThanOrEqual(2));
+      await waitFor(async () => {
+        expect((await outbox.list())[0]).toMatchObject({
+          anchor: { exact: "Test", prefix: "", suffix: "Before after" },
+          sourceKind: "legacy",
+          basisKind: "user_attestation",
+          status: "awaiting_determination",
+          requiresExplicitDetermination: true,
+          failure: { code: "provenance_actor_unavailable_at_capture" },
+        });
+      });
+      act(() => {
+        mounted!.editor.commands.setTextSelection({ from: 1, to: 5 });
+      });
+      const user = userEvent.setup();
+      await user.click(
+        await screen.findByRole("button", { name: "Record provenance" }),
+      );
+      await user.click(
+        within(
+          screen.getByRole("dialog", { name: "Record provenance" }),
+        ).getByRole("button", { name: "Record provenance" }),
+      );
+
+      await waitFor(() => expect(requests).toHaveLength(1), {
+        timeout: 10_000,
+      });
+      expect(requests[0]).toMatchObject({
+        sourceKind: "legacy",
+        basisKind: "user_attestation",
+        expectedActorRef: ACTOR.ref,
+        expectedActorIdentityStatus: ACTOR.identity_status,
+        anchor: { exact: "Test" },
+      });
+      await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+    } finally {
+      mounted?.unmount();
+      vi.unstubAllGlobals();
+    }
+  }, 30_000);
+
+  it("does not resurrect actorless automatic work when recovered typing races demotion", async () => {
+    const requests: CoworkPasteProvenanceRequest[] = [];
+    const memoryBacking = new InMemoryCoworkPasteProvenanceOutboxBackingStore();
+    const intentStage = new InMemoryCoworkPasteProvenanceIntentStage();
+    const outboxKey = `actorless-demotion-race-${String(Date.now())}`;
+    let releaseDemotion!: () => void;
+    let enteredDemotion!: () => void;
+    const demotionGate = new Promise<void>((resolve) => {
+      releaseDemotion = resolve;
+    });
+    const demotionEntered = new Promise<void>((resolve) => {
+      enteredDemotion = resolve;
+    });
+    let demotionPaused = false;
+    const blockingBacking: CoworkPasteProvenanceOutboxBackingStore = {
+      durable: false,
+      read: (key) => memoryBacking.read(key),
+      async mutate(key, mutation) {
+        let demoted = false;
+        const result = await memoryBacking.mutate(key, (current) => {
+          const next = mutation(current);
+          demoted =
+            !demotionPaused &&
+            current.entries.some(
+              (entry) =>
+                entry.sourceKind === "direct_entry" &&
+                entry.status === "capturing" &&
+                next.record.entries.some(
+                  (candidate) =>
+                    candidate.id === entry.id &&
+                    candidate.sourceKind === "legacy" &&
+                    candidate.status === "awaiting_determination",
+                ),
+            );
+          return next;
+        });
+        if (demoted) {
+          // Pause after the demotion replacement has passed its guards and
+          // committed, but before the outbox operation settles. A subsequent
+          // transaction can synchronously journal and enqueue an upsert now.
+          demotionPaused = true;
+          enteredDemotion();
+          await demotionGate;
+        }
+        return result;
+      },
+    };
+    const durableOutbox = new DurableCoworkPasteProvenanceOutbox(
+      outboxKey,
+      blockingBacking,
+      intentStage,
+    );
+    let sessionAttempts = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/truth/cowork/current-actor") {
+          return new Response(JSON.stringify(ACTOR), {
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        expect(url).toBe("/api/local-identity/session/csrf");
+        sessionAttempts += 1;
+        return new Response(
+          JSON.stringify(
+            sessionAttempts === 1
+              ? {
+                  ok: true,
+                  authenticated: false,
+                  human_authority_available: false,
+                }
+              : {
+                  ok: true,
+                  authenticated: true,
+                  principal: LOCAL_PRINCIPAL,
+                  csrf_token: "wbc_actorless_demotion_race",
+                },
+          ),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+
+    let mounted: MountedPasteEditor | undefined;
+    let reopened: MountedPasteEditor | undefined;
+    try {
+      mounted = await mountPasteEditor(
+        async (request) => {
+          requests.push(request);
+        },
+        {
+          outbox: durableOutbox,
+          resolveActorFromServer: true,
+          activeLens: "neutral",
+          provenanceProvider: provenanceProvider(),
+        },
+      );
+      await waitFor(() => expect(sessionAttempts).toBe(1));
+      act(() => mounted!.editor.commands.insertContentAt(8, "A"));
+      await waitFor(async () => {
+        expect((await durableOutbox.list())[0]).toMatchObject({
+          anchor: { exact: "A" },
+          sourceKind: "direct_entry",
+          status: "capturing",
+        });
+      });
+
+      await act(async () => {
+        await refreshLocalIdentity();
+      });
+      await demotionEntered;
+
+      // The first burst has passed the actor-mismatch pre-check and is now
+      // yielding inside durable demotion. This disjoint edit is actor-bound
+      // and maps the older burst once more before staging its own key.
+      act(() => mounted!.editor.commands.insertContentAt(1, "B"));
+      releaseDemotion();
+
+      await waitFor(() => expect(requests).toHaveLength(1), {
+        timeout: 10_000,
+      });
+      expect(requests[0]).toMatchObject({
+        sourceKind: "direct_entry",
+        basisKind: "automatic_direct_entry_attribution",
+        expectedActorRef: ACTOR.ref,
+        anchor: { exact: "B" },
+      });
+      let pending = await durableOutbox.list();
+      expect(pending).toHaveLength(1);
+      expect(pending[0]).toMatchObject({
+        anchor: { exact: "A" },
+        sourceKind: "legacy",
+        basisKind: "user_attestation",
+        status: "awaiting_determination",
+        requiresExplicitDetermination: true,
+      });
+      expect(
+        pending.filter(
+          (entry) =>
+            entry.sourceKind === "direct_entry" || entry.status === "capturing",
+        ),
+      ).toEqual([]);
+      const legacyId = pending[0]!.id;
+      const server = mounted.server;
+      mounted.unmount();
+      mounted = undefined;
+
+      const reopenedOutbox = new DurableCoworkPasteProvenanceOutbox(
+        outboxKey,
+        memoryBacking,
+        intentStage,
+      );
+      reopened = await mountPasteEditor(
+        async (request) => {
+          requests.push(request);
+        },
+        {
+          outbox: reopenedOutbox,
+          server,
+          document: new Y.Doc(),
+          activeLens: "provenance",
+          provenanceProvider: provenanceProvider(),
+        },
+      );
+      await waitFor(async () => {
+        pending = await reopenedOutbox.list();
+        expect(pending).toHaveLength(1);
+        expect(pending[0]).toMatchObject({
+          id: legacyId,
+          anchor: { exact: "A" },
+          sourceKind: "legacy",
+          status: "awaiting_determination",
+        });
+        expect(
+          pending.filter(
+            (entry) =>
+              entry.sourceKind === "direct_entry" ||
+              entry.status === "capturing",
+          ),
+        ).toEqual([]);
+      });
+      expect(requests).toHaveLength(1);
+    } finally {
+      releaseDemotion();
+      reopened?.unmount();
+      mounted?.unmount();
+      vi.unstubAllGlobals();
+    }
+  }, 30_000);
+
   it("keeps corrections inside one honest direct-entry span", async () => {
     const requests: CoworkPasteProvenanceRequest[] = [];
     const mounted = await mountPasteEditor(
@@ -465,7 +770,7 @@ describe("CoworkBridgeEditor paste provenance", () => {
     reopened.unmount();
   }, 30_000);
 
-  it("retires an ownerless legacy actor-change row after reload so selection can record again", async () => {
+  it("reassociates an ownerless legacy actor-change row after reload", async () => {
     const requests: CoworkPasteProvenanceRequest[] = [];
     const outbox = new DurableCoworkPasteProvenanceOutbox(
       `ownerless-legacy-${String(Date.now())}`,
@@ -498,7 +803,14 @@ describe("CoworkBridgeEditor paste provenance", () => {
         provenanceProvider: provenanceProvider(),
       },
     );
-    await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+    await waitFor(async () => {
+      expect((await outbox.list())[0]).toMatchObject({
+        sourceKind: "legacy",
+        basisKind: "user_attestation",
+        status: "awaiting_determination",
+        requiresExplicitDetermination: true,
+      });
+    });
 
     act(() => {
       mounted.editor.commands.setTextSelection({ from: 1, to: 7 });
@@ -1349,6 +1661,92 @@ describe("CoworkBridgeEditor paste provenance", () => {
       expect(editorSurface).toHaveAttribute("aria-readonly", "false");
       expect(screen.queryByRole("alert")).toBeNull();
       expect(sessionAttempts).toBeGreaterThanOrEqual(2);
+    } finally {
+      mounted?.unmount();
+      vi.unstubAllGlobals();
+    }
+  }, 20_000);
+
+  it("clears an expired actor and re-resolves it after trusted session recovery", async () => {
+    const recorder = vi.fn<CoworkPasteProvenanceRecorder>().mockResolvedValue();
+    const recoveredActor = {
+      kind: "human",
+      ref: "recovered-dashboard-user",
+      identity_status: "local_actor_ref",
+    } as const;
+    let sessionAttempts = 0;
+    let actorAttempts = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/local-identity/session/csrf") {
+          sessionAttempts += 1;
+          if (sessionAttempts === 2) {
+            return new Response(
+              JSON.stringify({
+                ok: true,
+                authenticated: false,
+                human_authority_available: false,
+              }),
+              { headers: { "Content-Type": "application/json" } },
+            );
+          }
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              authenticated: true,
+              principal: {
+                ...LOCAL_PRINCIPAL,
+                session_expires_at: 199,
+              },
+              csrf_token:
+                sessionAttempts === 1 ? "wbc_initial" : "wbc_recovered",
+            }),
+            { headers: { "Content-Type": "application/json" } },
+          );
+        }
+        expect(url).toBe("/api/truth/cowork/current-actor");
+        actorAttempts += 1;
+        return new Response(
+          JSON.stringify(actorAttempts === 1 ? ACTOR : recoveredActor),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+
+    let mounted: MountedPasteEditor | undefined;
+    try {
+      mounted = await mountPasteEditor(recorder, {
+        resolveActorFromServer: true,
+        activeLens: "provenance",
+        provenanceProvider: provenanceProvider(),
+      });
+      await waitFor(() => expect(actorAttempts).toBe(1));
+      act(() => {
+        mounted!.editor.commands.setTextSelection({ from: 1, to: 7 });
+      });
+      expect(
+        await screen.findByRole("button", { name: "Record provenance" }),
+      ).toBeVisible();
+
+      await act(async () => {
+        await refreshLocalIdentity();
+      });
+      await waitFor(() =>
+        expect(
+          screen.queryByRole("button", { name: "Record provenance" }),
+        ).toBeNull(),
+      );
+
+      await act(async () => {
+        await refreshLocalIdentity();
+      });
+      await waitFor(() => expect(actorAttempts).toBe(2));
+      expect(
+        await screen.findByRole("button", { name: "Record provenance" }),
+      ).toBeVisible();
+      expect(sessionAttempts).toBeGreaterThanOrEqual(4);
     } finally {
       mounted?.unmount();
       vi.unstubAllGlobals();

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.pasteProvenance.test.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.pasteProvenance.test.tsx
@@ -801,7 +801,9 @@ describe("CoworkBridgeEditor paste provenance", () => {
   }, 30_000);
 
   it("keeps actorless typing durable and records it explicitly after identity recovery", async () => {
+    const user = userEvent.setup();
     const requests: CoworkPasteProvenanceRequest[] = [];
+    const pendingChanges: boolean[] = [];
     const outbox = new DurableCoworkPasteProvenanceOutbox(
       `actorless-direct-${String(Date.now())}`,
       new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
@@ -853,6 +855,8 @@ describe("CoworkBridgeEditor paste provenance", () => {
           resolveActorFromServer: true,
           activeLens: "neutral",
           provenanceProvider: provenanceProvider(),
+          onInputProvenancePendingChange: (pending) =>
+            pendingChanges.push(pending),
         },
       );
       await waitFor(() => expect(sessionAttempts).toBe(1));
@@ -860,14 +864,18 @@ describe("CoworkBridgeEditor paste provenance", () => {
       act(() => mounted!.editor.commands.insertContentAt(1, "Test"));
       mounted.setActiveLens("provenance");
 
+      let pendingKey = "";
       await waitFor(async () => {
-        expect((await outbox.list())[0]).toMatchObject({
+        const pending = (await outbox.list())[0];
+        expect(pending).toMatchObject({
           anchor: { exact: "Test", prefix: "", suffix: "Before after" },
           sourceKind: "direct_entry",
           basisKind: "automatic_direct_entry_attribution",
           status: "capturing",
         });
+        pendingKey = pending!.idempotencyKey;
       });
+      expect(pendingChanges[pendingChanges.length - 1]).toBe(true);
       expect(requests).toEqual([]);
       await act(async () => {
         await refreshLocalIdentity();
@@ -883,17 +891,20 @@ describe("CoworkBridgeEditor paste provenance", () => {
           failure: { code: "provenance_actor_unavailable_at_capture" },
         });
       });
-      act(() => {
-        mounted!.editor.commands.setTextSelection({ from: 1, to: 5 });
+      await screen.findByRole("dialog", {
+        name: "Recent typing needs attribution",
       });
-      const user = userEvent.setup();
-      await user.click(
-        await screen.findByRole("button", { name: "Record provenance" }),
+      expect(screen.getByLabelText("Recent passage")).toHaveTextContent(
+        "Test",
       );
+      expect(pendingChanges[pendingChanges.length - 1]).toBe(false);
+      expect(requests).toEqual([]);
+      expect(await outbox.list()).toHaveLength(1);
+
+      await user.click(screen.getByRole("button", { name: /Authorship/i }));
+      await user.click(screen.getByRole("option", { name: /^Human-written/ }));
       await user.click(
-        within(
-          screen.getByRole("dialog", { name: "Record provenance" }),
-        ).getByRole("button", { name: "Record provenance" }),
+        screen.getByRole("button", { name: "Confirm attribution" }),
       );
 
       await waitFor(() => expect(requests).toHaveLength(1), {
@@ -906,10 +917,227 @@ describe("CoworkBridgeEditor paste provenance", () => {
         expectedActorIdentityStatus: ACTOR.identity_status,
         anchor: { exact: "Test" },
       });
+      expect(requests[0]!.idempotencyKey).toBe(pendingKey);
       await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
     } finally {
       mounted?.unmount();
       vi.unstubAllGlobals();
+    }
+  }, 30_000);
+
+  it("keeps dismissed actorless typing recoverable without creating another outbox row", async () => {
+    const user = userEvent.setup();
+    const recorder = vi.fn<CoworkPasteProvenanceRecorder>().mockResolvedValue();
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `actorless-direct-dismiss-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    let sessionAttempts = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/truth/cowork/current-actor") {
+          return new Response(JSON.stringify(ACTOR), {
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        expect(url).toBe("/api/local-identity/session/csrf");
+        sessionAttempts += 1;
+        return new Response(
+          JSON.stringify(
+            sessionAttempts === 1
+              ? {
+                  ok: true,
+                  authenticated: false,
+                  human_authority_available: false,
+                }
+              : {
+                  ok: true,
+                  authenticated: true,
+                  principal: LOCAL_PRINCIPAL,
+                  csrf_token: "wbc_recovered_dismissed_direct_entry",
+                },
+          ),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+
+    let mounted: MountedPasteEditor | undefined;
+    try {
+      mounted = await mountPasteEditor(recorder, {
+        outbox,
+        resolveActorFromServer: true,
+        activeLens: "neutral",
+        provenanceProvider: provenanceProvider(),
+      });
+      await waitFor(() => expect(sessionAttempts).toBe(1));
+      act(() => mounted!.editor.commands.insertContentAt(1, "Recover me"));
+      mounted.setActiveLens("provenance");
+      await waitFor(async () =>
+        expect((await outbox.list())[0]).toMatchObject({
+          sourceKind: "direct_entry",
+          status: "capturing",
+        }),
+      );
+      const initial = (await outbox.list())[0]!;
+
+      await act(async () => {
+        await refreshLocalIdentity();
+      });
+      await screen.findByRole("dialog", {
+        name: "Recent typing needs attribution",
+      });
+      await user.click(screen.getByRole("button", { name: "Keep for later" }));
+      await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+
+      const deferred = await outbox.list();
+      expect(deferred).toHaveLength(1);
+      expect(deferred[0]).toMatchObject({
+        id: initial.id,
+        idempotencyKey: initial.idempotencyKey,
+        sourceKind: "legacy",
+        status: "awaiting_determination",
+      });
+      expect(recorder).not.toHaveBeenCalled();
+
+      await user.click(
+        screen.getByRole("button", { name: "Review pending attribution" }),
+      );
+      await screen.findByRole("dialog", {
+        name: "Recent typing needs attribution",
+      });
+      expect(await outbox.list()).toHaveLength(1);
+      expect(recorder).not.toHaveBeenCalled();
+    } finally {
+      mounted?.unmount();
+      vi.unstubAllGlobals();
+    }
+  }, 30_000);
+
+  it("reconstructs actorless typing recovery from the durable row after a fresh mount", async () => {
+    const user = userEvent.setup();
+    const backing = new InMemoryCoworkPasteProvenanceOutboxBackingStore();
+    const outboxKey = `actorless-direct-reload-${String(Date.now())}`;
+    const beforeReload = new DurableCoworkPasteProvenanceOutbox(
+      outboxKey,
+      backing,
+    );
+    const capturing = await beforeReload.upsertCapture({
+      anchor: { exact: "Before", prefix: "", suffix: " after" },
+      idempotencyKey: "actorless-direct-reload-key",
+      substantial: false,
+      sourceKind: "direct_entry",
+      basisKind: "automatic_direct_entry_attribution",
+      determination: unknownCoworkProvenanceDetermination(),
+      capturedAt: "2026-08-21T12:00:00.000Z",
+      passageExcerpt: "Before",
+      status: "capturing",
+    });
+    const deferred = await beforeReload.deferDirectEntry(
+      capturing.id,
+      capturing.idempotencyKey,
+      unknownCoworkProvenanceDetermination(),
+      {
+        code: "provenance_actor_unavailable_at_capture",
+        message: "No enrolled local actor was available when this text was entered.",
+        kind: "terminal",
+      },
+    );
+
+    // Ctrl+R constructs both the component and the outbox adapter again. Only
+    // the persisted row/failure marker crosses this seam.
+    const afterReload = new DurableCoworkPasteProvenanceOutbox(
+      outboxKey,
+      backing,
+    );
+    const recorder = vi.fn<CoworkPasteProvenanceRecorder>().mockResolvedValue();
+    let mounted: MountedPasteEditor | undefined = await mountPasteEditor(
+      recorder,
+      {
+        outbox: afterReload,
+        activeLens: "provenance",
+        provenanceProvider: provenanceProvider(),
+      },
+    );
+    let remounted: MountedPasteEditor | undefined;
+
+    try {
+      await screen.findByRole("dialog", {
+        name: "Recent typing needs attribution",
+      });
+      expect(screen.getByLabelText("Recent passage")).toHaveTextContent(
+        "Before",
+      );
+      const recovered = await afterReload.list();
+      expect(recovered).toHaveLength(1);
+      expect(recovered[0]).toMatchObject({
+        id: deferred.id,
+        idempotencyKey: deferred.idempotencyKey,
+        sourceKind: "legacy",
+        status: "awaiting_determination",
+      });
+      expect(recorder).not.toHaveBeenCalled();
+
+      // The controlled form persists as the user chooses. Reload in this
+      // intermediate state, before Confirm, to prove the direct-entry lineage
+      // marker survives independently of component-local refs.
+      await user.click(screen.getByRole("button", { name: /Authorship/i }));
+      await user.click(screen.getByRole("option", { name: /^Human-written/ }));
+      await waitFor(async () =>
+        expect((await afterReload.list())[0]).toMatchObject({
+          id: deferred.id,
+          idempotencyKey: deferred.idempotencyKey,
+          determination: { authorship: { kind: "human" } },
+          failure: { code: "provenance_actor_unavailable_at_capture" },
+        }),
+      );
+
+      const server = mounted.server;
+      mounted.unmount();
+      mounted.document.destroy();
+      mounted = undefined;
+      const afterFormReload = new DurableCoworkPasteProvenanceOutbox(
+        outboxKey,
+        backing,
+      );
+      remounted = await mountPasteEditor(recorder, {
+        outbox: afterFormReload,
+        server,
+        document: new Y.Doc(),
+        activeLens: "provenance",
+        provenanceProvider: provenanceProvider(),
+      });
+
+      await screen.findByRole("dialog", {
+        name: "Recent typing needs attribution",
+      });
+      expect(
+        screen.getByRole("button", { name: /Authorship/i }),
+      ).toHaveTextContent("Human-written");
+      expect(await afterFormReload.list()).toHaveLength(1);
+      await user.click(
+        screen.getByRole("button", { name: "Confirm attribution" }),
+      );
+
+      await waitFor(() => expect(recorder).toHaveBeenCalledOnce(), {
+        timeout: 10_000,
+      });
+      expect(recorder.mock.calls[0]?.[0]).toMatchObject({
+        idempotencyKey: deferred.idempotencyKey,
+        sourceKind: "legacy",
+        basisKind: "user_attestation",
+        expectedActorRef: ACTOR.ref,
+        anchor: deferred.anchor,
+      });
+      await waitFor(() => expect(afterFormReload.list()).resolves.toEqual([]));
+      expect(recorder).toHaveBeenCalledOnce();
+    } finally {
+      remounted?.unmount();
+      remounted?.document.destroy();
+      mounted?.unmount();
+      mounted?.document.destroy();
     }
   }, 30_000);
 

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.pasteProvenance.test.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.pasteProvenance.test.tsx
@@ -1,6 +1,7 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Editor } from "@tiptap/core";
+import type { CoworkEditorLens } from "../editor/ledgerDecorations";
 import { DOMParser as ProseMirrorDOMParser } from "@tiptap/pm/model";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
@@ -21,6 +22,7 @@ import {
   DurableCoworkPasteProvenanceOutbox,
   InMemoryCoworkPasteProvenanceIntentStage,
   InMemoryCoworkPasteProvenanceOutboxBackingStore,
+  resolveCoworkPasteAnchor,
   unknownCoworkProvenanceDetermination,
   type CoworkPasteProvenanceCapture,
   type CoworkPasteProvenanceIntentStage,
@@ -28,6 +30,8 @@ import {
   type CoworkPasteProvenanceRecorder,
   type CoworkPasteProvenanceRequest,
   type CoworkProvenanceActorIdentity,
+  type ProvenanceData,
+  type ProvenanceProvider,
 } from "../provenance";
 import { CoworkHttpError } from "../providers/errors";
 import {
@@ -41,6 +45,7 @@ interface MountedPasteEditor {
   readonly server: InMemoryCoworkYdocTransport;
   readonly events: string[];
   readonly unmount: () => void;
+  readonly setActiveLens: (lens: CoworkEditorLens) => void;
 }
 
 let nextDocument = 0;
@@ -74,24 +79,31 @@ const mountPasteEditor = async (
     readonly provenanceActor?: CoworkProvenanceActorIdentity;
     readonly resolveActorFromServer?: boolean;
     readonly onPushStart?: () => void;
+    readonly beforePush?: () => Promise<void>;
+    readonly activeLens?: CoworkEditorLens;
+    readonly provenanceProvider?: ProvenanceProvider;
+    readonly document?: Y.Doc;
+    readonly server?: InMemoryCoworkYdocTransport;
   } = {},
 ): Promise<MountedPasteEditor> => {
-  const initialized = await bootstrapCoworkYdoc(
-    new TextEncoder().encode("Before after"),
-  );
-  if (!initialized.ok) throw new Error(initialized.message);
-  const server = new InMemoryCoworkYdocTransport();
-  const empty = await server.pull({});
-  await server.push({
-    batch: initialized.snapshot,
-    baseSha256: empty.docSha256,
-    baseStructuredHeadSha256: empty.structuredHeadSha256,
-    baseYdocGeneration: empty.ydocGeneration,
-    compaction: {
-      snapshot: initialized.snapshot,
-      snapshotSha256: initialized.snapshotSha256,
-    },
-  });
+  const server = options.server ?? new InMemoryCoworkYdocTransport();
+  if (options.server === undefined) {
+    const initialized = await bootstrapCoworkYdoc(
+      new TextEncoder().encode("Before after"),
+    );
+    if (!initialized.ok) throw new Error(initialized.message);
+    const empty = await server.pull({});
+    await server.push({
+      batch: initialized.snapshot,
+      baseSha256: empty.docSha256,
+      baseStructuredHeadSha256: empty.structuredHeadSha256,
+      baseYdocGeneration: empty.ydocGeneration,
+      compaction: {
+        snapshot: initialized.snapshot,
+        snapshotSha256: initialized.snapshotSha256,
+      },
+    });
+  }
 
   const events: string[] = [];
   const transport: CoworkYdocTransport = {
@@ -99,26 +111,31 @@ const mountPasteEditor = async (
     push: async (request: CoworkYdocPushRequest) => {
       events.push("push");
       options.onPushStart?.();
+      await options.beforePush?.();
       return server.push(request);
     },
   };
   const editorRef: { current: Editor | null } = { current: null };
-  const document = new Y.Doc();
+  const document = options.document ?? new Y.Doc();
   nextDocument += 1;
-  const rendered = render(
+  const documentId =
+    options.documentId ??
+    `paste-provenance-${String(nextDocument)}-${String(Date.now())}`;
+  const view = (activeLens: CoworkEditorLens | undefined) => (
     <CoworkBridgeEditor
       document={document}
       transport={transport}
       seedMarkdown=""
-      documentId={
-        options.documentId ??
-        `paste-provenance-${String(nextDocument)}-${String(Date.now())}`
-      }
+      documentId={documentId}
       storeId="paste-provenance-store"
+      activeLens={activeLens}
+      provenanceProvider={options.provenanceProvider}
+      provenanceSelectionActionsActive
+      onProvenanceSelectionAction={() => undefined}
       provenanceActor={
         options.resolveActorFromServer
           ? undefined
-          : options.provenanceActor ?? ACTOR
+          : (options.provenanceActor ?? ACTOR)
       }
       pasteProvenanceOutbox={options.outbox}
       onRecordPasteProvenance={async (request) => {
@@ -128,8 +145,9 @@ const mountPasteEditor = async (
       onReady={({ editor }) => {
         editorRef.current = editor;
       }}
-    />,
+    />
   );
+  const rendered = render(view(options.activeLens));
   await screen.findByRole(
     "textbox",
     { name: "Document editor" },
@@ -142,25 +160,49 @@ const mountPasteEditor = async (
     server,
     events,
     unmount: rendered.unmount,
+    setActiveLens: (lens) => rendered.rerender(view(lens)),
+  };
+};
+
+const emptyProvenanceData = (): ProvenanceData => ({
+  schema: "cowork-provenance-view/v1",
+  currentStructuredHeadSha256: null,
+  documentDefault: null,
+  spans: [],
+  history: [],
+  summary: {
+    totalTargets: 0,
+    currentSpanCount: 0,
+    aiUnreviewedCount: 0,
+    reviewedCount: 0,
+    conflictedCount: 0,
+    staleCount: 0,
+    unrecorded: true,
+  },
+});
+
+const provenanceProvider = (): ProvenanceProvider => {
+  const data = emptyProvenanceData();
+  return {
+    load: vi.fn().mockResolvedValue({ state: "ready", data }),
+    refresh: vi.fn().mockResolvedValue({ state: "ready", data }),
+    subscribe: () => () => undefined,
+    markReviewed: vi.fn().mockResolvedValue(undefined),
   };
 };
 
 const dispatchSimplePaste = (editor: Editor): void => {
   act(() => {
     editor.view.dispatch(
-      editor.state.tr
-        .insertText("pasted ", 8)
-        .setMeta("uiEvent", "paste"),
+      editor.state.tr.insertText("pasted ", 8).setMeta("uiEvent", "paste"),
     );
   });
 };
 
-const dispatchSubstantialPaste = (
-  editor: Editor,
-  position = 8,
-): void => {
+const dispatchSubstantialPaste = (editor: Editor, position = 8): void => {
   const host = document.createElement("div");
-  host.innerHTML = "<p>First pasted paragraph.</p><p>Second pasted paragraph.</p>";
+  host.innerHTML =
+    "<p>First pasted paragraph.</p><p>Second pasted paragraph.</p>";
   const slice = ProseMirrorDOMParser.fromSchema(editor.schema).parseSlice(host);
   act(() => {
     editor.view.dispatch(
@@ -172,18 +214,386 @@ const dispatchSubstantialPaste = (
 };
 
 describe("CoworkBridgeEditor paste provenance", () => {
+  it("records ordinary typing when Provenance opens immediately", async () => {
+    const requests: CoworkPasteProvenanceRequest[] = [];
+    const provider = provenanceProvider();
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `direct-entry-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    const mounted = await mountPasteEditor(
+      async (request) => {
+        requests.push(request);
+      },
+      { outbox, activeLens: "neutral", provenanceProvider: provider },
+    );
+
+    act(() => mounted.editor.commands.insertContentAt(1, "Test"));
+    mounted.setActiveLens("provenance");
+
+    await waitFor(() => expect(requests).toHaveLength(1), {
+      timeout: 10_000,
+    });
+    expect(requests[0]).toMatchObject({
+      sourceKind: "direct_entry",
+      basisKind: "automatic_direct_entry_attribution",
+      expectedActorRef: ACTOR.ref,
+      expectedActorIdentityStatus: ACTOR.identity_status,
+      anchor: { exact: "Test", prefix: "", suffix: "Before after" },
+      attestation: {
+        authorship: {
+          kind: "human",
+          contributors: [{ ref: ACTOR.ref }],
+        },
+      },
+    });
+    expect(provider.refresh).toHaveBeenCalledOnce();
+    await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+    expect(screen.queryByText(/where did this text come from/i)).toBeNull();
+  }, 30_000);
+
+  it("keeps corrections inside one honest direct-entry span", async () => {
+    const requests: CoworkPasteProvenanceRequest[] = [];
+    const mounted = await mountPasteEditor(
+      async (request) => {
+        requests.push(request);
+      },
+      { activeLens: "neutral", provenanceProvider: provenanceProvider() },
+    );
+
+    act(() => {
+      mounted.editor.commands.setTextSelection(1);
+      mounted.editor.commands.insertContent("Test");
+      mounted.editor.commands.deleteRange({ from: 4, to: 5 });
+      mounted.editor.commands.insertContentAt(4, "ting");
+    });
+    mounted.setActiveLens("provenance");
+
+    await waitFor(() => expect(requests).toHaveLength(1), {
+      timeout: 10_000,
+    });
+    expect(requests[0]?.anchor.exact).toBe("Testing");
+  }, 30_000);
+
+  it("maps displaced nearby bursts to one final head before freezing them", async () => {
+    const requests: CoworkPasteProvenanceRequest[] = [];
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `displaced-direct-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    const mounted = await mountPasteEditor(
+      async (request) => {
+        requests.push(request);
+      },
+      {
+        outbox,
+        activeLens: "neutral",
+        provenanceProvider: provenanceProvider(),
+      },
+    );
+
+    act(() => {
+      mounted.editor.commands.insertContentAt(8, "A");
+      // Insert before the first burst. This changes both its absolute position
+      // and its bounded prefix, so retaining the pre-transaction selector
+      // would not resolve against the final compacted document.
+      mounted.editor.commands.insertContentAt(1, "B");
+    });
+    mounted.setActiveLens("provenance");
+
+    await waitFor(() => expect(requests).toHaveLength(2), {
+      timeout: 10_000,
+    });
+    expect(
+      new Set(requests.map((request) => request.expectedStructuredHeadSha256))
+        .size,
+    ).toBe(1);
+    expect(requests.map((request) => request.anchor.exact).sort()).toEqual([
+      "A",
+      "B",
+    ]);
+    for (const request of requests) {
+      const resolution = resolveCoworkPasteAnchor(
+        mounted.editor.state.doc,
+        request.anchor,
+      );
+      expect(resolution.kind).toBe("unique");
+      if (resolution.kind === "unique") {
+        expect(
+          mounted.editor.state.doc.textBetween(
+            resolution.from,
+            resolution.to,
+            "\n",
+          ),
+        ).toBe(request.anchor.exact);
+      }
+    }
+    await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+  }, 30_000);
+
+  it("keeps a closing burst mapped when another edit lands during compaction", async () => {
+    let blockPush = false;
+    let releasePush!: () => void;
+    let enteredBlockedPush!: () => void;
+    const pushGate = new Promise<void>((resolve) => {
+      releasePush = resolve;
+    });
+    const blockedPushEntered = new Promise<void>((resolve) => {
+      enteredBlockedPush = resolve;
+    });
+    const requests: CoworkPasteProvenanceRequest[] = [];
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `inflight-map-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    const mounted = await mountPasteEditor(
+      async (request) => {
+        requests.push(request);
+      },
+      {
+        outbox,
+        activeLens: "neutral",
+        provenanceProvider: provenanceProvider(),
+        beforePush: async () => {
+          if (!blockPush) return;
+          enteredBlockedPush();
+          await pushGate;
+        },
+      },
+    );
+
+    act(() => mounted.editor.commands.insertContentAt(8, "A"));
+    await waitFor(() => expect(mounted.events).toContain("push"));
+    await waitFor(async () => {
+      expect((await outbox.list())[0]).toMatchObject({
+        status: "capturing",
+        anchor: { exact: "A" },
+      });
+    });
+
+    blockPush = true;
+    mounted.setActiveLens("provenance");
+    await blockedPushEntered;
+    act(() => mounted.editor.commands.insertContentAt(1, "B"));
+    releasePush();
+
+    await waitFor(() => expect(requests).toHaveLength(2), {
+      timeout: 10_000,
+    });
+    const original = requests.find((request) => request.anchor.exact === "A");
+    expect(original).toBeDefined();
+    const resolution = resolveCoworkPasteAnchor(
+      mounted.editor.state.doc,
+      original!.anchor,
+    );
+    expect(resolution.kind).toBe("unique");
+    if (resolution.kind === "unique") {
+      expect(
+        mounted.editor.state.doc.textBetween(
+          resolution.from,
+          resolution.to,
+          "\n",
+        ),
+      ).toBe("A");
+    }
+    await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+  }, 30_000);
+
+  it("cancels provenance when the whole newly typed burst is deleted", async () => {
+    const recorder = vi.fn<CoworkPasteProvenanceRecorder>().mockResolvedValue();
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `deleted-burst-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    const mounted = await mountPasteEditor(recorder, {
+      outbox,
+      activeLens: "neutral",
+      provenanceProvider: provenanceProvider(),
+    });
+
+    act(() => {
+      mounted.editor.commands.insertContentAt(1, "Test");
+      mounted.editor.commands.deleteRange({ from: 1, to: 5 });
+    });
+    mounted.setActiveLens("provenance");
+
+    await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+    expect(recorder).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alert")).toBeNull();
+  }, 30_000);
+
+  it("leaves an open typed burst durable across unmount and records it on reopen", async () => {
+    const requests: CoworkPasteProvenanceRequest[] = [];
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `reopen-direct-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    const documentId = `reopen-direct-document-${String(Date.now())}`;
+    const first = await mountPasteEditor(
+      async (request) => {
+        requests.push(request);
+      },
+      { outbox, document: new Y.Doc(), documentId, activeLens: "neutral" },
+    );
+    act(() => first.editor.commands.insertContentAt(1, "Test"));
+    await waitFor(async () => {
+      expect((await outbox.list())[0]).toMatchObject({
+        status: "capturing",
+        anchor: { exact: "Test" },
+      });
+    });
+    first.unmount();
+    expect(requests).toEqual([]);
+
+    const reopened = await mountPasteEditor(
+      async (request) => {
+        requests.push(request);
+      },
+      {
+        outbox,
+        documentId,
+        server: first.server,
+        document: new Y.Doc(),
+        activeLens: "provenance",
+        provenanceProvider: provenanceProvider(),
+      },
+    );
+    await waitFor(() => expect(requests).toHaveLength(1), {
+      timeout: 10_000,
+    });
+    expect(requests[0]?.anchor.exact).toBe("Test");
+    reopened.unmount();
+  }, 30_000);
+
+  it("retires an ownerless legacy actor-change row after reload so selection can record again", async () => {
+    const requests: CoworkPasteProvenanceRequest[] = [];
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `ownerless-legacy-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    await outbox.append({
+      anchor: { exact: "Before", prefix: "", suffix: " after" },
+      idempotencyKey: "prior-manual-key",
+      substantial: false,
+      capturedActor: ACTOR,
+      sourceKind: "legacy",
+      basisKind: "user_attestation",
+      determination: unknownCoworkProvenanceDetermination(),
+      capturedAt: new Date().toISOString(),
+      passageExcerpt: "Before",
+      status: "ready",
+    });
+    await outbox.resetAfterActorChange(
+      "actor-recovery",
+      unknownCoworkProvenanceDetermination(),
+    );
+
+    const mounted = await mountPasteEditor(
+      async (request) => {
+        requests.push(request);
+      },
+      {
+        outbox,
+        activeLens: "provenance",
+        provenanceProvider: provenanceProvider(),
+      },
+    );
+    await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+
+    act(() => {
+      mounted.editor.commands.setTextSelection({ from: 1, to: 7 });
+    });
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Record provenance" }),
+    );
+    await userEvent.click(
+      within(
+        screen.getByRole("dialog", { name: "Record provenance" }),
+      ).getByRole("button", { name: "Record provenance" }),
+    );
+
+    await waitFor(() => expect(requests).toHaveLength(1), {
+      timeout: 10_000,
+    });
+    expect(requests[0]).toMatchObject({
+      sourceKind: "legacy",
+      basisKind: "user_attestation",
+      expectedActorRef: ACTOR.ref,
+      anchor: { exact: "Before" },
+    });
+    await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+  }, 30_000);
+
+  it("never silently changes a frozen manual determination on ambiguous retry", async () => {
+    const recorder = vi
+      .fn<CoworkPasteProvenanceRecorder>()
+      .mockRejectedValueOnce(
+        new CoworkHttpError({
+          code: "network_error",
+          message: "Connection interrupted after submission.",
+          retryable: true,
+        }),
+      )
+      .mockResolvedValueOnce();
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `frozen-manual-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    const mounted = await mountPasteEditor(recorder, {
+      outbox,
+      activeLens: "provenance",
+      provenanceProvider: provenanceProvider(),
+    });
+    const user = userEvent.setup();
+
+    act(() => {
+      mounted.editor.commands.setTextSelection({ from: 1, to: 7 });
+    });
+    await user.click(
+      await screen.findByRole("button", { name: "Record provenance" }),
+    );
+    const dialog = screen.getByRole("dialog", { name: "Record provenance" });
+    const confirm = within(dialog).getByRole("button", {
+      name: "Record provenance",
+    });
+    await user.click(confirm);
+    await waitFor(() => expect(recorder).toHaveBeenCalledOnce());
+    await screen.findByText("Connection interrupted after submission.");
+
+    await user.click(
+      within(dialog).getByRole("button", { name: /Authorship/i }),
+    );
+    await user.click(screen.getByRole("option", { name: /AI-written/i }));
+    await user.click(confirm);
+
+    expect(recorder).toHaveBeenCalledOnce();
+    expect(
+      await screen.findByText(/pending request is already frozen/i),
+    ).toBeVisible();
+    expect(recorder.mock.calls[0]?.[0].attestation.authorship.kind).toBe(
+      "human",
+    );
+
+    await user.click(
+      within(dialog).getByRole("button", { name: /Authorship/i }),
+    );
+    await user.click(screen.getByRole("option", { name: /Human-written/i }));
+    await user.click(confirm);
+    await waitFor(() => expect(recorder).toHaveBeenCalledTimes(2));
+    expect(recorder.mock.calls[1]?.[0]).toEqual(recorder.mock.calls[0]?.[0]);
+    await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+  }, 30_000);
+
   it("journals provenance before the paste can enter durable Yjs state", async () => {
     const order: string[] = [];
-    const intentStage =
-      new InMemoryCoworkPasteProvenanceIntentStage();
+    const intentStage = new InMemoryCoworkPasteProvenanceIntentStage();
     const observingStage: CoworkPasteProvenanceIntentStage = {
       list: (key) => intentStage.list(key),
       put: (key: string, capture: CoworkPasteProvenanceCapture) => {
         order.push("journal");
         intentStage.put(key, capture);
       },
-      remove: (key, idempotencyKey) =>
-        intentStage.remove(key, idempotencyKey),
+      remove: (key, idempotencyKey) => intentStage.remove(key, idempotencyKey),
     };
     const outbox = new DurableCoworkPasteProvenanceOutbox(
       `ordering-${String(Date.now())}`,
@@ -214,10 +624,7 @@ describe("CoworkBridgeEditor paste provenance", () => {
     act(() => {
       mounted.editor.view.dispatch(
         mounted.editor.state.tr
-          .insertText(
-            "x".repeat(COWORK_PROVENANCE_EXACT_MAX_CHARS + 1),
-            8,
-          )
+          .insertText("x".repeat(COWORK_PROVENANCE_EXACT_MAX_CHARS + 1), 8)
           .setMeta("uiEvent", "paste"),
       );
     });
@@ -248,9 +655,7 @@ describe("CoworkBridgeEditor paste provenance", () => {
         if (!removeDuringFirstPush || liveEditor === null) return;
         removeDuringFirstPush = false;
         act(() => {
-          liveEditor!.view.dispatch(
-            liveEditor!.state.tr.delete(8, 15),
-          );
+          liveEditor!.view.dispatch(liveEditor!.state.tr.delete(8, 15));
         });
       },
     });
@@ -281,7 +686,7 @@ describe("CoworkBridgeEditor paste provenance", () => {
     // Recording is asynchronous; the user's text is present immediately.
     expect(mounted.editor.getText()).toBe("Before pasted after");
     await waitFor(() => expect(requests).toHaveLength(1));
-    expect(mounted.events).toEqual(["push", "record"]);
+    expect(mounted.events).toEqual(["push", "push", "record"]);
     expect(requests[0]).toMatchObject({
       storeId: "paste-provenance-store",
       basisKind: "automatic_short_text_attribution",
@@ -450,8 +855,7 @@ describe("CoworkBridgeEditor paste provenance", () => {
 
   it("rehydrates an unresolved determination after editor hydration", async () => {
     const user = userEvent.setup();
-    const backing =
-      new InMemoryCoworkPasteProvenanceOutboxBackingStore();
+    const backing = new InMemoryCoworkPasteProvenanceOutboxBackingStore();
     const persisted = new DurableCoworkPasteProvenanceOutbox(
       "paste-provenance-store:reload-doc",
       backing,
@@ -521,19 +925,11 @@ describe("CoworkBridgeEditor paste provenance", () => {
   }, 20_000);
 
   it("keeps one document queue across actor switches", () => {
-    const firstKey = coworkPasteProvenanceOutboxKey(
-      "store",
-      "document",
-    );
-    const secondKey = coworkPasteProvenanceOutboxKey(
-      "store",
-      "document",
-    );
+    const firstKey = coworkPasteProvenanceOutboxKey("store", "document");
+    const secondKey = coworkPasteProvenanceOutboxKey("store", "document");
 
     expect(secondKey).toBe(firstKey);
-    expect(coworkPasteProvenanceOutboxKey("store", "other")).not.toBe(
-      firstKey,
-    );
+    expect(coworkPasteProvenanceOutboxKey("store", "other")).not.toBe(firstKey);
   });
 
   it("refetches a changed actor and requires explicit reconfirmation without retrying blindly", async () => {
@@ -598,8 +994,7 @@ describe("CoworkBridgeEditor paste provenance", () => {
       await waitFor(() =>
         expect(
           actorFetch.mock.calls.filter(
-            ([input]) =>
-              String(input) === "/api/truth/cowork/current-actor",
+            ([input]) => String(input) === "/api/truth/cowork/current-actor",
           ),
         ).toHaveLength(1),
       );
@@ -632,9 +1027,7 @@ describe("CoworkBridgeEditor paste provenance", () => {
       );
       await screen.findByRole("dialog");
       await user.click(screen.getByRole("button", { name: /Authorship/i }));
-      await user.click(
-        screen.getByRole("option", { name: /^Human-written/ }),
-      );
+      await user.click(screen.getByRole("option", { name: /^Human-written/ }));
       await user.click(
         screen.getByRole("button", { name: "Confirm attribution" }),
       );
@@ -749,9 +1142,7 @@ describe("CoworkBridgeEditor paste provenance", () => {
     );
     await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
     await waitFor(() =>
-      expect(
-        screen.queryByText(/paste attribution is waiting/i),
-      ).toBeNull(),
+      expect(screen.queryByText(/paste attribution is waiting/i)).toBeNull(),
     );
   }, 20_000);
 
@@ -849,9 +1240,7 @@ describe("CoworkBridgeEditor paste provenance", () => {
       });
       await waitFor(() => expect(actorAttempts).toBe(1));
       expect(editorSurface).toHaveAttribute("aria-readonly", "false");
-      expect(
-        screen.queryByText(/Reconnect Work Buddy to edit/i),
-      ).toBeNull();
+      expect(screen.queryByText(/Reconnect Work Buddy to edit/i)).toBeNull();
 
       dispatchSimplePaste(mounted.editor);
       await waitFor(async () => {
@@ -876,9 +1265,7 @@ describe("CoworkBridgeEditor paste provenance", () => {
         }),
       ).toBeVisible();
       expect(editorSurface).toHaveAttribute("aria-readonly", "false");
-      expect(
-        screen.queryByText(/Reconnect Work Buddy to edit/i),
-      ).toBeNull();
+      expect(screen.queryByText(/Reconnect Work Buddy to edit/i)).toBeNull();
     } finally {
       mounted?.unmount();
       vi.unstubAllGlobals();

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.pasteProvenance.test.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.pasteProvenance.test.tsx
@@ -47,6 +47,9 @@ interface MountedPasteEditor {
   readonly events: string[];
   readonly unmount: () => void;
   readonly setActiveLens: (lens: CoworkEditorLens) => void;
+  readonly setProvenanceActor: (
+    actor: CoworkProvenanceActorIdentity | undefined,
+  ) => void;
 }
 
 let nextDocument = 0;
@@ -122,22 +125,22 @@ const mountPasteEditor = async (
   const documentId =
     options.documentId ??
     `paste-provenance-${String(nextDocument)}-${String(Date.now())}`;
-  const view = (activeLens: CoworkEditorLens | undefined) => (
+  let renderedLens = options.activeLens;
+  let renderedActor = options.resolveActorFromServer
+    ? undefined
+    : (options.provenanceActor ?? ACTOR);
+  const view = () => (
     <CoworkBridgeEditor
       document={document}
       transport={transport}
       seedMarkdown=""
       documentId={documentId}
       storeId="paste-provenance-store"
-      activeLens={activeLens}
+      activeLens={renderedLens}
       provenanceProvider={options.provenanceProvider}
       provenanceSelectionActionsActive
       onProvenanceSelectionAction={() => undefined}
-      provenanceActor={
-        options.resolveActorFromServer
-          ? undefined
-          : (options.provenanceActor ?? ACTOR)
-      }
+      provenanceActor={renderedActor}
       pasteProvenanceOutbox={options.outbox}
       onRecordPasteProvenance={async (request) => {
         events.push("record");
@@ -148,7 +151,7 @@ const mountPasteEditor = async (
       }}
     />
   );
-  const rendered = render(view(options.activeLens));
+  const rendered = render(view());
   await screen.findByRole(
     "textbox",
     { name: "Document editor" },
@@ -161,7 +164,14 @@ const mountPasteEditor = async (
     server,
     events,
     unmount: rendered.unmount,
-    setActiveLens: (lens) => rendered.rerender(view(lens)),
+    setActiveLens: (lens) => {
+      renderedLens = lens;
+      rendered.rerender(view());
+    },
+    setProvenanceActor: (actor) => {
+      renderedActor = actor;
+      rendered.rerender(view());
+    },
   };
 };
 
@@ -251,6 +261,260 @@ describe("CoworkBridgeEditor paste provenance", () => {
     expect(provider.refresh).toHaveBeenCalledOnce();
     await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
     expect(screen.queryByText(/where did this text come from/i)).toBeNull();
+  }, 30_000);
+
+  it("waits for the capture actor, then keeps top-block typing whole across a persistence settlement", async () => {
+    const user = userEvent.setup({ delay: 5 });
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `direct-entry-actor-loading-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    const requests: CoworkPasteProvenanceRequest[] = [];
+    let actorRequests = 0;
+    let releaseActor!: () => void;
+    const actorGate = new Promise<void>((resolve) => {
+      releaseActor = resolve;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/local-identity/session/csrf") {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              authenticated: true,
+              principal: LOCAL_PRINCIPAL,
+              csrf_token: "wbc_delayed_direct_entry_actor",
+            }),
+            { headers: { "Content-Type": "application/json" } },
+          );
+        }
+        expect(url).toBe("/api/truth/cowork/current-actor");
+        actorRequests += 1;
+        await actorGate;
+        return new Response(JSON.stringify(ACTOR), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    let mounted: MountedPasteEditor | undefined;
+    try {
+      mounted = await mountPasteEditor(
+        async (request) => {
+          requests.push(request);
+        },
+        {
+          outbox,
+          resolveActorFromServer: true,
+          activeLens: "neutral",
+          provenanceProvider: provenanceProvider(),
+        },
+      );
+      await waitFor(() => expect(actorRequests).toBe(1));
+
+      // Build the live shape from the reported regression: one empty top
+      // paragraph followed by existing text. A structural split introduces no
+      // authored text and therefore no provenance capture of its own.
+      act(() => {
+        mounted!.editor.commands.setTextSelection(1);
+        mounted!.editor.commands.splitBlock();
+      });
+      expect(mounted.editor.state.doc.childCount).toBe(2);
+
+      const editorSurface = screen.getByRole("textbox", {
+        name: "Document editor",
+      });
+      expect(editorSurface).toHaveAttribute("aria-readonly", "true");
+      expect(editorSurface).toHaveAttribute("contenteditable", "false");
+      releaseActor();
+      await waitFor(() => {
+        expect(editorSurface).toHaveAttribute("aria-readonly", "false");
+        expect(editorSurface).toHaveAttribute("contenteditable", "true");
+      });
+      await waitFor(() => expect(mounted!.events).toContain("push"), {
+        timeout: 5_000,
+      });
+      const pushesBeforeTyping = mounted.events.filter(
+        (event) => event === "push",
+      ).length;
+
+      mounted.editor.view.setProps({
+        handleScrollToSelection: () => true,
+      });
+      act(() => {
+        mounted!.editor.commands.setTextSelection(1);
+      });
+      editorSurface.focus();
+      await user.type(editorSurface, "The party's r", {
+        skipClick: true,
+      });
+      // Cross a real idle persistence push while focus and selection stay in
+      // the same text block. Network settlement must not split an authorship
+      // burst.
+      await waitFor(
+        () =>
+          expect(
+            mounted!.events.filter((event) => event === "push").length,
+          ).toBeGreaterThan(pushesBeforeTyping),
+        { timeout: 5_000 },
+      );
+      await user.type(editorSurface, "ocking, yes", {
+        skipClick: true,
+      });
+      mounted.setActiveLens("provenance");
+
+      await waitFor(() => expect(requests).toHaveLength(1), {
+        timeout: 10_000,
+      });
+      expect(requests[0]).toMatchObject({
+        sourceKind: "direct_entry",
+        basisKind: "automatic_direct_entry_attribution",
+        expectedActorRef: ACTOR.ref,
+        expectedActorIdentityStatus: ACTOR.identity_status,
+        anchor: {
+          exact: "The party's rocking, yes",
+          prefix: "",
+          suffix: "\nBefore after",
+        },
+      });
+      expect(await outbox.list()).toEqual([]);
+    } finally {
+      releaseActor();
+      mounted?.unmount();
+      vi.unstubAllGlobals();
+    }
+  }, 30_000);
+
+  it("retains a direct-entry request after a non-target 409 and retries the exact frozen request", async () => {
+    const user = userEvent.setup();
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `direct-entry-binding-mismatch-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    const recorder = vi
+      .fn<CoworkPasteProvenanceRecorder>()
+      .mockRejectedValueOnce(
+        new CoworkHttpError({
+          code: "gesture_binding_mismatch",
+          message: "The gesture did not bind to this request.",
+          retryable: false,
+          status: 409,
+        }),
+      )
+      .mockResolvedValueOnce();
+    const mounted = await mountPasteEditor(recorder, {
+      outbox,
+      activeLens: "neutral",
+      provenanceProvider: provenanceProvider(),
+    });
+
+    act(() => mounted.editor.commands.insertContentAt(1, "Test"));
+    mounted.setActiveLens("provenance");
+
+    await waitFor(() => expect(recorder).toHaveBeenCalledOnce(), {
+      timeout: 10_000,
+    });
+    const firstRequest = recorder.mock.calls[0]![0];
+    await waitFor(async () => {
+      const entries = await outbox.list();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        sourceKind: "direct_entry",
+        status: "retryable_failure",
+        failure: {
+          code: "gesture_binding_mismatch",
+          kind: "retryable",
+        },
+      });
+      expect(entries[0]?.frozenRequest).toEqual(firstRequest);
+    });
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Co-work couldn’t record provenance for recent typing. Your capture is safe; retry provenance storage.",
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Retry provenance storage" }),
+    );
+
+    await waitFor(() => expect(recorder).toHaveBeenCalledTimes(2), {
+      timeout: 10_000,
+    });
+    expect(recorder.mock.calls[1]![0]).toEqual(firstRequest);
+    await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeNull());
+  }, 30_000);
+
+  it("retains a direct-entry target conflict until an explicit retry re-resolves it", async () => {
+    const user = userEvent.setup();
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `direct-entry-target-changed-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    const recorder = vi
+      .fn<CoworkPasteProvenanceRecorder>()
+      .mockRejectedValueOnce(
+        new CoworkHttpError({
+          code: "provenance_target_changed",
+          message: "The document target changed.",
+          retryable: true,
+          status: 409,
+        }),
+      )
+      .mockResolvedValueOnce();
+    const mounted = await mountPasteEditor(recorder, {
+      outbox,
+      activeLens: "neutral",
+      provenanceProvider: provenanceProvider(),
+    });
+
+    act(() => mounted.editor.commands.insertContentAt(1, "Test"));
+    mounted.setActiveLens("provenance");
+
+    await waitFor(() => expect(recorder).toHaveBeenCalledOnce(), {
+      timeout: 10_000,
+    });
+    const rejectedRequest = recorder.mock.calls[0]![0];
+    await waitFor(async () => {
+      const entries = await outbox.list();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        sourceKind: "direct_entry",
+        status: "stale_target",
+        failure: {
+          code: "provenance_target_changed",
+          kind: "stale_target",
+        },
+      });
+      expect(entries[0]?.frozenRequest).toEqual(rejectedRequest);
+    });
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Co-work couldn’t record provenance for recent typing. Your capture is safe; retry provenance storage.",
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Retry provenance storage" }),
+    );
+
+    await waitFor(() => expect(recorder).toHaveBeenCalledTimes(2), {
+      timeout: 10_000,
+    });
+    const retriedRequest = recorder.mock.calls[1]![0];
+    expect(retriedRequest.idempotencyKey).not.toBe(
+      rejectedRequest.idempotencyKey,
+    );
+    expect(retriedRequest).toMatchObject({
+      sourceKind: rejectedRequest.sourceKind,
+      basisKind: rejectedRequest.basisKind,
+      expectedActorRef: rejectedRequest.expectedActorRef,
+      expectedActorIdentityStatus:
+        rejectedRequest.expectedActorIdentityStatus,
+      anchor: rejectedRequest.anchor,
+      attestation: rejectedRequest.attestation,
+    });
+    await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeNull());
   }, 30_000);
 
   it("keeps actorless typing durable and records it explicitly after identity recovery", async () => {
@@ -554,6 +818,97 @@ describe("CoworkBridgeEditor paste provenance", () => {
       reopened?.unmount();
       mounted?.unmount();
       vi.unstubAllGlobals();
+    }
+  }, 30_000);
+
+  it("keeps adjacent direct-entry bursts disjoint when the capture actor changes", async () => {
+    const nextActor = {
+      kind: "human",
+      ref: "next-dashboard-user",
+      identity_status: "local_actor_ref",
+    } as const;
+    const memoryBacking = new InMemoryCoworkPasteProvenanceOutboxBackingStore();
+    let blockNextMutation = false;
+    let releaseActorRecovery!: () => void;
+    let actorRecoveryEntered!: () => void;
+    const actorRecoveryGate = new Promise<void>((resolve) => {
+      releaseActorRecovery = resolve;
+    });
+    const enteredActorRecovery = new Promise<void>((resolve) => {
+      actorRecoveryEntered = resolve;
+    });
+    const gatedBacking: CoworkPasteProvenanceOutboxBackingStore = {
+      durable: false,
+      read: (key) => memoryBacking.read(key),
+      async mutate(key, mutation) {
+        if (blockNextMutation) {
+          blockNextMutation = false;
+          actorRecoveryEntered();
+          await actorRecoveryGate;
+        }
+        return memoryBacking.mutate(key, mutation);
+      },
+    };
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `adjacent-actor-transition-${String(Date.now())}`,
+      gatedBacking,
+    );
+    const requests: CoworkPasteProvenanceRequest[] = [];
+    const mounted = await mountPasteEditor(
+      async (request) => {
+        requests.push(request);
+      },
+      {
+        outbox,
+        provenanceActor: ACTOR,
+        activeLens: "neutral",
+        provenanceProvider: provenanceProvider(),
+      },
+    );
+
+    try {
+      act(() => mounted.editor.commands.insertContentAt(1, "A"));
+      await waitFor(async () =>
+        expect((await outbox.list())[0]).toMatchObject({
+          sourceKind: "direct_entry",
+          capturedActor: ACTOR,
+          anchor: { exact: "A" },
+          status: "capturing",
+        }),
+      );
+
+      // Hold the new-actor recovery read before it can demote the old burst.
+      // The adjacent transaction now deterministically exercises the mapping
+      // boundary between two capture-time actors.
+      blockNextMutation = true;
+      mounted.setProvenanceActor(nextActor);
+      await enteredActorRecovery;
+      act(() => mounted.editor.commands.insertContentAt(2, "B"));
+      releaseActorRecovery();
+      mounted.setActiveLens("provenance");
+
+      await waitFor(() => expect(requests).toHaveLength(1), {
+        timeout: 10_000,
+      });
+      expect(requests[0]).toMatchObject({
+        sourceKind: "direct_entry",
+        expectedActorRef: nextActor.ref,
+        expectedActorIdentityStatus: nextActor.identity_status,
+        anchor: { exact: "B" },
+      });
+      await waitFor(async () => {
+        const pending = await outbox.list();
+        expect(pending).toHaveLength(1);
+        expect(pending[0]).toMatchObject({
+          sourceKind: "legacy",
+          anchor: { exact: "A" },
+          status: "awaiting_determination",
+          requiresExplicitDetermination: true,
+        });
+      });
+    } finally {
+      releaseActorRecovery();
+      mounted.unmount();
     }
   }, 30_000);
 
@@ -1499,6 +1854,10 @@ describe("CoworkBridgeEditor paste provenance", () => {
       new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
     );
     let actorAttempts = 0;
+    let releaseRecoveredActor!: () => void;
+    const recoveredActorGate = new Promise<void>((resolve) => {
+      releaseRecoveredActor = resolve;
+    });
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
@@ -1530,6 +1889,7 @@ describe("CoworkBridgeEditor paste provenance", () => {
             },
           );
         }
+        await recoveredActorGate;
         return new Response(
           JSON.stringify({
             kind: "human",
@@ -1571,6 +1931,9 @@ describe("CoworkBridgeEditor paste provenance", () => {
         await refreshLocalIdentity();
       });
       await waitFor(() => expect(actorAttempts).toBe(2));
+      expect(editorSurface).toHaveAttribute("aria-readonly", "true");
+      expect(editorSurface).toHaveAttribute("contenteditable", "false");
+      releaseRecoveredActor();
       expect(
         await screen.findByRole("dialog", {
           name: "Where did this text come from?",
@@ -1579,6 +1942,7 @@ describe("CoworkBridgeEditor paste provenance", () => {
       expect(editorSurface).toHaveAttribute("aria-readonly", "false");
       expect(screen.queryByText(/Reconnect Work Buddy to edit/i)).toBeNull();
     } finally {
+      releaseRecoveredActor();
       mounted?.unmount();
       vi.unstubAllGlobals();
     }

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.tsx
@@ -346,6 +346,18 @@ function MountedBridgeEditor({
       (capture) =>
         capture.sourceKind !== undefined && capture.sourceKind !== "paste",
     );
+  const directEntryFailurePending = pasteEntries.some(
+    (entry) =>
+      entry.sourceKind === "direct_entry" &&
+      (entry.status === "retryable_failure" ||
+        entry.status === "stale_target" ||
+        entry.status === "terminal_failure"),
+  );
+  const visibleOutboxError =
+    outboxError ??
+    (directEntryFailurePending
+      ? "Co-work couldn’t record provenance for recent typing. Your capture is safe; retry provenance storage."
+      : null);
   onReadyRef.current = onReady;
   onTeardownRef.current = onTeardown;
   pasteRecorderRef.current = onRecordPasteProvenance;
@@ -521,15 +533,6 @@ function MountedBridgeEditor({
                   })),
               );
               onProvenanceActorChanged?.();
-            } else if (
-              stored?.sourceKind === "direct_entry" &&
-              (apiError.code === COWORK_PROVENANCE_TARGET_CHANGED ||
-                !apiError.retryable)
-            ) {
-              // A superseded automatic observation has no honest manual
-              // determination to ask for. Leave the text uncovered instead
-              // of creating an invisible permanent failure row.
-              await resolvedPasteProvenanceOutbox.remove(entryId);
             } else if (stored !== undefined) {
               await resolvedPasteProvenanceOutbox.markFailure(entryId, {
                 code: apiError.code,
@@ -537,13 +540,14 @@ function MountedBridgeEditor({
                 kind:
                   apiError.code === COWORK_PROVENANCE_TARGET_CHANGED
                     ? "stale_target"
-                    : apiError.retryable
+                    : stored.sourceKind === "direct_entry" ||
+                        apiError.retryable
                       ? "retryable"
                       : "terminal",
               });
               if (stored.sourceKind !== "paste") {
                 setOutboxError(
-                  "Co-work couldn’t record provenance for edited text. Retry when the connection is available.",
+                  "Co-work couldn’t record provenance for recent typing. Your capture is safe; retry provenance storage.",
                 );
               }
             }
@@ -925,8 +929,10 @@ function MountedBridgeEditor({
         for (const queued of directEntryClosingBurstsRef.current.values()) {
           const mapped: DirectEntryBurst = {
             ...queued,
-            from: transaction.mapping.map(queued.from, -1),
-            to: transaction.mapping.map(queued.to, 1),
+            // This burst is already sealed. Insertions exactly at either
+            // boundary belong to the new gesture, never to both gestures.
+            from: transaction.mapping.map(queued.from, 1),
+            to: transaction.mapping.map(queued.to, -1),
           };
           if (mapped.to <= mapped.from) {
             directEntryClosingBurstsRef.current.delete(queued.idempotencyKey);
@@ -989,8 +995,8 @@ function MountedBridgeEditor({
         const prior = directEntryBurstRef.current;
         if (prior === null) return;
         if (transaction.docChanged) {
-          const mappedFrom = transaction.mapping.map(prior.from, -1);
-          const mappedTo = transaction.mapping.map(prior.to, 1);
+          const continuingMappedFrom = transaction.mapping.map(prior.from, -1);
+          const continuingMappedTo = transaction.mapping.map(prior.to, 1);
           const previous = transactionEditor.state.selection;
           const touchesBurst =
             previous.from <= prior.to && previous.to >= prior.from;
@@ -999,7 +1005,7 @@ function MountedBridgeEditor({
             transaction.getMeta("uiEvent") !== "paste" &&
             transaction.getMeta("uiEvent") !== "drop"
           ) {
-            if (mappedTo <= mappedFrom) {
+            if (continuingMappedTo <= continuingMappedFrom) {
               directEntryBurstRef.current = null;
               void resolvedPasteProvenanceOutbox
                 .list()
@@ -1019,8 +1025,8 @@ function MountedBridgeEditor({
             }
             const nextBurst: DirectEntryBurst = {
               ...prior,
-              from: mappedFrom,
-              to: mappedTo,
+              from: continuingMappedFrom,
+              to: continuingMappedTo,
             };
             const nextCapture = directCaptureForBurst(
               nextBurst,
@@ -1039,7 +1045,9 @@ function MountedBridgeEditor({
           // the closing burst's positions and quote aligned with it before a
           // second, disjoint burst can be staged and before compaction freezes
           // both rows against that same head.
-          if (mappedTo <= mappedFrom) {
+          const sealedMappedFrom = transaction.mapping.map(prior.from, 1);
+          const sealedMappedTo = transaction.mapping.map(prior.to, -1);
+          if (sealedMappedTo <= sealedMappedFrom) {
             directEntryBurstRef.current = null;
             void resolvedPasteProvenanceOutbox
               .list()
@@ -1059,8 +1067,8 @@ function MountedBridgeEditor({
           }
           const mappedBurst: DirectEntryBurst = {
             ...prior,
-            from: mappedFrom,
-            to: mappedTo,
+            from: sealedMappedFrom,
+            to: sealedMappedTo,
           };
           const mappedCapture = directCaptureForBurst(
             mappedBurst,
@@ -1104,12 +1112,22 @@ function MountedBridgeEditor({
 
       const now = Date.now();
       const prior = directEntryBurstRef.current;
-      const mappedPrior =
+      const mappedPriorForExtension =
         prior === null
           ? null
           : {
               from: transaction.mapping.map(prior.from, -1),
               to: transaction.mapping.map(prior.to, 1),
+            };
+      const mappedPriorForSeal =
+        prior === null
+          ? null
+          : {
+              // Keep a displaced burst disjoint from text inserted exactly at
+              // its boundaries. A valid same-actor continuation still merges
+              // the outward mapping with `capture` below.
+              from: transaction.mapping.map(prior.from, 1),
+              to: transaction.mapping.map(prior.to, -1),
             };
       const previousSelection = transactionEditor.state.selection;
       const selectionContinuesBurst =
@@ -1120,17 +1138,17 @@ function MountedBridgeEditor({
         prior.capturedActor?.identity_status ===
           resolvedProvenanceActor?.identity_status;
       const touchesPrior =
-        mappedPrior !== null &&
-        capture.range.from <= mappedPrior.to &&
-        capture.range.to >= mappedPrior.from;
+        mappedPriorForExtension !== null &&
+        capture.range.from <= mappedPriorForExtension.to &&
+        capture.range.to >= mappedPriorForExtension.from;
       const mergedFrom =
-        mappedPrior === null
+        mappedPriorForExtension === null
           ? capture.range.from
-          : Math.min(mappedPrior.from, capture.range.from);
+          : Math.min(mappedPriorForExtension.from, capture.range.from);
       const mergedTo =
-        mappedPrior === null
+        mappedPriorForExtension === null
           ? capture.range.to
-          : Math.max(mappedPrior.to, capture.range.to);
+          : Math.max(mappedPriorForExtension.to, capture.range.to);
       const safeTo = Math.max(mergedFrom, mergedTo - 1);
       const sameTextblock = (() => {
         try {
@@ -1149,8 +1167,8 @@ function MountedBridgeEditor({
       if (prior !== null && !canExtend) {
         const displacedBurst: DirectEntryBurst = {
           ...prior,
-          from: mappedPrior!.from,
-          to: mappedPrior!.to,
+          from: mappedPriorForSeal!.from,
+          to: mappedPriorForSeal!.to,
         };
         const displacedCapture = directCaptureForBurst(
           displacedBurst,
@@ -1576,6 +1594,22 @@ function MountedBridgeEditor({
     }
     setOutboxError(null);
     for (const entry of entries) {
+      if (
+        entry.sourceKind === "direct_entry" &&
+        (entry.status === "stale_target" ||
+          entry.status === "terminal_failure")
+      ) {
+        // The server explicitly rejected the frozen target, so this visible
+        // user retry starts a new attempt: resolve the captured quote against
+        // the current document, compact a fresh head, and freeze a new key.
+        await resolvedPasteProvenanceOutbox.retarget(
+          entry.id,
+          pasteIdempotencyKey(),
+          entry.determination,
+        );
+        await attemptPasteProvenance(entry.id);
+        continue;
+      }
       if (entry.status === "ready" || entry.status === "retryable_failure") {
         await attemptPasteProvenance(entry.id);
       }
@@ -1757,9 +1791,9 @@ function MountedBridgeEditor({
           </Button>
         </InlineAlert>
       ) : null}
-      {outboxError !== null ? (
+      {visibleOutboxError !== null ? (
         <InlineAlert tone="danger" role="alert">
-          <span>{outboxError}</span>
+          <span>{visibleOutboxError}</span>
           <Button
             size="small"
             onClick={() =>
@@ -1968,6 +2002,13 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
   const [hydrationError, setHydrationError] = useState<string>();
   const [attempt, setAttempt] = useState(0);
   const effectiveReadOnly = props.readOnly ?? false;
+  // A writable frame cannot precede the capture-time actor lookup. Otherwise
+  // normal typing can begin actorless and be split when that initial lookup
+  // resolves. A genuine lookup failure still restores actorless editing so
+  // the durable/manual recovery contract remains available.
+  const editorReadOnly =
+    effectiveReadOnly ||
+    (provenanceEnabled && provenanceActorState === "loading");
   const persistenceReadOnly = effectiveReadOnly || hydration === undefined;
   const editorRef = useRef<Editor | null>(null);
   const editGeneration = useRef(0);
@@ -1985,8 +2026,8 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
   const [materializationState, setMaterializationState] =
     useState<CoworkMaterializationState>({ kind: "checking" });
   const materializationStateRef = useRef(materializationState);
-  const readOnlyRef = useRef(effectiveReadOnly);
-  readOnlyRef.current = effectiveReadOnly;
+  const readOnlyRef = useRef(editorReadOnly);
+  readOnlyRef.current = editorReadOnly;
 
   const actionSnapshotController = useMemo(
     () =>
@@ -2722,7 +2763,7 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
       ) : hydration !== undefined ? (
         <MountedBridgeEditor
           {...props}
-          readOnly={effectiveReadOnly}
+          readOnly={editorReadOnly}
           onReady={(context) => {
             editorRef.current = context.editor;
             actionSnapshotController?.attach(context.editor);

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.tsx
@@ -8,10 +8,8 @@ import {
 } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { Extension, type Editor } from "@tiptap/core";
-import {
-  Plugin,
-  type Transaction,
-} from "@tiptap/pm/state";
+import { Plugin, type Transaction } from "@tiptap/pm/state";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import * as Y from "yjs";
 
 import {
@@ -29,12 +27,11 @@ import { importCoworkMarkdown } from "../editor/markdownImport";
 import type { ProposalInput } from "../suggestions/types";
 import type { CoworkApiError, CoworkDriftState } from "../contracts";
 import { isLocalHumanOrigin } from "../editor/applyOrigin";
+import type { CoworkEditorLens } from "../editor/ledgerDecorations";
 import { serializeCoworkEditorMarkdown } from "../editor/serializeCoworkMarkdown";
 import { sha256Hex } from "../persistence/hashing";
 import { asCoworkApiError } from "../providers/errors";
-import {
-  HttpCoworkMaterializationClient,
-} from "../materialization/HttpCoworkMaterializationClient";
+import { HttpCoworkMaterializationClient } from "../materialization/HttpCoworkMaterializationClient";
 import { CoworkHttpClient } from "../providers/CoworkHttpClient";
 import type {
   CoworkMaterializationController,
@@ -42,7 +39,11 @@ import type {
   CoworkMaterializeReceipt,
   CoworkMaterializeRequest,
 } from "../materialization/contracts";
-import type { ProvenanceMutationBarrier } from "../provenance/view/contracts";
+import type {
+  ProvenanceMutationBarrier,
+  ProvenanceProvider,
+  ProvenanceSelectionAction,
+} from "../provenance/view/contracts";
 import type { FeedbackCapture } from "../chat";
 import {
   CoworkFeedbackAffordance,
@@ -66,6 +67,7 @@ import {
 import { CoworkWorkingTargetProjector } from "./CoworkWorkingTargetProjector";
 import {
   CoworkProvenanceDeterminationDialog,
+  CoworkProvenanceSelectionAffordance,
   COWORK_PROVENANCE_ACTOR_CHANGED,
   COWORK_PROVENANCE_EXACT_MAX_CHARS,
   COWORK_PROVENANCE_TARGET_CHANGED,
@@ -73,6 +75,7 @@ import {
   DurableCoworkPasteProvenanceOutbox,
   coworkPastePassageExcerpt,
   coworkPasteCaptureFromTransaction,
+  coworkDirectEntryCaptureFromTransaction,
   coworkPasteTransactionExceedsProvenanceLimit,
   coworkProvenanceExactWithinLimit,
   defaultCoworkProvenanceDetermination,
@@ -85,6 +88,10 @@ import {
   type CoworkProvenanceActorIdentity,
   type CoworkProvenanceDetermination,
 } from "../provenance";
+import {
+  quoteAnchorFromRange,
+  type RangeQuoteAnchor,
+} from "../feedback/feedbackAnchor";
 import {
   initializeLocalIdentity,
   refreshLocalIdentity,
@@ -121,6 +128,19 @@ export interface CoworkBridgeEditorProps {
   readonly onFeedbackCaptured?: (capture: FeedbackCapture) => void;
   /** Injectable R9 transport for the affordance, else the same-origin HTTP one. */
   readonly feedbackTransport?: CoworkFeedbackTransport;
+  /** The active view lens controls contextual selection actions. */
+  readonly activeLens?: CoworkEditorLens;
+  /** Authoritative projection used by Provenance selection actions. */
+  readonly provenanceProvider?: ProvenanceProvider;
+  /** Whether the stable Provenance rail can receive selection actions. */
+  readonly provenanceSelectionActionsActive?: boolean;
+  readonly onProvenanceSelectionAction?: (
+    action: ProvenanceSelectionAction & {
+      readonly intent: "review" | "view" | "inspect";
+    },
+  ) => void;
+  /** Pending input attribution remains true through authoritative refresh. */
+  readonly onInputProvenancePendingChange?: (pending: boolean) => void;
   /**
    * Persists authorship and human-review provenance for the exact span inserted
    * by a paste. Omitted in non-registered/demo editors that have no durable
@@ -146,7 +166,9 @@ export interface CoworkBridgeEditorProps {
     controller: CoworkMaterializationController | null,
   ) => void;
   readonly onMaterialized?: (receipt: CoworkMaterializeReceipt) => void;
-  readonly onSittingWorkspace?: (workspace: CoworkSittingWorkspace | null) => void;
+  readonly onSittingWorkspace?: (
+    workspace: CoworkSittingWorkspace | null,
+  ) => void;
   readonly onProvenanceMutationBarrier?: (
     barrier: ProvenanceMutationBarrier | null,
   ) => void;
@@ -183,6 +205,15 @@ const pasteIdempotencyKey = (): string =>
   globalThis.crypto?.randomUUID?.() ??
   `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`;
 
+interface DirectEntryBurst {
+  readonly idempotencyKey: string;
+  readonly from: number;
+  readonly to: number;
+  readonly capturedAt: string;
+  readonly determination: CoworkProvenanceDetermination;
+  readonly capturedActor?: CoworkProvenanceActorIdentity;
+}
+
 export const coworkPasteProvenanceOutboxKey = (
   storeId: string,
   documentId: string,
@@ -199,7 +230,7 @@ const terminalPasteProvenanceError = (): string =>
   "Co-work rejected this attribution. Review or correct it before starting a new save attempt.";
 
 const outboxPasteProvenanceError = (): string =>
-  "Co-work couldn’t safely store this paste attribution. The pasted text remains in the document; keep this page open and retry.";
+  "Co-work couldn’t safely store provenance for edited text. Your text remains in the document; keep this page open and retry.";
 
 const actorChangedPasteProvenanceError = (): string =>
   "The active identity changed before this attribution was saved. Confirm it again for the current person.";
@@ -225,6 +256,11 @@ function MountedBridgeEditor({
   storeId,
   onFeedbackCaptured,
   feedbackTransport,
+  activeLens,
+  provenanceProvider,
+  provenanceSelectionActionsActive,
+  onProvenanceSelectionAction,
+  onInputProvenancePendingChange,
   onRecordPasteProvenance,
   resolvedProvenanceActor,
   resolvedPasteProvenanceOutbox,
@@ -267,6 +303,20 @@ function MountedBridgeEditor({
   const onTeardownRef = useRef(onTeardown);
   const pasteRecorderRef = useRef(onRecordPasteProvenance);
   const pasteRecordTailRef = useRef<Promise<void>>(Promise.resolve());
+  const directEntryBurstRef = useRef<DirectEntryBurst | null>(null);
+  const directEntryClosingBurstsRef = useRef(
+    new Map<string, DirectEntryBurst>(),
+  );
+  const directEntryCaptureEnabledRef = useRef(false);
+  const provenanceEditGenerationRef = useRef(0);
+  const directEntryFinalizationRef = useRef<Promise<void> | null>(null);
+  const finalizeDirectEntryBurstRef = useRef<() => Promise<void>>(
+    async () => undefined,
+  );
+  const closeDirectEntryBurstRef = useRef<() => Promise<void>>(
+    async () => undefined,
+  );
+  const manualRecordEntryRef = useRef(new Map<string, number>());
   const pasteAttemptsRef = useRef(new Set<number>());
   const pasteSettlementsRef = useRef(new Set<number>());
   const pasteEditorRef = useRef<Editor | null>(null);
@@ -283,9 +333,20 @@ function MountedBridgeEditor({
   const [volatilePasteCaptures, setVolatilePasteCaptures] = useState<
     readonly CoworkPasteProvenanceCapture[]
   >([]);
+  const inputProvenancePending =
+    pasteEntries.some((entry) => entry.sourceKind !== "paste") ||
+    volatilePasteCaptures.some(
+      (capture) =>
+        capture.sourceKind !== undefined && capture.sourceKind !== "paste",
+    );
   onReadyRef.current = onReady;
   onTeardownRef.current = onTeardown;
   pasteRecorderRef.current = onRecordPasteProvenance;
+
+  useEffect(() => {
+    onInputProvenancePendingChange?.(inputProvenancePending);
+    return () => onInputProvenancePendingChange?.(false);
+  }, [inputProvenancePending, onInputProvenancePendingChange]);
 
   const refreshPasteEntries = useCallback(async (): Promise<
     readonly CoworkPasteProvenanceOutboxEntry[] | null
@@ -297,14 +358,17 @@ function MountedBridgeEditor({
       if (currentEditor === null) return null;
       const validated: CoworkPasteProvenanceOutboxEntry[] = [];
       for (const entry of listed) {
+        // An evolving direct-entry quote is not a target yet. A frozen request
+        // is an immutable exactly-once retry and the server owns its CAS.
+        if (entry.status === "capturing" || entry.frozenRequest !== undefined) {
+          validated.push(entry);
+          continue;
+        }
         const resolution = resolveCoworkPasteAnchor(
           currentEditor.state.doc,
           entry.anchor,
         );
-        if (
-          resolution.kind === "unique" ||
-          entry.status === "stale_target"
-        ) {
+        if (resolution.kind === "unique" || entry.status === "stale_target") {
           validated.push(entry);
           continue;
         }
@@ -313,10 +377,9 @@ function MountedBridgeEditor({
             await resolvedPasteProvenanceOutbox.markFailure(entry.id, {
               code:
                 resolution.kind === "ambiguous"
-                  ? "paste_anchor_ambiguous"
-                  : "paste_anchor_absent",
-              message:
-                "The captured pasted passage no longer resolves uniquely.",
+                  ? "provenance_anchor_ambiguous"
+                  : "provenance_anchor_absent",
+              message: "The captured text no longer resolves uniquely.",
               kind: "stale_target",
             }),
           );
@@ -346,44 +409,18 @@ function MountedBridgeEditor({
       pasteAttemptsRef.current.add(entryId);
       setBusyPasteIds((current) => new Set(current).add(entryId));
       const run = async (): Promise<void> => {
+        let stored: CoworkPasteProvenanceOutboxEntry | undefined;
         try {
-          const stored = (
-            await resolvedPasteProvenanceOutbox.list()
-          ).find((entry) => entry.id === entryId);
+          stored = (await resolvedPasteProvenanceOutbox.list()).find(
+            (entry) => entry.id === entryId,
+          );
           if (
             stored === undefined ||
-            (stored.status !== "ready" &&
-              stored.status !== "retryable_failure")
+            (stored.status !== "ready" && stored.status !== "retryable_failure")
           ) {
             return;
           }
 
-          // The paste transaction enters Yjs after the synchronous recovery
-          // journal. Flush that update before resolving its quote anchor: the
-          // passage and the structured head frozen below must describe the
-          // same persisted document version.
-          await Promise.resolve();
-          await persistence.flush();
-          const currentEditor = pasteEditorRef.current;
-          const anchorResolution =
-            currentEditor === null
-              ? { kind: "absent" as const }
-              : resolveCoworkPasteAnchor(
-                  currentEditor.state.doc,
-                  stored.anchor,
-                );
-          if (anchorResolution.kind !== "unique") {
-            await resolvedPasteProvenanceOutbox.markFailure(entryId, {
-              code:
-                anchorResolution.kind === "ambiguous"
-                  ? "paste_anchor_ambiguous"
-                  : "paste_anchor_absent",
-              message:
-                "The captured pasted passage no longer resolves uniquely.",
-              kind: "stale_target",
-            });
-            return;
-          }
           const recorder = pasteRecorderRef.current;
           if (
             recorder === undefined ||
@@ -391,16 +428,41 @@ function MountedBridgeEditor({
             storeId === undefined
           ) {
             throw new Error(
-              "Paste provenance is unavailable for this document.",
+              "Text provenance is unavailable for this document.",
             );
           }
 
           let request = stored.frozenRequest;
           if (request === undefined) {
-            const expectedStructuredHeadSha256 = persistence.docSha256;
+            // Only an unfrozen capture is revalidated. Once frozen, replay the
+            // exact request/key first: the server may have committed it before
+            // the browser lost the response.
+            await Promise.resolve();
+            await persistence.flush();
+            const compacted = await persistence.compact();
+            const currentEditor = pasteEditorRef.current;
+            const anchorResolution =
+              currentEditor === null
+                ? { kind: "absent" as const }
+                : resolveCoworkPasteAnchor(
+                    currentEditor.state.doc,
+                    stored.anchor,
+                  );
+            if (anchorResolution.kind !== "unique") {
+              await resolvedPasteProvenanceOutbox.markFailure(entryId, {
+                code:
+                  anchorResolution.kind === "ambiguous"
+                    ? "provenance_anchor_ambiguous"
+                    : "provenance_anchor_absent",
+                message: "The captured text no longer resolves uniquely.",
+                kind: "stale_target",
+              });
+              return;
+            }
+            const expectedStructuredHeadSha256 = compacted.structuredHeadSha256;
             if (expectedStructuredHeadSha256.length === 0) {
               throw new Error(
-                "The pasted text does not have a persisted structured head.",
+                "The edited text does not have a persisted structured head.",
               );
             }
             const frozen = await resolvedPasteProvenanceOutbox.freezeRequest(
@@ -415,35 +477,81 @@ function MountedBridgeEditor({
           }
           if (request === undefined) {
             throw new Error(
-              "Paste provenance is unavailable for this document.",
+              "Text provenance is unavailable for this document.",
             );
           }
 
           // A resolved recorder call is the confirmed server receipt boundary.
           // Until then the complete frozen request remains replayable.
           await recorder(request);
+          // Keep the immutable request until the authoritative view includes
+          // the receipt. Manual Record must not close into an empty/stale lens.
+          await provenanceProvider?.refresh();
           await resolvedPasteProvenanceOutbox.remove(entryId);
         } catch (error) {
           const apiError = asCoworkApiError(error);
           try {
             if (apiError.code === COWORK_PROVENANCE_ACTOR_CHANGED) {
+              const directEntryIds = (
+                await resolvedPasteProvenanceOutbox.list()
+              )
+                .filter((entry) => entry.sourceKind === "direct_entry")
+                .map((entry) => entry.id);
               const recoveryPrefix = pasteIdempotencyKey();
               await resolvedPasteProvenanceOutbox.resetAfterActorChange(
                 recoveryPrefix,
                 unknownCoworkProvenanceDetermination(),
               );
+              // Automatic direct-entry observation cannot be rebound to a new
+              // actor. Retire it so it neither lies nor blocks Provenance;
+              // the unchanged passage remains honestly uncovered and can be
+              // explicitly recorded as legacy. Paste/manual rows retain their
+              // explicit reconfirmation path.
+              for (const directEntryId of directEntryIds) {
+                await resolvedPasteProvenanceOutbox.remove(directEntryId);
+              }
+              const ownedManualIds = new Set(
+                manualRecordEntryRef.current.values(),
+              );
+              for (const entry of await resolvedPasteProvenanceOutbox.list()) {
+                if (
+                  entry.sourceKind === "legacy" &&
+                  entry.status === "awaiting_determination" &&
+                  !ownedManualIds.has(entry.id)
+                ) {
+                  // A rehydrated/manual request has no dialog that can
+                  // reconfirm it after an actor switch. Retire the rejected
+                  // request so it cannot invisibly block a fresh selection.
+                  await resolvedPasteProvenanceOutbox.remove(entry.id);
+                }
+              }
               setVolatilePasteCaptures((current) =>
-                current.map((capture, index) => ({
-                  ...capture,
-                  idempotencyKey: `${recoveryPrefix}:volatile:${String(index)}`,
-                  basisKind: "user_attestation",
-                  determination: unknownCoworkProvenanceDetermination(),
-                  requiresExplicitDetermination: true,
-                  status: "awaiting_determination",
-                })),
+                current
+                  // An automatic capture cannot be rebound to the new actor,
+                  // and unlike paste it has no determination UI. Leave its
+                  // text uncovered instead of manufacturing hidden legacy
+                  // work that gates the Provenance surface forever.
+                  .filter((capture) => capture.sourceKind !== "direct_entry")
+                  .map((capture, index) => ({
+                    ...capture,
+                    idempotencyKey: `${recoveryPrefix}:volatile:${String(index)}`,
+                    basisKind: "user_attestation",
+                    determination: unknownCoworkProvenanceDetermination(),
+                    requiresExplicitDetermination: true,
+                    status: "awaiting_determination",
+                  })),
               );
               onProvenanceActorChanged?.();
-            } else {
+            } else if (
+              stored?.sourceKind === "direct_entry" &&
+              (apiError.code === COWORK_PROVENANCE_TARGET_CHANGED ||
+                !apiError.retryable)
+            ) {
+              // A superseded automatic observation has no honest manual
+              // determination to ask for. Leave the text uncovered instead
+              // of creating an invisible permanent failure row.
+              await resolvedPasteProvenanceOutbox.remove(entryId);
+            } else if (stored !== undefined) {
               await resolvedPasteProvenanceOutbox.markFailure(entryId, {
                 code: apiError.code,
                 message: apiError.message,
@@ -454,6 +562,11 @@ function MountedBridgeEditor({
                       ? "retryable"
                       : "terminal",
               });
+              if (stored.sourceKind !== "paste") {
+                setOutboxError(
+                  "Co-work couldn’t record provenance for edited text. Retry when the connection is available.",
+                );
+              }
             }
           } catch {
             setOutboxError(outboxPasteProvenanceError());
@@ -479,6 +592,7 @@ function MountedBridgeEditor({
       resolvedProvenanceActor,
       resolvedPasteProvenanceOutbox,
       onProvenanceActorChanged,
+      provenanceProvider,
       storeId,
     ],
   );
@@ -513,19 +627,22 @@ function MountedBridgeEditor({
       const captureRequest = {
         anchor: capture.anchor,
         idempotencyKey: pasteIdempotencyKey(),
+        ...(resolvedProvenanceActor === undefined
+          ? {}
+          : { capturedActor: resolvedProvenanceActor }),
         capturedAt: new Date().toISOString(),
         passageExcerpt: coworkPastePassageExcerpt(capture.anchor.exact),
         ...(persistence.docSha256.length === 0
           ? {}
           : {
-              capturedBaseStructuredHeadSha256:
-                persistence.docSha256,
+              capturedBaseStructuredHeadSha256: persistence.docSha256,
             }),
       };
       if (capture.substantial || resolvedProvenanceActor === undefined) {
         const pendingCapture: CoworkPasteProvenanceCapture = {
           ...captureRequest,
           substantial: capture.substantial,
+          sourceKind: "paste",
           basisKind: "user_attestation",
           determination: unknownCoworkProvenanceDetermination(),
           ...(resolvedProvenanceActor === undefined
@@ -544,8 +661,7 @@ function MountedBridgeEditor({
             setVolatilePasteCaptures((current) => [
               ...current.filter(
                 (candidate) =>
-                  candidate.idempotencyKey !==
-                  pendingCapture.idempotencyKey,
+                  candidate.idempotencyKey !== pendingCapture.idempotencyKey,
               ),
               pendingCapture,
             ]);
@@ -559,6 +675,7 @@ function MountedBridgeEditor({
       const automaticCapture: CoworkPasteProvenanceCapture = {
         ...captureRequest,
         substantial: false,
+        sourceKind: "paste",
         basisKind: "automatic_short_text_attribution",
         determination: automatic,
         status: "ready",
@@ -577,8 +694,7 @@ function MountedBridgeEditor({
           setVolatilePasteCaptures((current) => [
             ...current.filter(
               (candidate) =>
-                candidate.idempotencyKey !==
-                automaticCapture.idempotencyKey,
+                candidate.idempotencyKey !== automaticCapture.idempotencyKey,
             ),
             automaticCapture,
           ]);
@@ -593,6 +709,561 @@ function MountedBridgeEditor({
       persistence,
       resolvedProvenanceActor,
       storeId,
+    ],
+  );
+
+  const directCaptureForBurst = useCallback(
+    (
+      burst: DirectEntryBurst,
+      editorDocument: ProseMirrorNode,
+    ): CoworkPasteProvenanceCapture | null => {
+      const anchor = quoteAnchorFromRange(editorDocument, burst.from, burst.to);
+      if (anchor === null) return null;
+      return {
+        anchor,
+        idempotencyKey: burst.idempotencyKey,
+        substantial: false,
+        sourceKind: "direct_entry",
+        basisKind: "automatic_direct_entry_attribution",
+        determination: burst.determination,
+        ...(burst.capturedActor === undefined
+          ? {}
+          : { capturedActor: burst.capturedActor }),
+        capturedAt: burst.capturedAt,
+        passageExcerpt: coworkPastePassageExcerpt(anchor.exact),
+        ...(persistence.docSha256.length === 0
+          ? {}
+          : {
+              capturedBaseStructuredHeadSha256: persistence.docSha256,
+            }),
+        status: "capturing",
+      };
+    },
+    [persistence],
+  );
+
+  const finalizeDirectEntryBurst = useCallback((): Promise<void> => {
+    if (directEntryFinalizationRef.current !== null) {
+      return directEntryFinalizationRef.current;
+    }
+    let retryForChangedGeneration = false;
+    const run = (async (): Promise<void> => {
+      if (resolvedPasteProvenanceOutbox === undefined) return;
+      const listed = await resolvedPasteProvenanceOutbox.list();
+      const closing = [...directEntryClosingBurstsRef.current.values()];
+      const current = directEntryBurstRef.current;
+      const bursts = [
+        ...closing,
+        ...(current === null ||
+        closing.some((burst) => burst.idempotencyKey === current.idempotencyKey)
+          ? []
+          : [current]),
+      ];
+      if (bursts.length === 0) return;
+
+      const generation = provenanceEditGenerationRef.current;
+      await persistence.flush();
+      const compacted = await persistence.compact();
+      if (generation !== provenanceEditGenerationRef.current) {
+        retryForChangedGeneration = true;
+        return;
+      }
+
+      for (const burst of bursts) {
+        let entry = listed.find(
+          (candidate) => candidate.idempotencyKey === burst.idempotencyKey,
+        );
+        if (entry === undefined) continue;
+
+        if (
+          burst.capturedActor === undefined ||
+          resolvedProvenanceActor === undefined ||
+          burst.capturedActor.ref !== resolvedProvenanceActor.ref ||
+          burst.capturedActor.identity_status !==
+            resolvedProvenanceActor.identity_status
+        ) {
+          // Automatic attribution cannot honestly survive a missing/changed
+          // actor. Retire the hidden automatic row; existing text can be
+          // recorded explicitly as legacy from Provenance.
+          if (entry.status === "capturing") {
+            await resolvedPasteProvenanceOutbox.cancelCapture(entry.id);
+          } else {
+            await resolvedPasteProvenanceOutbox.remove(entry.id);
+          }
+          directEntryClosingBurstsRef.current.delete(burst.idempotencyKey);
+          if (
+            directEntryBurstRef.current?.idempotencyKey === burst.idempotencyKey
+          ) {
+            directEntryBurstRef.current = null;
+          }
+          continue;
+        }
+
+        if (entry.status === "capturing") {
+          entry = await resolvedPasteProvenanceOutbox.markReady(
+            entry.id,
+            entry.determination,
+            "automatic_direct_entry_attribution",
+          );
+          entry = await resolvedPasteProvenanceOutbox.freezeRequest(entry.id, {
+            storeId: storeId!,
+            documentId: documentId!,
+            expectedStructuredHeadSha256: compacted.structuredHeadSha256,
+          });
+          if (generation !== provenanceEditGenerationRef.current) {
+            const currentEditor = pasteEditorRef.current;
+            const latestBurst =
+              directEntryClosingBurstsRef.current.get(burst.idempotencyKey) ??
+              (directEntryBurstRef.current?.idempotencyKey ===
+              burst.idempotencyKey
+                ? directEntryBurstRef.current
+                : burst);
+            const latestCapture =
+              currentEditor === null
+                ? null
+                : directCaptureForBurst(latestBurst, currentEditor.state.doc);
+            if (latestCapture !== null) {
+              await resolvedPasteProvenanceOutbox.reopenCapture(
+                entry.id,
+                latestCapture,
+              );
+              retryForChangedGeneration = true;
+            }
+            return;
+          }
+        }
+
+        directEntryClosingBurstsRef.current.delete(burst.idempotencyKey);
+        if (
+          directEntryBurstRef.current?.idempotencyKey === burst.idempotencyKey
+        ) {
+          directEntryBurstRef.current = null;
+        }
+        await attemptPasteProvenance(entry.id);
+      }
+      await refreshPasteEntries();
+    })()
+      .catch(() => {
+        // The mutable burst and synchronous intent remain available for a
+        // same-mount retry; fire-and-forget lifecycle callers never leak an
+        // unhandled rejection.
+        setOutboxError(outboxPasteProvenanceError());
+      })
+      .finally(() => {
+        directEntryFinalizationRef.current = null;
+        if (
+          retryForChangedGeneration &&
+          (directEntryBurstRef.current !== null ||
+            directEntryClosingBurstsRef.current.size > 0)
+        ) {
+          queueMicrotask(() => {
+            void finalizeDirectEntryBurstRef.current();
+          });
+        }
+      });
+    directEntryFinalizationRef.current = run;
+    return run;
+  }, [
+    attemptPasteProvenance,
+    directCaptureForBurst,
+    documentId,
+    persistence,
+    refreshPasteEntries,
+    resolvedPasteProvenanceOutbox,
+    resolvedProvenanceActor,
+    storeId,
+  ]);
+  finalizeDirectEntryBurstRef.current = finalizeDirectEntryBurst;
+
+  const closeDirectEntryBurst = useCallback((): Promise<void> => {
+    const burst = directEntryBurstRef.current;
+    if (burst !== null) {
+      directEntryClosingBurstsRef.current.set(burst.idempotencyKey, burst);
+      directEntryBurstRef.current = null;
+    }
+    return finalizeDirectEntryBurst();
+  }, [finalizeDirectEntryBurst]);
+  closeDirectEntryBurstRef.current = closeDirectEntryBurst;
+
+  const stageDirectEntryProvenanceBeforeTransaction = useCallback(
+    ({
+      editor: transactionEditor,
+      transaction,
+    }: {
+      readonly editor: Editor;
+      readonly transaction: Transaction;
+    }): void => {
+      if (
+        !directEntryCaptureEnabledRef.current ||
+        pasteRecorderRef.current === undefined ||
+        documentId === undefined ||
+        storeId === undefined ||
+        resolvedPasteProvenanceOutbox === undefined
+      ) {
+        return;
+      }
+      pasteEditorRef.current = transactionEditor;
+      if (
+        transaction.docChanged &&
+        directEntryClosingBurstsRef.current.size > 0
+      ) {
+        for (const queued of directEntryClosingBurstsRef.current.values()) {
+          const mapped: DirectEntryBurst = {
+            ...queued,
+            from: transaction.mapping.map(queued.from, -1),
+            to: transaction.mapping.map(queued.to, 1),
+          };
+          if (mapped.to <= mapped.from) {
+            directEntryClosingBurstsRef.current.delete(queued.idempotencyKey);
+            void resolvedPasteProvenanceOutbox
+              .list()
+              .then((entries) =>
+                entries.find(
+                  (entry) => entry.idempotencyKey === queued.idempotencyKey,
+                ),
+              )
+              .then((entry) => {
+                if (entry === undefined) return undefined;
+                return entry.status === "capturing"
+                  ? resolvedPasteProvenanceOutbox.cancelCapture(entry.id)
+                  : resolvedPasteProvenanceOutbox.remove(entry.id);
+              })
+              .then(refreshPasteEntries)
+              .catch(() => setOutboxError(outboxPasteProvenanceError()));
+            continue;
+          }
+          const mappedCapture = directCaptureForBurst(mapped, transaction.doc);
+          if (mappedCapture === null) {
+            directEntryClosingBurstsRef.current.delete(queued.idempotencyKey);
+            void resolvedPasteProvenanceOutbox
+              .list()
+              .then((entries) =>
+                entries.find(
+                  (entry) => entry.idempotencyKey === queued.idempotencyKey,
+                ),
+              )
+              .then((entry) => {
+                if (entry === undefined) return undefined;
+                return entry.status === "capturing"
+                  ? resolvedPasteProvenanceOutbox.cancelCapture(entry.id)
+                  : resolvedPasteProvenanceOutbox.remove(entry.id);
+              })
+              .then(refreshPasteEntries)
+              .catch(() => setOutboxError(outboxPasteProvenanceError()));
+            continue;
+          }
+          directEntryClosingBurstsRef.current.set(
+            mapped.idempotencyKey,
+            mapped,
+          );
+          // upsertCapture stages the post-transaction quote synchronously. If
+          // the row was frozen a moment earlier, its durable mutation rejects;
+          // the generation guard reopens the same unsent key from this latest
+          // queued burst rather than from an obsolete loop snapshot.
+          void resolvedPasteProvenanceOutbox
+            .upsertCapture(mappedCapture)
+            .then(refreshPasteEntries)
+            .catch(() => undefined);
+        }
+      }
+      const capture = coworkDirectEntryCaptureFromTransaction(
+        transaction,
+        transaction.doc,
+      );
+      if (capture === null) {
+        const prior = directEntryBurstRef.current;
+        if (prior === null) return;
+        if (transaction.docChanged) {
+          const mappedFrom = transaction.mapping.map(prior.from, -1);
+          const mappedTo = transaction.mapping.map(prior.to, 1);
+          const previous = transactionEditor.state.selection;
+          const touchesBurst =
+            previous.from <= prior.to && previous.to >= prior.from;
+          if (
+            touchesBurst &&
+            transaction.getMeta("uiEvent") !== "paste" &&
+            transaction.getMeta("uiEvent") !== "drop"
+          ) {
+            if (mappedTo <= mappedFrom) {
+              directEntryBurstRef.current = null;
+              void resolvedPasteProvenanceOutbox
+                .list()
+                .then((entries) =>
+                  entries.find(
+                    (entry) => entry.idempotencyKey === prior.idempotencyKey,
+                  ),
+                )
+                .then((entry) =>
+                  entry === undefined
+                    ? undefined
+                    : resolvedPasteProvenanceOutbox.cancelCapture(entry.id),
+                )
+                .then(refreshPasteEntries)
+                .catch(() => setOutboxError(outboxPasteProvenanceError()));
+              return;
+            }
+            const nextBurst: DirectEntryBurst = {
+              ...prior,
+              from: mappedFrom,
+              to: mappedTo,
+            };
+            const nextCapture = directCaptureForBurst(
+              nextBurst,
+              transaction.doc,
+            );
+            if (nextCapture !== null) {
+              directEntryBurstRef.current = nextBurst;
+              void resolvedPasteProvenanceOutbox
+                .upsertCapture(nextCapture)
+                .then(refreshPasteEntries)
+                .catch(() => setOutboxError(outboxPasteProvenanceError()));
+              return;
+            }
+          }
+          // The transaction document is already the post-edit document. Keep
+          // the closing burst's positions and quote aligned with it before a
+          // second, disjoint burst can be staged and before compaction freezes
+          // both rows against that same head.
+          if (mappedTo <= mappedFrom) {
+            directEntryBurstRef.current = null;
+            void resolvedPasteProvenanceOutbox
+              .list()
+              .then((entries) =>
+                entries.find(
+                  (entry) => entry.idempotencyKey === prior.idempotencyKey,
+                ),
+              )
+              .then((entry) =>
+                entry === undefined
+                  ? undefined
+                  : resolvedPasteProvenanceOutbox.cancelCapture(entry.id),
+              )
+              .then(refreshPasteEntries)
+              .catch(() => setOutboxError(outboxPasteProvenanceError()));
+            return;
+          }
+          const mappedBurst: DirectEntryBurst = {
+            ...prior,
+            from: mappedFrom,
+            to: mappedTo,
+          };
+          const mappedCapture = directCaptureForBurst(
+            mappedBurst,
+            transaction.doc,
+          );
+          if (mappedCapture === null) {
+            directEntryBurstRef.current = null;
+            void resolvedPasteProvenanceOutbox
+              .list()
+              .then((entries) =>
+                entries.find(
+                  (entry) => entry.idempotencyKey === prior.idempotencyKey,
+                ),
+              )
+              .then((entry) =>
+                entry === undefined
+                  ? undefined
+                  : resolvedPasteProvenanceOutbox.cancelCapture(entry.id),
+              )
+              .then(refreshPasteEntries)
+              .catch(() => setOutboxError(outboxPasteProvenanceError()));
+            return;
+          }
+          directEntryBurstRef.current = mappedBurst;
+          void resolvedPasteProvenanceOutbox
+            .upsertCapture(mappedCapture)
+            .then(refreshPasteEntries)
+            .catch(() => setOutboxError(outboxPasteProvenanceError()));
+          void closeDirectEntryBurstRef.current();
+          return;
+        }
+        if (
+          transaction.selectionSet &&
+          (!transaction.selection.empty ||
+            transaction.selection.head !== prior.to)
+        ) {
+          void closeDirectEntryBurstRef.current();
+        }
+        return;
+      }
+
+      const now = Date.now();
+      const prior = directEntryBurstRef.current;
+      const mappedPrior =
+        prior === null
+          ? null
+          : {
+              from: transaction.mapping.map(prior.from, -1),
+              to: transaction.mapping.map(prior.to, 1),
+            };
+      const previousSelection = transactionEditor.state.selection;
+      const selectionContinuesBurst =
+        prior !== null &&
+        previousSelection.empty &&
+        previousSelection.head === prior.to &&
+        prior.capturedActor?.ref === resolvedProvenanceActor?.ref &&
+        prior.capturedActor?.identity_status ===
+          resolvedProvenanceActor?.identity_status;
+      const touchesPrior =
+        mappedPrior !== null &&
+        capture.range.from <= mappedPrior.to &&
+        capture.range.to >= mappedPrior.from;
+      const mergedFrom =
+        mappedPrior === null
+          ? capture.range.from
+          : Math.min(mappedPrior.from, capture.range.from);
+      const mergedTo =
+        mappedPrior === null
+          ? capture.range.to
+          : Math.max(mappedPrior.to, capture.range.to);
+      const safeTo = Math.max(mergedFrom, mergedTo - 1);
+      const sameTextblock = (() => {
+        try {
+          const start = transaction.doc.resolve(mergedFrom);
+          const end = transaction.doc.resolve(safeTo);
+          return start.sameParent(end) && start.parent.isTextblock;
+        } catch {
+          return false;
+        }
+      })();
+      const canExtend =
+        prior !== null &&
+        selectionContinuesBurst &&
+        touchesPrior &&
+        sameTextblock;
+      if (prior !== null && !canExtend) {
+        const displacedBurst: DirectEntryBurst = {
+          ...prior,
+          from: mappedPrior!.from,
+          to: mappedPrior!.to,
+        };
+        const displacedCapture = directCaptureForBurst(
+          displacedBurst,
+          transaction.doc,
+        );
+        if (displacedCapture !== null) {
+          // upsertCapture journals synchronously. The finalizer may start now,
+          // but list() will reconcile this post-transaction selector before it
+          // freezes any queued burst.
+          void resolvedPasteProvenanceOutbox
+            .upsertCapture(displacedCapture)
+            .then(refreshPasteEntries)
+            .catch(() => setOutboxError(outboxPasteProvenanceError()));
+          directEntryClosingBurstsRef.current.set(
+            displacedBurst.idempotencyKey,
+            displacedBurst,
+          );
+        } else {
+          void resolvedPasteProvenanceOutbox
+            .list()
+            .then((entries) =>
+              entries.find(
+                (entry) => entry.idempotencyKey === prior.idempotencyKey,
+              ),
+            )
+            .then((entry) =>
+              entry === undefined
+                ? undefined
+                : resolvedPasteProvenanceOutbox.cancelCapture(entry.id),
+            )
+            .then(refreshPasteEntries)
+            .catch(() => setOutboxError(outboxPasteProvenanceError()));
+        }
+        directEntryBurstRef.current = null;
+        void finalizeDirectEntryBurst();
+      }
+      const range = canExtend
+        ? { from: mergedFrom, to: mergedTo }
+        : capture.range;
+      const anchor = canExtend
+        ? quoteAnchorFromRange(transaction.doc, range.from, range.to)
+        : capture.anchor;
+      if (anchor === null) return;
+      const idempotencyKey = canExtend
+        ? prior!.idempotencyKey
+        : pasteIdempotencyKey();
+      const nextBurst: DirectEntryBurst = {
+        idempotencyKey,
+        from: range.from,
+        to: range.to,
+        capturedAt: canExtend ? prior!.capturedAt : new Date(now).toISOString(),
+        determination: canExtend
+          ? prior!.determination
+          : resolvedProvenanceActor === undefined
+            ? unknownCoworkProvenanceDetermination()
+            : defaultCoworkProvenanceDetermination(resolvedProvenanceActor),
+        ...(canExtend
+          ? prior!.capturedActor === undefined
+            ? {}
+            : { capturedActor: prior!.capturedActor }
+          : resolvedProvenanceActor === undefined
+            ? {}
+            : { capturedActor: resolvedProvenanceActor }),
+      };
+      directEntryBurstRef.current = nextBurst;
+      const directCapture: CoworkPasteProvenanceCapture = {
+        anchor,
+        idempotencyKey,
+        substantial: false,
+        sourceKind: "direct_entry",
+        basisKind: "automatic_direct_entry_attribution",
+        determination: nextBurst.determination,
+        ...(nextBurst.capturedActor === undefined
+          ? {}
+          : { capturedActor: nextBurst.capturedActor }),
+        capturedAt: nextBurst.capturedAt,
+        passageExcerpt: coworkPastePassageExcerpt(anchor.exact),
+        ...(persistence.docSha256.length === 0
+          ? {}
+          : {
+              capturedBaseStructuredHeadSha256: persistence.docSha256,
+            }),
+        status: "capturing",
+      };
+      // upsertCapture synchronously replaces the recovery-journal record before
+      // returning its promise. Focused contiguous typing stays mutable across
+      // idle pauses; blur, navigation, selection movement, or recovery closes it.
+      void resolvedPasteProvenanceOutbox
+        .upsertCapture(directCapture)
+        .then(refreshPasteEntries)
+        .catch(() => {
+          setVolatilePasteCaptures((current) => [
+            ...current.filter(
+              (candidate) => candidate.idempotencyKey !== idempotencyKey,
+            ),
+            directCapture,
+          ]);
+          setOutboxError(outboxPasteProvenanceError());
+        });
+    },
+    [
+      documentId,
+      persistence,
+      refreshPasteEntries,
+      resolvedPasteProvenanceOutbox,
+      resolvedProvenanceActor,
+      storeId,
+      directCaptureForBurst,
+    ],
+  );
+
+  const stageProvenanceBeforeTransaction = useCallback(
+    (context: {
+      readonly editor: Editor;
+      readonly transaction: Transaction;
+    }) => {
+      if (
+        directEntryCaptureEnabledRef.current &&
+        context.transaction.docChanged
+      ) {
+        provenanceEditGenerationRef.current += 1;
+      }
+      stageDirectEntryProvenanceBeforeTransaction(context);
+      stagePasteProvenanceBeforeTransaction(context);
+    },
+    [
+      stageDirectEntryProvenanceBeforeTransaction,
+      stagePasteProvenanceBeforeTransaction,
     ],
   );
 
@@ -619,26 +1290,22 @@ function MountedBridgeEditor({
     // Tiptap exposes beforeTransaction as an editor event (not a constructor
     // option). Attach before the first writable paint; it fires before
     // EditorView.updateState, so the synchronous recovery journal is durable
-    // before y-prosemirror can publish the paste.
-    editor.on(
-      "beforeTransaction",
-      stagePasteProvenanceBeforeTransaction,
-    );
+    // before y-prosemirror can publish the inserted text.
+    editor.on("beforeTransaction", stageProvenanceBeforeTransaction);
     return () => {
-      editor.off(
-        "beforeTransaction",
-        stagePasteProvenanceBeforeTransaction,
-      );
+      editor.off("beforeTransaction", stageProvenanceBeforeTransaction);
     };
-  }, [editor, stagePasteProvenanceBeforeTransaction]);
+  }, [editor, stageProvenanceBeforeTransaction]);
 
-  const dismissedPasteEntries = pasteEntries.filter((entry) =>
-    dismissedPasteIds.has(entry.id),
+  const dismissedPasteEntries = pasteEntries.filter(
+    (entry) => entry.sourceKind === "paste" && dismissedPasteIds.has(entry.id),
   );
   const visiblePasteEntry =
     pasteEntries.find(
       (entry) =>
         !dismissedPasteIds.has(entry.id) &&
+        entry.sourceKind === "paste" &&
+        entry.status !== "capturing" &&
         (entry.substantial || entry.status !== "ready"),
     ) ?? null;
   const visiblePasteActorChanged =
@@ -718,6 +1385,7 @@ function MountedBridgeEditor({
             entry.id,
             determination,
             entry.basisKind,
+            resolvedProvenanceActor,
           );
         }
         await refreshPasteEntries();
@@ -739,6 +1407,7 @@ function MountedBridgeEditor({
       attemptPasteProvenance,
       refreshPasteEntries,
       resolvedPasteProvenanceOutbox,
+      resolvedProvenanceActor,
     ],
   );
 
@@ -747,16 +1416,56 @@ function MountedBridgeEditor({
     if (resolvedPasteProvenanceOutbox === undefined || editor === null) return;
     pasteEditorRef.current = editor;
     void refreshPasteEntries()
-      .then((entries) => {
+      .then(async (entries) => {
         if (!active || entries === null) return;
-        // "ready" means a determination was already made but the browser
-        // stopped before receipt. Attempt performs a second strict anchor
-        // resolution immediately before network egress.
+        // Recover an open typing burst exactly as captured. Capture-time actor
+        // and determination are immutable; a newly available identity never
+        // gets substituted for the author observed before the restart.
         for (const entry of entries) {
-          if (entry.status === "ready") {
-            void attemptPasteProvenance(entry.id);
+          if (
+            entry.sourceKind === "legacy" &&
+            (entry.status === "awaiting_determination" ||
+              entry.status === "stale_target" ||
+              entry.status === "terminal_failure") &&
+            ![...manualRecordEntryRef.current.values()].includes(entry.id)
+          ) {
+            // Selection dialogs are intentionally in-memory. After a reload
+            // no owner exists to reconfirm a rejected manual request, so do
+            // not leave it as an invisible permanent pending gate. The user
+            // can select the still-uncovered text and record a fresh request.
+            await resolvedPasteProvenanceOutbox.remove(entry.id);
+            continue;
+          }
+          if (
+            entry.status === "capturing" &&
+            entry.sourceKind === "direct_entry"
+          ) {
+            const resolution = resolveCoworkPasteAnchor(
+              editor.state.doc,
+              entry.anchor,
+            );
+            if (resolution.kind !== "unique") continue;
+            directEntryBurstRef.current = {
+              idempotencyKey: entry.idempotencyKey,
+              from: resolution.from,
+              to: resolution.to,
+              capturedAt: entry.capturedAt,
+              determination: entry.determination,
+              ...(entry.capturedActor === undefined
+                ? {}
+                : { capturedActor: entry.capturedActor }),
+            };
+            if (active) await finalizeDirectEntryBurstRef.current();
+            continue;
+          }
+          if (
+            entry.status === "ready" ||
+            entry.status === "retryable_failure"
+          ) {
+            await attemptPasteProvenance(entry.id);
           }
         }
+        if (active) await refreshPasteEntries();
       })
       .catch(() => {
         if (active) setOutboxError(outboxPasteProvenanceError());
@@ -768,6 +1477,7 @@ function MountedBridgeEditor({
     attemptPasteProvenance,
     editor,
     refreshPasteEntries,
+    resolvedProvenanceActor,
     resolvedPasteProvenanceOutbox,
   ]);
 
@@ -782,6 +1492,7 @@ function MountedBridgeEditor({
   useEffect(() => {
     if (editor === null || boundRef.current) return;
     boundRef.current = true;
+    directEntryCaptureEnabledRef.current = false;
     pasteEditorRef.current = editor;
     // Persistence starts before seeding so a brand-new document's seed is
     // pushed through R4 as its first human-origin update (SP-2 load-order).
@@ -790,11 +1501,33 @@ function MountedBridgeEditor({
       editor.commands.setContent(seedContent);
     }
     stopCapturingLoadTimeIds(editor);
+    directEntryCaptureEnabledRef.current = true;
     onReadyRef.current?.({ editor, dom: editor.view.dom as HTMLElement });
   }, [editor, persistence, seedContent, seedWhenEmpty]);
 
   useEffect(() => {
+    if (editor === null) return;
+    const finishBurst = (): void => {
+      void closeDirectEntryBurst();
+    };
+    editor.view.dom.addEventListener("blur", finishBurst);
     return () => {
+      editor.view.dom.removeEventListener("blur", finishBurst);
+    };
+  }, [closeDirectEntryBurst, editor]);
+
+  useEffect(() => {
+    if (activeLens === "provenance") {
+      void closeDirectEntryBurst();
+    }
+  }, [activeLens, closeDirectEntryBurst]);
+
+  useEffect(() => {
+    return () => {
+      directEntryCaptureEnabledRef.current = false;
+      // Do not start network work after the editor disappears. The latest
+      // mutable burst is already in both the synchronous recovery journal and
+      // durable outbox; the next mount closes it against a live editor/head.
       pasteEditorRef.current = null;
       onTeardownRef.current?.();
     };
@@ -809,7 +1542,11 @@ function MountedBridgeEditor({
         continue;
       }
       try {
-        await resolvedPasteProvenanceOutbox.append(capture);
+        if (capture.status === "capturing") {
+          await resolvedPasteProvenanceOutbox.upsertCapture(capture);
+        } else {
+          await resolvedPasteProvenanceOutbox.append(capture);
+        }
       } catch {
         failed.push(capture);
       }
@@ -822,7 +1559,7 @@ function MountedBridgeEditor({
     }
     setOutboxError(null);
     for (const entry of entries) {
-      if (entry.status === "ready") {
+      if (entry.status === "ready" || entry.status === "retryable_failure") {
         await attemptPasteProvenance(entry.id);
       }
     }
@@ -833,16 +1570,149 @@ function MountedBridgeEditor({
     volatilePasteCaptures,
   ]);
 
+  const recordSelectedProvenance = useCallback(
+    async (
+      anchor: RangeQuoteAnchor,
+      determination: CoworkProvenanceDetermination,
+    ): Promise<void> => {
+      if (
+        resolvedPasteProvenanceOutbox === undefined ||
+        resolvedProvenanceActor === undefined
+      ) {
+        throw new Error("Provenance recording is not ready yet.");
+      }
+      if (!coworkProvenanceExactWithinLimit(anchor.exact)) {
+        throw new Error("The selected passage is too large to record at once.");
+      }
+      await closeDirectEntryBurst();
+      const manualKey = JSON.stringify(anchor);
+      let entries = await resolvedPasteProvenanceOutbox.list();
+      const existingId = manualRecordEntryRef.current.get(manualKey);
+      let entry =
+        existingId === undefined
+          ? undefined
+          : entries.find((candidate) => candidate.id === existingId);
+      if (existingId !== undefined && entry === undefined) {
+        manualRecordEntryRef.current.delete(manualKey);
+      }
+
+      if (
+        entry?.sourceKind === "legacy" &&
+        entry.frozenRequest !== undefined &&
+        JSON.stringify(entry.frozenRequest.attestation) !==
+          JSON.stringify(determination)
+      ) {
+        throw new Error(
+          "This pending request is already frozen. Retry using the provenance choice you previously confirmed; changing it requires a new selection after the pending request is resolved.",
+        );
+      }
+
+      if (entry === undefined) {
+        if (entries.some((candidate) => candidate.sourceKind !== "paste")) {
+          throw new Error(
+            "Recording recent typing. Try again when provenance finishes refreshing.",
+          );
+        }
+        const refreshed = await provenanceProvider?.refresh();
+        const currentEditor = pasteEditorRef.current;
+        if (refreshed?.state === "ready" && currentEditor !== null) {
+          const selected = resolveCoworkPasteAnchor(
+            currentEditor.state.doc,
+            anchor,
+          );
+          const overlapsRecordedTarget =
+            selected.kind === "unique" &&
+            (refreshed.data.documentDefault?.target.currentness === "current" ||
+              refreshed.data.spans.some((target) => {
+                if (target.span === null) return false;
+                const resolved = resolveCoworkPasteAnchor(
+                  currentEditor.state.doc,
+                  target.span,
+                );
+                return (
+                  resolved.kind === "unique" &&
+                  resolved.from < selected.to &&
+                  resolved.to > selected.from
+                );
+              }));
+          if (overlapsRecordedTarget) {
+            throw new Error(
+              "Provenance was already recorded for this selection. Refresh the selection to inspect it.",
+            );
+          }
+        }
+        entry = await resolvedPasteProvenanceOutbox.append({
+          anchor,
+          idempotencyKey: pasteIdempotencyKey(),
+          substantial: false,
+          capturedActor: resolvedProvenanceActor,
+          sourceKind: "legacy",
+          basisKind: "user_attestation",
+          determination,
+          capturedAt: new Date().toISOString(),
+          passageExcerpt: coworkPastePassageExcerpt(anchor.exact),
+          ...(persistence.docSha256.length === 0
+            ? {}
+            : {
+                capturedBaseStructuredHeadSha256: persistence.docSha256,
+              }),
+          status: "ready",
+        });
+        manualRecordEntryRef.current.set(manualKey, entry.id);
+      } else if (
+        (entry.status === "stale_target" ||
+          entry.status === "terminal_failure") &&
+        entry.failure?.code === COWORK_PROVENANCE_TARGET_CHANGED
+      ) {
+        entry = await resolvedPasteProvenanceOutbox.retarget(
+          entry.id,
+          pasteIdempotencyKey(),
+          determination,
+        );
+      } else if (
+        entry.status === "awaiting_determination" &&
+        entry.sourceKind === "legacy"
+      ) {
+        await resolvedPasteProvenanceOutbox.updateDetermination(
+          entry.id,
+          determination,
+        );
+        entry = await resolvedPasteProvenanceOutbox.markReady(
+          entry.id,
+          determination,
+          "user_attestation",
+          resolvedProvenanceActor,
+        );
+      }
+      await refreshPasteEntries();
+      await attemptPasteProvenance(entry.id);
+      entries = await resolvedPasteProvenanceOutbox.list();
+      const pending = entries.find((candidate) => candidate.id === entry.id);
+      if (pending !== undefined) {
+        throw new Error(
+          pending.failure?.message ?? "Provenance could not be recorded.",
+        );
+      }
+      manualRecordEntryRef.current.delete(manualKey);
+    },
+    [
+      attemptPasteProvenance,
+      closeDirectEntryBurst,
+      persistence,
+      provenanceProvider,
+      refreshPasteEntries,
+      resolvedPasteProvenanceOutbox,
+      resolvedProvenanceActor,
+    ],
+  );
+
   return (
     <>
       <EditorContent editor={editor} className="wb-cowork-editor__content" />
       {oversizedPasteBlocked ? (
         <InlineAlert tone="warning" role="alert">
           <span>{oversizedPasteProvenanceError()}</span>
-          <Button
-            size="small"
-            onClick={() => setOversizedPasteBlocked(false)}
-          >
+          <Button size="small" onClick={() => setOversizedPasteBlocked(false)}>
             Dismiss
           </Button>
         </InlineAlert>
@@ -852,11 +1722,13 @@ function MountedBridgeEditor({
           <span>{outboxError}</span>
           <Button
             size="small"
-            onClick={() => void retryPasteOutbox().catch(() => {
-              setOutboxError(outboxPasteProvenanceError());
-            })}
+            onClick={() =>
+              void retryPasteOutbox().catch(() => {
+                setOutboxError(outboxPasteProvenanceError());
+              })
+            }
           >
-            Retry attribution storage
+            Retry provenance storage
           </Button>
         </InlineAlert>
       ) : null}
@@ -864,7 +1736,10 @@ function MountedBridgeEditor({
         <InlineAlert tone="info" role="status">
           <span>
             {String(dismissedPasteEntries.length)} paste{" "}
-            {dismissedPasteEntries.length === 1 ? "attribution is" : "attributions are"} waiting.
+            {dismissedPasteEntries.length === 1
+              ? "attribution is"
+              : "attributions are"}{" "}
+            waiting.
           </span>
           <Button
             size="small"
@@ -881,7 +1756,11 @@ function MountedBridgeEditor({
           </Button>
         </InlineAlert>
       ) : null}
-      {editor !== null && !readOnly && onFeedbackCaptured !== undefined && documentId !== undefined ? (
+      {editor !== null &&
+      activeLens !== "provenance" &&
+      !readOnly &&
+      onFeedbackCaptured !== undefined &&
+      documentId !== undefined ? (
         <CoworkFeedbackAffordance
           editor={editor}
           documentId={documentId}
@@ -890,8 +1769,23 @@ function MountedBridgeEditor({
           transport={feedbackTransport}
         />
       ) : null}
-      {visiblePasteEntry !== null &&
-      resolvedProvenanceActor !== undefined ? (
+      {editor !== null &&
+      activeLens === "provenance" &&
+      provenanceProvider !== undefined &&
+      resolvedProvenanceActor !== undefined &&
+      onProvenanceSelectionAction !== undefined ? (
+        <CoworkProvenanceSelectionAffordance
+          editor={editor}
+          active={provenanceSelectionActionsActive ?? true}
+          provider={provenanceProvider}
+          currentUserIdentity={resolvedProvenanceActor}
+          readOnly={readOnly}
+          inputProvenancePending={inputProvenancePending}
+          onRecord={recordSelectedProvenance}
+          onAction={onProvenanceSelectionAction}
+        />
+      ) : null}
+      {visiblePasteEntry !== null && resolvedProvenanceActor !== undefined ? (
         <CoworkProvenanceDeterminationDialog
           key={`${String(visiblePasteEntry.id)}:${resolvedProvenanceActor.identity_status}:${resolvedProvenanceActor.ref}`}
           value={visiblePasteEntry.determination}
@@ -940,9 +1834,7 @@ function MountedBridgeEditor({
           onChange={(value) =>
             updatePasteDetermination(visiblePasteEntry, value)
           }
-          onConfirm={(value) =>
-            settlePasteEntry(visiblePasteEntry, value)
-          }
+          onConfirm={(value) => settlePasteEntry(visiblePasteEntry, value)}
           onClose={() => {
             if (
               visiblePasteRequiresExplicitDetermination ||
@@ -1024,10 +1916,7 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
       return undefined;
     }
     return new DurableCoworkPasteProvenanceOutbox(
-      coworkPasteProvenanceOutboxKey(
-        props.storeId,
-        props.documentId,
-      ),
+      coworkPasteProvenanceOutboxKey(props.storeId, props.documentId),
     );
   }, [
     props.documentId,
@@ -1113,7 +2002,8 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
     }
     void persistence.setReadOnly(readOnly).then(
       () => {
-        if (!readOnly && !readOnlyRef.current) editorRef.current?.setEditable(true);
+        if (!readOnly && !readOnlyRef.current)
+          editorRef.current?.setEditable(true);
       },
       () => undefined,
     );
@@ -1174,7 +2064,8 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
           fileSha256: null,
           error: {
             code: "file_hash_unavailable",
-            message: "Co-work could not verify the current Markdown file, so Save is disabled.",
+            message:
+              "Co-work could not verify the current Markdown file, so Save is disabled.",
             retryable: false,
           },
           canRetry: false,
@@ -1183,10 +2074,13 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
       }
       const checkedGeneration = editGeneration.current;
       const rendered = serializeCoworkEditorMarkdown(editor, props.document);
-      const renderedSha256 = await sha256Hex(new TextEncoder().encode(rendered));
+      const renderedSha256 = await sha256Hex(
+        new TextEncoder().encode(rendered),
+      );
       publishMaterializationState({
         kind:
-          editGeneration.current === checkedGeneration && renderedSha256 === fileSha256
+          editGeneration.current === checkedGeneration &&
+          renderedSha256 === fileSha256
             ? "up_to_date"
             : "unsaved",
         fileSha256,
@@ -1228,22 +2122,28 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
         props.onMaterialized?.(receipt);
       } catch (saveError) {
         const error = asCoworkApiError(saveError);
-        const isConflict = error.status === 409 || [
-          "snapshot_mismatch",
-          "stale_structured_head",
-          "update_tail_present",
-          "stale_file",
-          "missing_file",
-          "open_flags_block_save",
-          "external_write_race",
-          "recovery_required",
-        ].includes(error.code);
-        const canRetry = isConflict ? retryableConflict(error) : error.retryable;
+        const isConflict =
+          error.status === 409 ||
+          [
+            "snapshot_mismatch",
+            "stale_structured_head",
+            "update_tail_present",
+            "stale_file",
+            "missing_file",
+            "open_flags_block_save",
+            "external_write_race",
+            "recovery_required",
+          ].includes(error.code);
+        const canRetry = isConflict
+          ? retryableConflict(error)
+          : error.retryable;
         const canReplayExactRequest =
           !isConflict &&
           editGeneration.current === capturedGeneration &&
           (error.code === "network_error" ||
-            (error.status !== undefined && error.status >= 500 && error.retryable));
+            (error.status !== undefined &&
+              error.status >= 500 &&
+              error.retryable));
         if (!canReplayExactRequest) {
           retryAttempt.current = null;
         }
@@ -1288,15 +2188,25 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
         return;
       }
       try {
-        for (let stabilityAttempt = 0; stabilityAttempt < 2; stabilityAttempt += 1) {
+        for (
+          let stabilityAttempt = 0;
+          stabilityAttempt < 2;
+          stabilityAttempt += 1
+        ) {
           const generation = editGeneration.current;
-          if (persistence.lastError !== null || persistence.pendingBatchCount > 0) {
+          if (
+            persistence.lastError !== null ||
+            persistence.pendingBatchCount > 0
+          ) {
             await persistence.retry();
           }
           await persistence.flush();
           assertCanonicalCoworkEditorState(editor);
           const compacted = await persistence.compact();
-          const renderedMarkdown = serializeCoworkEditorMarkdown(editor, props.document);
+          const renderedMarkdown = serializeCoworkEditorMarkdown(
+            editor,
+            props.document,
+          );
           const renderedSha256 = await sha256Hex(
             new TextEncoder().encode(renderedMarkdown),
           );
@@ -1334,7 +2244,12 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
     } finally {
       saveInFlight.current = null;
     }
-  }, [persistence, props.document, publishMaterializationState, settleMaterialize]);
+  }, [
+    persistence,
+    props.document,
+    publishMaterializationState,
+    settleMaterialize,
+  ]);
 
   const retrySync = useCallback(async (): Promise<void> => {
     try {
@@ -1368,9 +2283,7 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
           return;
         }
         lastProvenanceSettlementGeneration.current = generation;
-        props.onProvenancePersistenceSettled?.(
-          receipt.structuredHeadSha256,
-        );
+        props.onProvenancePersistenceSettled?.(receipt.structuredHeadSha256);
       } catch {
         // Persistence publishes the actionable failure. Provenance remains
         // dirty until a later successful settlement and fresh R2 projection.
@@ -1419,13 +2332,18 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
         // A user edit racing the checkpoint causes a bounded recapture; Review
         // never pairs current prose with an older projection receipt.
         for (let attempt = 0; attempt < 2; attempt += 1) {
-          if (persistence.lastError !== null || persistence.pendingBatchCount > 0) {
+          if (
+            persistence.lastError !== null ||
+            persistence.pendingBatchCount > 0
+          ) {
             await persistence.retry();
           }
           await persistence.flush();
           const editor = editorRef.current;
           if (editor === null) {
-            throw new Error("The document is still loading. Try again in a moment.");
+            throw new Error(
+              "The document is still loading. Try again in a moment.",
+            );
           }
           assertCanonicalCoworkEditorState(editor);
           const generation = editGeneration.current;
@@ -1445,7 +2363,8 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
             projectionMarkdown,
             projectionSha256,
           });
-          if (receipt === null || generation !== editGeneration.current) continue;
+          if (receipt === null || generation !== editGeneration.current)
+            continue;
           return {
             expectedFileSha256: fileSha256,
             expectedStructuredHeadSha256: receipt.structuredHeadSha256,
@@ -1458,7 +2377,9 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
       },
       prepare: async (admittedItems, generation) => {
         if (editorRef.current === null) {
-          throw new Error("The document is still loading. Try again in a moment.");
+          throw new Error(
+            "The document is still loading. Try again in a moment.",
+          );
         }
         if (editGeneration.current !== generation) {
           throw new Error(
@@ -1497,9 +2418,7 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
         }
         const editor = editorRef.current;
         if (editor !== null) assertCanonicalCoworkEditorState(editor);
-        props.onProvenancePersistenceSettled?.(
-          response.structured_head_sha256,
-        );
+        props.onProvenancePersistenceSettled?.(response.structured_head_sha256);
         props.onSittingServerRefreshed?.();
       },
     }),
@@ -1518,12 +2437,17 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
       runWithSynchronizedDocument: async (operation) => {
         const liveEditor = editorRef.current;
         if (liveEditor === null) {
-          throw new Error("The document is still loading. Try again in a moment.");
+          throw new Error(
+            "The document is still loading. Try again in a moment.",
+          );
         }
         const wasEditable = liveEditor.isEditable;
         liveEditor.setEditable(false);
         try {
-          if (persistence.lastError !== null || persistence.pendingBatchCount > 0) {
+          if (
+            persistence.lastError !== null ||
+            persistence.pendingBatchCount > 0
+          ) {
             await persistence.retry();
           }
           await persistence.flush();
@@ -1560,7 +2484,11 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
     };
     props.document.on("update", onUpdate);
     return () => props.document.off("update", onUpdate);
-  }, [props.document, props.onLocalProvenanceEdit, publishMaterializationState]);
+  }, [
+    props.document,
+    props.onLocalProvenanceEdit,
+    publishMaterializationState,
+  ]);
 
   useEffect(() => {
     props.onMaterializationController?.(materializationController);
@@ -1654,10 +2582,7 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
         active = false;
       };
     }
-    if (
-      props.provenanceActor !== undefined &&
-      provenanceActorAttempt === 0
-    ) {
+    if (props.provenanceActor !== undefined && provenanceActorAttempt === 0) {
       setResolvedProvenanceActor(props.provenanceActor);
       setProvenanceActorState("ready");
       return () => {
@@ -1667,9 +2592,10 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
     setResolvedProvenanceActor(undefined);
     setProvenanceActorState("loading");
     const resolveActor = async (): Promise<CoworkProvenanceActorIdentity> => {
-      const identity = provenanceActorAttempt > 0
-        ? await refreshLocalIdentity()
-        : await initializeLocalIdentity();
+      const identity =
+        provenanceActorAttempt > 0
+          ? await refreshLocalIdentity()
+          : await initializeLocalIdentity();
       if (!identity.authenticated) {
         throw new Error(
           identity.reason ??
@@ -1723,10 +2649,17 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
   return (
     <section className="wb-cowork-editor" aria-label="Editor">
       {hydrationError !== undefined ? (
-        <InlineAlert tone="danger" role="alert" className="wb-cowork-editor__hydration-error">
+        <InlineAlert
+          tone="danger"
+          role="alert"
+          className="wb-cowork-editor__hydration-error"
+        >
           <strong>Document couldn’t be opened.</strong>
           <span>{hydrationError}</span>
-          <Button size="small" onClick={() => setAttempt((current) => current + 1)}>
+          <Button
+            size="small"
+            onClick={() => setAttempt((current) => current + 1)}
+          >
             Try again
           </Button>
         </InlineAlert>

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.tsx
@@ -334,7 +334,14 @@ function MountedBridgeEditor({
     readonly CoworkPasteProvenanceCapture[]
   >([]);
   const inputProvenancePending =
-    pasteEntries.some((entry) => entry.sourceKind !== "paste") ||
+    pasteEntries.some(
+      (entry) =>
+        entry.sourceKind === "direct_entry" ||
+        (entry.sourceKind === "legacy" &&
+          entry.status !== "awaiting_determination" &&
+          entry.status !== "stale_target" &&
+          entry.status !== "terminal_failure"),
+    ) ||
     volatilePasteCaptures.some(
       (capture) =>
         capture.sourceKind !== undefined && capture.sourceKind !== "paste",
@@ -492,50 +499,22 @@ function MountedBridgeEditor({
           const apiError = asCoworkApiError(error);
           try {
             if (apiError.code === COWORK_PROVENANCE_ACTOR_CHANGED) {
-              const directEntryIds = (
-                await resolvedPasteProvenanceOutbox.list()
-              )
-                .filter((entry) => entry.sourceKind === "direct_entry")
-                .map((entry) => entry.id);
               const recoveryPrefix = pasteIdempotencyKey();
               await resolvedPasteProvenanceOutbox.resetAfterActorChange(
                 recoveryPrefix,
                 unknownCoworkProvenanceDetermination(),
               );
-              // Automatic direct-entry observation cannot be rebound to a new
-              // actor. Retire it so it neither lies nor blocks Provenance;
-              // the unchanged passage remains honestly uncovered and can be
-              // explicitly recorded as legacy. Paste/manual rows retain their
-              // explicit reconfirmation path.
-              for (const directEntryId of directEntryIds) {
-                await resolvedPasteProvenanceOutbox.remove(directEntryId);
-              }
-              const ownedManualIds = new Set(
-                manualRecordEntryRef.current.values(),
-              );
-              for (const entry of await resolvedPasteProvenanceOutbox.list()) {
-                if (
-                  entry.sourceKind === "legacy" &&
-                  entry.status === "awaiting_determination" &&
-                  !ownedManualIds.has(entry.id)
-                ) {
-                  // A rehydrated/manual request has no dialog that can
-                  // reconfirm it after an actor switch. Retire the rejected
-                  // request so it cannot invisibly block a fresh selection.
-                  await resolvedPasteProvenanceOutbox.remove(entry.id);
-                }
-              }
               setVolatilePasteCaptures((current) =>
                 current
-                  // An automatic capture cannot be rebound to the new actor,
-                  // and unlike paste it has no determination UI. Leave its
-                  // text uncovered instead of manufacturing hidden legacy
-                  // work that gates the Provenance surface forever.
-                  .filter((capture) => capture.sourceKind !== "direct_entry")
                   .map((capture, index) => ({
                     ...capture,
                     idempotencyKey: `${recoveryPrefix}:volatile:${String(index)}`,
+                    sourceKind:
+                      capture.sourceKind === "direct_entry"
+                        ? "legacy"
+                        : capture.sourceKind,
                     basisKind: "user_attestation",
+                    capturedActor: undefined,
                     determination: unknownCoworkProvenanceDetermination(),
                     requiresExplicitDetermination: true,
                     status: "awaiting_determination",
@@ -775,20 +754,56 @@ function MountedBridgeEditor({
         );
         if (entry === undefined) continue;
 
-        if (
-          burst.capturedActor === undefined ||
-          resolvedProvenanceActor === undefined ||
-          burst.capturedActor.ref !== resolvedProvenanceActor.ref ||
-          burst.capturedActor.identity_status !==
-            resolvedProvenanceActor.identity_status
-        ) {
-          // Automatic attribution cannot honestly survive a missing/changed
-          // actor. Retire the hidden automatic row; existing text can be
-          // recorded explicitly as legacy from Provenance.
+        if (resolvedProvenanceActor === undefined) {
+          // Identity may recover from a trusted launcher without changing the
+          // editor. Preserve both actor-bound and actorless observations until
+          // that boundary can decide whether automatic attribution is honest.
+          continue;
+        }
+        const captureActorUnavailable = burst.capturedActor === undefined;
+        const captureActorChanged =
+          burst.capturedActor !== undefined &&
+          (burst.capturedActor.ref !== resolvedProvenanceActor.ref ||
+            burst.capturedActor.identity_status !==
+              resolvedProvenanceActor.identity_status);
+        if (captureActorUnavailable || captureActorChanged) {
+          // Never let an unavailable/changed actor make the observation
+          // disappear, and never let a later actor inherit it. Preserve the
+          // exact selector as an explicit legacy determination the user can
+          // resolve after a legitimate identity session is available.
           if (entry.status === "capturing") {
-            await resolvedPasteProvenanceOutbox.cancelCapture(entry.id);
-          } else {
-            await resolvedPasteProvenanceOutbox.remove(entry.id);
+            const deferred = await resolvedPasteProvenanceOutbox.deferDirectEntry(
+              entry.id,
+              // This automatic request has never been frozen or submitted, so
+              // preserving its key is both safe and important: a transaction
+              // that mapped the burst while demotion was queued may already
+              // have journalled one last capture under this key. Rotating it
+              // here would let that queued upsert append an orphan automatic
+              // row after the legacy replacement commits.
+              burst.idempotencyKey,
+              unknownCoworkProvenanceDetermination(),
+              {
+                code: captureActorUnavailable
+                  ? "provenance_actor_unavailable_at_capture"
+                  : COWORK_PROVENANCE_ACTOR_CHANGED,
+                message: captureActorUnavailable
+                  ? "No enrolled local actor was available when this text was entered."
+                  : "The acting identity changed before this attribution was saved.",
+                kind: "terminal",
+              },
+            );
+            if (
+              generation !== provenanceEditGenerationRef.current ||
+              deferred.idempotencyKey !== burst.idempotencyKey
+            ) {
+              // A disjoint edit can arrive while durable demotion yields. Keep
+              // the burst refs intact and run the full close loop again so the
+              // newly actor-bound burst is frozen and delivered at its current
+              // structured head. The same-key replacement makes the queued
+              // stale upsert reject instead of resurrecting automatic work.
+              retryForChangedGeneration = true;
+              return;
+            }
           }
           directEntryClosingBurstsRef.current.delete(burst.idempotencyKey);
           if (
@@ -1423,20 +1438,6 @@ function MountedBridgeEditor({
         // gets substituted for the author observed before the restart.
         for (const entry of entries) {
           if (
-            entry.sourceKind === "legacy" &&
-            (entry.status === "awaiting_determination" ||
-              entry.status === "stale_target" ||
-              entry.status === "terminal_failure") &&
-            ![...manualRecordEntryRef.current.values()].includes(entry.id)
-          ) {
-            // Selection dialogs are intentionally in-memory. After a reload
-            // no owner exists to reconfirm a rejected manual request, so do
-            // not leave it as an invisible permanent pending gate. The user
-            // can select the still-uncovered text and record a fresh request.
-            await resolvedPasteProvenanceOutbox.remove(entry.id);
-            continue;
-          }
-          if (
             entry.status === "capturing" &&
             entry.sourceKind === "direct_entry"
           ) {
@@ -1456,6 +1457,22 @@ function MountedBridgeEditor({
                 : { capturedActor: entry.capturedActor }),
             };
             if (active) await finalizeDirectEntryBurstRef.current();
+            if (active && resolvedProvenanceActor !== undefined) {
+              // Actor recovery can race the actorless finalizer already in
+              // flight. Re-check the durable row after that promise settles;
+              // the ref now points at the callback bound to the recovered
+              // actor, so one follow-up closes rather than stranding it.
+              const stillCapturing = (
+                await resolvedPasteProvenanceOutbox.list()
+              ).some(
+                (candidate) =>
+                  candidate.id === entry.id &&
+                  candidate.status === "capturing",
+              );
+              if (stillCapturing) {
+                await finalizeDirectEntryBurstRef.current();
+              }
+            }
             continue;
           }
           if (
@@ -1595,6 +1612,22 @@ function MountedBridgeEditor({
       if (existingId !== undefined && entry === undefined) {
         manualRecordEntryRef.current.delete(manualKey);
       }
+      if (entry === undefined) {
+        // Selection-dialog ownership is intentionally in-memory, while an
+        // actorless typing capture is durable. Reassociate the same exact
+        // selector after a reload/session recovery so explicit confirmation
+        // completes that row instead of appending an overlapping duplicate.
+        entry = entries.find(
+          (candidate) =>
+            candidate.sourceKind === "legacy" &&
+            candidate.status === "awaiting_determination" &&
+            candidate.frozenRequest === undefined &&
+            JSON.stringify(candidate.anchor) === manualKey,
+        );
+        if (entry !== undefined) {
+          manualRecordEntryRef.current.set(manualKey, entry.id);
+        }
+      }
 
       if (
         entry?.sourceKind === "legacy" &&
@@ -1608,7 +1641,14 @@ function MountedBridgeEditor({
       }
 
       if (entry === undefined) {
-        if (entries.some((candidate) => candidate.sourceKind !== "paste")) {
+        if (
+          entries.some(
+            (candidate) =>
+              candidate.sourceKind === "direct_entry" ||
+              (candidate.sourceKind === "legacy" &&
+                candidate.status !== "awaiting_determination"),
+          )
+        ) {
           throw new Error(
             "Recording recent typing. Try again when provenance finishes refreshing.",
           );
@@ -2629,11 +2669,27 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
   useEffect(
     () =>
       subscribeLocalIdentity((identity) => {
-        if (identity.authenticated && provenanceActorState === "error") {
+        if (!provenanceEnabled) return;
+        if (!identity.authenticated) {
+          // A session can expire or be replaced while the editor remains
+          // mounted. Never keep presenting its cached actor as current; direct
+          // entry remains durable and actorless until trusted recovery.
+          setResolvedProvenanceActor(undefined);
+          setProvenanceActorState("error");
+          return;
+        }
+        if (provenanceActorState !== "loading") {
+          // Authenticated publications can represent a newly delivered cookie
+          // (and potentially a different enrolled actor), so re-read the
+          // canonical actor even when the prior actor looked healthy.
           requestProvenanceActorRefresh();
         }
       }),
-    [provenanceActorState, requestProvenanceActorRefresh],
+    [
+      provenanceActorState,
+      provenanceEnabled,
+      requestProvenanceActorRefresh,
+    ],
   );
 
   useEffect(

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.tsx
@@ -1412,8 +1412,19 @@ function MountedBridgeEditor({
     setCoworkPendingProvenance(editor, pendingDirectEntryDecorations);
   }, [editor, pendingDirectEntryDecorations]);
 
-  const dismissedPasteEntries = pasteEntries.filter(
-    (entry) => entry.sourceKind === "paste" && dismissedPasteIds.has(entry.id),
+  const manualRecordEntryIds = new Set(manualRecordEntryRef.current.values());
+  const isDirectEntryRecovery = (
+    entry: CoworkPasteProvenanceOutboxEntry,
+  ): boolean =>
+    entry.sourceKind === "legacy" &&
+    entry.status === "awaiting_determination" &&
+    entry.requiresExplicitDetermination === true &&
+    entry.failure?.code === "provenance_actor_unavailable_at_capture" &&
+    !manualRecordEntryIds.has(entry.id);
+  const dismissedDeterminationEntries = pasteEntries.filter(
+    (entry) =>
+      dismissedPasteIds.has(entry.id) &&
+      (entry.sourceKind === "paste" || isDirectEntryRecovery(entry)),
   );
   const visiblePasteEntry =
     pasteEntries.find(
@@ -1422,7 +1433,14 @@ function MountedBridgeEditor({
         entry.sourceKind === "paste" &&
         entry.status !== "capturing" &&
         (entry.substantial || entry.status !== "ready"),
-    ) ?? null;
+    ) ??
+    pasteEntries.find(
+      (entry) =>
+        !dismissedPasteIds.has(entry.id) && isDirectEntryRecovery(entry),
+    ) ??
+    null;
+  const visibleDirectEntryRecovery =
+    visiblePasteEntry !== null && isDirectEntryRecovery(visiblePasteEntry);
   const visiblePasteActorChanged =
     visiblePasteEntry?.failure?.code === COWORK_PROVENANCE_ACTOR_CHANGED;
   const visiblePasteRequiresExplicitDetermination =
@@ -1886,21 +1904,22 @@ function MountedBridgeEditor({
           </Button>
         </InlineAlert>
       ) : null}
-      {dismissedPasteEntries.length > 0 && visiblePasteEntry === null ? (
+      {dismissedDeterminationEntries.length > 0 &&
+      visiblePasteEntry === null ? (
         <InlineAlert tone="info" role="status">
           <span>
-            {String(dismissedPasteEntries.length)} paste{" "}
-            {dismissedPasteEntries.length === 1
-              ? "attribution is"
-              : "attributions are"}{" "}
-            waiting.
+            {String(dismissedDeterminationEntries.length)} pending{" "}
+            {dismissedDeterminationEntries.length === 1
+              ? "attribution needs"
+              : "attributions need"}{" "}
+            your decision.
           </span>
           <Button
             size="small"
             onClick={() =>
               setDismissedPasteIds((current) => {
                 const next = new Set(current);
-                const first = dismissedPasteEntries[0]?.id;
+                const first = dismissedDeterminationEntries[0]?.id;
                 if (first !== undefined) next.delete(first);
                 return next;
               })
@@ -1944,7 +1963,15 @@ function MountedBridgeEditor({
           key={`${String(visiblePasteEntry.id)}:${resolvedProvenanceActor.identity_status}:${resolvedProvenanceActor.ref}`}
           value={visiblePasteEntry.determination}
           currentUserIdentity={resolvedProvenanceActor}
+          title={
+            visibleDirectEntryRecovery
+              ? "Recent typing needs attribution"
+              : undefined
+          }
           passageExcerpt={visiblePasteEntry.passageExcerpt}
+          passageLabel={
+            visibleDirectEntryRecovery ? "Recent passage" : undefined
+          }
           busy={busyPasteIds.has(visiblePasteEntry.id)}
           formDisabled={
             visiblePasteEntry.frozenRequest !== undefined &&
@@ -1963,12 +1990,16 @@ function MountedBridgeEditor({
                     : null
           }
           description={
-            pasteEntries.length > 1
+            visibleDirectEntryRecovery
+              ? "Choose who created this passage and, if AI contributed, whether a person reviewed it."
+              : pasteEntries.length > 1
               ? `Record its authorship and review status. ${String(pasteEntries.length - 1)} more pasted ${pasteEntries.length === 2 ? "passage is" : "passages are"} waiting.`
               : undefined
           }
           confirmLabel={
-            visiblePasteActorChanged
+            visibleDirectEntryRecovery
+              ? "Confirm attribution"
+              : visiblePasteActorChanged
               ? "Confirm attribution"
               : visiblePasteEntry.status === "stale_target"
                 ? "Save against current version"
@@ -1979,6 +2010,7 @@ function MountedBridgeEditor({
                     : undefined
           }
           cancelLabel={
+            visibleDirectEntryRecovery ||
             visiblePasteRequiresExplicitDetermination ||
             visiblePasteEntry.status === "stale_target" ||
             visiblePasteEntry.status === "terminal_failure"
@@ -1991,6 +2023,7 @@ function MountedBridgeEditor({
           onConfirm={(value) => settlePasteEntry(visiblePasteEntry, value)}
           onClose={() => {
             if (
+              visibleDirectEntryRecovery ||
               visiblePasteRequiresExplicitDetermination ||
               visiblePasteEntry.status === "stale_target" ||
               visiblePasteEntry.status === "terminal_failure"

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.tsx
@@ -27,7 +27,11 @@ import { importCoworkMarkdown } from "../editor/markdownImport";
 import type { ProposalInput } from "../suggestions/types";
 import type { CoworkApiError, CoworkDriftState } from "../contracts";
 import { isLocalHumanOrigin } from "../editor/applyOrigin";
-import type { CoworkEditorLens } from "../editor/ledgerDecorations";
+import {
+  setCoworkPendingProvenance,
+  type CoworkEditorLens,
+  type CoworkPendingProvenanceDecoration,
+} from "../editor/ledgerDecorations";
 import { serializeCoworkEditorMarkdown } from "../editor/serializeCoworkMarkdown";
 import { sha256Hex } from "../persistence/hashing";
 import { asCoworkApiError } from "../providers/errors";
@@ -333,6 +337,21 @@ function MountedBridgeEditor({
   const [volatilePasteCaptures, setVolatilePasteCaptures] = useState<
     readonly CoworkPasteProvenanceCapture[]
   >([]);
+  const pendingDirectEntryDecorations = useMemo(() => {
+    const pending = new Map<string, CoworkPendingProvenanceDecoration>();
+    for (const capture of [...pasteEntries, ...volatilePasteCaptures]) {
+      if (capture.sourceKind !== "direct_entry") continue;
+      pending.set(capture.idempotencyKey, {
+        captureId: capture.idempotencyKey,
+        quoteAnchor: capture.anchor,
+      });
+    }
+    return [...pending.values()];
+  }, [pasteEntries, volatilePasteCaptures]);
+  const pendingDirectEntryDecorationsRef = useRef(
+    pendingDirectEntryDecorations,
+  );
+  pendingDirectEntryDecorationsRef.current = pendingDirectEntryDecorations;
   const inputProvenancePending =
     pasteEntries.some(
       (entry) =>
@@ -502,10 +521,26 @@ function MountedBridgeEditor({
 
           // A resolved recorder call is the confirmed server receipt boundary.
           // Until then the complete frozen request remains replayable.
-          await recorder(request);
+          const receipt = await recorder(request);
           // Keep the immutable request until the authoritative view includes
           // the receipt. Manual Record must not close into an empty/stale lens.
-          await provenanceProvider?.refresh();
+          if (provenanceProvider !== undefined) {
+            const refreshed = await provenanceProvider.refresh();
+            if (
+              refreshed.state !== "ready" ||
+              !refreshed.data.history.some(
+                (record) =>
+                  record.attestationId === receipt.attestationId &&
+                  record.scope.documentSpanId === receipt.documentSpanId &&
+                  record.scope.structuredHeadSha256 ===
+                    receipt.targetStructuredHeadSha256,
+              )
+            ) {
+              throw new Error(
+                "Co-work saved the provenance record but could not confirm it in the current view yet.",
+              );
+            }
+          }
           await resolvedPasteProvenanceOutbox.remove(entryId);
         } catch (error) {
           const apiError = asCoworkApiError(error);
@@ -517,20 +552,19 @@ function MountedBridgeEditor({
                 unknownCoworkProvenanceDetermination(),
               );
               setVolatilePasteCaptures((current) =>
-                current
-                  .map((capture, index) => ({
-                    ...capture,
-                    idempotencyKey: `${recoveryPrefix}:volatile:${String(index)}`,
-                    sourceKind:
-                      capture.sourceKind === "direct_entry"
-                        ? "legacy"
-                        : capture.sourceKind,
-                    basisKind: "user_attestation",
-                    capturedActor: undefined,
-                    determination: unknownCoworkProvenanceDetermination(),
-                    requiresExplicitDetermination: true,
-                    status: "awaiting_determination",
-                  })),
+                current.map((capture, index) => ({
+                  ...capture,
+                  idempotencyKey: `${recoveryPrefix}:volatile:${String(index)}`,
+                  sourceKind:
+                    capture.sourceKind === "direct_entry"
+                      ? "legacy"
+                      : capture.sourceKind,
+                  basisKind: "user_attestation",
+                  capturedActor: undefined,
+                  determination: unknownCoworkProvenanceDetermination(),
+                  requiresExplicitDetermination: true,
+                  status: "awaiting_determination",
+                })),
               );
               onProvenanceActorChanged?.();
             } else if (stored !== undefined) {
@@ -540,8 +574,7 @@ function MountedBridgeEditor({
                 kind:
                   apiError.code === COWORK_PROVENANCE_TARGET_CHANGED
                     ? "stale_target"
-                    : stored.sourceKind === "direct_entry" ||
-                        apiError.retryable
+                    : stored.sourceKind === "direct_entry" || apiError.retryable
                       ? "retryable"
                       : "terminal",
               });
@@ -776,26 +809,27 @@ function MountedBridgeEditor({
           // exact selector as an explicit legacy determination the user can
           // resolve after a legitimate identity session is available.
           if (entry.status === "capturing") {
-            const deferred = await resolvedPasteProvenanceOutbox.deferDirectEntry(
-              entry.id,
-              // This automatic request has never been frozen or submitted, so
-              // preserving its key is both safe and important: a transaction
-              // that mapped the burst while demotion was queued may already
-              // have journalled one last capture under this key. Rotating it
-              // here would let that queued upsert append an orphan automatic
-              // row after the legacy replacement commits.
-              burst.idempotencyKey,
-              unknownCoworkProvenanceDetermination(),
-              {
-                code: captureActorUnavailable
-                  ? "provenance_actor_unavailable_at_capture"
-                  : COWORK_PROVENANCE_ACTOR_CHANGED,
-                message: captureActorUnavailable
-                  ? "No enrolled local actor was available when this text was entered."
-                  : "The acting identity changed before this attribution was saved.",
-                kind: "terminal",
-              },
-            );
+            const deferred =
+              await resolvedPasteProvenanceOutbox.deferDirectEntry(
+                entry.id,
+                // This automatic request has never been frozen or submitted, so
+                // preserving its key is both safe and important: a transaction
+                // that mapped the burst while demotion was queued may already
+                // have journalled one last capture under this key. Rotating it
+                // here would let that queued upsert append an orphan automatic
+                // row after the legacy replacement commits.
+                burst.idempotencyKey,
+                unknownCoworkProvenanceDetermination(),
+                {
+                  code: captureActorUnavailable
+                    ? "provenance_actor_unavailable_at_capture"
+                    : COWORK_PROVENANCE_ACTOR_CHANGED,
+                  message: captureActorUnavailable
+                    ? "No enrolled local actor was available when this text was entered."
+                    : "The acting identity changed before this attribution was saved.",
+                  kind: "terminal",
+                },
+              );
             if (
               generation !== provenanceEditGenerationRef.current ||
               deferred.idempotencyKey !== burst.idempotencyKey
@@ -1293,8 +1327,51 @@ function MountedBridgeEditor({
       }
       stageDirectEntryProvenanceBeforeTransaction(context);
       stagePasteProvenanceBeforeTransaction(context);
+      if (context.transaction.docChanged) {
+        const pending = new Map(
+          pendingDirectEntryDecorationsRef.current.map((item) => [
+            item.captureId,
+            item,
+          ]),
+        );
+        const stageBurst = (burst: DirectEntryBurst): void => {
+          const capture = directCaptureForBurst(burst, context.transaction.doc);
+          if (capture === null) {
+            pending.delete(burst.idempotencyKey);
+            return;
+          }
+          pending.set(burst.idempotencyKey, {
+            captureId: burst.idempotencyKey,
+            quoteAnchor: capture.anchor,
+          });
+        };
+        for (const burst of directEntryClosingBurstsRef.current.values()) {
+          stageBurst(burst);
+        }
+        if (directEntryBurstRef.current !== null) {
+          stageBurst(directEntryBurstRef.current);
+        }
+        const staged = [...pending.values()];
+        // `beforeTransaction` fires after ProseMirror has derived the next
+        // state, so changing this transaction's metadata is too late. A
+        // microtask dispatch lands before the browser can paint the edited
+        // frame and avoids a re-entrant EditorView transaction.
+        queueMicrotask(() => {
+          if (
+            pasteEditorRef.current === context.editor &&
+            !context.editor.isDestroyed
+          ) {
+            setCoworkPendingProvenance(context.editor, staged);
+          }
+        });
+        if (staged.length > 0) {
+          onInputProvenancePendingChange?.(true);
+        }
+      }
     },
     [
+      directCaptureForBurst,
+      onInputProvenancePendingChange,
       stageDirectEntryProvenanceBeforeTransaction,
       stagePasteProvenanceBeforeTransaction,
     ],
@@ -1329,6 +1406,11 @@ function MountedBridgeEditor({
       editor.off("beforeTransaction", stageProvenanceBeforeTransaction);
     };
   }, [editor, stageProvenanceBeforeTransaction]);
+
+  useEffect(() => {
+    if (editor === null) return;
+    setCoworkPendingProvenance(editor, pendingDirectEntryDecorations);
+  }, [editor, pendingDirectEntryDecorations]);
 
   const dismissedPasteEntries = pasteEntries.filter(
     (entry) => entry.sourceKind === "paste" && dismissedPasteIds.has(entry.id),
@@ -1484,8 +1566,7 @@ function MountedBridgeEditor({
                 await resolvedPasteProvenanceOutbox.list()
               ).some(
                 (candidate) =>
-                  candidate.id === entry.id &&
-                  candidate.status === "capturing",
+                  candidate.id === entry.id && candidate.status === "capturing",
               );
               if (stillCapturing) {
                 await finalizeDirectEntryBurstRef.current();
@@ -1596,8 +1677,7 @@ function MountedBridgeEditor({
     for (const entry of entries) {
       if (
         entry.sourceKind === "direct_entry" &&
-        (entry.status === "stale_target" ||
-          entry.status === "terminal_failure")
+        (entry.status === "stale_target" || entry.status === "terminal_failure")
       ) {
         // The server explicitly rejected the frozen target, so this visible
         // user retry starts a new attempt: resolve the captured quote against
@@ -2726,11 +2806,7 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
           requestProvenanceActorRefresh();
         }
       }),
-    [
-      provenanceActorState,
-      provenanceEnabled,
-      requestProvenanceActorRefresh,
-    ],
+    [provenanceActorState, provenanceEnabled, requestProvenanceActorRefresh],
   );
 
   useEffect(

--- a/dashboard-react/src/apps/cowork/editor/ledgerDecorations.test.ts
+++ b/dashboard-react/src/apps/cowork/editor/ledgerDecorations.test.ts
@@ -11,6 +11,7 @@ import {
   projectCoworkLedgerDecorations,
   readCoworkLedgerDecorationState,
   setCoworkEditorLens,
+  setCoworkPendingProvenance,
 } from "./ledgerDecorations";
 
 const CONTENT =
@@ -51,7 +52,11 @@ describe("CoworkLedgerDecorations", () => {
       flags: [
         {
           proposalId: "lens-flag",
-          quoteAnchor: { exact: "flagged phrase", prefix: "A ", suffix: ". An" },
+          quoteAnchor: {
+            exact: "flagged phrase",
+            prefix: "A ",
+            suffix: ". An",
+          },
         },
       ],
       expressions: [
@@ -67,12 +72,20 @@ describe("CoworkLedgerDecorations", () => {
       provenance: [],
     });
 
-    expect(current.view.dom.querySelector('[data-wb-decoration="flag"]')).not.toBeNull();
+    expect(
+      current.view.dom.querySelector('[data-wb-decoration="flag"]'),
+    ).not.toBeNull();
     setCoworkEditorLens(current, "truth");
-    expect(current.view.dom.querySelector('[data-wb-decoration="flag"]')).toBeNull();
-    expect(current.view.dom.querySelector('[data-wb-decoration="expression"]')).not.toBeNull();
+    expect(
+      current.view.dom.querySelector('[data-wb-decoration="flag"]'),
+    ).toBeNull();
+    expect(
+      current.view.dom.querySelector('[data-wb-decoration="expression"]'),
+    ).not.toBeNull();
     setCoworkEditorLens(current, "neutral");
-    expect(current.view.dom.querySelector(".wb-cowork-ledger-decoration")).toBeNull();
+    expect(
+      current.view.dom.querySelector(".wb-cowork-ledger-decoration"),
+    ).toBeNull();
     expect(current.getJSON()).toEqual(beforeJson);
     expect(current.state.selection.toJSON()).toEqual(beforeSelection);
   });
@@ -115,7 +128,9 @@ describe("CoworkLedgerDecorations", () => {
 
     expect(updateCount).toBe(0);
     expect(Y.encodeStateVector(collaborativeDocument)).toEqual(stateBefore);
-    expect(Y.encodeStateAsUpdate(collaborativeDocument)).toEqual(snapshotBefore);
+    expect(Y.encodeStateAsUpdate(collaborativeDocument)).toEqual(
+      snapshotBefore,
+    );
     expect(editor.view.dom).toHaveTextContent(
       "Canonical passageProposed passage.",
     );
@@ -126,9 +141,7 @@ describe("CoworkLedgerDecorations", () => {
   });
 
   it("renders edit proposals as view-only strike and replacement decorations", () => {
-    const current = mountEditor(
-      "<p>Keep this. Remove this. Change this.</p>",
-    );
+    const current = mountEditor("<p>Keep this. Remove this. Change this.</p>");
     const beforeJson = current.getJSON();
     const beforeHtml = current.getHTML();
 
@@ -172,9 +185,7 @@ describe("CoworkLedgerDecorations", () => {
     });
 
     expect(
-      current.view.dom.querySelector(
-        '[data-wb-anchor-id="delete-1"]',
-      ),
+      current.view.dom.querySelector('[data-wb-anchor-id="delete-1"]'),
     ).toHaveClass("wb-cowork-suggestion--deletion");
     expect(
       current.view.dom.querySelector(
@@ -182,9 +193,11 @@ describe("CoworkLedgerDecorations", () => {
       ),
     ).toHaveTextContent("Revise this");
     expect(
-      [...current.view.dom.querySelectorAll<HTMLElement>(
-        '[data-wb-anchor-id="insert-1"][data-wb-decoration="edit-proposal-replacement"]',
-      )].map((element) => element.textContent),
+      [
+        ...current.view.dom.querySelectorAll<HTMLElement>(
+          '[data-wb-anchor-id="insert-1"][data-wb-decoration="edit-proposal-replacement"]',
+        ),
+      ].map((element) => element.textContent),
     ).toEqual(["Please ", " now"]);
 
     focusCoworkLedgerAnchor(current, {
@@ -278,7 +291,7 @@ describe("CoworkLedgerDecorations", () => {
     expect(expression).toHaveAttribute("data-wb-expression-id", "expression-1");
 
     const claim = current.view.dom.querySelector<HTMLElement>(
-      '[data-wb-claim-ids]',
+      "[data-wb-claim-ids]",
     );
     expect(claim).toHaveAttribute("data-wb-claim-ids", '["same-id"]');
     expect(claim).toHaveClass("wb-cowork-claim-anchor");
@@ -314,7 +327,11 @@ describe("CoworkLedgerDecorations", () => {
       recordState: "recorded" as const,
     };
     projectCoworkLedgerDecorations(current, {
-      edits: [], flags: [], expressions: [], claims: [], provenance: [],
+      edits: [],
+      flags: [],
+      expressions: [],
+      claims: [],
+      provenance: [],
       provenanceOverlay: [
         {
           ...base,
@@ -356,6 +373,80 @@ describe("CoworkLedgerDecorations", () => {
     expect(gap).toHaveClass("wb-cowork-provenance--unrecorded");
     expect(gap).not.toHaveAttribute("data-wb-anchor-kind");
     expect(current.getJSON()).toEqual(before);
+  });
+
+  it("projects pending delivery on its exact range and lets a recorded server span win", () => {
+    const current = mountEditor("<p>Before Pending text after.</p>");
+    const anchor = {
+      exact: "Pending text",
+      prefix: "Before ",
+      suffix: " after.",
+    };
+    projectCoworkLedgerDecorations(current, {
+      edits: [],
+      flags: [],
+      expressions: [],
+      claims: [],
+      provenance: [],
+      provenanceOverlay: [],
+    });
+    setCoworkPendingProvenance(current, [
+      { captureId: "capture-1", quoteAnchor: anchor },
+    ]);
+    setCoworkEditorLens(current, "provenance");
+
+    const pending = current.view.dom.querySelector<HTMLElement>(
+      '[data-wb-provenance-record-state="pending"]',
+    );
+    expect(pending).toHaveTextContent("Pending text");
+    expect(pending).toHaveClass("wb-cowork-provenance--pending");
+    expect(pending).not.toHaveClass("wb-cowork-provenance--unknown");
+    expect(pending).not.toHaveAttribute("data-wb-anchor-kind");
+    expect(pending?.textContent).not.toContain("Before");
+    expect(pending?.textContent).not.toContain("after");
+
+    projectCoworkLedgerDecorations(current, {
+      edits: [],
+      flags: [],
+      expressions: [],
+      claims: [],
+      provenance: [],
+      provenanceOverlay: [
+        {
+          targetId: "recorded-target",
+          recordId: "recorded-attestation",
+          quoteAnchor: anchor,
+          isDocumentDefault: false,
+          authorship: "human",
+          reviewStatus: "not_applicable",
+          currentness: "current",
+          resolution: "resolved",
+          source: "direct_entry",
+          sourceDetail: "Input: keyboard",
+          contributors: "user-1",
+          reviewers: "No reviewers recorded",
+          attester: "user-1",
+          basis: "automatic_direct_entry_attribution",
+          historyCount: 1,
+          effectiveCount: 1,
+          recordState: "recorded",
+          authorshipFingerprint: "human:user-1",
+          reviewFingerprint: "not_applicable",
+          sourceFingerprint: "direct_entry",
+        },
+      ],
+    });
+
+    const recorded = current.view.dom.querySelector<HTMLElement>(
+      '[data-wb-provenance-record-state="recorded"]',
+    );
+    expect(recorded).toHaveTextContent("Pending text");
+    expect(recorded).toHaveAttribute("data-wb-authorship", "human");
+    expect(
+      current.view.dom.querySelector(
+        '[data-wb-provenance-record-state="pending"]',
+      ),
+    ).toBeNull();
   });
 
   it("keeps compatible overlap target health explicit and rejects changed selector context", () => {
@@ -467,16 +558,11 @@ describe("CoworkLedgerDecorations", () => {
     });
     setCoworkEditorLens(current, "truth");
 
-    focusCoworkLedgerAnchor(
-      current,
-      { id: "same-id", kind: "claim" },
-      true,
+    focusCoworkLedgerAnchor(current, { id: "same-id", kind: "claim" }, true);
+    expect(current.view.dom.querySelector("[data-wb-claim-ids]")).toHaveClass(
+      "wb-cowork-anchor--active",
+      "wb-cowork-anchor--flash",
     );
-    expect(
-      current.view.dom.querySelector(
-        "[data-wb-claim-ids]",
-      ),
-    ).toHaveClass("wb-cowork-anchor--active", "wb-cowork-anchor--flash");
     expect(
       current.view.dom.querySelector(
         '[data-wb-anchor-kind="proposal"][data-wb-anchor-id="same-id"]',

--- a/dashboard-react/src/apps/cowork/editor/ledgerDecorations.ts
+++ b/dashboard-react/src/apps/cowork/editor/ledgerDecorations.ts
@@ -72,8 +72,10 @@ export interface CoworkProvenanceOverlayDecoration {
   readonly quoteAnchor: QuoteAnchor | null;
   readonly isDocumentDefault: boolean;
   readonly authorship: "human" | "ai" | "mixed" | "unknown";
-  readonly reviewStatus: "reviewed" | "not_reviewed" | "not_applicable" | "unknown";
-  readonly currentness: "current" | "stale" | "requires_reanchor" | "unavailable";
+  readonly reviewStatus:
+    "reviewed" | "not_reviewed" | "not_applicable" | "unknown";
+  readonly currentness:
+    "current" | "stale" | "requires_reanchor" | "unavailable";
   readonly resolution: "resolved" | "conflicted";
   readonly source: string;
   readonly sourceDetail: string;
@@ -83,20 +85,27 @@ export interface CoworkProvenanceOverlayDecoration {
   readonly basis: string;
   readonly historyCount: number;
   readonly effectiveCount: number;
-  readonly recordState: "recorded" | "unrecorded";
+  readonly recordState: "recorded" | "unrecorded" | "pending";
   readonly authorshipFingerprint: string;
   readonly reviewFingerprint: string;
   readonly sourceFingerprint: string;
+}
+
+/**
+ * A browser-local direct-entry capture that has not received an authoritative
+ * server ledger projection yet. This is delivery state only: it deliberately
+ * carries no authorship, reviewer, or attester claim.
+ */
+export interface CoworkPendingProvenanceDecoration {
+  readonly captureId: string;
+  readonly quoteAnchor: QuoteAnchor;
 }
 
 export interface CoworkEvaluationDecoration {
   readonly resultId: string;
   readonly quoteAnchor: QuoteAnchor;
   readonly resultKind:
-    | "conforming"
-    | "nonconforming"
-    | "inconclusive"
-    | "review_comment";
+    "conforming" | "nonconforming" | "inconclusive" | "review_comment";
 }
 
 /**
@@ -119,11 +128,7 @@ export interface CoworkLedgerDecorationProjection {
 export interface CoworkFocusedAnchor {
   readonly id: string;
   readonly kind:
-    | "proposal"
-    | "claim"
-    | "expression"
-    | "provenance"
-    | "evaluation_result";
+    "proposal" | "claim" | "expression" | "provenance" | "evaluation_result";
 }
 
 export interface CoworkPassageHighlight {
@@ -134,6 +139,7 @@ export interface CoworkPassageHighlight {
 
 interface CoworkLedgerDecorationState {
   readonly projection: CoworkLedgerDecorationProjection;
+  readonly pendingProvenance: readonly CoworkPendingProvenanceDecoration[];
   readonly lens: CoworkEditorLens;
   readonly focused: CoworkFocusedAnchor | null;
   readonly flashFocused: boolean;
@@ -149,6 +155,10 @@ type CoworkLedgerDecorationMeta =
   | {
       readonly type: "set-lens";
       readonly lens: CoworkEditorLens;
+    }
+  | {
+      readonly type: "set-pending-provenance";
+      readonly pending: readonly CoworkPendingProvenanceDecoration[];
     }
   | {
       readonly type: "focus";
@@ -185,10 +195,7 @@ const rangeForQuote = (
   exact: string,
   quoteAnchor?: QuoteAnchor,
 ): { readonly from: number; readonly to: number } | null =>
-  resolveQuoteAnchor(
-    doc,
-    quoteAnchor ?? { exact, prefix: "", suffix: "" },
-  );
+  resolveQuoteAnchor(doc, quoteAnchor ?? { exact, prefix: "", suffix: "" });
 
 const anchorAttributes = (
   kind: CoworkEditorAnchorKind,
@@ -198,9 +205,7 @@ const anchorAttributes = (
   flashFocused: boolean,
   extra: Readonly<Record<string, string>> = {},
 ): Record<string, string> => {
-  const active =
-    focused?.kind === kind &&
-    focused.id === id;
+  const active = focused?.kind === kind && focused.id === id;
   return {
     class: [
       "wb-cowork-ledger-decoration",
@@ -262,7 +267,8 @@ const suggestionId = (raw: unknown): string | null =>
 const atomSuggestion = (
   raw: unknown,
 ): { readonly id: string; readonly type: string } | null => {
-  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw))
+    return null;
   const value = raw as Record<string, unknown>;
   return typeof value["id"] === "string" && typeof value["type"] === "string"
     ? { id: value["id"], type: value["type"] }
@@ -290,11 +296,15 @@ const provenanceClass = (
   const target = targets[0];
   const classes = [
     "wb-cowork-provenance-mark",
-    `wb-cowork-provenance--${target.authorship}`,
-    `wb-cowork-provenance--review-${target.reviewStatus.replace(/_/gu, "-")}`,
+    target.recordState === "pending"
+      ? ""
+      : `wb-cowork-provenance--${target.authorship}`,
+    target.recordState === "pending"
+      ? ""
+      : `wb-cowork-provenance--review-${target.reviewStatus.replace(/_/gu, "-")}`,
     `wb-cowork-provenance--${target.recordState}`,
   ];
-  return classes.join(" ");
+  return classes.filter(Boolean).join(" ");
 };
 
 /**
@@ -306,11 +316,17 @@ const provenanceClass = (
 const provenanceOverlayDecorations = (
   doc: ProseMirrorNode,
   projection: CoworkLedgerDecorationProjection,
+  pendingProvenance: readonly CoworkPendingProvenanceDecoration[],
   focused: CoworkFocusedAnchor | null,
   flashFocused: boolean,
 ): Decoration[] => {
-  if (projection.provenanceOverlay === undefined) return [];
-  const overlays = projection.provenanceOverlay;
+  if (
+    projection.provenanceOverlay === undefined &&
+    pendingProvenance.length === 0
+  ) {
+    return [];
+  }
+  const overlays = projection.provenanceOverlay ?? [];
   const documentDefaults = overlays.filter(
     (item) => item.isDocumentDefault && item.currentness === "current",
   );
@@ -331,6 +347,42 @@ const provenanceOverlayDecorations = (
       ? []
       : [{ target, from: resolution.from, to: resolution.to }];
   });
+  const resolvedPending: ResolvedProvenanceOverlay[] =
+    pendingProvenance.flatMap((pending) => {
+      const resolution = resolveProvenanceQuoteAnchorDetailed(
+        doc,
+        pending.quoteAnchor,
+      );
+      if (resolution.state !== "unique") return [];
+      return [
+        {
+          target: {
+            targetId: `pending:${pending.captureId}`,
+            recordId: `pending:${pending.captureId}`,
+            quoteAnchor: pending.quoteAnchor,
+            isDocumentDefault: false,
+            authorship: "unknown",
+            reviewStatus: "unknown",
+            currentness: "current",
+            resolution: "resolved",
+            source: "direct_entry",
+            sourceDetail: "Waiting for a durable provenance receipt",
+            contributors: "Not asserted while recording",
+            reviewers: "Not asserted while recording",
+            attester: "Not asserted while recording",
+            basis: "automatic_direct_entry_attribution",
+            historyCount: 0,
+            effectiveCount: 0,
+            recordState: "pending",
+            authorshipFingerprint: "pending",
+            reviewFingerprint: "pending",
+            sourceFingerprint: "pending",
+          },
+          from: resolution.from,
+          to: resolution.to,
+        },
+      ];
+    });
   const result: Decoration[] = [];
   doc.descendants((node, pos) => {
     if (!node.isText || node.nodeSize === 0) return true;
@@ -342,6 +394,11 @@ const provenanceOverlayDecorations = (
       boundaries.add(Math.max(nodeFrom, item.from));
       boundaries.add(Math.min(nodeTo, item.to));
     }
+    for (const item of resolvedPending) {
+      if (item.to <= nodeFrom || item.from >= nodeTo) continue;
+      boundaries.add(Math.max(nodeFrom, item.from));
+      boundaries.add(Math.min(nodeTo, item.to));
+    }
     const ordered = [...boundaries].sort((a, b) => a - b);
     for (let index = 0; index < ordered.length - 1; index += 1) {
       const from = ordered[index];
@@ -349,9 +406,17 @@ const provenanceOverlayDecorations = (
       const covering = resolved.filter(
         (item) => item.from < to && item.to > from,
       );
+      const pending = resolvedPending.filter(
+        (item) => item.from < to && item.to > from,
+      );
       let targets: readonly CoworkProvenanceOverlayDecoration[];
       if (covering.length > 0) {
+        // A server-projected span is authoritative as soon as it appears. The
+        // local pending marker may remain until outbox cleanup, but must never
+        // obscure or conflict with the recorded receipt.
         targets = covering.map((item) => item.target);
+      } else if (pending.length > 0) {
+        targets = pending.map((item) => item.target);
       } else if (documentDefaults.length > 0) {
         targets = documentDefaults;
       } else {
@@ -382,12 +447,13 @@ const provenanceOverlayDecorations = (
       }
       const incompatible = new Set(targets.map(provenanceAxes)).size > 1;
       const conflicted =
-        incompatible || targets.some((item) => item.resolution === "conflicted");
+        incompatible ||
+        targets.some((item) => item.resolution === "conflicted");
       const ids = targets.map((item) => item.targetId);
       const recordIds = targets.map((item) => item.recordId);
       const primary =
         focused?.kind === "provenance"
-          ? targets.find((item) => item.targetId === focused.id) ?? targets[0]
+          ? (targets.find((item) => item.targetId === focused.id) ?? targets[0])
           : targets[0];
       const attester =
         new Set(targets.map((item) => item.attester)).size > 1
@@ -410,30 +476,34 @@ const provenanceOverlayDecorations = (
           ? "multiple reviewer records"
           : primary.reviewers;
       const metadata = {
-          "data-wb-decoration": "provenance-overlay",
-          "data-wb-provenance-id": primary.targetId,
-          "data-wb-provenance-ids": JSON.stringify(ids),
-          "data-wb-provenance-record-ids": JSON.stringify(recordIds),
-          "data-wb-authorship": conflicted ? "conflict" : primary.authorship,
-          "data-wb-human-review": conflicted ? "conflict" : primary.reviewStatus,
-          "data-wb-source": conflicted ? "conflict" : primary.source,
-          "data-wb-source-detail": conflicted ? "multiple sources" : sourceDetail,
-          "data-wb-contributors": conflicted ? "multiple contributor records" : contributors,
-          "data-wb-reviewers": conflicted ? "multiple reviewer records" : reviewers,
-          "data-wb-attester": conflicted ? "multiple" : attester,
-          "data-wb-basis": conflicted ? "multiple" : basis,
-          "data-wb-history-count": String(
-            targets.reduce((count, item) => count + item.historyCount, 0),
-          ),
-          "data-wb-provenance-conflict": String(conflicted),
-          "data-wb-provenance-record-state": primary.recordState,
-          "data-wb-provenance-currentness":
-            new Set(targets.map((item) => item.currentness)).size > 1
-              ? "multiple target states"
-              : primary.currentness,
+        "data-wb-decoration": "provenance-overlay",
+        "data-wb-provenance-id": primary.targetId,
+        "data-wb-provenance-ids": JSON.stringify(ids),
+        "data-wb-provenance-record-ids": JSON.stringify(recordIds),
+        "data-wb-authorship": conflicted ? "conflict" : primary.authorship,
+        "data-wb-human-review": conflicted ? "conflict" : primary.reviewStatus,
+        "data-wb-source": conflicted ? "conflict" : primary.source,
+        "data-wb-source-detail": conflicted ? "multiple sources" : sourceDetail,
+        "data-wb-contributors": conflicted
+          ? "multiple contributor records"
+          : contributors,
+        "data-wb-reviewers": conflicted
+          ? "multiple reviewer records"
+          : reviewers,
+        "data-wb-attester": conflicted ? "multiple" : attester,
+        "data-wb-basis": conflicted ? "multiple" : basis,
+        "data-wb-history-count": String(
+          targets.reduce((count, item) => count + item.historyCount, 0),
+        ),
+        "data-wb-provenance-conflict": String(conflicted),
+        "data-wb-provenance-record-state": primary.recordState,
+        "data-wb-provenance-currentness":
+          new Set(targets.map((item) => item.currentness)).size > 1
+            ? "multiple target states"
+            : primary.currentness,
       };
       const attributes =
-        primary.recordState === "unrecorded"
+        primary.recordState !== "recorded"
           ? {
               class: `wb-cowork-ledger-decoration ${provenanceClass(targets, conflicted)}`,
               ...metadata,
@@ -462,6 +532,7 @@ const provenanceOverlayDecorations = (
 function buildDecorations(
   doc: ProseMirrorNode,
   projection: CoworkLedgerDecorationProjection,
+  pendingProvenance: readonly CoworkPendingProvenanceDecoration[],
   lens: CoworkEditorLens,
   focused: CoworkFocusedAnchor | null,
   flashFocused: boolean,
@@ -479,6 +550,7 @@ function buildDecorations(
       ...provenanceOverlayDecorations(
         doc,
         projection,
+        pendingProvenance,
         focused,
         flashFocused,
       ),
@@ -573,58 +645,59 @@ function buildDecorations(
   // Suggestion marks already carry the proposed text. These extra wrappers add one
   // plain, namespace-qualified anchor identity so geometry never has to parse the
   // vendored mark's JSON-encoded data-id attribute.
-  if (lens === "review") doc.descendants((node, pos) => {
-    if (node.isText) {
-      for (const mark of node.marks) {
-        if (
-          mark.type.name !== "insertion" &&
-          mark.type.name !== "deletion" &&
-          mark.type.name !== "modification"
-        ) {
-          continue;
+  if (lens === "review")
+    doc.descendants((node, pos) => {
+      if (node.isText) {
+        for (const mark of node.marks) {
+          if (
+            mark.type.name !== "insertion" &&
+            mark.type.name !== "deletion" &&
+            mark.type.name !== "modification"
+          ) {
+            continue;
+          }
+          const id = suggestionId(mark.attrs["id"]);
+          if (id === null) continue;
+          const decoration = inlineDecoration(
+            pos,
+            pos + node.nodeSize,
+            anchorAttributes(
+              "proposal",
+              id,
+              "wb-cowork-proposal-anchor",
+              focused,
+              flashFocused,
+              { "data-wb-decoration": "suggestion-anchor" },
+            ),
+            `proposal:${id}:${String(pos)}`,
+          );
+          if (decoration !== null) decorations.push(decoration);
         }
-        const id = suggestionId(mark.attrs["id"]);
-        if (id === null) continue;
-        const decoration = inlineDecoration(
-          pos,
-          pos + node.nodeSize,
-          anchorAttributes(
-            "proposal",
-            id,
-            "wb-cowork-proposal-anchor",
-            focused,
-            flashFocused,
-            { "data-wb-decoration": "suggestion-anchor" },
-          ),
-          `proposal:${id}:${String(pos)}`,
-        );
-        if (decoration !== null) decorations.push(decoration);
       }
-    }
 
-    const atom = atomSuggestion(node.attrs["wbSuggestion"]);
-    if (atom !== null) {
-      decorations.push(
-        Decoration.node(
-          pos,
-          pos + node.nodeSize,
-          anchorAttributes(
-            "proposal",
-            atom.id,
-            "wb-cowork-proposal-anchor",
-            focused,
-            flashFocused,
-            {
-              "data-wb-decoration": "atom-suggestion-anchor",
-              "data-wb-suggestion": atom.type,
-            },
+      const atom = atomSuggestion(node.attrs["wbSuggestion"]);
+      if (atom !== null) {
+        decorations.push(
+          Decoration.node(
+            pos,
+            pos + node.nodeSize,
+            anchorAttributes(
+              "proposal",
+              atom.id,
+              "wb-cowork-proposal-anchor",
+              focused,
+              flashFocused,
+              {
+                "data-wb-decoration": "atom-suggestion-anchor",
+                "data-wb-suggestion": atom.type,
+              },
+            ),
+            { key: `proposal-atom:${atom.id}:${String(pos)}` },
           ),
-          { key: `proposal-atom:${atom.id}:${String(pos)}` },
-        ),
-      );
-    }
-    return true;
-  });
+        );
+      }
+      return true;
+    });
 
   for (const flag of lens === "review" ? projection.flags : []) {
     const range = resolveQuoteAnchor(doc, flag.quoteAnchor);
@@ -653,7 +726,9 @@ function buildDecorations(
    * document pull as its Review card. The double underline distinguishes a
    * checked observation from proposals and provenance without relying on color.
    */
-  for (const evaluation of lens === "review" ? projection.evaluations ?? [] : []) {
+  for (const evaluation of lens === "review"
+    ? (projection.evaluations ?? [])
+    : []) {
     const range = resolveQuoteAnchor(doc, evaluation.quoteAnchor);
     if (range === null) continue;
     const decoration = inlineDecoration(
@@ -676,11 +751,7 @@ function buildDecorations(
   }
 
   for (const expression of lens === "truth" ? projection.expressions : []) {
-    const range = rangeForQuote(
-      doc,
-      expression.quote,
-      expression.quoteAnchor,
-    );
+    const range = rangeForQuote(doc, expression.quote, expression.quoteAnchor);
     if (range === null) continue;
     const expressionClaims =
       claimsByExpression.get(expression.expressionId) ?? [];
@@ -768,6 +839,7 @@ const mappedHighlight = (
 function createPluginState(
   doc: ProseMirrorNode,
   projection: CoworkLedgerDecorationProjection,
+  pendingProvenance: readonly CoworkPendingProvenanceDecoration[],
   lens: CoworkEditorLens,
   focused: CoworkFocusedAnchor | null,
   flashFocused: boolean,
@@ -775,6 +847,7 @@ function createPluginState(
 ): CoworkLedgerDecorationState {
   return {
     projection,
+    pendingProvenance,
     lens,
     focused,
     flashFocused,
@@ -782,6 +855,7 @@ function createPluginState(
     decorations: buildDecorations(
       doc,
       projection,
+      pendingProvenance,
       lens,
       focused,
       flashFocused,
@@ -798,6 +872,7 @@ export function coworkLedgerDecorationsPlugin(): Plugin<CoworkLedgerDecorationSt
         createPluginState(
           state.doc,
           EMPTY_PROJECTION,
+          [],
           "review",
           null,
           false,
@@ -805,8 +880,7 @@ export function coworkLedgerDecorationsPlugin(): Plugin<CoworkLedgerDecorationSt
         ),
       apply(transaction, value) {
         const meta = transaction.getMeta(coworkLedgerDecorationsKey) as
-          | CoworkLedgerDecorationMeta
-          | undefined;
+          CoworkLedgerDecorationMeta | undefined;
         if (meta === undefined && !transaction.docChanged) return value;
 
         /*
@@ -821,6 +895,7 @@ export function coworkLedgerDecorationsPlugin(): Plugin<CoworkLedgerDecorationSt
             return createPluginState(
               transaction.doc,
               value.projection,
+              value.pendingProvenance,
               value.lens,
               value.focused,
               value.flashFocused,
@@ -838,6 +913,7 @@ export function coworkLedgerDecorationsPlugin(): Plugin<CoworkLedgerDecorationSt
         }
 
         let projection = value.projection;
+        let pendingProvenance = value.pendingProvenance;
         let lens = value.lens;
         let focused = value.focused;
         let flashFocused = value.flashFocused;
@@ -845,6 +921,8 @@ export function coworkLedgerDecorationsPlugin(): Plugin<CoworkLedgerDecorationSt
 
         if (meta?.type === "project") {
           projection = meta.projection;
+        } else if (meta?.type === "set-pending-provenance") {
+          pendingProvenance = meta.pending;
         } else if (meta?.type === "set-lens") {
           lens = meta.lens;
           const visible =
@@ -876,6 +954,7 @@ export function coworkLedgerDecorationsPlugin(): Plugin<CoworkLedgerDecorationSt
         return createPluginState(
           transaction.doc,
           projection,
+          pendingProvenance,
           lens,
           focused,
           flashFocused,
@@ -904,7 +983,10 @@ const dispatchMeta = (
   editor: Editor,
   meta: CoworkLedgerDecorationMeta,
 ): boolean => {
-  if (editor.isDestroyed || coworkLedgerDecorationsKey.getState(editor.state) === undefined) {
+  if (
+    editor.isDestroyed ||
+    coworkLedgerDecorationsKey.getState(editor.state) === undefined
+  ) {
     return false;
   }
   editor.view.dispatch(
@@ -923,6 +1005,12 @@ export const setCoworkEditorLens = (
   editor: Editor,
   lens: CoworkEditorLens,
 ): boolean => dispatchMeta(editor, { type: "set-lens", lens });
+
+/** Replace only the browser-local delivery projection; server ledger data is untouched. */
+export const setCoworkPendingProvenance = (
+  editor: Editor,
+  pending: readonly CoworkPendingProvenanceDecoration[],
+): boolean => dispatchMeta(editor, { type: "set-pending-provenance", pending });
 
 export const focusCoworkLedgerAnchor = (
   editor: Editor,

--- a/dashboard-react/src/apps/cowork/provenance/CoworkPasteProvenanceOutbox.test.ts
+++ b/dashboard-react/src/apps/cowork/provenance/CoworkPasteProvenanceOutbox.test.ts
@@ -62,9 +62,7 @@ class MemoryStorage implements Storage {
   }
 }
 
-const fakeIndexedDatabase = (
-  records: Map<string, unknown>,
-): IDBDatabase =>
+const fakeIndexedDatabase = (records: Map<string, unknown>): IDBDatabase =>
   ({
     transaction: () => {
       let aborted = false;
@@ -123,8 +121,7 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
   });
 
   it("rehydrates unresolved entries in capture order and isolates documents", async () => {
-    const backing =
-      new InMemoryCoworkPasteProvenanceOutboxBackingStore();
+    const backing = new InMemoryCoworkPasteProvenanceOutboxBackingStore();
     const first = new DurableCoworkPasteProvenanceOutbox(
       "store:document",
       backing,
@@ -150,9 +147,9 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
       "store:document",
       backing,
     );
-    expect((await reopened.list()).map((entry) => entry.idempotencyKey)).toEqual(
-      ["paste-1", "paste-2"],
-    );
+    expect(
+      (await reopened.list()).map((entry) => entry.idempotencyKey),
+    ).toEqual(["paste-1", "paste-2"]);
     expect(
       await new DurableCoworkPasteProvenanceOutbox(
         "store:other",
@@ -192,9 +189,113 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
     });
   });
 
+  it("recovers the latest staged shape of an open typing burst", async () => {
+    const key = "store:direct-recovery";
+    const backing = new InMemoryCoworkPasteProvenanceOutboxBackingStore();
+    const stage = new InMemoryCoworkPasteProvenanceIntentStage();
+    const first = new DurableCoworkPasteProvenanceOutbox(key, backing, stage);
+    await first.upsertCapture({
+      anchor: { exact: "T", prefix: "", suffix: " after" },
+      idempotencyKey: "typing-burst",
+      substantial: false,
+      capturedActor: actorIdentity,
+      sourceKind: "direct_entry",
+      basisKind: "automatic_direct_entry_attribution",
+      determination: humanDetermination(),
+      status: "capturing",
+    });
+
+    // Simulate a crash after the synchronous journal advanced to `Test` but
+    // before the older durable `T` row was updated.
+    stage.put(key, {
+      anchor: { exact: "Test", prefix: "", suffix: " after" },
+      idempotencyKey: "typing-burst",
+      substantial: false,
+      capturedActor: actorIdentity,
+      sourceKind: "direct_entry",
+      basisKind: "automatic_direct_entry_attribution",
+      determination: humanDetermination(),
+      status: "capturing",
+    });
+
+    const reopened = new DurableCoworkPasteProvenanceOutbox(
+      key,
+      backing,
+      stage,
+    );
+    expect((await reopened.list())[0]).toMatchObject({
+      id: 1,
+      status: "capturing",
+      anchor: { exact: "Test" },
+    });
+  });
+
+  it("never lets a stale open-stage row overwrite a ready frozen request", async () => {
+    const key = "store:frozen-stage";
+    const backing = new InMemoryCoworkPasteProvenanceOutboxBackingStore();
+    const stage = new InMemoryCoworkPasteProvenanceIntentStage();
+    const outbox = new DurableCoworkPasteProvenanceOutbox(key, backing, stage);
+    const open = await outbox.upsertCapture({
+      anchor: { exact: "T", prefix: "", suffix: " after" },
+      idempotencyKey: "typing-burst",
+      substantial: false,
+      capturedActor: actorIdentity,
+      sourceKind: "direct_entry",
+      basisKind: "automatic_direct_entry_attribution",
+      determination: humanDetermination(),
+      status: "capturing",
+    });
+    await outbox.markReady(
+      open.id,
+      open.determination,
+      "automatic_direct_entry_attribution",
+    );
+    await outbox.freezeRequest(open.id, {
+      storeId: "store",
+      documentId: "document",
+      expectedStructuredHeadSha256: "a".repeat(64),
+    });
+    stage.put(key, {
+      anchor: { exact: "Test", prefix: "", suffix: " after" },
+      idempotencyKey: "typing-burst",
+      substantial: false,
+      capturedActor: actorIdentity,
+      sourceKind: "direct_entry",
+      basisKind: "automatic_direct_entry_attribution",
+      determination: humanDetermination(),
+      status: "capturing",
+    });
+
+    const [recovered] = await new DurableCoworkPasteProvenanceOutbox(
+      key,
+      backing,
+      stage,
+    ).list();
+    expect(recovered).toMatchObject({
+      status: "ready",
+      anchor: { exact: "T" },
+      frozenRequest: {
+        expectedActorRef: actorIdentity.ref,
+        expectedActorIdentityStatus: actorIdentity.identity_status,
+      },
+    });
+    await expect(
+      outbox.updateDetermination(
+        open.id,
+        unknownCoworkProvenanceDetermination(),
+      ),
+    ).rejects.toThrow("frozen");
+    await expect(
+      outbox.markReady(
+        open.id,
+        unknownCoworkProvenanceDetermination(),
+        "automatic_direct_entry_attribution",
+      ),
+    ).rejects.toThrow("frozen");
+  });
+
   it("atomically requires fresh explicit determinations for every pending entry after an actor change", async () => {
-    const backing =
-      new InMemoryCoworkPasteProvenanceOutboxBackingStore();
+    const backing = new InMemoryCoworkPasteProvenanceOutboxBackingStore();
     const outbox = new DurableCoworkPasteProvenanceOutbox(
       "store:actor-change",
       backing,
@@ -220,16 +321,27 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
       determination: humanDetermination(),
       status: "ready",
     });
+    await outbox.upsertCapture({
+      anchor: { ...anchor, exact: "typed text" },
+      idempotencyKey: "old-direct-entry-key",
+      substantial: false,
+      capturedActor: actorIdentity,
+      sourceKind: "direct_entry",
+      basisKind: "automatic_direct_entry_attribution",
+      determination: humanDetermination(),
+      status: "capturing",
+    });
 
     const reset = await outbox.resetAfterActorChange(
       "new-actor-attempt",
       unknownCoworkProvenanceDetermination(),
     );
 
-    expect(reset).toHaveLength(2);
+    expect(reset).toHaveLength(3);
     expect(reset.map((entry) => entry.idempotencyKey)).toEqual([
       `new-actor-attempt:${String(first.id)}`,
       "new-actor-attempt:2",
+      "new-actor-attempt:3",
     ]);
     for (const entry of reset) {
       expect(entry).toMatchObject({
@@ -243,6 +355,11 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
       });
       expect(entry.frozenRequest).toBeUndefined();
     }
+    expect(reset[2]).toMatchObject({
+      sourceKind: "legacy",
+      basisKind: "user_attestation",
+      determination: { authorship: { kind: "unknown" } },
+    });
 
     const edited = await outbox.updateDetermination(
       first.id,
@@ -271,10 +388,8 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
 
   it("rejects an oversized exact span before touching either recovery journal", async () => {
     const key = "store:oversized";
-    const backing =
-      new InMemoryCoworkPasteProvenanceOutboxBackingStore();
-    const intentStage =
-      new InMemoryCoworkPasteProvenanceIntentStage();
+    const backing = new InMemoryCoworkPasteProvenanceOutboxBackingStore();
+    const intentStage = new InMemoryCoworkPasteProvenanceIntentStage();
     const outbox = new DurableCoworkPasteProvenanceOutbox(
       key,
       backing,
@@ -295,6 +410,37 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
       }),
     ).rejects.toBeInstanceOf(CoworkPasteProvenanceExactLimitError);
     expect(intentStage.list(key)).toEqual([]);
+    expect(await outbox.list()).toEqual([]);
+  });
+
+  it("rejects invisible capturing states for paste and legacy sources", async () => {
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      "store:invalid-capturing",
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+      new InMemoryCoworkPasteProvenanceIntentStage(),
+    );
+    await expect(
+      outbox.upsertCapture({
+        anchor,
+        idempotencyKey: "capturing-paste",
+        substantial: false,
+        sourceKind: "paste",
+        basisKind: "user_attestation",
+        determination: humanDetermination(),
+        status: "capturing",
+      }),
+    ).rejects.toThrow("automatic direct-entry");
+    await expect(
+      outbox.append({
+        anchor,
+        idempotencyKey: "capturing-legacy",
+        substantial: false,
+        sourceKind: "legacy",
+        basisKind: "user_attestation",
+        determination: humanDetermination(),
+        status: "capturing",
+      }),
+    ).rejects.toThrow("invalid source, basis, or state");
     expect(await outbox.list()).toEqual([]);
   });
 
@@ -368,8 +514,7 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
   });
 
   it("rehydrates a synchronously staged intent after the IndexedDB write fails", async () => {
-    const backing =
-      new InMemoryCoworkPasteProvenanceOutboxBackingStore();
+    const backing = new InMemoryCoworkPasteProvenanceOutboxBackingStore();
     const stage = new InMemoryCoworkPasteProvenanceIntentStage();
     let fail = true;
     const flaky: CoworkPasteProvenanceOutboxBackingStore = {
@@ -508,9 +653,7 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
     const quarantineKey = storage
       .keys()
       .find((candidate) =>
-        candidate.startsWith(
-          `${prefix}quarantine:${encodeURIComponent(key)}:`,
-        ),
+        candidate.startsWith(`${prefix}quarantine:${encodeURIComponent(key)}:`),
       );
     expect(quarantineKey).toBeDefined();
     expect(storage.getItem(quarantineKey!)).toBe(raw);
@@ -533,6 +676,7 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
       anchor,
       idempotencyKey: "valid-paste",
       substantial: false,
+      sourceKind: "paste",
       basisKind: "automatic_short_text_attribution",
       determination: humanDetermination(),
       capturedAt: "2026-07-30T12:00:00.000Z",
@@ -561,9 +705,7 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
     );
 
     expect(stage.list(key)).toEqual([valid]);
-    expect(JSON.parse(storage.getItem(`${prefix}${key}`)!)).toEqual([
-      valid,
-    ]);
+    expect(JSON.parse(storage.getItem(`${prefix}${key}`)!)).toEqual([valid]);
     expect(
       storage
         .keys()
@@ -590,6 +732,7 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
       anchor,
       idempotencyKey: "valid-indexeddb-paste",
       substantial: false,
+      sourceKind: "paste",
       basisKind: "automatic_short_text_attribution",
       determination: humanDetermination(),
       capturedAt: "2026-07-30T12:00:00.000Z",
@@ -603,14 +746,13 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
     };
     const records = new Map<string, unknown>([[key, malformed]]);
     const warnings: CoworkPasteProvenanceStorageWarning[] = [];
-    const backing =
-      new IndexedDbCoworkPasteProvenanceOutboxBackingStore(
-        "test-database",
-        {
-          openDatabase: async () => fakeIndexedDatabase(records),
-          onWarning: (warning) => warnings.push(warning),
-        },
-      );
+    const backing = new IndexedDbCoworkPasteProvenanceOutboxBackingStore(
+      "test-database",
+      {
+        openDatabase: async () => fakeIndexedDatabase(records),
+        onWarning: (warning) => warnings.push(warning),
+      },
+    );
 
     const recovered = await backing.read(key);
 
@@ -622,9 +764,7 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
     expect(records.get(key)).toEqual(recovered);
     expect(
       [...records.keys()].some((candidate) =>
-        candidate.startsWith(
-          `__quarantine__:${encodeURIComponent(key)}:`,
-        ),
+        candidate.startsWith(`__quarantine__:${encodeURIComponent(key)}:`),
       ),
     ).toBe(true);
     expect(warnings).toEqual([
@@ -642,20 +782,19 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
     const database = fakeIndexedDatabase(records);
     const warnings: CoworkPasteProvenanceStorageWarning[] = [];
     let attempts = 0;
-    const backing =
-      new IndexedDbCoworkPasteProvenanceOutboxBackingStore(
-        "test-retry-database",
-        {
-          openDatabase: async () => {
-            attempts += 1;
-            if (attempts === 1) {
-              throw new Error("temporary browser failure");
-            }
-            return database;
-          },
-          onWarning: (warning) => warnings.push(warning),
+    const backing = new IndexedDbCoworkPasteProvenanceOutboxBackingStore(
+      "test-retry-database",
+      {
+        openDatabase: async () => {
+          attempts += 1;
+          if (attempts === 1) {
+            throw new Error("temporary browser failure");
+          }
+          return database;
         },
-      );
+        onWarning: (warning) => warnings.push(warning),
+      },
+    );
 
     await expect(backing.read("store:retry")).rejects.toThrow(
       "temporary browser failure",

--- a/dashboard-react/src/apps/cowork/provenance/CoworkPasteProvenanceOutbox.test.ts
+++ b/dashboard-react/src/apps/cowork/provenance/CoworkPasteProvenanceOutbox.test.ts
@@ -230,6 +230,62 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
     });
   });
 
+  it("preserves actorless typing as an explicit legacy determination across reopen", async () => {
+    const key = "store:actorless-direct";
+    const backing = new InMemoryCoworkPasteProvenanceOutboxBackingStore();
+    const stage = new InMemoryCoworkPasteProvenanceIntentStage();
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      key,
+      backing,
+      stage,
+    );
+    const open = await outbox.upsertCapture({
+      anchor: { exact: "Test", prefix: "", suffix: " after" },
+      idempotencyKey: "actorless-direct-key",
+      substantial: false,
+      sourceKind: "direct_entry",
+      basisKind: "automatic_direct_entry_attribution",
+      determination: unknownCoworkProvenanceDetermination(),
+      status: "capturing",
+    });
+
+    await outbox.deferDirectEntry(
+      open.id,
+      "explicit-recovery-key",
+      unknownCoworkProvenanceDetermination(),
+      {
+        code: "provenance_actor_unavailable_at_capture",
+        message: "No actor was available at capture.",
+        kind: "terminal",
+      },
+    );
+
+    expect(stage.list(key)).toEqual([
+      expect.objectContaining({
+        idempotencyKey: "explicit-recovery-key",
+        sourceKind: "legacy",
+        status: "awaiting_determination",
+      }),
+    ]);
+    const [recovered] = await new DurableCoworkPasteProvenanceOutbox(
+      key,
+      backing,
+      stage,
+    ).list();
+    expect(recovered).toMatchObject({
+      id: open.id,
+      idempotencyKey: "explicit-recovery-key",
+      anchor: { exact: "Test" },
+      sourceKind: "legacy",
+      basisKind: "user_attestation",
+      status: "awaiting_determination",
+      requiresExplicitDetermination: true,
+      determination: { authorship: { kind: "unknown" } },
+      failure: { code: "provenance_actor_unavailable_at_capture" },
+    });
+    expect(recovered?.capturedActor).toBeUndefined();
+  });
+
   it("never lets a stale open-stage row overwrite a ready frozen request", async () => {
     const key = "store:frozen-stage";
     const backing = new InMemoryCoworkPasteProvenanceOutboxBackingStore();

--- a/dashboard-react/src/apps/cowork/provenance/CoworkPasteProvenanceOutbox.test.ts
+++ b/dashboard-react/src/apps/cowork/provenance/CoworkPasteProvenanceOutbox.test.ts
@@ -267,11 +267,12 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
         status: "awaiting_determination",
       }),
     ]);
-    const [recovered] = await new DurableCoworkPasteProvenanceOutbox(
+    const reopened = new DurableCoworkPasteProvenanceOutbox(
       key,
       backing,
       stage,
-    ).list();
+    );
+    const [recovered] = await reopened.list();
     expect(recovered).toMatchObject({
       id: open.id,
       idempotencyKey: "explicit-recovery-key",
@@ -284,6 +285,39 @@ describe("DurableCoworkPasteProvenanceOutbox", () => {
       failure: { code: "provenance_actor_unavailable_at_capture" },
     });
     expect(recovered?.capturedActor).toBeUndefined();
+
+    const edited = await reopened.updateDetermination(
+      open.id,
+      humanDetermination(),
+    );
+    expect(edited).toMatchObject({
+      status: "awaiting_determination",
+      requiresExplicitDetermination: true,
+      determination: { authorship: { kind: "human" } },
+      failure: { code: "provenance_actor_unavailable_at_capture" },
+    });
+    expect(
+      (
+        await new DurableCoworkPasteProvenanceOutbox(
+          key,
+          backing,
+          stage,
+        ).list()
+      )[0],
+    ).toMatchObject({
+      status: "awaiting_determination",
+      determination: { authorship: { kind: "human" } },
+      failure: { code: "provenance_actor_unavailable_at_capture" },
+    });
+
+    const readied = await reopened.markReady(
+      open.id,
+      humanDetermination(),
+      "user_attestation",
+      actorIdentity,
+    );
+    expect(readied.requiresExplicitDetermination).toBeUndefined();
+    expect(readied.failure).toBeUndefined();
   });
 
   it("never lets a stale open-stage row overwrite a ready frozen request", async () => {

--- a/dashboard-react/src/apps/cowork/provenance/CoworkPasteProvenanceOutbox.ts
+++ b/dashboard-react/src/apps/cowork/provenance/CoworkPasteProvenanceOutbox.ts
@@ -107,6 +107,17 @@ export interface CoworkPasteProvenanceOutbox {
     id: number,
     capture: CoworkPasteProvenanceCapture,
   ): Promise<CoworkPasteProvenanceOutboxEntry>;
+  /**
+   * Preserve an automatic typing capture that cannot be bound to its
+   * capture-time actor. It becomes an explicit legacy determination instead
+   * of disappearing or being attributed to whichever actor arrives later.
+   */
+  deferDirectEntry(
+    id: number,
+    idempotencyKey: string,
+    determination: CoworkProvenanceDetermination,
+    failure: CoworkPasteProvenanceFailure,
+  ): Promise<CoworkPasteProvenanceOutboxEntry>;
   updateDetermination(
     id: number,
     determination: CoworkProvenanceDetermination,
@@ -1387,6 +1398,49 @@ export class DurableCoworkPasteProvenanceOutbox implements CoworkPasteProvenance
     });
   }
 
+  deferDirectEntry(
+    id: number,
+    idempotencyKey: string,
+    determination: CoworkProvenanceDetermination,
+    failure: CoworkPasteProvenanceFailure,
+  ): Promise<CoworkPasteProvenanceOutboxEntry> {
+    if (idempotencyKey.length === 0 || idempotencyKey.length > 200) {
+      return Promise.reject(
+        new Error("Deferred provenance requires a bounded idempotency key."),
+      );
+    }
+    let priorIdempotencyKey = idempotencyKey;
+    return this.#replace(id, (entry) => {
+      priorIdempotencyKey = entry.idempotencyKey;
+      if (
+        entry.sourceKind !== "direct_entry" ||
+        entry.status !== "capturing" ||
+        entry.frozenRequest !== undefined
+      ) {
+        throw new Error(
+          "Only an unfrozen direct-entry capture can require a determination.",
+        );
+      }
+      return {
+        ...entry,
+        idempotencyKey,
+        capturedActor: undefined,
+        sourceKind: "legacy",
+        basisKind: "user_attestation",
+        determination,
+        status: "awaiting_determination",
+        requiresExplicitDetermination: true,
+        frozenRequest: undefined,
+        failure,
+      };
+    }).then((entry) => {
+      // The direct-entry intent is no longer allowed to recover as automatic.
+      // Volatile backing stores receive the replacement intent below.
+      this.#intentStage.remove(this.#key, priorIdempotencyKey);
+      return this.#refreshVolatileIntent(entry, priorIdempotencyKey);
+    });
+  }
+
   updateDetermination(
     id: number,
     determination: CoworkProvenanceDetermination,
@@ -1520,6 +1574,7 @@ export class DurableCoworkPasteProvenanceOutbox implements CoworkPasteProvenance
           sourceKind:
             entry.sourceKind === "direct_entry" ? "legacy" : entry.sourceKind,
           basisKind: "user_attestation",
+          capturedActor: undefined,
           determination,
           status: "awaiting_determination",
           requiresExplicitDetermination: true,
@@ -1540,12 +1595,12 @@ export class DurableCoworkPasteProvenanceOutbox implements CoworkPasteProvenance
         },
       };
     }).then(({ entries, priorIdempotencyKeys }) =>
-      entries.map((entry, index) =>
-        this.#refreshVolatileIntent(
-          entry,
-          priorIdempotencyKeys[index] ?? entry.idempotencyKey,
-        ),
-      ),
+      entries.map((entry, index) => {
+        const priorIdempotencyKey =
+          priorIdempotencyKeys[index] ?? entry.idempotencyKey;
+        this.#intentStage.remove(this.#key, priorIdempotencyKey);
+        return this.#refreshVolatileIntent(entry, priorIdempotencyKey);
+      }),
     );
   }
 

--- a/dashboard-react/src/apps/cowork/provenance/CoworkPasteProvenanceOutbox.ts
+++ b/dashboard-react/src/apps/cowork/provenance/CoworkPasteProvenanceOutbox.ts
@@ -2,6 +2,7 @@ import type { RangeQuoteAnchor } from "../feedback/feedbackAnchor";
 import {
   COWORK_PROVENANCE_DETERMINATION_SCHEMA,
   coworkProvenanceDeterminationIssue,
+  type CoworkProvenanceActorIdentity,
   type CoworkProvenanceDetermination,
   type CoworkProvenancePerson,
 } from "./contracts";
@@ -16,6 +17,8 @@ const DATABASE_NAME = "work-buddy-cowork-paste-provenance";
 const STORE_NAME = "paste-provenance-outbox";
 
 export type CoworkPasteProvenanceStatus =
+  | "capturing"
+  | "cancelled"
   | "awaiting_determination"
   | "ready"
   | "retryable_failure"
@@ -47,6 +50,9 @@ export interface CoworkPasteProvenanceOutboxEntry {
   readonly anchor: RangeQuoteAnchor;
   readonly idempotencyKey: string;
   readonly substantial: boolean;
+  /** Actor session in force when the input gesture began. */
+  readonly capturedActor?: CoworkProvenanceActorIdentity;
+  readonly sourceKind: CoworkPasteProvenanceRequest["sourceKind"];
   readonly basisKind: CoworkPasteProvenanceRequest["basisKind"];
   readonly determination: CoworkProvenanceDetermination;
   readonly capturedAt: string;
@@ -64,6 +70,9 @@ export interface CoworkPasteProvenanceCapture {
   readonly anchor: RangeQuoteAnchor;
   readonly idempotencyKey: string;
   readonly substantial: boolean;
+  readonly capturedActor?: CoworkProvenanceActorIdentity;
+  /** Omitted only by persisted v1/v2 paste records and older adapters. */
+  readonly sourceKind?: CoworkPasteProvenanceRequest["sourceKind"];
   readonly basisKind: CoworkPasteProvenanceRequest["basisKind"];
   readonly determination: CoworkProvenanceDetermination;
   readonly capturedAt?: string;
@@ -72,13 +81,30 @@ export interface CoworkPasteProvenanceCapture {
   readonly requiresExplicitDetermination?: boolean;
   readonly status: Extract<
     CoworkPasteProvenanceStatus,
-    "awaiting_determination" | "ready"
+    "capturing" | "awaiting_determination" | "ready"
   >;
 }
 
 export interface CoworkPasteProvenanceOutbox {
   list(): Promise<readonly CoworkPasteProvenanceOutboxEntry[]>;
   append(
+    capture: CoworkPasteProvenanceCapture,
+  ): Promise<CoworkPasteProvenanceOutboxEntry>;
+  /**
+   * Synchronously stage, then durably insert/update one still-open typing
+   * burst. The shared idempotency key is the burst identity.
+   */
+  upsertCapture(
+    capture: CoworkPasteProvenanceCapture,
+  ): Promise<CoworkPasteProvenanceOutboxEntry>;
+  /** Retire an open burst whose entire inserted range was deleted. */
+  cancelCapture(id: number): Promise<void>;
+  /**
+   * Reopen a direct-entry request frozen locally but not yet handed to the
+   * recorder because another keystroke advanced its target generation.
+   */
+  reopenCapture(
+    id: number,
     capture: CoworkPasteProvenanceCapture,
   ): Promise<CoworkPasteProvenanceOutboxEntry>;
   updateDetermination(
@@ -89,6 +115,7 @@ export interface CoworkPasteProvenanceOutbox {
     id: number,
     determination: CoworkProvenanceDetermination,
     basisKind: CoworkPasteProvenanceRequest["basisKind"],
+    capturedActor?: CoworkProvenanceActorIdentity,
   ): Promise<CoworkPasteProvenanceOutboxEntry>;
   freezeRequest(
     id: number,
@@ -150,9 +177,7 @@ interface NormalizedValue<Value> {
   readonly droppedEntries: number;
 }
 
-const storageWarning = (
-  warning: CoworkPasteProvenanceStorageWarning,
-): void => {
+const storageWarning = (warning: CoworkPasteProvenanceStorageWarning): void => {
   console.warn(`[Co-work paste provenance] ${warning.message}`, warning);
 };
 
@@ -191,6 +216,26 @@ const normalizedPerson = (value: unknown): CoworkProvenancePerson | null => {
     return { kind: "named_person", display_name: value.display_name };
   }
   return null;
+};
+
+const normalizedActor = (
+  value: unknown,
+): CoworkProvenanceActorIdentity | null => {
+  if (
+    !isObject(value) ||
+    value.kind !== "human" ||
+    typeof value.ref !== "string" ||
+    value.ref.trim().length === 0 ||
+    (value.identity_status !== "local_actor_ref" &&
+      value.identity_status !== "account_ref")
+  ) {
+    return null;
+  }
+  return {
+    kind: "human",
+    ref: value.ref,
+    identity_status: value.identity_status,
+  };
 };
 
 const normalizedDetermination = (
@@ -269,11 +314,25 @@ const normalizedAnchor = (value: unknown): RangeQuoteAnchor | null => {
   };
 };
 
-const PASTE_BASIS_KINDS = new Set([
+const PROVENANCE_BASIS_KINDS = new Set([
   "automatic_short_text_attribution",
+  "automatic_direct_entry_attribution",
   "user_attestation",
 ]);
+const PROVENANCE_SOURCE_KINDS = new Set(["paste", "direct_entry", "legacy"]);
+const provenanceSourceBasisAllowed = (
+  sourceKind: CoworkPasteProvenanceRequest["sourceKind"],
+  basisKind: CoworkPasteProvenanceRequest["basisKind"],
+): boolean =>
+  (sourceKind === "paste" &&
+    (basisKind === "automatic_short_text_attribution" ||
+      basisKind === "user_attestation")) ||
+  (sourceKind === "direct_entry" &&
+    basisKind === "automatic_direct_entry_attribution") ||
+  (sourceKind === "legacy" && basisKind === "user_attestation");
 const PASTE_STATUSES = new Set<CoworkPasteProvenanceStatus>([
+  "capturing",
+  "cancelled",
   "awaiting_determination",
   "ready",
   "retryable_failure",
@@ -294,24 +353,43 @@ const normalizedCapture = (
     typeof value.idempotencyKey !== "string" ||
     value.idempotencyKey.length === 0 ||
     typeof value.substantial !== "boolean" ||
+    (value.sourceKind !== undefined &&
+      (typeof value.sourceKind !== "string" ||
+        !PROVENANCE_SOURCE_KINDS.has(value.sourceKind))) ||
     typeof value.basisKind !== "string" ||
-    !PASTE_BASIS_KINDS.has(value.basisKind) ||
+    !PROVENANCE_BASIS_KINDS.has(value.basisKind) ||
     typeof value.status !== "string" ||
     !PASTE_STATUSES.has(value.status as CoworkPasteProvenanceStatus)
   ) {
     return null;
   }
+  const capturedActor =
+    value.capturedActor === undefined
+      ? undefined
+      : normalizedActor(value.capturedActor);
+  if (value.capturedActor !== undefined && capturedActor === null) return null;
+  const sourceKind = (value.sourceKind ??
+    "paste") as CoworkPasteProvenanceRequest["sourceKind"];
+  const basisKind =
+    value.basisKind as CoworkPasteProvenanceRequest["basisKind"];
+  if (
+    !provenanceSourceBasisAllowed(sourceKind, basisKind) ||
+    (value.status === "capturing" &&
+      (sourceKind !== "direct_entry" ||
+        basisKind !== "automatic_direct_entry_attribution")) ||
+    (!persisted && value.status === "cancelled")
+  ) {
+    return null;
+  }
   if (
     !persisted &&
+    value.status !== "capturing" &&
     value.status !== "awaiting_determination" &&
     value.status !== "ready"
   ) {
     return null;
   }
-  if (
-    value.capturedAt !== undefined &&
-    typeof value.capturedAt !== "string"
-  ) {
+  if (value.capturedAt !== undefined && typeof value.capturedAt !== "string") {
     return null;
   }
   if (
@@ -337,8 +415,12 @@ const normalizedCapture = (
     anchor,
     idempotencyKey: value.idempotencyKey,
     substantial: value.substantial,
-    basisKind: value.basisKind as CoworkPasteProvenanceRequest["basisKind"],
+    // v1/v2 records predate the explicit source discriminator and were all
+    // paste captures. Preserve them without inventing a new source.
+    sourceKind,
+    basisKind,
     determination,
+    ...(capturedActor == null ? {} : { capturedActor }),
     ...(typeof value.capturedAt === "string"
       ? { capturedAt: value.capturedAt }
       : persisted
@@ -389,22 +471,59 @@ const normalizedCapture = (
       typeof value.frozenRequest.idempotencyKey !== "string" ||
       value.frozenRequest.idempotencyKey !== value.idempotencyKey ||
       typeof value.frozenRequest.basisKind !== "string" ||
-      !PASTE_BASIS_KINDS.has(value.frozenRequest.basisKind)
+      !PROVENANCE_BASIS_KINDS.has(value.frozenRequest.basisKind) ||
+      (value.frozenRequest.sourceKind !== undefined &&
+        (typeof value.frozenRequest.sourceKind !== "string" ||
+          !PROVENANCE_SOURCE_KINDS.has(value.frozenRequest.sourceKind))) ||
+      (value.frozenRequest.expectedActorRef !== undefined &&
+        typeof value.frozenRequest.expectedActorRef !== "string") ||
+      (value.frozenRequest.expectedActorIdentityStatus !== undefined &&
+        value.frozenRequest.expectedActorIdentityStatus !== "local_actor_ref" &&
+        value.frozenRequest.expectedActorIdentityStatus !== "account_ref")
     ) {
       return null;
     }
     frozenRequest = {
       storeId: value.frozenRequest.storeId,
       documentId: value.frozenRequest.documentId,
-      basisKind:
-        value.frozenRequest
-          .basisKind as CoworkPasteProvenanceRequest["basisKind"],
+      ...(typeof value.frozenRequest.expectedActorRef === "string"
+        ? { expectedActorRef: value.frozenRequest.expectedActorRef }
+        : {}),
+      ...(value.frozenRequest.expectedActorIdentityStatus ===
+        "local_actor_ref" ||
+      value.frozenRequest.expectedActorIdentityStatus === "account_ref"
+        ? {
+            expectedActorIdentityStatus:
+              value.frozenRequest.expectedActorIdentityStatus,
+          }
+        : {}),
+      sourceKind: (value.frozenRequest.sourceKind ??
+        "paste") as CoworkPasteProvenanceRequest["sourceKind"],
+      basisKind: value.frozenRequest
+        .basisKind as CoworkPasteProvenanceRequest["basisKind"],
       expectedStructuredHeadSha256:
         value.frozenRequest.expectedStructuredHeadSha256,
       anchor: frozenAnchor,
       attestation: frozenAttestation,
       idempotencyKey: value.frozenRequest.idempotencyKey,
     };
+    if (
+      value.status === "capturing" ||
+      value.status === "cancelled" ||
+      frozenRequest.sourceKind !== sourceKind ||
+      frozenRequest.basisKind !== basisKind ||
+      !portableEqual(frozenRequest.anchor, anchor) ||
+      !portableEqual(frozenRequest.attestation, determination) ||
+      (frozenRequest.sourceKind !== "paste" &&
+        (frozenRequest.expectedActorRef === undefined ||
+          frozenRequest.expectedActorIdentityStatus === undefined)) ||
+      (capturedActor != null &&
+        (frozenRequest.expectedActorRef !== capturedActor.ref ||
+          frozenRequest.expectedActorIdentityStatus !==
+            capturedActor.identity_status))
+    ) {
+      return null;
+    }
   }
 
   let failure: CoworkPasteProvenanceFailure | undefined;
@@ -461,9 +580,7 @@ const portableEqual = (
       Array.isArray(left) &&
       Array.isArray(right) &&
       left.length === right.length &&
-      left.every((value, index) =>
-        portableEqual(value, right[index], seen),
-      )
+      left.every((value, index) => portableEqual(value, right[index], seen))
     );
   }
   const leftRecord = left as Record<string, unknown>;
@@ -495,10 +612,7 @@ const normalizeIntentCaptures = (
   let droppedEntries = 0;
   for (const candidate of value) {
     const normalized = normalizedCapture(candidate, { persisted: false });
-    if (
-      normalized === null ||
-      seen.has(normalized.idempotencyKey)
-    ) {
+    if (normalized === null || seen.has(normalized.idempotencyKey)) {
       droppedEntries += 1;
       continue;
     }
@@ -507,8 +621,7 @@ const normalizeIntentCaptures = (
   }
   return {
     value: captures,
-    repaired:
-      droppedEntries > 0 || !portableEqual(value, captures),
+    repaired: droppedEntries > 0 || !portableEqual(value, captures),
     droppedEntries,
   };
 };
@@ -523,7 +636,11 @@ const normalizePersistedOutbox = (
   const seenIds = new Set<number>();
   const seenKeys = new Set<string>();
   let droppedEntries =
-    isObject(value) && Array.isArray(value.entries) ? 0 : value === undefined ? 0 : 1;
+    isObject(value) && Array.isArray(value.entries)
+      ? 0
+      : value === undefined
+        ? 0
+        : 1;
   for (const candidate of rawEntries) {
     const normalized = normalizedCapture(candidate, { persisted: true });
     if (
@@ -570,9 +687,10 @@ export interface CoworkPasteProvenanceOutboxBackingStore {
   read(key: string): Promise<PersistedOutbox | undefined>;
   mutate<Value>(
     key: string,
-    mutation: (
-      current: PersistedOutbox,
-    ) => { readonly record: PersistedOutbox; readonly result: Value },
+    mutation: (current: PersistedOutbox) => {
+      readonly record: PersistedOutbox;
+      readonly result: Value;
+    },
   ): Promise<Value>;
 }
 
@@ -606,9 +724,7 @@ const emptyRecord = (key: string): PersistedOutbox => ({
   entries: [],
 });
 
-export class InMemoryCoworkPasteProvenanceOutboxBackingStore
-  implements CoworkPasteProvenanceOutboxBackingStore
-{
+export class InMemoryCoworkPasteProvenanceOutboxBackingStore implements CoworkPasteProvenanceOutboxBackingStore {
   readonly durable = false;
   readonly #records = new Map<string, PersistedOutbox>();
   #chain: Promise<unknown> = Promise.resolve();
@@ -621,9 +737,10 @@ export class InMemoryCoworkPasteProvenanceOutboxBackingStore
 
   mutate<Value>(
     key: string,
-    mutation: (
-      current: PersistedOutbox,
-    ) => { readonly record: PersistedOutbox; readonly result: Value },
+    mutation: (current: PersistedOutbox) => {
+      readonly record: PersistedOutbox;
+      readonly result: Value;
+    },
   ): Promise<Value> {
     const run = this.#chain.then(() => {
       const current = cloneRecord(this.#records.get(key) ?? emptyRecord(key));
@@ -644,9 +761,7 @@ export class InMemoryCoworkPasteProvenanceOutboxBackingStore
   }
 }
 
-export class InMemoryCoworkPasteProvenanceIntentStage
-  implements CoworkPasteProvenanceIntentStage
-{
+export class InMemoryCoworkPasteProvenanceIntentStage implements CoworkPasteProvenanceIntentStage {
   readonly #records = new Map<
     string,
     readonly CoworkPasteProvenanceCapture[]
@@ -659,8 +774,7 @@ export class InMemoryCoworkPasteProvenanceIntentStage
   put(key: string, capture: CoworkPasteProvenanceCapture): void {
     const current = this.list(key);
     const found = current.some(
-      (candidate) =>
-        candidate.idempotencyKey === capture.idempotencyKey,
+      (candidate) => candidate.idempotencyKey === capture.idempotencyKey,
     );
     this.#records.set(
       key,
@@ -684,9 +798,7 @@ export class InMemoryCoworkPasteProvenanceIntentStage
   }
 }
 
-export class WebStorageCoworkPasteProvenanceIntentStage
-  implements CoworkPasteProvenanceIntentStage
-{
+export class WebStorageCoworkPasteProvenanceIntentStage implements CoworkPasteProvenanceIntentStage {
   readonly #storage: Storage;
   readonly #prefix: string;
   readonly #onWarning: CoworkPasteProvenanceStorageWarningSink;
@@ -758,8 +870,7 @@ export class WebStorageCoworkPasteProvenanceIntentStage
   put(key: string, capture: CoworkPasteProvenanceCapture): void {
     const current = this.list(key);
     const found = current.some(
-      (candidate) =>
-        candidate.idempotencyKey === capture.idempotencyKey,
+      (candidate) => candidate.idempotencyKey === capture.idempotencyKey,
     );
     this.#write(
       key,
@@ -782,10 +893,7 @@ export class WebStorageCoworkPasteProvenanceIntentStage
     );
   }
 
-  #write(
-    key: string,
-    captures: readonly CoworkPasteProvenanceCapture[],
-  ): void {
+  #write(key: string, captures: readonly CoworkPasteProvenanceCapture[]): void {
     const storageKey = `${this.#prefix}${key}`;
     if (captures.length === 0) {
       this.#storage.removeItem(storageKey);
@@ -880,15 +988,11 @@ const quarantinedOutboxRecord = (
 });
 
 export interface IndexedDbCoworkPasteProvenanceOutboxBackingStoreOptions {
-  readonly openDatabase?: (
-    databaseName: string,
-  ) => Promise<IDBDatabase>;
+  readonly openDatabase?: (databaseName: string) => Promise<IDBDatabase>;
   readonly onWarning?: CoworkPasteProvenanceStorageWarningSink;
 }
 
-export class IndexedDbCoworkPasteProvenanceOutboxBackingStore
-  implements CoworkPasteProvenanceOutboxBackingStore
-{
+export class IndexedDbCoworkPasteProvenanceOutboxBackingStore implements CoworkPasteProvenanceOutboxBackingStore {
   readonly durable = true;
   readonly #databaseName: string;
   readonly #openDatabase: (databaseName: string) => Promise<IDBDatabase>;
@@ -909,9 +1013,7 @@ export class IndexedDbCoworkPasteProvenanceOutboxBackingStore
     const transaction = database.transaction(STORE_NAME, "readwrite");
     const done = transactionDone(transaction);
     const store = transaction.objectStore(STORE_NAME);
-    let warning:
-      | CoworkPasteProvenanceStorageWarning
-      | undefined;
+    let warning: CoworkPasteProvenanceStorageWarning | undefined;
     try {
       const stored = (await requestResult(store.get(key))) as unknown;
       if (stored === undefined) {
@@ -954,17 +1056,16 @@ export class IndexedDbCoworkPasteProvenanceOutboxBackingStore
 
   async mutate<Value>(
     key: string,
-    mutation: (
-      current: PersistedOutbox,
-    ) => { readonly record: PersistedOutbox; readonly result: Value },
+    mutation: (current: PersistedOutbox) => {
+      readonly record: PersistedOutbox;
+      readonly result: Value;
+    },
   ): Promise<Value> {
     const database = await this.#open();
     const transaction = database.transaction(STORE_NAME, "readwrite");
     const done = transactionDone(transaction);
     const store = transaction.objectStore(STORE_NAME);
-    let warning:
-      | CoworkPasteProvenanceStorageWarning
-      | undefined;
+    let warning: CoworkPasteProvenanceStorageWarning | undefined;
     try {
       const stored = (await requestResult(store.get(key))) as unknown;
       const normalized = normalizePersistedOutbox(stored, key);
@@ -979,9 +1080,7 @@ export class IndexedDbCoworkPasteProvenanceOutboxBackingStore
           droppedEntries: normalized.droppedEntries,
         };
       }
-      const { record, result } = mutation(
-        cloneRecord(normalized.value),
-      );
+      const { record, result } = mutation(cloneRecord(normalized.value));
       if (record.key !== key) {
         transaction.abort();
         await done.catch(() => undefined);
@@ -1045,14 +1144,10 @@ export class IndexedDbCoworkPasteProvenanceOutboxBackingStore
   }
 }
 
-const fallbackBacking =
-  new InMemoryCoworkPasteProvenanceOutboxBackingStore();
-const fallbackIntentStage =
-  new InMemoryCoworkPasteProvenanceIntentStage();
+const fallbackBacking = new InMemoryCoworkPasteProvenanceOutboxBackingStore();
+const fallbackIntentStage = new InMemoryCoworkPasteProvenanceIntentStage();
 
-export class DurableCoworkPasteProvenanceOutbox
-  implements CoworkPasteProvenanceOutbox
-{
+export class DurableCoworkPasteProvenanceOutbox implements CoworkPasteProvenanceOutbox {
   readonly #key: string;
   readonly #backing: CoworkPasteProvenanceOutboxBackingStore;
   readonly #intentStage: CoworkPasteProvenanceIntentStage;
@@ -1060,14 +1155,14 @@ export class DurableCoworkPasteProvenanceOutbox
 
   constructor(
     key: string,
-    backing: CoworkPasteProvenanceOutboxBackingStore =
-      typeof indexedDB === "undefined"
-        ? fallbackBacking
-        : new IndexedDbCoworkPasteProvenanceOutboxBackingStore(),
-    intentStage: CoworkPasteProvenanceIntentStage =
-      typeof localStorage === "undefined"
-        ? fallbackIntentStage
-        : new WebStorageCoworkPasteProvenanceIntentStage(),
+    backing: CoworkPasteProvenanceOutboxBackingStore = typeof indexedDB ===
+    "undefined"
+      ? fallbackBacking
+      : new IndexedDbCoworkPasteProvenanceOutboxBackingStore(),
+    intentStage: CoworkPasteProvenanceIntentStage = typeof localStorage ===
+    "undefined"
+      ? fallbackIntentStage
+      : new WebStorageCoworkPasteProvenanceIntentStage(),
   ) {
     this.#key = key;
     this.#backing = backing;
@@ -1077,9 +1172,15 @@ export class DurableCoworkPasteProvenanceOutbox
   list(): Promise<readonly CoworkPasteProvenanceOutboxEntry[]> {
     return this.#enqueue(async () => {
       await this.#reconcileStagedIntents();
-      const record =
-        (await this.#backing.read(this.#key)) ?? emptyRecord(this.#key);
-      return record.entries.map(cloneEntry);
+      return this.#backing.mutate(this.#key, (current) => {
+        const entries = current.entries.filter(
+          (entry) => entry.status !== "cancelled",
+        );
+        return {
+          record: { ...current, entries },
+          result: entries.map(cloneEntry),
+        };
+      });
     });
   }
 
@@ -1091,11 +1192,25 @@ export class DurableCoworkPasteProvenanceOutbox
     }
     const normalized: CoworkPasteProvenanceCapture = {
       ...capture,
+      sourceKind: capture.sourceKind ?? "paste",
       capturedAt: capture.capturedAt ?? new Date().toISOString(),
       passageExcerpt:
         capture.passageExcerpt ??
         coworkPastePassageExcerpt(capture.anchor.exact),
     };
+    if (
+      normalized.status === "capturing" ||
+      !provenanceSourceBasisAllowed(
+        normalized.sourceKind ?? "paste",
+        normalized.basisKind,
+      )
+    ) {
+      return Promise.reject(
+        new Error(
+          "This provenance capture has an invalid source, basis, or state.",
+        ),
+      );
+    }
     try {
       // This synchronous journal is the smallest honest cross-store barrier:
       // Yjs and IndexedDB cannot participate in one atomic browser transaction.
@@ -1105,8 +1220,7 @@ export class DurableCoworkPasteProvenanceOutbox
     }
     return this.#update((current) => {
       const existing = current.entries.find(
-        (entry) =>
-          entry.idempotencyKey === normalized.idempotencyKey,
+        (entry) => entry.idempotencyKey === normalized.idempotencyKey,
       );
       if (existing !== undefined) {
         return { record: current, result: cloneEntry(existing) };
@@ -1114,6 +1228,7 @@ export class DurableCoworkPasteProvenanceOutbox
       const entry: CoworkPasteProvenanceOutboxEntry = {
         id: current.nextId,
         ...normalized,
+        sourceKind: normalized.sourceKind ?? "paste",
         capturedAt: normalized.capturedAt!,
         passageExcerpt: normalized.passageExcerpt!,
       };
@@ -1137,33 +1252,191 @@ export class DurableCoworkPasteProvenanceOutbox
     });
   }
 
+  upsertCapture(
+    capture: CoworkPasteProvenanceCapture,
+  ): Promise<CoworkPasteProvenanceOutboxEntry> {
+    if (!coworkProvenanceExactWithinLimit(capture.anchor.exact)) {
+      return Promise.reject(new CoworkPasteProvenanceExactLimitError());
+    }
+    if (
+      capture.status !== "capturing" ||
+      capture.sourceKind !== "direct_entry" ||
+      capture.basisKind !== "automatic_direct_entry_attribution"
+    ) {
+      return Promise.reject(
+        new Error("Only an automatic direct-entry burst can be kept open."),
+      );
+    }
+    const normalized: CoworkPasteProvenanceCapture = {
+      ...capture,
+      sourceKind: "direct_entry",
+      capturedAt: capture.capturedAt ?? new Date().toISOString(),
+      passageExcerpt:
+        capture.passageExcerpt ??
+        coworkPastePassageExcerpt(capture.anchor.exact),
+    };
+    try {
+      // This overwrite is synchronous. A crash can lose neither the first
+      // character nor the latest shape of a still-open typing burst merely
+      // because IndexedDB has not run yet.
+      this.#intentStage.put(this.#key, normalized);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+    return this.#update((current) => {
+      const existing = current.entries.find(
+        (entry) => entry.idempotencyKey === normalized.idempotencyKey,
+      );
+      if (existing !== undefined) {
+        if (
+          existing.status !== "capturing" ||
+          existing.frozenRequest !== undefined
+        ) {
+          throw new Error("A frozen provenance capture cannot be extended.");
+        }
+        const next: CoworkPasteProvenanceOutboxEntry = {
+          id: existing.id,
+          ...normalized,
+          sourceKind: normalized.sourceKind ?? "paste",
+          capturedAt: normalized.capturedAt!,
+          passageExcerpt: normalized.passageExcerpt!,
+        };
+        return {
+          record: {
+            ...current,
+            entries: current.entries.map((entry) =>
+              entry.id === existing.id ? next : entry,
+            ),
+          },
+          result: cloneEntry(next),
+        };
+      }
+      const entry: CoworkPasteProvenanceOutboxEntry = {
+        id: current.nextId,
+        ...normalized,
+        sourceKind: normalized.sourceKind ?? "paste",
+        capturedAt: normalized.capturedAt!,
+        passageExcerpt: normalized.passageExcerpt!,
+      };
+      return {
+        record: {
+          ...current,
+          nextId: current.nextId + 1,
+          entries: [...current.entries, entry],
+        },
+        result: cloneEntry(entry),
+      };
+    });
+  }
+
+  cancelCapture(id: number): Promise<void> {
+    return this.#replace(id, (entry) => {
+      if (entry.status !== "capturing" || entry.frozenRequest !== undefined) {
+        throw new Error("Only an open provenance capture can be cancelled.");
+      }
+      return { ...entry, status: "cancelled" };
+    }).then((entry) => {
+      // The persisted tombstone wins if the page stops before physical cleanup.
+      this.#intentStage.remove(this.#key, entry.idempotencyKey);
+      return this.#update((current) => ({
+        record: {
+          ...current,
+          entries: current.entries.filter((candidate) => candidate.id !== id),
+        },
+        result: undefined,
+      }));
+    });
+  }
+
+  reopenCapture(
+    id: number,
+    capture: CoworkPasteProvenanceCapture,
+  ): Promise<CoworkPasteProvenanceOutboxEntry> {
+    if (
+      capture.status !== "capturing" ||
+      capture.sourceKind !== "direct_entry" ||
+      capture.basisKind !== "automatic_direct_entry_attribution"
+    ) {
+      return Promise.reject(
+        new Error("Only an automatic direct-entry request can be reopened."),
+      );
+    }
+    try {
+      this.#intentStage.put(this.#key, capture);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+    return this.#replace(id, (entry) => {
+      if (
+        entry.sourceKind !== "direct_entry" ||
+        entry.idempotencyKey !== capture.idempotencyKey
+      ) {
+        throw new Error(
+          "Only the same unsent direct-entry request can be reopened.",
+        );
+      }
+      return {
+        id: entry.id,
+        ...capture,
+        sourceKind: "direct_entry",
+        capturedAt: capture.capturedAt ?? entry.capturedAt,
+        passageExcerpt:
+          capture.passageExcerpt ??
+          coworkPastePassageExcerpt(capture.anchor.exact),
+      };
+    });
+  }
+
   updateDetermination(
     id: number,
     determination: CoworkProvenanceDetermination,
   ): Promise<CoworkPasteProvenanceOutboxEntry> {
-    return this.#replace(id, (entry) => ({
-      ...entry,
-      determination,
-      failure:
-        entry.failure?.code === COWORK_PROVENANCE_ACTOR_CHANGED
-          ? entry.failure
-          : undefined,
-    })).then((entry) => this.#refreshVolatileIntent(entry, entry.idempotencyKey));
+    return this.#replace(id, (entry) => {
+      if (entry.frozenRequest !== undefined) {
+        throw new Error("A frozen provenance request cannot be edited.");
+      }
+      return {
+        ...entry,
+        determination,
+        failure:
+          entry.failure?.code === COWORK_PROVENANCE_ACTOR_CHANGED
+            ? entry.failure
+            : undefined,
+      };
+    }).then((entry) =>
+      this.#refreshVolatileIntent(entry, entry.idempotencyKey),
+    );
   }
 
   markReady(
     id: number,
     determination: CoworkProvenanceDetermination,
     basisKind: CoworkPasteProvenanceRequest["basisKind"],
+    capturedActor?: CoworkProvenanceActorIdentity,
   ): Promise<CoworkPasteProvenanceOutboxEntry> {
-    return this.#replace(id, (entry) => ({
-      ...entry,
-      determination,
-      basisKind,
-      status: "ready",
-      requiresExplicitDetermination: undefined,
-      failure: undefined,
-    })).then((entry) => this.#refreshVolatileIntent(entry, entry.idempotencyKey));
+    return this.#replace(id, (entry) => {
+      if (entry.frozenRequest !== undefined) {
+        throw new Error("A frozen provenance request is already ready.");
+      }
+      if (!provenanceSourceBasisAllowed(entry.sourceKind, basisKind)) {
+        throw new Error("The provenance source and basis are incompatible.");
+      }
+      return {
+        ...entry,
+        determination,
+        basisKind,
+        ...(capturedActor === undefined ? {} : { capturedActor }),
+        status: "ready",
+        requiresExplicitDetermination: undefined,
+        failure: undefined,
+      };
+    }).then((entry) => {
+      if (this.#backing.durable) {
+        this.#intentStage.remove(this.#key, entry.idempotencyKey);
+        return entry;
+      }
+      return this.#refreshVolatileIntent(entry, entry.idempotencyKey);
+    });
   }
 
   freezeRequest(
@@ -1176,14 +1449,26 @@ export class DurableCoworkPasteProvenanceOutbox
   ): Promise<CoworkPasteProvenanceOutboxEntry> {
     return this.#replace(id, (entry) => {
       if (entry.frozenRequest !== undefined) return entry;
+      if (entry.sourceKind !== "paste" && entry.capturedActor === undefined) {
+        throw new Error(
+          "A direct or manual provenance request has no capture-time actor binding.",
+        );
+      }
       return {
         ...entry,
         frozenRequest: {
           storeId: target.storeId,
           documentId: target.documentId,
+          ...(entry.capturedActor === undefined
+            ? {}
+            : {
+                expectedActorRef: entry.capturedActor.ref,
+                expectedActorIdentityStatus:
+                  entry.capturedActor.identity_status,
+              }),
+          sourceKind: entry.sourceKind,
           basisKind: entry.basisKind,
-          expectedStructuredHeadSha256:
-            target.expectedStructuredHeadSha256,
+          expectedStructuredHeadSha256: target.expectedStructuredHeadSha256,
           anchor: entry.anchor,
           attestation: entry.determination,
           idempotencyKey: entry.idempotencyKey,
@@ -1228,6 +1513,12 @@ export class DurableCoworkPasteProvenanceOutbox
         (entry): CoworkPasteProvenanceOutboxEntry => ({
           ...entry,
           idempotencyKey: `${idempotencyKeyPrefix}:${String(entry.id)}`,
+          // A stale automatic direct-entry assertion must not be resent as
+          // though it were still machine-observed under the new actor. It is
+          // now an explicit, legacy/manual determination. Paste keeps its
+          // actual input source while likewise requiring a fresh attestation.
+          sourceKind:
+            entry.sourceKind === "direct_entry" ? "legacy" : entry.sourceKind,
           basisKind: "user_attestation",
           determination,
           status: "awaiting_determination",
@@ -1282,9 +1573,7 @@ export class DurableCoworkPasteProvenanceOutbox
         frozenRequest: undefined,
         failure: undefined,
       };
-    }).then((entry) =>
-      this.#refreshVolatileIntent(entry, priorIdempotencyKey),
-    );
+    }).then((entry) => this.#refreshVolatileIntent(entry, priorIdempotencyKey));
   }
 
   remove(id: number): Promise<void> {
@@ -1330,9 +1619,10 @@ export class DurableCoworkPasteProvenanceOutbox
   }
 
   #update<Value>(
-    mutation: (
-      current: PersistedOutbox,
-    ) => { readonly record: PersistedOutbox; readonly result: Value },
+    mutation: (current: PersistedOutbox) => {
+      readonly record: PersistedOutbox;
+      readonly result: Value;
+    },
   ): Promise<Value> {
     return this.#enqueue(() => this.#backing.mutate(this.#key, mutation));
   }
@@ -1343,8 +1633,7 @@ export class DurableCoworkPasteProvenanceOutbox
   ): CoworkPasteProvenanceOutboxEntry {
     if (
       this.#backing.durable ||
-      (entry.status !== "awaiting_determination" &&
-        entry.status !== "ready")
+      (entry.status !== "awaiting_determination" && entry.status !== "ready")
     ) {
       return entry;
     }
@@ -1352,8 +1641,12 @@ export class DurableCoworkPasteProvenanceOutbox
       anchor: entry.anchor,
       idempotencyKey: entry.idempotencyKey,
       substantial: entry.substantial,
+      sourceKind: entry.sourceKind,
       basisKind: entry.basisKind,
       determination: entry.determination,
+      ...(entry.capturedActor === undefined
+        ? {}
+        : { capturedActor: entry.capturedActor }),
       capturedAt: entry.capturedAt,
       passageExcerpt: entry.passageExcerpt,
       ...(entry.capturedBaseStructuredHeadSha256 === undefined
@@ -1381,15 +1674,41 @@ export class DurableCoworkPasteProvenanceOutbox
     for (const capture of staged) {
       await this.#backing.mutate(this.#key, (current) => {
         const existing = current.entries.find(
-          (entry) =>
-            entry.idempotencyKey === capture.idempotencyKey,
+          (entry) => entry.idempotencyKey === capture.idempotencyKey,
         );
         if (existing !== undefined) {
+          if (
+            capture.status === "capturing" &&
+            existing.status === "capturing" &&
+            existing.frozenRequest === undefined
+          ) {
+            const replacement: CoworkPasteProvenanceOutboxEntry = {
+              id: existing.id,
+              ...capture,
+              sourceKind: capture.sourceKind ?? "paste",
+              capturedAt: capture.capturedAt ?? existing.capturedAt,
+              passageExcerpt:
+                capture.passageExcerpt ??
+                coworkPastePassageExcerpt(capture.anchor.exact),
+            };
+            return {
+              record: {
+                ...current,
+                entries: current.entries.map((entry) =>
+                  entry.id === existing.id ? replacement : entry,
+                ),
+              },
+              result: undefined,
+            };
+          }
+          // A ready or frozen row is an immutable retry contract. A stale
+          // synchronous journal from before that close may never reopen it.
           return { record: current, result: undefined };
         }
         const entry: CoworkPasteProvenanceOutboxEntry = {
           id: current.nextId,
           ...capture,
+          sourceKind: capture.sourceKind ?? "paste",
           capturedAt: capture.capturedAt ?? new Date(0).toISOString(),
           passageExcerpt:
             capture.passageExcerpt ??

--- a/dashboard-react/src/apps/cowork/provenance/CoworkPasteProvenanceOutbox.ts
+++ b/dashboard-react/src/apps/cowork/provenance/CoworkPasteProvenanceOutbox.ts
@@ -1453,7 +1453,12 @@ export class DurableCoworkPasteProvenanceOutbox implements CoworkPasteProvenance
         ...entry,
         determination,
         failure:
-          entry.failure?.code === COWORK_PROVENANCE_ACTOR_CHANGED
+          entry.failure?.code === COWORK_PROVENANCE_ACTOR_CHANGED ||
+          (entry.sourceKind === "legacy" &&
+            entry.status === "awaiting_determination" &&
+            entry.requiresExplicitDetermination === true &&
+            entry.failure?.code ===
+              "provenance_actor_unavailable_at_capture")
             ? entry.failure
             : undefined,
       };

--- a/dashboard-react/src/apps/cowork/provenance/CoworkProvenanceDeterminationDialog.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/CoworkProvenanceDeterminationDialog.tsx
@@ -19,6 +19,7 @@ export interface CoworkProvenanceDeterminationDialogProps {
   readonly title?: string;
   readonly description?: string;
   readonly passageExcerpt?: string;
+  readonly passageLabel?: string;
   readonly confirmLabel?: string;
   readonly cancelLabel?: string;
   readonly busy?: boolean;
@@ -40,6 +41,7 @@ export function CoworkProvenanceDeterminationDialog({
   title = "Where did this text come from?",
   description = "Record its authorship and, for AI-written text, whether a person reviewed it.",
   passageExcerpt,
+  passageLabel = "Pasted passage",
   confirmLabel = "Save",
   cancelLabel = "Decide later",
   busy = false,
@@ -78,7 +80,7 @@ export function CoworkProvenanceDeterminationDialog({
           {passageExcerpt !== undefined && passageExcerpt.length > 0 ? (
             <blockquote
               className="wb-cowork-provenance-dialog__excerpt"
-              aria-label="Pasted passage"
+              aria-label={passageLabel}
             >
               {passageExcerpt}
             </blockquote>

--- a/dashboard-react/src/apps/cowork/provenance/CoworkProvenanceSelectionAffordance.test.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/CoworkProvenanceSelectionAffordance.test.tsx
@@ -1,0 +1,340 @@
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Editor } from "@tiptap/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveQuoteAnchor } from "../suggestions/anchor";
+import { makeSuggestionEditor } from "../suggestions/__tests__/support";
+import type {
+  ProvenanceAttestation,
+  ProvenanceData,
+  ProvenanceProvider,
+  ProvenanceSelectionAction,
+  ProvenanceTarget,
+} from "./view/contracts";
+import {
+  CoworkProvenanceSelectionAffordance,
+  type CoworkProvenanceSelectionAffordanceProps,
+} from "./CoworkProvenanceSelectionAffordance";
+
+const ACTOR = {
+  kind: "human",
+  ref: "dashboard-user",
+  identity_status: "local_actor_ref",
+} as const;
+const HEAD = "a".repeat(64);
+const CONTENT = "<p>Make this sentence precise and clear enough.</p>";
+
+let editor: Editor | undefined;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = undefined;
+});
+
+const record = (
+  overrides: Partial<ProvenanceAttestation> = {},
+): ProvenanceAttestation => ({
+  attestationId: "attestation-1",
+  at: "2026-08-12T12:00:00Z",
+  assertedBy: { kind: "human", ref: ACTOR.ref, meta: null },
+  scope: {
+    kind: "document_span",
+    documentVersionId: null,
+    documentSpanId: "span-1",
+    structuredHeadSha256: HEAD,
+  },
+  authorship: { kind: "ai", contributors: [] },
+  humanReview: { status: "not_reviewed", reviewers: [] },
+  source: { kind: "direct_entry" },
+  basis: { kind: "user_attestation", ref: null },
+  supersedesId: null,
+  canonicalSha256: "b".repeat(64),
+  ...overrides,
+});
+
+const target = (
+  overrides: Partial<ProvenanceTarget> = {},
+): ProvenanceTarget => {
+  const attestation = record();
+  return {
+    projectionId: "document_span:span-1",
+    target: {
+      kind: "document_span",
+      documentVersionId: null,
+      documentSpanId: "span-1",
+      structuredHeadSha256: HEAD,
+      currentness: "current",
+    },
+    span: { exact: "precise", prefix: "", suffix: "" },
+    effectiveAttestations: [attestation],
+    effectiveAttestation: attestation,
+    resolution: "resolved",
+    reviewEligibility: "eligible",
+    issue: null,
+    history: [attestation],
+    ...overrides,
+  };
+};
+
+const data = (spans: readonly ProvenanceTarget[] = []): ProvenanceData => ({
+  schema: "cowork-provenance-view/v1",
+  currentStructuredHeadSha256: HEAD,
+  documentDefault: null,
+  spans,
+  history: spans.flatMap((item) => item.history),
+  summary: {
+    totalTargets: spans.length,
+    currentSpanCount: spans.length,
+    aiUnreviewedCount: spans.length,
+    reviewedCount: 0,
+    conflictedCount: 0,
+    staleCount: 0,
+    unrecorded: spans.length === 0,
+  },
+});
+
+const provider = (value: ProvenanceData): ProvenanceProvider => ({
+  load: vi.fn().mockResolvedValue({ state: "ready", data: value }),
+  refresh: vi.fn().mockResolvedValue({ state: "ready", data: value }),
+  subscribe: () => () => undefined,
+  markReviewed: vi.fn().mockResolvedValue(undefined),
+});
+
+const select = (value: string): void => {
+  if (editor === undefined) throw new Error("editor unavailable");
+  const range = resolveQuoteAnchor(editor.state.doc, {
+    exact: value,
+    prefix: "",
+    suffix: "",
+  });
+  if (range === null) throw new Error(`selection not found: ${value}`);
+  act(() => editor!.commands.setTextSelection(range));
+};
+
+const mount = (
+  value: ProvenanceData,
+  options: {
+    readonly onAction?: CoworkProvenanceSelectionAffordanceProps["onAction"];
+    readonly active?: boolean;
+  } = {},
+) => {
+  editor = makeSuggestionEditor({ content: CONTENT });
+  const source = provider(value);
+  const onRecord = vi
+    .fn<CoworkProvenanceSelectionAffordanceProps["onRecord"]>()
+    .mockResolvedValue(undefined);
+  const onAction =
+    options.onAction ??
+    vi.fn<CoworkProvenanceSelectionAffordanceProps["onAction"]>();
+  render(
+    <CoworkProvenanceSelectionAffordance
+      editor={editor}
+      active={options.active ?? true}
+      provider={source}
+      currentUserIdentity={ACTOR}
+      onRecord={onRecord}
+      onAction={onAction}
+    />,
+  );
+  return { source, onRecord, onAction };
+};
+
+describe("CoworkProvenanceSelectionAffordance", () => {
+  it("offers Record provenance for uncovered text and freezes the selected anchor", async () => {
+    const { onRecord } = mount(data());
+    select("precise");
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Record provenance" }),
+    );
+    const dialog = screen.getByRole("dialog", { name: "Record provenance" });
+    expect(dialog).toHaveTextContent("precise");
+    expect(within(dialog).getByLabelText("Selected passage")).toHaveTextContent(
+      "precise",
+    );
+
+    select("clear");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Record provenance" }),
+    );
+
+    await waitFor(() => expect(onRecord).toHaveBeenCalledOnce());
+    expect(onRecord.mock.calls[0]![0]).toMatchObject({ exact: "precise" });
+  });
+
+  it("routes an eligible AI passage to stable review detail without mutating", async () => {
+    const onAction =
+      vi.fn<CoworkProvenanceSelectionAffordanceProps["onAction"]>();
+    const source = provider(data([target()]));
+    editor = makeSuggestionEditor({ content: CONTENT });
+    render(
+      <CoworkProvenanceSelectionAffordance
+        editor={editor}
+        active
+        provider={source}
+        currentUserIdentity={ACTOR}
+        onRecord={vi
+          .fn<CoworkProvenanceSelectionAffordanceProps["onRecord"]>()
+          .mockResolvedValue(undefined)}
+        onAction={onAction}
+      />,
+    );
+    select("precise");
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Review provenance" }),
+    );
+
+    const action = onAction.mock.calls[0]![0] as ProvenanceSelectionAction;
+    expect(action).toMatchObject({
+      intent: "review",
+      targetIds: ["document_span:span-1"],
+    });
+    expect(source.markReviewed).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("uses View provenance when the selection is only part of a larger review target", async () => {
+    const onAction =
+      vi.fn<CoworkProvenanceSelectionAffordanceProps["onAction"]>();
+    mount(data([target()]), { onAction });
+    select("recis");
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "View provenance" }),
+    );
+    expect(onAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: "view",
+        targetIds: ["document_span:span-1"],
+      }),
+    );
+  });
+
+  it("offers View provenance for a healthy passage without a review action", async () => {
+    const human = record({
+      authorship: {
+        kind: "human",
+        contributors: [
+          {
+            kind: "human",
+            ref: ACTOR.ref,
+            label: null,
+            identityStatus: "local_actor_ref",
+          },
+        ],
+      },
+      humanReview: { status: "not_applicable", reviewers: [] },
+    });
+    const onAction =
+      vi.fn<CoworkProvenanceSelectionAffordanceProps["onAction"]>();
+    mount(
+      data([
+        target({
+          effectiveAttestations: [human],
+          effectiveAttestation: human,
+          history: [human],
+          reviewEligibility: "not_ai_authored",
+        }),
+      ]),
+      { onAction },
+    );
+    select("precise");
+    await userEvent.click(
+      await screen.findByRole("button", { name: "View provenance" }),
+    );
+    expect(onAction).toHaveBeenCalledWith(
+      expect.objectContaining({ intent: "view" }),
+    );
+  });
+
+  it("treats text beyond a stale whole-document record as uncovered", async () => {
+    const wholeDocumentRecord = record({
+      scope: {
+        kind: "document_version",
+        documentVersionId: "version-1",
+        documentSpanId: null,
+        structuredHeadSha256: "c".repeat(64),
+      },
+    });
+    const staleDefault: ProvenanceTarget = {
+      ...target(),
+      projectionId: "document_version:version-1",
+      target: {
+        kind: "document_version",
+        documentVersionId: "version-1",
+        documentSpanId: null,
+        structuredHeadSha256: "c".repeat(64),
+        currentness: "stale",
+      },
+      span: null,
+      effectiveAttestations: [wholeDocumentRecord],
+      effectiveAttestation: wholeDocumentRecord,
+      reviewEligibility: "stale_target",
+      history: [wholeDocumentRecord],
+    };
+    mount({
+      ...data(),
+      documentDefault: staleDefault,
+      history: [wholeDocumentRecord],
+    });
+    select("precise");
+    expect(
+      await screen.findByRole("button", { name: "Record provenance" }),
+    ).toBeVisible();
+  });
+
+  it("routes stale and multiply covered selections to Inspect provenance", async () => {
+    const stale = target({
+      target: { ...target().target, currentness: "requires_reanchor" },
+      reviewEligibility: "stale_target",
+    });
+    const duplicate = target({
+      projectionId: "document_span:span-2",
+      target: { ...target().target, documentSpanId: "span-2" },
+    });
+    const onAction =
+      vi.fn<CoworkProvenanceSelectionAffordanceProps["onAction"]>();
+    editor = makeSuggestionEditor({ content: CONTENT });
+    const firstProvider = provider(data([stale]));
+    const { rerender } = render(
+      <CoworkProvenanceSelectionAffordance
+        editor={editor}
+        active
+        provider={firstProvider}
+        currentUserIdentity={ACTOR}
+        onRecord={vi
+          .fn<CoworkProvenanceSelectionAffordanceProps["onRecord"]>()
+          .mockResolvedValue(undefined)}
+        onAction={onAction}
+      />,
+    );
+    select("precise");
+    expect(
+      await screen.findByRole("button", { name: "Inspect provenance" }),
+    ).toBeVisible();
+
+    const secondProvider = provider(data([target(), duplicate]));
+    rerender(
+      <CoworkProvenanceSelectionAffordance
+        editor={editor!}
+        active
+        provider={secondProvider}
+        currentUserIdentity={ACTOR}
+        onRecord={vi
+          .fn<CoworkProvenanceSelectionAffordanceProps["onRecord"]>()
+          .mockResolvedValue(undefined)}
+        onAction={onAction}
+      />,
+    );
+    expect(
+      await screen.findByRole("button", { name: "Inspect provenance" }),
+    ).toBeVisible();
+  });
+
+  it("renders no provenance action outside the Provenance lens", () => {
+    mount(data(), { active: false });
+    select("precise");
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});

--- a/dashboard-react/src/apps/cowork/provenance/CoworkProvenanceSelectionAffordance.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/CoworkProvenanceSelectionAffordance.tsx
@@ -1,0 +1,422 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Editor } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+
+import { quoteAnchorFromRange } from "../feedback/feedbackAnchor";
+import { resolveProvenanceQuoteAnchorDetailed } from "../suggestions/anchor";
+import { coworkPastePassageExcerpt } from "./pasteProvenance";
+import { CoworkProvenanceDeterminationDialog } from "./CoworkProvenanceDeterminationDialog";
+import {
+  defaultCoworkProvenanceDetermination,
+  type CoworkProvenanceActorIdentity,
+  type CoworkProvenanceDetermination,
+} from "./contracts";
+import type {
+  ProvenanceData,
+  ProvenanceLoad,
+  ProvenanceProvider,
+  ProvenanceSelectionAction,
+  ProvenanceTarget,
+} from "./view/contracts";
+import "./styles.css";
+
+interface FloatPosition {
+  readonly left: number;
+  readonly top: number;
+}
+
+interface EditorSelection {
+  readonly from: number;
+  readonly to: number;
+  readonly position: FloatPosition | null;
+}
+
+interface SelectionClassification {
+  readonly intent: ProvenanceSelectionAction["intent"];
+  readonly targetIds: readonly string[];
+}
+
+export interface CoworkProvenanceSelectionAffordanceProps {
+  readonly editor: Editor;
+  /** Only the active Provenance lens may replace the general feedback action. */
+  readonly active: boolean;
+  readonly provider: ProvenanceProvider;
+  readonly currentUserIdentity: CoworkProvenanceActorIdentity;
+  readonly readOnly?: boolean;
+  /** Authoritative editor/outbox state; survives mounting after the edit. */
+  readonly inputProvenancePending?: boolean;
+  /**
+   * Persists a user-confirmed attestation for a frozen uncovered selection.
+   * The caller owns persistence settlement, target/head checks, and refresh.
+   */
+  readonly onRecord: (
+    anchor: ProvenanceSelectionAction["anchor"],
+    determination: CoworkProvenanceDetermination,
+  ) => Promise<void>;
+  /** Routes review/view/inspect into stable Provenance detail. */
+  readonly onAction: (
+    action: ProvenanceSelectionAction & {
+      readonly intent: "review" | "view" | "inspect";
+    },
+  ) => void;
+}
+
+const actionLabel = (intent: ProvenanceSelectionAction["intent"]): string => {
+  if (intent === "record") return "Record provenance";
+  if (intent === "review") return "Review provenance";
+  if (intent === "view") return "View provenance";
+  return "Inspect provenance";
+};
+
+const actionTitle = (intent: ProvenanceSelectionAction["intent"]): string => {
+  if (intent === "record") {
+    return "Record who wrote the selected text and whether it was reviewed; its earlier source remains untracked.";
+  }
+  if (intent === "review") {
+    return "Open Provenance to confirm and record human review for this passage.";
+  }
+  if (intent === "view") {
+    return "Open the provenance details for this passage.";
+  }
+  return "Inspect the provenance records and targeting issues for this selection.";
+};
+
+const computeFloatPosition = (
+  editor: Editor,
+  to: number,
+): FloatPosition | null => {
+  try {
+    const coords = editor.view.coordsAtPos(to);
+    const host =
+      (editor.view.dom.closest(".wb-cowork-editor") as HTMLElement | null) ??
+      editor.view.dom;
+    const rect = host.getBoundingClientRect();
+    return {
+      left: coords.left - rect.left,
+      top: coords.bottom - rect.top,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const effectiveRecord = (target: ProvenanceTarget) =>
+  target.resolution === "resolved" ? target.effectiveAttestation : null;
+
+const targetIsHealthy = (
+  target: ProvenanceTarget,
+  rangeState: "document" | "unique",
+): boolean =>
+  target.resolution === "resolved" &&
+  target.target.currentness === "current" &&
+  (target.target.kind === "document_version" || rangeState === "unique") &&
+  effectiveRecord(target) !== null;
+
+/**
+ * Classify a selection against the same authoritative projection the panel
+ * consumes. Explicit span targets take precedence over a document fallback.
+ */
+export const classifyCoworkProvenanceSelection = ({
+  data,
+  doc,
+  from,
+  to,
+  readOnly,
+  locallyDirty = false,
+}: {
+  readonly data: ProvenanceData;
+  readonly doc: ProseMirrorNode;
+  readonly from: number;
+  readonly to: number;
+  readonly readOnly: boolean;
+  readonly locallyDirty?: boolean;
+}): SelectionClassification => {
+  const explicit = data.spans.flatMap((target) => {
+    if (target.span === null) return [];
+    const resolution = resolveProvenanceQuoteAnchorDetailed(doc, target.span);
+    if (
+      resolution.state !== "unique" ||
+      resolution.from >= to ||
+      resolution.to <= from
+    ) {
+      return [];
+    }
+    return [
+      {
+        target,
+        state: "unique" as const,
+        completelyCoversSelection:
+          resolution.from <= from && resolution.to >= to,
+        selectionExactlyMatchesTarget:
+          resolution.from === from && resolution.to === to,
+      },
+    ];
+  });
+  const matches =
+    explicit.length > 0
+      ? explicit
+      : data.documentDefault === null ||
+          !targetIsHealthy(data.documentDefault, "document")
+        ? []
+        : [
+            {
+              target: data.documentDefault,
+              state: "document" as const,
+              completelyCoversSelection: true,
+              selectionExactlyMatchesTarget: false,
+            },
+          ];
+  const targetIds = [
+    ...new Set(matches.map(({ target }) => target.projectionId)),
+  ];
+
+  if (matches.length === 0) {
+    return {
+      intent: readOnly || locallyDirty ? "inspect" : "record",
+      targetIds: [],
+    };
+  }
+  if (
+    locallyDirty ||
+    matches.length !== 1 ||
+    !matches[0]!.completelyCoversSelection ||
+    !targetIsHealthy(matches[0]!.target, matches[0]!.state)
+  ) {
+    return { intent: "inspect", targetIds };
+  }
+
+  const target = matches[0]!.target;
+  const record = effectiveRecord(target)!;
+  const canOfferReview =
+    !readOnly &&
+    target.reviewEligibility === "eligible" &&
+    matches[0]!.selectionExactlyMatchesTarget &&
+    (record.authorship.kind === "ai" || record.authorship.kind === "mixed") &&
+    (record.humanReview.status === "not_reviewed" ||
+      record.humanReview.status === "unknown");
+  return {
+    intent: canOfferReview ? "review" : "view",
+    targetIds,
+  };
+};
+
+export function CoworkProvenanceSelectionAffordance({
+  editor,
+  active,
+  provider,
+  currentUserIdentity,
+  readOnly = false,
+  inputProvenancePending = false,
+  onRecord,
+  onAction,
+}: CoworkProvenanceSelectionAffordanceProps) {
+  const [selection, setSelection] = useState<EditorSelection | null>(null);
+  const [load, setLoad] = useState<ProvenanceLoad | null>(null);
+  const requestSequence = useRef(0);
+  const actionSequence = useRef(0);
+  const [locallyDirty, setLocallyDirty] = useState(false);
+  const [recording, setRecording] = useState<{
+    readonly action: ProvenanceSelectionAction;
+    readonly value: CoworkProvenanceDetermination;
+  } | null>(null);
+  const [recordBusy, setRecordBusy] = useState(false);
+  const [recordError, setRecordError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!active) {
+      setSelection(null);
+      return undefined;
+    }
+    const sync = (): void => {
+      const { from, to, empty } = editor.state.selection;
+      setSelection(
+        empty || to <= from
+          ? null
+          : { from, to, position: computeFloatPosition(editor, to) },
+      );
+    };
+    sync();
+    editor.on("selectionUpdate", sync);
+    return () => {
+      editor.off("selectionUpdate", sync);
+    };
+  }, [active, editor]);
+
+  useEffect(() => {
+    const dirty = (): void => setLocallyDirty(true);
+    editor.on("update", dirty);
+    return () => {
+      editor.off("update", dirty);
+    };
+  }, [editor]);
+
+  useEffect(() => {
+    if (!active) {
+      setLoad(null);
+      return undefined;
+    }
+    let mounted = true;
+    const loadProjection = (): void => {
+      const sequence = ++requestSequence.current;
+      void provider.load().then(
+        (next) => {
+          if (mounted && sequence === requestSequence.current) {
+            setLoad(next);
+            setLocallyDirty(false);
+          }
+        },
+        () => {
+          if (mounted && sequence === requestSequence.current) setLoad(null);
+        },
+      );
+    };
+    loadProjection();
+    const unsubscribe = provider.subscribe(loadProjection);
+    return () => {
+      mounted = false;
+      requestSequence.current += 1;
+      unsubscribe();
+    };
+  }, [active, provider]);
+
+  const anchor = useMemo(
+    () =>
+      selection === null
+        ? null
+        : quoteAnchorFromRange(editor.state.doc, selection.from, selection.to),
+    [editor, selection],
+  );
+  const classification = useMemo(() => {
+    if (
+      selection === null ||
+      anchor === null ||
+      load === null ||
+      load.state !== "ready"
+    ) {
+      return null;
+    }
+    return classifyCoworkProvenanceSelection({
+      data: load.data,
+      doc: editor.state.doc,
+      from: selection.from,
+      to: selection.to,
+      readOnly,
+      locallyDirty: locallyDirty || inputProvenancePending,
+    });
+  }, [
+    anchor,
+    editor,
+    inputProvenancePending,
+    load,
+    locallyDirty,
+    readOnly,
+    selection,
+  ]);
+
+  if (
+    recording === null &&
+    (!active ||
+      selection === null ||
+      anchor === null ||
+      classification === null)
+  ) {
+    return null;
+  }
+  const label =
+    classification === null ? null : actionLabel(classification.intent);
+  const style =
+    selection?.position === null || selection?.position === undefined
+      ? undefined
+      : { left: selection.position.left, top: selection.position.top };
+  return (
+    <>
+      {selection === null ||
+      anchor === null ||
+      classification === null ||
+      label === null ? null : (
+        <div className="wb-cowork-provenance-selection" style={style}>
+          <button
+            type="button"
+            className="wb-cowork-provenance-selection__trigger"
+            title={
+              inputProvenancePending
+                ? "Co-work is recording provenance for recent typing."
+                : actionTitle(classification.intent)
+            }
+            disabled={inputProvenancePending}
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => {
+              actionSequence.current += 1;
+              const action: ProvenanceSelectionAction = {
+                requestId: actionSequence.current,
+                intent: classification.intent,
+                anchor,
+                from: selection.from,
+                to: selection.to,
+                targetIds: classification.targetIds,
+              };
+              if (action.intent === "record") {
+                setRecordError(null);
+                setRecording({
+                  action,
+                  value:
+                    defaultCoworkProvenanceDetermination(currentUserIdentity),
+                });
+                return;
+              }
+              onAction({ ...action, intent: action.intent });
+            }}
+          >
+            {inputProvenancePending ? "Recording recent typing…" : label}
+          </button>
+        </div>
+      )}
+      {recording === null ? null : (
+        <CoworkProvenanceDeterminationDialog
+          value={recording.value}
+          currentUserIdentity={currentUserIdentity}
+          title="Record provenance"
+          description="Record who wrote this selected text and whether it was reviewed. Its earlier source remains untracked."
+          passageExcerpt={coworkPastePassageExcerpt(
+            recording.action.anchor.exact,
+          )}
+          passageLabel="Selected passage"
+          confirmLabel="Record provenance"
+          cancelLabel="Cancel"
+          busy={recordBusy}
+          error={recordError}
+          onChange={(value) =>
+            setRecording((current) =>
+              current === null ? null : { ...current, value },
+            )
+          }
+          onClose={() => {
+            if (!recordBusy) {
+              setRecording(null);
+              setRecordError(null);
+            }
+          }}
+          onConfirm={async (value) => {
+            if (recordBusy) return;
+            setRecordBusy(true);
+            setRecordError(null);
+            try {
+              await onRecord(recording.action.anchor, value);
+              setRecording(null);
+            } catch (cause) {
+              setRecordError(
+                cause instanceof Error
+                  ? cause.message
+                  : "Provenance could not be recorded.",
+              );
+            } finally {
+              setRecordBusy(false);
+            }
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+export default CoworkProvenanceSelectionAffordance;

--- a/dashboard-react/src/apps/cowork/provenance/index.ts
+++ b/dashboard-react/src/apps/cowork/provenance/index.ts
@@ -7,6 +7,11 @@ export {
   type CoworkProvenanceFormProps,
 } from "./CoworkProvenanceForm";
 export {
+  CoworkProvenanceSelectionAffordance,
+  classifyCoworkProvenanceSelection,
+  type CoworkProvenanceSelectionAffordanceProps,
+} from "./CoworkProvenanceSelectionAffordance";
+export {
   COWORK_PROVENANCE_DETERMINATION_SCHEMA,
   coworkProvenanceDeterminationIssue,
   currentCoworkUser,
@@ -27,6 +32,7 @@ export {
   COWORK_PROVENANCE_EXACT_MAX_CHARS,
   COWORK_PROVENANCE_TARGET_CHANGED,
   coworkPastePassageExcerpt,
+  coworkDirectEntryCaptureFromTransaction,
   coworkPasteCaptureFromTransaction,
   coworkPasteTransactionExceedsProvenanceLimit,
   coworkPasteRangeFromTransaction,
@@ -34,6 +40,7 @@ export {
   isSubstantialCoworkPaste,
   resolveCoworkPasteAnchor,
   type CoworkPasteAnchorResolution,
+  type CoworkDirectEntryCapture,
   type CoworkPasteCapture,
   type CoworkPasteProvenanceRecorder,
   type CoworkPasteProvenanceRequest,

--- a/dashboard-react/src/apps/cowork/provenance/index.ts
+++ b/dashboard-react/src/apps/cowork/provenance/index.ts
@@ -42,6 +42,7 @@ export {
   type CoworkPasteAnchorResolution,
   type CoworkDirectEntryCapture,
   type CoworkPasteCapture,
+  type CoworkPasteProvenanceReceipt,
   type CoworkPasteProvenanceRecorder,
   type CoworkPasteProvenanceRequest,
   type CoworkPasteRange,

--- a/dashboard-react/src/apps/cowork/provenance/pasteProvenance.test.ts
+++ b/dashboard-react/src/apps/cowork/provenance/pasteProvenance.test.ts
@@ -1,10 +1,12 @@
 import { Editor } from "@tiptap/core";
 import { DOMParser as ProseMirrorDOMParser, Slice } from "@tiptap/pm/model";
 import { describe, expect, it } from "vitest";
+import { ySyncPluginKey } from "@tiptap/y-tiptap";
 
 import { buildSchemaExtensions } from "../editor/extensions";
 import {
   COWORK_PROVENANCE_EXACT_MAX_CHARS,
+  coworkDirectEntryCaptureFromTransaction,
   coworkPastePassageExcerpt,
   coworkPasteCaptureFromTransaction,
   coworkPasteRangeFromTransaction,
@@ -143,5 +145,64 @@ describe("paste provenance classification", () => {
         "😀".repeat(COWORK_PROVENANCE_EXACT_MAX_CHARS),
       ),
     ).toBe(true);
+  });
+});
+
+describe("direct-entry provenance capture", () => {
+  it("captures the exact text inserted by a local typing transaction", () => {
+    const editor = new Editor({
+      extensions: buildSchemaExtensions(),
+      content: "<p>After</p>",
+    });
+    const transaction = editor.state.tr.insertText("Test", 1);
+    expect(coworkDirectEntryCaptureFromTransaction(transaction)).toEqual({
+      range: { from: 1, to: 5 },
+      anchor: { exact: "Test", prefix: "", suffix: "After" },
+    });
+    editor.destroy();
+  });
+
+  it("keeps paste, deletion, formatting, history, and applied Yjs work out", () => {
+    const editor = new Editor({
+      extensions: buildSchemaExtensions(),
+      content: "<p>Before</p>",
+    });
+    expect(
+      coworkDirectEntryCaptureFromTransaction(
+        editor.state.tr.insertText("paste", 1).setMeta("uiEvent", "paste"),
+      ),
+    ).toBeNull();
+    expect(
+      coworkDirectEntryCaptureFromTransaction(editor.state.tr.delete(1, 2)),
+    ).toBeNull();
+    expect(
+      coworkDirectEntryCaptureFromTransaction(
+        editor.state.tr.addMark(1, 3, editor.schema.marks.bold!.create()),
+      ),
+    ).toBeNull();
+    expect(
+      coworkDirectEntryCaptureFromTransaction(
+        editor.state.tr.insertText("undo", 1).setMeta("history$", {}),
+      ),
+    ).toBeNull();
+    expect(
+      coworkDirectEntryCaptureFromTransaction(
+        editor.state.tr
+          .insertText("remote", 1)
+          .setMeta(ySyncPluginKey, { isChangeOrigin: true }),
+      ),
+    ).toBeNull();
+    editor.destroy();
+  });
+
+  it("never attributes untouched text between disjoint inserted ranges", () => {
+    const editor = new Editor({
+      extensions: buildSchemaExtensions(),
+      content: "<p>alpha omega</p>",
+    });
+    const transaction = editor.state.tr.insertText("X", 2).insertText("Y", 10);
+
+    expect(coworkDirectEntryCaptureFromTransaction(transaction)).toBeNull();
+    editor.destroy();
   });
 });

--- a/dashboard-react/src/apps/cowork/provenance/pasteProvenance.ts
+++ b/dashboard-react/src/apps/cowork/provenance/pasteProvenance.ts
@@ -1,13 +1,16 @@
 import { getChangedRanges } from "@tiptap/core";
 import type { Node, Slice } from "@tiptap/pm/model";
 import type { Transaction } from "@tiptap/pm/state";
+import { ReplaceAroundStep, ReplaceStep } from "@tiptap/pm/transform";
 
+import { isAppliedTransaction } from "../editor/applyOrigin";
 import {
   quoteAnchorFromRange,
   type RangeQuoteAnchor,
 } from "../feedback/feedbackAnchor";
 import { buildTextIndex } from "../suggestions/anchor";
 import type { CoworkProvenanceDetermination } from "./contracts";
+import type { CoworkProvenanceIdentityStatus } from "./contracts";
 
 /** Authoritative conflict code returned by the provenance-attestation route. */
 export const COWORK_PROVENANCE_TARGET_CHANGED =
@@ -32,6 +35,12 @@ export interface CoworkPasteCapture {
   readonly substantial: boolean;
 }
 
+/** One text-bearing local direct-entry transaction, before burst coalescing. */
+export interface CoworkDirectEntryCapture {
+  readonly range: CoworkPasteRange;
+  readonly anchor: RangeQuoteAnchor;
+}
+
 /**
  * Narrow boundary between the editor-owned paste transaction and whichever
  * same-origin API adapter persists its span attestation.
@@ -39,8 +48,14 @@ export interface CoworkPasteCapture {
 export interface CoworkPasteProvenanceRequest {
   readonly storeId: string;
   readonly documentId: string;
+  /** Immutable capture-time actor precondition for delayed/replayed writes. */
+  readonly expectedActorRef?: string;
+  readonly expectedActorIdentityStatus?: CoworkProvenanceIdentityStatus;
+  /** How this exact passage entered Co-work. */
+  readonly sourceKind: "paste" | "direct_entry" | "legacy";
   readonly basisKind:
     | "automatic_short_text_attribution"
+    | "automatic_direct_entry_attribution"
     | "user_attestation";
   readonly expectedStructuredHeadSha256: string;
   readonly anchor: RangeQuoteAnchor;
@@ -107,18 +122,15 @@ export const resolveCoworkPasteAnchor = (
     return (
       index.flat.slice(offset - anchor.prefix.length, offset) ===
         anchor.prefix &&
-      index.flat.slice(
-        afterOffset,
-        afterOffset + anchor.suffix.length,
-      ) === anchor.suffix
+      index.flat.slice(afterOffset, afterOffset + anchor.suffix.length) ===
+        anchor.suffix
     );
   });
   if (contextual.length === 0) return { kind: "absent" };
   if (contextual.length > 1) return { kind: "ambiguous" };
   const offset = contextual[0];
   const from = index.charPositions[offset];
-  const to =
-    index.charPositions[offset + anchor.exact.length - 1] + 1;
+  const to = index.charPositions[offset + anchor.exact.length - 1] + 1;
   return { kind: "unique", from, to };
 };
 
@@ -156,7 +168,9 @@ export const isSubstantialCoworkPaste = (
     }
     return undefined;
   });
-  return complex || Array.from(plainText).length >= SUBSTANTIAL_SINGLE_BLOCK_CHARS;
+  return (
+    complex || Array.from(plainText).length >= SUBSTANTIAL_SINGLE_BLOCK_CHARS
+  );
 };
 
 /**
@@ -203,6 +217,56 @@ export const coworkPasteCaptureFromTransaction = (
   };
 };
 
+const insertsText = (transaction: Transaction): boolean =>
+  transaction.steps.some((step) => {
+    if (
+      !(step instanceof ReplaceStep) &&
+      !(step instanceof ReplaceAroundStep)
+    ) {
+      return false;
+    }
+    return (
+      step.slice.content.textBetween(0, step.slice.content.size, "\n", "\n")
+        .length > 0
+    );
+  });
+
+/**
+ * Capture text inserted by one genuine local direct-entry transaction.
+ *
+ * Paste/drop have their own source semantics, applied Yjs transactions are
+ * remote/system/undo work, and mark-only or deletion-only transactions did
+ * not introduce authored text. Seed/system callers keep this helper fenced
+ * until the mounted editor is ready for human input.
+ */
+export const coworkDirectEntryCaptureFromTransaction = (
+  transaction: Transaction,
+  document: Node = transaction.doc,
+): CoworkDirectEntryCapture | null => {
+  if (
+    !transaction.docChanged ||
+    transaction.getMeta("uiEvent") === "paste" ||
+    transaction.getMeta("uiEvent") === "drop" ||
+    transaction.getMeta("history$") !== undefined ||
+    isAppliedTransaction(transaction) ||
+    !insertsText(transaction)
+  ) {
+    return null;
+  }
+  const ranges = getChangedRanges(transaction)
+    .map((item) => item.newRange)
+    .filter((range) => range.to > range.from);
+  // Never manufacture provenance over untouched text between independent
+  // insertions (multi-cursor, structural normalization, or a compound command).
+  // The mounted capture path deliberately records only one contiguous gesture.
+  if (ranges.length !== 1) return null;
+  const range = ranges[0]!;
+  const anchor = quoteAnchorFromRange(document, range.from, range.to);
+  return anchor === null || !coworkProvenanceExactWithinLimit(anchor.exact)
+    ? null
+    : { range, anchor };
+};
+
 /** True when a paste transaction would create an API-invalid exact selector. */
 export const coworkPasteTransactionExceedsProvenanceLimit = (
   transaction: Transaction,
@@ -213,7 +277,6 @@ export const coworkPasteTransactionExceedsProvenanceLimit = (
     transaction.doc,
   );
   return (
-    capture !== null &&
-    !coworkProvenanceExactWithinLimit(capture.anchor.exact)
+    capture !== null && !coworkProvenanceExactWithinLimit(capture.anchor.exact)
   );
 };

--- a/dashboard-react/src/apps/cowork/provenance/pasteProvenance.ts
+++ b/dashboard-react/src/apps/cowork/provenance/pasteProvenance.ts
@@ -63,9 +63,16 @@ export interface CoworkPasteProvenanceRequest {
   readonly idempotencyKey: string;
 }
 
+/** Immutable server receipt for one persisted provenance attestation. */
+export interface CoworkPasteProvenanceReceipt {
+  readonly attestationId: string;
+  readonly documentSpanId: string;
+  readonly targetStructuredHeadSha256: string;
+}
+
 export type CoworkPasteProvenanceRecorder = (
   request: CoworkPasteProvenanceRequest,
-) => Promise<void>;
+) => Promise<CoworkPasteProvenanceReceipt>;
 
 export type CoworkPasteAnchorResolution =
   | {

--- a/dashboard-react/src/apps/cowork/provenance/provenanceStyles.test.ts
+++ b/dashboard-react/src/apps/cowork/provenance/provenanceStyles.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import provenanceStyles from "./styles.css?raw";
+
+describe("Provenance selection affordance styles", () => {
+  it("sizes the floating wrapper to its control instead of covering the editor", () => {
+    expect(provenanceStyles).toMatch(
+      /\.wb-cowork-provenance-selection\s*\{[^}]*inline-size:\s*max-content;/su,
+    );
+    expect(provenanceStyles).toMatch(
+      /\.wb-cowork-provenance-selection\s*\{[^}]*max-inline-size:/su,
+    );
+  });
+});

--- a/dashboard-react/src/apps/cowork/provenance/styles.css
+++ b/dashboard-react/src/apps/cowork/provenance/styles.css
@@ -10,9 +10,51 @@
 
 .wb-cowork-provenance-dialog__excerpt {
   margin: 0;
+  max-block-size: 12rem;
   padding: var(--wb-space-3);
   border-inline-start: 3px solid var(--wb-color-border-subtle);
   color: var(--wb-color-text-secondary);
   background: var(--wb-color-surface-subtle);
+  overflow: auto;
   overflow-wrap: anywhere;
+}
+
+/* Provenance replaces the generic selection-feedback verb while its lens is
+ * active. The trigger is intentionally only a router/ceremony opener: review
+ * mutations remain in stable panel detail. */
+.wb-cowork-provenance-selection {
+  position: absolute;
+  inset-block-start: var(--wb-space-4);
+  inset-inline-end: var(--wb-space-4);
+  inline-size: max-content;
+  max-inline-size: min(24rem, calc(100% - (2 * var(--wb-space-4))));
+  z-index: 5;
+}
+
+.wb-cowork-provenance-selection__trigger {
+  padding: var(--wb-space-2) var(--wb-space-4);
+  border: 1px solid var(--wb-color-border-default);
+  border-radius: var(--wb-radius-control);
+  background: var(--wb-color-surface-raised);
+  color: var(--wb-color-text-primary);
+  box-shadow: var(--wb-shadow-raised, 0 1px 2px rgba(0, 0, 0, 0.15));
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--wb-font-size-xs);
+  font-weight: var(--wb-font-weight-medium);
+}
+
+.wb-cowork-provenance-selection__trigger:hover {
+  background: var(--wb-color-surface-overlay);
+}
+
+.wb-cowork-provenance-selection__trigger:focus-visible {
+  outline: none;
+  box-shadow: var(--wb-shadow-focus);
+}
+
+@media (forced-colors: active) {
+  .wb-cowork-provenance-selection__trigger {
+    border-color: ButtonText;
+  }
 }

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenanceHoverCard.test.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenanceHoverCard.test.tsx
@@ -12,7 +12,8 @@ describe("ProvenanceHoverCard", () => {
     passage.dataset.wbAuthorship = "ai";
     passage.dataset.wbHumanReview = "not_reviewed";
     passage.dataset.wbSource = "paste";
-    passage.dataset.wbSourceDetail = "plain text · source identity not verified";
+    passage.dataset.wbSourceDetail =
+      "plain text · source identity not verified";
     passage.dataset.wbContributors = "model:gpt-5 · asserted identity";
     passage.dataset.wbReviewers = "user-1 · enrolled local identity";
     passage.dataset.wbAttester = "user-1";
@@ -27,7 +28,9 @@ describe("ProvenanceHoverCard", () => {
 
     fireEvent.pointerOver(passage);
     expect(screen.getByRole("tooltip")).toHaveTextContent("ai authorship");
-    expect(screen.getByRole("tooltip")).toHaveTextContent("multiple target states");
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "multiple target states",
+    );
     expect(screen.getByRole("tooltip")).toHaveTextContent(
       "model:gpt-5 · asserted identity",
     );
@@ -99,6 +102,55 @@ describe("ProvenanceHoverCard", () => {
       expect(screen.getByRole("tooltip")).toHaveTextContent("human authorship");
       expect(screen.getByRole("tooltip")).toHaveTextContent(
         "direct entry · plain text",
+      );
+    });
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: originalElementFromPoint,
+    });
+    root.remove();
+  });
+
+  it("describes pending delivery without asserting authorship, then settles in place", async () => {
+    const root = document.createElement("div");
+    const pending = document.createElement("span");
+    pending.dataset.wbDecoration = "provenance-overlay";
+    pending.dataset.wbAuthorship = "unknown";
+    pending.dataset.wbHumanReview = "unknown";
+    pending.dataset.wbSource = "direct_entry";
+    pending.dataset.wbProvenanceRecordState = "pending";
+    root.append(pending);
+    document.body.append(root);
+    const ref = createRef<HTMLElement>();
+    ref.current = root;
+    render(<ProvenanceHoverCard rootRef={ref} active editorReady />);
+
+    fireEvent.pointerOver(pending, { clientX: 24, clientY: 24 });
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toHaveTextContent("Recording provenance…");
+    expect(tooltip).toHaveTextContent(/after the server confirms the record/u);
+    expect(tooltip).not.toHaveTextContent("unknown authorship");
+    expect(tooltip.querySelector("dl")).toBeNull();
+
+    const recorded = document.createElement("span");
+    recorded.dataset.wbDecoration = "provenance-overlay";
+    recorded.dataset.wbAuthorship = "human";
+    recorded.dataset.wbHumanReview = "not_applicable";
+    recorded.dataset.wbSource = "direct_entry";
+    recorded.dataset.wbSourceDetail = "Input: keyboard";
+    recorded.dataset.wbProvenanceRecordState = "recorded";
+    recorded.dataset.wbProvenanceCurrentness = "current";
+    const originalElementFromPoint = document.elementFromPoint;
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: () => recorded,
+    });
+    pending.replaceWith(recorded);
+
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveTextContent("human authorship");
+      expect(screen.getByRole("tooltip")).not.toHaveTextContent(
+        "Recording provenance…",
       );
     });
     Object.defineProperty(document, "elementFromPoint", {

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenanceHoverCard.test.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenanceHoverCard.test.tsx
@@ -61,4 +61,37 @@ describe("ProvenanceHoverCard", () => {
     expect(screen.getByRole("tooltip")).toHaveTextContent("mixed authorship");
     root.remove();
   });
+
+  it("yields to an expanded editor selection and cannot reopen over its action", () => {
+    const root = document.createElement("div");
+    root.tabIndex = 0;
+    const passage = document.createElement("span");
+    passage.dataset.wbDecoration = "provenance-overlay";
+    passage.dataset.wbAuthorship = "human";
+    passage.textContent = "Selected passage";
+    root.append(passage);
+    document.body.append(root);
+    const ref = createRef<HTMLElement>();
+    ref.current = root;
+    render(<ProvenanceHoverCard rootRef={ref} active editorReady />);
+
+    fireEvent.pointerOver(passage);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("human authorship");
+
+    const range = document.createRange();
+    range.selectNodeContents(passage);
+    const selection = document.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    fireEvent(document, new Event("selectionchange"));
+
+    expect(screen.queryByRole("tooltip")).toBeNull();
+    fireEvent.pointerOver(passage);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+
+    selection?.removeAllRanges();
+    fireEvent.pointerOver(passage);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("human authorship");
+    root.remove();
+  });
 });

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenanceHoverCard.test.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenanceHoverCard.test.tsx
@@ -1,5 +1,5 @@
 import { createRef } from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { ProvenanceHoverCard } from "./ProvenanceHoverCard";
@@ -59,6 +59,52 @@ describe("ProvenanceHoverCard", () => {
     fireEvent.pointerOver(passage);
 
     expect(screen.getByRole("tooltip")).toHaveTextContent("mixed authorship");
+    root.remove();
+  });
+
+  it("refreshes an open card when an asynchronous projection replaces the hovered decoration", async () => {
+    const root = document.createElement("div");
+    const unrecorded = document.createElement("span");
+    unrecorded.dataset.wbDecoration = "provenance-overlay";
+    unrecorded.dataset.wbAuthorship = "unknown";
+    unrecorded.dataset.wbSource = "unrecorded";
+    unrecorded.dataset.wbProvenanceRecordState = "unrecorded";
+    root.append(unrecorded);
+    document.body.append(root);
+    const ref = createRef<HTMLElement>();
+    ref.current = root;
+    render(<ProvenanceHoverCard rootRef={ref} active editorReady />);
+
+    fireEvent.pointerOver(unrecorded, { clientX: 20, clientY: 20 });
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "No provenance recorded",
+    );
+
+    const recorded = document.createElement("span");
+    recorded.dataset.wbDecoration = "provenance-overlay";
+    recorded.dataset.wbAuthorship = "human";
+    recorded.dataset.wbHumanReview = "not_applicable";
+    recorded.dataset.wbSource = "direct_entry";
+    recorded.dataset.wbSourceDetail = "plain text";
+    recorded.dataset.wbProvenanceRecordState = "recorded";
+    recorded.dataset.wbProvenanceCurrentness = "current";
+    const originalElementFromPoint = document.elementFromPoint;
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: () => recorded,
+    });
+    unrecorded.replaceWith(recorded);
+
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveTextContent("human authorship");
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "direct entry · plain text",
+      );
+    });
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: originalElementFromPoint,
+    });
     root.remove();
   });
 

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenanceHoverCard.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenanceHoverCard.tsx
@@ -57,11 +57,14 @@ export function ProvenanceHoverCard({
       setHover(null);
       return undefined;
     }
+    let hoveredDecoration: HTMLElement | null = null;
+    let pointerPosition: { readonly x: number; readonly y: number } | null = null;
     const showElement = (target: Element | null): void => {
       // A deliberate text selection owns the contextual UI. Mouse-dragging a
       // decorated passage first fires pointerover, so without this guard the
       // passive card remains above and completely covers the selection action.
       if (expandedSelectionTouches(root)) {
+        hoveredDecoration = null;
         setHover(null);
         return;
       }
@@ -69,9 +72,11 @@ export function ProvenanceHoverCard({
         "[data-wb-decoration='provenance-overlay']",
       ) ?? null;
       if (element === null || !root.contains(element)) {
+        hoveredDecoration = null;
         setHover(null);
         return;
       }
+      hoveredDecoration = element;
       const rect = element.getBoundingClientRect();
       setHover({
         left: Math.max(8, rect.left),
@@ -94,7 +99,17 @@ export function ProvenanceHoverCard({
       });
     };
     const show = (event: Event): void => {
+      if ("clientX" in event && "clientY" in event) {
+        const x = Number(event.clientX);
+        const y = Number(event.clientY);
+        if (Number.isFinite(x) && Number.isFinite(y)) {
+          pointerPosition = { x, y };
+        }
+      }
       showElement(event.target instanceof Element ? event.target : null);
+    };
+    const trackPointer = (event: PointerEvent): void => {
+      pointerPosition = { x: event.clientX, y: event.clientY };
     };
     const showSelection = (): void => {
       if (expandedSelectionTouches(root)) {
@@ -109,9 +124,45 @@ export function ProvenanceHoverCard({
     };
     const hide = (event: Event): void => {
       if (event instanceof FocusEvent && event.relatedTarget instanceof Node && root.contains(event.relatedTarget)) return;
+      hoveredDecoration = null;
+      pointerPosition = null;
       setHover(null);
     };
+    const refreshHoveredDecoration = (): void => {
+      if (hoveredDecoration === null) return;
+      if (hoveredDecoration.isConnected && root.contains(hoveredDecoration)) {
+        showElement(hoveredDecoration);
+        return;
+      }
+      const pointed =
+        pointerPosition === null || typeof document.elementFromPoint !== "function"
+          ? null
+          : document.elementFromPoint(pointerPosition.x, pointerPosition.y);
+      showElement(pointed);
+    };
+    const observer = new MutationObserver(refreshHoveredDecoration);
+    observer.observe(root, {
+      attributes: true,
+      childList: true,
+      subtree: true,
+      attributeFilter: [
+        "data-wb-decoration",
+        "data-wb-authorship",
+        "data-wb-human-review",
+        "data-wb-source",
+        "data-wb-source-detail",
+        "data-wb-contributors",
+        "data-wb-reviewers",
+        "data-wb-attester",
+        "data-wb-basis",
+        "data-wb-history-count",
+        "data-wb-provenance-conflict",
+        "data-wb-provenance-record-state",
+        "data-wb-provenance-currentness",
+      ],
+    });
     root.addEventListener("pointerover", show);
+    root.addEventListener("pointermove", trackPointer);
     root.addEventListener("focusin", show);
     root.addEventListener("pointerleave", hide);
     root.addEventListener("focusout", hide);
@@ -121,7 +172,9 @@ export function ProvenanceHoverCard({
     document.addEventListener("keydown", escape);
     document.addEventListener("selectionchange", showSelection);
     return () => {
+      observer.disconnect();
       root.removeEventListener("pointerover", show);
+      root.removeEventListener("pointermove", trackPointer);
       root.removeEventListener("focusin", show);
       root.removeEventListener("pointerleave", hide);
       root.removeEventListener("focusout", hide);

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenanceHoverCard.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenanceHoverCard.tsx
@@ -29,6 +29,15 @@ interface HoverState {
 
 const label = (value: string): string => value.replace(/_/gu, " ");
 
+const expandedSelectionTouches = (root: HTMLElement): boolean => {
+  const selection = document.getSelection();
+  if (selection === null || selection.isCollapsed) return false;
+  return (
+    (selection.anchorNode !== null && root.contains(selection.anchorNode)) ||
+    (selection.focusNode !== null && root.contains(selection.focusNode))
+  );
+};
+
 /** Passive explanation for provenance-decorated text; all actions stay in the panel. */
 export function ProvenanceHoverCard({
   rootRef,
@@ -49,6 +58,13 @@ export function ProvenanceHoverCard({
       return undefined;
     }
     const showElement = (target: Element | null): void => {
+      // A deliberate text selection owns the contextual UI. Mouse-dragging a
+      // decorated passage first fires pointerover, so without this guard the
+      // passive card remains above and completely covers the selection action.
+      if (expandedSelectionTouches(root)) {
+        setHover(null);
+        return;
+      }
       const element = target?.closest<HTMLElement>(
         "[data-wb-decoration='provenance-overlay']",
       ) ?? null;
@@ -81,6 +97,10 @@ export function ProvenanceHoverCard({
       showElement(event.target instanceof Element ? event.target : null);
     };
     const showSelection = (): void => {
+      if (expandedSelectionTouches(root)) {
+        setHover(null);
+        return;
+      }
       if (!root.contains(document.activeElement)) return;
       const anchorNode = document.getSelection()?.anchorNode ?? null;
       const element =

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenanceHoverCard.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenanceHoverCard.tsx
@@ -58,7 +58,8 @@ export function ProvenanceHoverCard({
       return undefined;
     }
     let hoveredDecoration: HTMLElement | null = null;
-    let pointerPosition: { readonly x: number; readonly y: number } | null = null;
+    let pointerPosition: { readonly x: number; readonly y: number } | null =
+      null;
     const showElement = (target: Element | null): void => {
       // A deliberate text selection owns the contextual UI. Mouse-dragging a
       // decorated passage first fires pointerover, so without this guard the
@@ -68,9 +69,10 @@ export function ProvenanceHoverCard({
         setHover(null);
         return;
       }
-      const element = target?.closest<HTMLElement>(
-        "[data-wb-decoration='provenance-overlay']",
-      ) ?? null;
+      const element =
+        target?.closest<HTMLElement>(
+          "[data-wb-decoration='provenance-overlay']",
+        ) ?? null;
       if (element === null || !root.contains(element)) {
         hoveredDecoration = null;
         setHover(null);
@@ -87,8 +89,10 @@ export function ProvenanceHoverCard({
         authorship: element.dataset.wbAuthorship ?? "unknown",
         review: element.dataset.wbHumanReview ?? "unknown",
         source: element.dataset.wbSource ?? "unknown",
-        sourceDetail: element.dataset.wbSourceDetail ?? "No additional source detail",
-        contributors: element.dataset.wbContributors ?? "No contributors recorded",
+        sourceDetail:
+          element.dataset.wbSourceDetail ?? "No additional source detail",
+        contributors:
+          element.dataset.wbContributors ?? "No contributors recorded",
         reviewers: element.dataset.wbReviewers ?? "No reviewers recorded",
         attester: element.dataset.wbAttester ?? "not recorded",
         basis: element.dataset.wbBasis ?? "not recorded",
@@ -119,11 +123,18 @@ export function ProvenanceHoverCard({
       if (!root.contains(document.activeElement)) return;
       const anchorNode = document.getSelection()?.anchorNode ?? null;
       const element =
-        anchorNode instanceof Element ? anchorNode : anchorNode?.parentElement ?? null;
+        anchorNode instanceof Element
+          ? anchorNode
+          : (anchorNode?.parentElement ?? null);
       showElement(element);
     };
     const hide = (event: Event): void => {
-      if (event instanceof FocusEvent && event.relatedTarget instanceof Node && root.contains(event.relatedTarget)) return;
+      if (
+        event instanceof FocusEvent &&
+        event.relatedTarget instanceof Node &&
+        root.contains(event.relatedTarget)
+      )
+        return;
       hoveredDecoration = null;
       pointerPosition = null;
       setHover(null);
@@ -135,7 +146,8 @@ export function ProvenanceHoverCard({
         return;
       }
       const pointed =
-        pointerPosition === null || typeof document.elementFromPoint !== "function"
+        pointerPosition === null ||
+        typeof document.elementFromPoint !== "function"
           ? null
           : document.elementFromPoint(pointerPosition.x, pointerPosition.y);
       showElement(pointed);
@@ -198,7 +210,10 @@ export function ProvenanceHoverCard({
       gutter,
       below + height <= window.innerHeight - gutter
         ? below
-        : Math.min(hover.anchorTop - height - gutter, window.innerHeight - height - gutter),
+        : Math.min(
+            hover.anchorTop - height - gutter,
+            window.innerHeight - height - gutter,
+          ),
     );
     if (left !== hover.left || top !== hover.top) {
       setHover((current) =>
@@ -207,6 +222,7 @@ export function ProvenanceHoverCard({
     }
   }, [hover]);
   if (!active || hover === null) return null;
+  const pending = hover.recordState === "pending";
   return createPortal(
     <aside
       className="wb-cowork-provenance-hover"
@@ -214,18 +230,62 @@ export function ProvenanceHoverCard({
       ref={cardRef}
       style={{ left: hover.left, top: hover.top }}
     >
-      <strong>{hover.conflicted ? "Conflicting provenance" : hover.recordState === "unrecorded" ? "No provenance recorded" : `${label(hover.authorship)} authorship`}</strong>
-      <dl>
-        <div><dt>Human review</dt><dd>{label(hover.review)}</dd></div>
-        <div><dt>Contributors</dt><dd>{hover.contributors}</dd></div>
-        <div><dt>Reviewers</dt><dd>{hover.reviewers}</dd></div>
-        <div><dt>Source</dt><dd>{label(hover.source)} · {hover.sourceDetail}</dd></div>
-        <div><dt>Attested by</dt><dd>{hover.attester}</dd></div>
-        <div><dt>Basis</dt><dd>{label(hover.basis)}</dd></div>
-        <div><dt>Target</dt><dd>{label(hover.currentness)}</dd></div>
-        <div><dt>History</dt><dd>{hover.historyCount} records</dd></div>
-      </dl>
-      <p>Open Provenance for details and actions.</p>
+      <strong>
+        {hover.conflicted
+          ? "Conflicting provenance"
+          : pending
+            ? "Recording provenance…"
+            : hover.recordState === "unrecorded"
+              ? "No provenance recorded"
+              : `${label(hover.authorship)} authorship`}
+      </strong>
+      {pending ? (
+        <p>
+          This recent typing is captured in the editor while its provenance
+          record is saved. Authorship and review appear after the server
+          confirms the record.
+        </p>
+      ) : (
+        <>
+          <dl>
+            <div>
+              <dt>Human review</dt>
+              <dd>{label(hover.review)}</dd>
+            </div>
+            <div>
+              <dt>Contributors</dt>
+              <dd>{hover.contributors}</dd>
+            </div>
+            <div>
+              <dt>Reviewers</dt>
+              <dd>{hover.reviewers}</dd>
+            </div>
+            <div>
+              <dt>Source</dt>
+              <dd>
+                {label(hover.source)} · {hover.sourceDetail}
+              </dd>
+            </div>
+            <div>
+              <dt>Attested by</dt>
+              <dd>{hover.attester}</dd>
+            </div>
+            <div>
+              <dt>Basis</dt>
+              <dd>{label(hover.basis)}</dd>
+            </div>
+            <div>
+              <dt>Target</dt>
+              <dd>{label(hover.currentness)}</dd>
+            </div>
+            <div>
+              <dt>History</dt>
+              <dd>{hover.historyCount} records</dd>
+            </div>
+          </dl>
+          <p>Open Provenance for details and actions.</p>
+        </>
+      )}
     </aside>,
     document.body,
   );

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.test.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.test.tsx
@@ -245,12 +245,10 @@ describe("ProvenancePanel", () => {
       <ProvenancePanel
         provider={{
           ...provider(),
-          load: vi
-            .fn()
-            .mockResolvedValue({
-              state: "ready",
-              data: { ...data, spans: [], history: [] },
-            }),
+          load: vi.fn().mockResolvedValue({
+            state: "ready",
+            data: { ...data, spans: [], history: [] },
+          }),
         }}
         active
         editor={{ ...editor, hasText: () => false }}
@@ -286,6 +284,9 @@ describe("ProvenancePanel", () => {
     ).toBeNull();
     expect(
       screen.queryByText("No provenance has been recorded for this document"),
+    ).toBeNull();
+    expect(
+      screen.queryByText("No provenance records match this filter."),
     ).toBeNull();
   });
 

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.test.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.test.tsx
@@ -7,6 +7,7 @@ import type {
   ProvenanceEditorIntegration,
   ProvenanceMutationBarrier,
   ProvenanceProvider,
+  ProvenanceSelectionAction,
 } from "./contracts";
 import { ProvenancePanel } from "./ProvenancePanel";
 
@@ -238,6 +239,135 @@ describe("ProvenancePanel", () => {
     expect(screen.queryByText("No provenance records match this filter.")).toBeNull();
   });
 
+  it("gives a textful document with zero records one actionable empty state", async () => {
+    render(
+      <ProvenancePanel
+        provider={{
+          ...provider(),
+          load: vi.fn().mockResolvedValue({
+            state: "ready",
+            data: { ...data, spans: [], history: [], documentDefault: null },
+          }),
+        }}
+        active
+        editor={editor}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "No provenance has been recorded for this document",
+      }),
+    ).toBeVisible();
+    expect(screen.getByText(/Select existing text to record/u)).toBeVisible();
+    expect(screen.queryByText(/Some text has no current provenance/u)).toBeNull();
+    expect(screen.queryByText("No provenance records match this filter.")).toBeNull();
+  });
+
+  it("does not present a terminal empty state while recent typing is unsettled", async () => {
+    render(
+      <ProvenancePanel
+        provider={{
+          ...provider(),
+          load: vi.fn().mockResolvedValue({
+            state: "ready",
+            data: { ...data, spans: [], history: [], documentDefault: null },
+          }),
+        }}
+        active
+        editor={{ ...editor, isLocallyDirty: () => true }}
+      />,
+    );
+
+    expect(
+      await screen.findByText(/Local edits are not yet represented/u),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("heading", {
+        name: "No provenance has been recorded for this document",
+      }),
+    ).toBeNull();
+  });
+
+  it("does not leave a zero-record filtered view blank", async () => {
+    render(
+      <ProvenancePanel
+        provider={{
+          ...provider(),
+          load: vi.fn().mockResolvedValue({
+            state: "ready",
+            data: { ...data, spans: [], history: [], documentDefault: null },
+          }),
+        }}
+        active
+        editor={editor}
+      />,
+    );
+
+    await userEvent.click(await screen.findByRole("button", { name: "Issues" }));
+    expect(screen.getByText("No provenance records match this filter.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "All" })).toBeVisible();
+  });
+
+  it("opens stable target detail for a routed selection action", async () => {
+    const selectionAction: ProvenanceSelectionAction = {
+      requestId: 1,
+      intent: "review",
+      anchor: { exact: "AI passage", prefix: "", suffix: "" },
+      from: 5,
+      to: 15,
+      targetIds: ["document_span:span-1"],
+    };
+    render(
+      <ProvenancePanel
+        provider={provider()}
+        active
+        editor={editor}
+        mutationBarrier={{ runWithSynchronizedDocument: vi.fn() }}
+        selectionAction={selectionAction}
+      />,
+    );
+
+    expect(await screen.findByText("Actions")).toBeVisible();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /AI passage/u })).toHaveFocus(),
+    );
+    expect(screen.getByRole("button", { name: "Mark reviewed" })).toBeEnabled();
+  });
+
+  it("keeps Mark reviewed discoverable but disabled with a specific reason", async () => {
+    const stale = {
+      ...data.spans[0]!,
+      target: {
+        ...data.spans[0]!.target,
+        currentness: "requires_reanchor" as const,
+      },
+      reviewEligibility: "stale_target" as const,
+    };
+    render(
+      <ProvenancePanel
+        provider={{
+          ...provider(),
+          load: vi.fn().mockResolvedValue({
+            state: "ready",
+            data: { ...data, spans: [stale] },
+          }),
+        }}
+        active
+        editor={editor}
+        mutationBarrier={{ runWithSynchronizedDocument: vi.fn() }}
+      />,
+    );
+
+    await userEvent.click(await screen.findByRole("button", { name: /AI passage/u }));
+    const action = screen.getByRole("button", { name: "Mark reviewed" });
+    expect(action).toBeDisabled();
+    expect(
+      screen.getByText(/re-anchored for inspection/u),
+    ).toBeVisible();
+    expect(action).toHaveAttribute("aria-describedby");
+  });
+
   it("keeps global append-only history inspectable without a current head", async () => {
     render(
       <ProvenancePanel
@@ -353,6 +483,40 @@ describe("ProvenancePanel", () => {
     expect(screen.queryByText(/must_not_render/u)).toBeNull();
   });
 
+  it("labels manually repaired legacy source as untracked", async () => {
+    const untracked = {
+      ...attestation,
+      source: { kind: "legacy" },
+    };
+    render(
+      <ProvenancePanel
+        provider={{
+          ...provider(),
+          load: vi.fn().mockResolvedValue({
+            state: "ready",
+            data: {
+              ...data,
+              spans: [
+                {
+                  ...data.spans[0]!,
+                  effectiveAttestations: [untracked],
+                  effectiveAttestation: untracked,
+                  history: [untracked],
+                },
+              ],
+              history: [untracked],
+            },
+          }),
+        }}
+        active
+        editor={editor}
+      />,
+    );
+
+    await userEvent.click(await screen.findByRole("button", { name: /AI passage/u }));
+    expect(screen.getAllByText("Untracked / legacy").length).toBeGreaterThan(0);
+  });
+
   it("blocks review and explains incompatible overlapping provenance", async () => {
     const human = {
       ...attestation,
@@ -395,7 +559,9 @@ describe("ProvenancePanel", () => {
     expect(
       screen.getByText(/Overlapping provenance records disagree on authorship/u),
     ).toBeVisible();
-    expect(screen.queryByRole("button", { name: "Mark reviewed" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Mark reviewed" }),
+    ).toBeDisabled();
     await userEvent.click(screen.getByRole("button", { name: "Issues" }));
     expect(screen.getAllByText("Conflicts with overlapping passage")).toHaveLength(2);
   });

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.test.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.test.tsx
@@ -89,7 +89,11 @@ const provider = (): ProvenanceProvider => ({
 });
 
 const editor: ProvenanceEditorIntegration = {
-  resolveTarget: () => ({ state: "unique", documentOrder: 20, documentEnd: 30 }),
+  resolveTarget: () => ({
+    state: "unique",
+    documentOrder: 20,
+    documentEnd: 30,
+  }),
   isLocallyDirty: () => false,
   hasText: () => true,
   hasUncoveredText: () => true,
@@ -140,7 +144,9 @@ describe("ProvenancePanel", () => {
     await userEvent.click(item);
     expect(editor.focusTarget).toHaveBeenCalledWith("document_span:span-1");
     expect(editor.revealTarget).not.toHaveBeenCalled();
-    await userEvent.click(screen.getByRole("button", { name: "Show in document" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Show in document" }),
+    );
     expect(editor.revealTarget).toHaveBeenCalledWith("document_span:span-1");
     expect(screen.getByText(/no current provenance record/u)).toBeVisible();
   });
@@ -174,8 +180,12 @@ describe("ProvenancePanel", () => {
         mutationBarrier={barrier}
       />,
     );
-    await userEvent.click(await screen.findByRole("button", { name: /AI passage/u }));
-    await userEvent.click(screen.getByRole("button", { name: "Mark reviewed" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /AI passage/u }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Mark reviewed" }),
+    );
     await waitFor(() => expect(source.markReviewed).toHaveBeenCalledOnce());
     expect(locked).toBe(false);
   });
@@ -220,8 +230,12 @@ describe("ProvenancePanel", () => {
         }}
       />,
     );
-    await userEvent.click(await screen.findByRole("button", { name: /AI passage/u }));
-    await userEvent.click(screen.getByRole("button", { name: "Mark reviewed" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /AI passage/u }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Mark reviewed" }),
+    );
     await screen.findByRole("alert");
     expect(source.markReviewed).not.toHaveBeenCalled();
   });
@@ -229,14 +243,50 @@ describe("ProvenancePanel", () => {
   it("does not claim an empty editor contains unrecorded text", async () => {
     render(
       <ProvenancePanel
-        provider={{ ...provider(), load: vi.fn().mockResolvedValue({ state: "ready", data: { ...data, spans: [], history: [] } }) }}
+        provider={{
+          ...provider(),
+          load: vi
+            .fn()
+            .mockResolvedValue({
+              state: "ready",
+              data: { ...data, spans: [], history: [] },
+            }),
+        }}
         active
         editor={{ ...editor, hasText: () => false }}
       />,
     );
-    expect(await screen.findByText("There is no text to map yet.")).toBeVisible();
-    expect(screen.queryByText(/Some text has no current provenance/u)).toBeNull();
-    expect(screen.queryByText("No provenance records match this filter.")).toBeNull();
+    expect(
+      await screen.findByText("There is no text to map yet."),
+    ).toBeVisible();
+    expect(
+      screen.queryByText(/Some text has no current provenance/u),
+    ).toBeNull();
+    expect(
+      screen.queryByText("No provenance records match this filter."),
+    ).toBeNull();
+  });
+
+  it("shows recent typing as recording instead of definitively unrecorded", async () => {
+    render(
+      <ProvenancePanel
+        provider={provider()}
+        active
+        editor={{ ...editor, isLocallyDirty: () => true }}
+        inputProvenancePending
+      />,
+    );
+
+    expect(
+      await screen.findByText(/Recording provenance for recent typing…/u),
+    ).toBeVisible();
+    expect(screen.getByText("Updating…")).toBeVisible();
+    expect(
+      screen.queryByText("Some text has no current provenance record"),
+    ).toBeNull();
+    expect(
+      screen.queryByText("No provenance has been recorded for this document"),
+    ).toBeNull();
   });
 
   it("gives a textful document with zero records one actionable empty state", async () => {
@@ -260,8 +310,12 @@ describe("ProvenancePanel", () => {
       }),
     ).toBeVisible();
     expect(screen.getByText(/Select existing text to record/u)).toBeVisible();
-    expect(screen.queryByText(/Some text has no current provenance/u)).toBeNull();
-    expect(screen.queryByText("No provenance records match this filter.")).toBeNull();
+    expect(
+      screen.queryByText(/Some text has no current provenance/u),
+    ).toBeNull();
+    expect(
+      screen.queryByText("No provenance records match this filter."),
+    ).toBeNull();
   });
 
   it("does not present a terminal empty state while recent typing is unsettled", async () => {
@@ -304,8 +358,12 @@ describe("ProvenancePanel", () => {
       />,
     );
 
-    await userEvent.click(await screen.findByRole("button", { name: "Issues" }));
-    expect(screen.getByText("No provenance records match this filter.")).toBeVisible();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Issues" }),
+    );
+    expect(
+      screen.getByText("No provenance records match this filter."),
+    ).toBeVisible();
     expect(screen.getByRole("button", { name: "All" })).toBeVisible();
   });
 
@@ -359,12 +417,12 @@ describe("ProvenancePanel", () => {
       />,
     );
 
-    await userEvent.click(await screen.findByRole("button", { name: /AI passage/u }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /AI passage/u }),
+    );
     const action = screen.getByRole("button", { name: "Mark reviewed" });
     expect(action).toBeDisabled();
-    expect(
-      screen.getByText(/re-anchored for inspection/u),
-    ).toBeVisible();
+    expect(screen.getByText(/re-anchored for inspection/u)).toBeVisible();
     expect(action).toHaveAttribute("aria-describedby");
   });
 
@@ -413,10 +471,12 @@ describe("ProvenancePanel", () => {
         editor={editor}
       />,
     );
-    await userEvent.click(await screen.findByRole("button", { name: "Issues" }));
-    expect(screen.getByRole("button", { name: /AI passage/u })).toHaveTextContent(
-      "Reanchored for inspection",
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Issues" }),
     );
+    expect(
+      screen.getByRole("button", { name: /AI passage/u }),
+    ).toHaveTextContent("Reanchored for inspection");
   });
 
   it("labels an unavailable orphaned passage without document actions", async () => {
@@ -457,30 +517,96 @@ describe("ProvenancePanel", () => {
     expect(item).toHaveTextContent("Passage unavailable");
     expect(item).not.toHaveTextContent("Whole document");
     await userEvent.click(item);
-    expect(screen.queryByRole("button", { name: "Show in document" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Show in document" }),
+    ).toBeNull();
     expect(screen.queryByRole("button", { name: "Mark reviewed" })).toBeNull();
-    expect(screen.getByText(/append-only history remains inspectable/u)).toBeVisible();
+    expect(
+      screen.getByText(/append-only history remains inspectable/u),
+    ).toBeVisible();
   });
 
   it("shows bounded source fields and identity strength without dumping raw metadata", async () => {
+    render(<ProvenancePanel provider={provider()} active editor={editor} />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: /AI passage/u }),
+    );
+
+    expect(
+      screen.getAllByText(/Taylor \(claimed name; not account-verified\)/u)
+        .length,
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Provider: clipboard/u).length).toBeGreaterThan(
+      0,
+    );
+    expect(
+      screen.getAllByText(/Media type: text\/plain/u).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/Path: notes\/source\.txt/u).length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText(/must_not_render/u)).toBeNull();
+  });
+
+  it("shows the bounded producing run for accepted AI proposals", async () => {
+    const accepted = {
+      ...attestation,
+      source: {
+        kind: "proposal_acceptance",
+        proposal_id: "proposal-demo",
+        acceptance_gesture_id: "gesture-demo",
+        producer: {
+          model: "gpt-5.6-sol",
+          harness: "codex",
+          surface: "mcp",
+          session_id: "session-demo",
+          private_metadata: "must not render",
+        },
+      },
+      basis: { kind: "proposal_acceptance", ref: "gesture-demo" },
+    };
+    const acceptedData: ProvenanceData = {
+      ...data,
+      spans: [
+        {
+          ...data.spans[0]!,
+          effectiveAttestations: [accepted],
+          effectiveAttestation: accepted,
+          history: [accepted],
+        },
+      ],
+      history: [accepted],
+    };
     render(
       <ProvenancePanel
-        provider={provider()}
+        provider={{
+          ...provider(),
+          load: vi.fn().mockResolvedValue({
+            state: "ready",
+            data: acceptedData,
+          }),
+        }}
         active
         editor={editor}
       />,
     );
-    await userEvent.click(await screen.findByRole("button", { name: /AI passage/u }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /AI passage/u }),
+    );
 
     expect(
-      screen.getAllByText(
-        /Taylor \(claimed name; not account-verified\)/u,
-      ).length,
+      screen.getAllByText(/Proposal: proposal-demo/u).length,
     ).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Provider: clipboard/u).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Media type: text\/plain/u).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Path: notes\/source\.txt/u).length).toBeGreaterThan(0);
-    expect(screen.queryByText(/must_not_render/u)).toBeNull();
+    expect(
+      screen.getAllByText(/Producer model: gpt-5\.6-sol/u).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/Producer harness: codex/u).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/Producer run: session-demo/u).length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText(/must not render/u)).toBeNull();
   });
 
   it("labels manually repaired legacy source as untracked", async () => {
@@ -513,7 +639,9 @@ describe("ProvenancePanel", () => {
       />,
     );
 
-    await userEvent.click(await screen.findByRole("button", { name: /AI passage/u }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /AI passage/u }),
+    );
     expect(screen.getAllByText("Untracked / legacy").length).toBeGreaterThan(0);
   });
 
@@ -555,14 +683,20 @@ describe("ProvenancePanel", () => {
         mutationBarrier={{ runWithSynchronizedDocument: vi.fn() }}
       />,
     );
-    await userEvent.click(await screen.findByRole("button", { name: /AI passage/u }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /AI passage/u }),
+    );
     expect(
-      screen.getByText(/Overlapping provenance records disagree on authorship/u),
+      screen.getByText(
+        /Overlapping provenance records disagree on authorship/u,
+      ),
     ).toBeVisible();
     expect(
       screen.getByRole("button", { name: "Mark reviewed" }),
     ).toBeDisabled();
     await userEvent.click(screen.getByRole("button", { name: "Issues" }));
-    expect(screen.getAllByText("Conflicts with overlapping passage")).toHaveLength(2);
+    expect(
+      screen.getAllByText("Conflicts with overlapping passage"),
+    ).toHaveLength(2);
   });
 });

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -11,6 +12,7 @@ import type {
   ProvenanceAttestation, ProvenanceEditorIntegration, ProvenanceLoad,
   ProvenanceProvider, ProvenanceTarget,
   ProvenanceMutationBarrier,
+  ProvenanceSelectionAction,
 } from "./contracts";
 import {
   provenanceDisplayedAxesFingerprint,
@@ -31,10 +33,13 @@ export interface ProvenancePanelProps {
   readonly editor?: ProvenanceEditorIntegration;
   readonly readOnly?: boolean;
   readonly mutationBarrier?: ProvenanceMutationBarrier;
+  /** Opens stable detail for a provenance-aware editor selection action. */
+  readonly selectionAction?: ProvenanceSelectionAction | null;
 }
 
 const sourceLabel = (attestation: ProvenanceAttestation): string => {
   const kind = attestation.source.kind;
+  if (kind === "legacy") return "Untracked / legacy";
   return typeof kind === "string" ? kind.replace(/_/gu, " ") : "Unknown source";
 };
 
@@ -332,20 +337,49 @@ function ProvenanceContents({
   load,
   provider, editor, mutationBarrier,
   readOnly,
+  selectionAction,
 }: {
   readonly load: ProvenanceLoad;
   readonly provider: ProvenanceProvider;
   readonly editor?: ProvenanceEditorIntegration;
   readonly readOnly?: boolean;
   readonly mutationBarrier?: ProvenanceMutationBarrier;
+  readonly selectionAction?: ProvenanceSelectionAction | null;
 }) {
   const view = load.state === "ready" ? load.data : undefined;
   const [filter, setFilter] = useState<ProvenanceFilter>("all");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [pendingId, setPendingId] = useState<string | null>(null);
   const mutationLock = useRef(false);
+  const routedRowRef = useRef<HTMLButtonElement | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  useEffect(() => {
+    if (
+      selectionAction === null ||
+      selectionAction === undefined ||
+      selectionAction.intent === "record" ||
+      selectionAction.targetIds.length === 0
+    ) {
+      return;
+    }
+    setFilter("all");
+    setSelectedId(selectionAction.targetIds[0]!);
+  }, [selectionAction]);
+  useLayoutEffect(() => {
+    const target = selectionAction?.targetIds[0];
+    if (
+      target === undefined ||
+      selectionAction?.intent === "record" ||
+      selectedId !== target
+    ) {
+      return;
+    }
+    const row = routedRowRef.current;
+    if (row === null) return;
+    row.focus({ preventScroll: true });
+    row.scrollIntoView?.({ block: "nearest" });
+  }, [selectedId, selectionAction]);
   if (view === undefined) {
     return (
       <div className="wb-cowork-provenance-panel__unavailable" role="status">
@@ -397,6 +431,9 @@ function ProvenanceContents({
       ),
     ) ?? true);
   const selected = targets.find((item) => targetId(item.target) === selectedId)?.target ?? null;
+  const hasText = editor?.hasText() ?? true;
+  const noRecordedProvenance =
+    !locallyDirty && hasText && targets.length === 0 && view.history.length === 0;
   const markReviewed = async (target: ProvenanceTarget): Promise<void> => {
     if (mutationLock.current) return;
     const record = effective(target);
@@ -492,17 +529,28 @@ function ProvenanceContents({
       <p className="wb-cowork-provenance-panel__success" aria-live="polite">
         {success ?? ""}
       </p>
-      {unrecorded && filter === "all" ? (
+      {noRecordedProvenance && filter === "all" ? (
+        <article className="wb-cowork-provenance-panel__unrecorded">
+          <h3>No provenance has been recorded for this document</h3>
+          <p>
+            New typing is recorded automatically. Select existing text to
+            record who wrote it and whether it was reviewed; its earlier source
+            will remain untracked.
+          </p>
+        </article>
+      ) : unrecorded && filter === "all" ? (
         <article className="wb-cowork-provenance-panel__unrecorded">
           <h3>Some text has no current provenance record</h3>
           <p>Unrecorded text is shown with the unknown pattern. It is not assumed to be human-authored.</p>
         </article>
       ) : null}
-      {!unrecorded && targets.length === 0 ? (
+      {!hasText ? (
         <p className="wb-cowork-provenance-panel__empty">There is no text to map yet.</p>
       ) : null}
-      {visible.length === 0 && (editor?.hasText() ?? true) ? (
-        <p className="wb-cowork-provenance-panel__empty">No provenance records match this filter.</p>
+      {visible.length === 0 ? (
+        hasText && (!noRecordedProvenance || filter !== "all") ? (
+          <p className="wb-cowork-provenance-panel__empty">No provenance records match this filter.</p>
+        ) : null
       ) : (
         <ol className="wb-cowork-provenance-panel__list">
           {visible.map(({ target, anchorResolution, peerConflictIds }, index) => {
@@ -519,6 +567,11 @@ function ProvenanceContents({
               <li key={`${id}:${String(index)}`} data-state={peerConflictIds.length > 0 || target.resolution === "conflicted" || target.target.currentness !== "current" ? "issue" : "recorded"}>
                 <button
                   type="button"
+                  ref={
+                    selectionAction?.targetIds[0] === id
+                      ? routedRowRef
+                      : undefined
+                  }
                   className="wb-cowork-provenance-panel__item"
                   aria-expanded={active}
                   onClick={() => {
@@ -568,29 +621,66 @@ function ProvenanceContents({
                         Show in document
                       </button>
                     ) : null}
-                    {canReview(target, anchorResolution.state, peerConflictIds.length > 0, locallyDirty) && view.currentStructuredHeadSha256 !== null && readOnly !== true && mutationBarrier !== undefined ? (
-                      <button
-                        type="button"
-                        disabled={pendingId !== null}
-                        onClick={() => void markReviewed(target)}
-                      >
-                        {pendingId === record?.attestationId ? "Recording…" : "Mark reviewed"}
-                      </button>
-                    ) : (
-                      <p className="wb-cowork-provenance-panel__reason">
-                        {peerConflictIds.length > 0
+                    {record !== null &&
+                    (record.authorship.kind === "ai" ||
+                      record.authorship.kind === "mixed") ? (() => {
+                        const targetCanReview = canReview(
+                          target,
+                          anchorResolution.state,
+                          peerConflictIds.length > 0,
+                          locallyDirty,
+                        );
+                        const reviewEnabled =
+                          targetCanReview &&
+                          view.currentStructuredHeadSha256 !== null &&
+                          readOnly !== true &&
+                          mutationBarrier !== undefined &&
+                          pendingId === null;
+                        const reason = pendingId === record.attestationId
+                          ? "Human review is being recorded."
+                          : pendingId !== null
+                            ? "Finish recording the current review before starting another."
+                          : peerConflictIds.length > 0
                           ? "Overlapping provenance records disagree, so review cannot be recorded."
                           : locallyDirty
                             ? "Synchronize local edits and refresh provenance before recording review."
-                          : view.currentStructuredHeadSha256 === null && canReview(target, anchorResolution.state)
-                            ? "No current structured document head is available, so review cannot be recorded."
-                          : readOnly === true && canReview(target, anchorResolution.state)
-                          ? "This document is read-only, so review cannot be recorded."
-                          : mutationBarrier === undefined && canReview(target, anchorResolution.state)
-                            ? "The editor is not ready to record review safely."
-                          : reviewBlockedReason(target)}
-                      </p>
-                    )}
+                            : view.currentStructuredHeadSha256 === null && targetCanReview
+                              ? "No current structured document head is available, so review cannot be recorded."
+                              : readOnly === true && targetCanReview
+                                ? "This document is read-only, so review cannot be recorded."
+                                : mutationBarrier === undefined && targetCanReview
+                                  ? "The editor is not ready to record review safely."
+                                  : reviewBlockedReason(target);
+                        const reasonId = `wb-cowork-provenance-review-reason-${id}`;
+                        return (
+                          <div className="wb-cowork-provenance-panel__actions">
+                            <h4>Actions</h4>
+                            <button
+                              type="button"
+                              disabled={!reviewEnabled}
+                              aria-describedby={reviewEnabled ? undefined : reasonId}
+                              onClick={() => void markReviewed(target)}
+                            >
+                              {pendingId === record.attestationId
+                                ? "Recording…"
+                                : "Mark reviewed"}
+                            </button>
+                            {reviewEnabled ? (
+                              <p className="wb-cowork-provenance-panel__reason">
+                                Records that you reviewed this text. It does not
+                                change its authorship or assert that it is true.
+                              </p>
+                            ) : (
+                              <p
+                                id={reasonId}
+                                className="wb-cowork-provenance-panel__reason"
+                              >
+                                {reason}
+                              </p>
+                            )}
+                          </div>
+                        );
+                      })() : null}
                   </div>
                 ) : null}
               </li>
@@ -673,7 +763,7 @@ export function ProvenancePanel(props: ProvenancePanelProps) {
     if (error !== null && data === null) return <div className="wb-cowork-provenance-panel__unavailable" role="alert"><h2>Provenance could not load</h2><p>{error}</p><button type="button" onClick={() => setReload((value) => value + 1)}>Retry</button></div>;
     if (data === null) return <p className="wb-cowork-provenance-panel__empty" role="status">Loading provenance…</p>;
     if (data.state === "unavailable") return <div className="wb-cowork-provenance-panel__unavailable" role="status"><h2>Provenance view unavailable</h2><p>{data.reason}</p><button type="button" onClick={() => setReload((value) => value + 1)}>Retry</button></div>;
-    return <>{error === null ? null : <p className="wb-cowork-provenance-panel__error" role="alert">{error} <button type="button" onClick={() => setReload((value) => value + 1)}>Retry</button></p>}<ProvenanceContents load={data} provider={props.provider} editor={props.editor} readOnly={props.readOnly} mutationBarrier={props.mutationBarrier} /></>;
-  }, [data, error, props.editor, props.mutationBarrier, props.provider, props.readOnly]);
+    return <>{error === null ? null : <p className="wb-cowork-provenance-panel__error" role="alert">{error} <button type="button" onClick={() => setReload((value) => value + 1)}>Retry</button></p>}<ProvenanceContents load={data} provider={props.provider} editor={props.editor} readOnly={props.readOnly} mutationBarrier={props.mutationBarrier} selectionAction={props.selectionAction} /></>;
+  }, [data, error, props.editor, props.mutationBarrier, props.provider, props.readOnly, props.selectionAction]);
   return <section className="wb-cowork-provenance-panel" aria-label="Document provenance" ref={props.scrollContainerRef}>{content}</section>;
 }

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.tsx
@@ -678,7 +678,9 @@ function ProvenanceContents({
         </p>
       ) : null}
       {visible.length === 0 ? (
-        hasText && (!noRecordedProvenance || filter !== "all") ? (
+        !inputProvenancePending &&
+        hasText &&
+        (!noRecordedProvenance || filter !== "all") ? (
           <p className="wb-cowork-provenance-panel__empty">
             No provenance records match this filter.
           </p>

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.tsx
@@ -9,8 +9,11 @@ import {
 } from "react";
 
 import type {
-  ProvenanceAttestation, ProvenanceEditorIntegration, ProvenanceLoad,
-  ProvenanceProvider, ProvenanceTarget,
+  ProvenanceAttestation,
+  ProvenanceEditorIntegration,
+  ProvenanceLoad,
+  ProvenanceProvider,
+  ProvenanceTarget,
   ProvenanceMutationBarrier,
   ProvenanceSelectionAction,
 } from "./contracts";
@@ -19,10 +22,7 @@ import {
   provenancePersonDetail,
   provenanceSourceDetails,
 } from "./semantics";
-import {
-  asCoworkApiError,
-  coworkErrorMessage,
-} from "../../providers/errors";
+import { asCoworkApiError, coworkErrorMessage } from "../../providers/errors";
 
 type ProvenanceFilter = "all" | "needs_review" | "ai_authored" | "issues";
 
@@ -35,6 +35,8 @@ export interface ProvenancePanelProps {
   readonly mutationBarrier?: ProvenanceMutationBarrier;
   /** Opens stable detail for a provenance-aware editor selection action. */
   readonly selectionAction?: ProvenanceSelectionAction | null;
+  /** Browser-local direct entry is awaiting an authoritative ledger receipt. */
+  readonly inputProvenancePending?: boolean;
 }
 
 const sourceLabel = (attestation: ProvenanceAttestation): string => {
@@ -66,18 +68,13 @@ const mutationErrorMessage = (cause: unknown): string => {
   );
 };
 
-const targetId = (target: ProvenanceTarget): string =>
-  target.projectionId;
+const targetId = (target: ProvenanceTarget): string => target.projectionId;
 
 const effective = (target: ProvenanceTarget): ProvenanceAttestation | null =>
   target.resolution === "resolved" ? target.effectiveAttestation : null;
 
 type AnchorState =
-  | "unique"
-  | "missing"
-  | "ambiguous"
-  | "document"
-  | "unavailable";
+  "unique" | "missing" | "ambiguous" | "document" | "unavailable";
 
 interface ResolvedPanelTarget {
   readonly target: ProvenanceTarget;
@@ -115,7 +112,9 @@ const incompatibleOverlap = (
   ) {
     return false;
   }
-  return new Set([...targetAxes(left.target), ...targetAxes(right.target)]).size > 1;
+  return (
+    new Set([...targetAxes(left.target), ...targetAxes(right.target)]).size > 1
+  );
 };
 
 const withPeerConflicts = (
@@ -138,41 +137,47 @@ const resolvePanelTargets = (
   view: Extract<ProvenanceLoad, { readonly state: "ready" }>["data"],
   editor: ProvenanceEditorIntegration | undefined,
 ): readonly ResolvedPanelTarget[] =>
-  [...withPeerConflicts(
-    [
-      ...(view.documentDefault === null ? [] : [view.documentDefault]),
-      ...view.spans,
-    ].map((target, payloadOrder) => {
-      const anchorResolution =
-        target.span === null && target.target.kind === "document_version"
-          ? {
-              state: "document" as const,
-              documentOrder: -1,
-              documentEnd: null,
-            }
-          : target.span === null
+  [
+    ...withPeerConflicts(
+      [
+        ...(view.documentDefault === null ? [] : [view.documentDefault]),
+        ...view.spans,
+      ].map((target, payloadOrder) => {
+        const anchorResolution =
+          target.span === null && target.target.kind === "document_version"
             ? {
-                state: "unavailable" as const,
-                documentOrder: null,
+                state: "document" as const,
+                documentOrder: -1,
                 documentEnd: null,
               }
-          : editor?.resolveTarget(target.span) ?? {
-              state: "missing" as const,
-              documentOrder: null,
-              documentEnd: null,
-            };
-      return { target, payloadOrder, anchorResolution };
-    }),
-  )].sort((left, right) => {
+            : target.span === null
+              ? {
+                  state: "unavailable" as const,
+                  documentOrder: null,
+                  documentEnd: null,
+                }
+              : (editor?.resolveTarget(target.span) ?? {
+                  state: "missing" as const,
+                  documentOrder: null,
+                  documentEnd: null,
+                });
+        return { target, payloadOrder, anchorResolution };
+      }),
+    ),
+  ].sort((left, right) => {
     const leftOrder = left.anchorResolution.documentOrder;
     const rightOrder = right.anchorResolution.documentOrder;
-    if (leftOrder !== null && rightOrder !== null) return leftOrder - rightOrder;
+    if (leftOrder !== null && rightOrder !== null)
+      return leftOrder - rightOrder;
     if (leftOrder !== null) return -1;
     if (rightOrder !== null) return 1;
     return left.payloadOrder - right.payloadOrder;
   });
 
-const statusLabel = (target: ProvenanceTarget, anchorState: AnchorState): string => {
+const statusLabel = (
+  target: ProvenanceTarget,
+  anchorState: AnchorState,
+): string => {
   if (anchorState === "unavailable") return "Passage unavailable";
   if (target.resolution === "conflicted") return "Conflicting records";
   if (anchorState === "missing") return "Passage not found";
@@ -180,11 +185,14 @@ const statusLabel = (target: ProvenanceTarget, anchorState: AnchorState): string
   if (target.target.currentness === "stale") return "Stale target";
   if (target.target.currentness === "unavailable") return "Target unavailable";
   if (target.target.currentness === "requires_reanchor") {
-    return anchorState === "unique" ? "Reanchored for inspection" : "Needs location check";
+    return anchorState === "unique"
+      ? "Reanchored for inspection"
+      : "Needs location check";
   }
   const record = effective(target);
   if (record === null) return "Unrecorded";
-  const author = record.authorship.kind === "ai" ? "AI" : record.authorship.kind;
+  const author =
+    record.authorship.kind === "ai" ? "AI" : record.authorship.kind;
   const review = record.humanReview.status.replace(/_/gu, " ");
   return `${author} · ${review}`;
 };
@@ -250,17 +258,18 @@ const matches = (
   }
   if (filter === "needs_review") {
     return (
-      (record?.authorship.kind === "ai" || record?.authorship.kind === "mixed") &&
-      (record.humanReview.status === "not_reviewed" || record.humanReview.status === "unknown")
+      (record?.authorship.kind === "ai" ||
+        record?.authorship.kind === "mixed") &&
+      (record.humanReview.status === "not_reviewed" ||
+        record.humanReview.status === "unknown")
     );
   }
-  return record?.authorship.kind === "ai" || record?.authorship.kind === "mixed";
+  return (
+    record?.authorship.kind === "ai" || record?.authorship.kind === "mixed"
+  );
 };
 
-const isIssue = (
-  item: ResolvedPanelTarget,
-  locallyDirty: boolean,
-): boolean =>
+const isIssue = (item: ResolvedPanelTarget, locallyDirty: boolean): boolean =>
   locallyDirty ||
   matches(
     item.target,
@@ -279,21 +288,74 @@ function RecordDetails({ record }: { readonly record: ProvenanceAttestation }) {
   const sourceDetails = provenanceSourceDetails(record);
   return (
     <dl className="wb-cowork-provenance-panel__facts">
-      <div><dt>Authorship</dt><dd>{record.authorship.kind}</dd></div>
-      <div><dt>Contributors</dt><dd>{record.authorship.contributors.map(provenancePersonDetail).join(", ") || "None recorded"}</dd></div>
-      <div><dt>Human review</dt><dd>{record.humanReview.status.replace(/_/gu, " ")}</dd></div>
-      <div><dt>Reviewers</dt><dd>{record.humanReview.reviewers.map(provenancePersonDetail).join(", ") || "None recorded"}</dd></div>
-      <div><dt>Source</dt><dd>{sourceLabel(record)}</dd></div>
+      <div>
+        <dt>Authorship</dt>
+        <dd>{record.authorship.kind}</dd>
+      </div>
+      <div>
+        <dt>Contributors</dt>
+        <dd>
+          {record.authorship.contributors
+            .map(provenancePersonDetail)
+            .join(", ") || "None recorded"}
+        </dd>
+      </div>
+      <div>
+        <dt>Human review</dt>
+        <dd>{record.humanReview.status.replace(/_/gu, " ")}</dd>
+      </div>
+      <div>
+        <dt>Reviewers</dt>
+        <dd>
+          {record.humanReview.reviewers
+            .map(provenancePersonDetail)
+            .join(", ") || "None recorded"}
+        </dd>
+      </div>
+      <div>
+        <dt>Source</dt>
+        <dd>{sourceLabel(record)}</dd>
+      </div>
       {sourceDetails.length === 0 ? null : (
         <div>
           <dt>Source details</dt>
-          <dd>{sourceDetails.map((detail) => `${detail.label}: ${detail.value}`).join(" · ")}</dd>
+          <dd>
+            {sourceDetails
+              .map((detail) => `${detail.label}: ${detail.value}`)
+              .join(" · ")}
+          </dd>
         </div>
       )}
-      <div><dt>Attested by</dt><dd>{attester}</dd></div>
-      <div><dt>Basis</dt><dd>{record.basis.kind.replace(/_/gu, " ")}</dd></div>
-      <div><dt>Target</dt><dd>{record.scope.kind === "document_span" ? "Passage" : "Document version"}{record.scope.documentSpanId === null ? "" : ` · ${shortIdentity(record.scope.documentSpanId)}`}{record.scope.documentVersionId === null ? "" : ` · ${shortIdentity(record.scope.documentVersionId)}`}</dd></div>
-      <div><dt>Recorded</dt><dd><time dateTime={record.at}>{new Date(record.at).toLocaleString()}</time></dd></div>
+      <div>
+        <dt>Attested by</dt>
+        <dd>{attester}</dd>
+      </div>
+      <div>
+        <dt>Basis</dt>
+        <dd>{record.basis.kind.replace(/_/gu, " ")}</dd>
+      </div>
+      <div>
+        <dt>Target</dt>
+        <dd>
+          {record.scope.kind === "document_span"
+            ? "Passage"
+            : "Document version"}
+          {record.scope.documentSpanId === null
+            ? ""
+            : ` · ${shortIdentity(record.scope.documentSpanId)}`}
+          {record.scope.documentVersionId === null
+            ? ""
+            : ` · ${shortIdentity(record.scope.documentVersionId)}`}
+        </dd>
+      </div>
+      <div>
+        <dt>Recorded</dt>
+        <dd>
+          <time dateTime={record.at}>
+            {new Date(record.at).toLocaleString()}
+          </time>
+        </dd>
+      </div>
     </dl>
   );
 }
@@ -304,7 +366,8 @@ function ProvenanceDetails({ target }: { readonly target: ProvenanceTarget }) {
     return (
       <div className="wb-cowork-provenance-panel__conflict">
         <p className="wb-cowork-provenance-panel__reason">
-          {target.issue?.message ?? `${String(target.effectiveAttestations.length)} effective records disagree; none is treated as authoritative.`}
+          {target.issue?.message ??
+            `${String(target.effectiveAttestations.length)} effective records disagree; none is treated as authoritative.`}
         </p>
         {target.effectiveAttestations.map((leaf) => (
           <article key={leaf.attestationId}>
@@ -319,12 +382,19 @@ function ProvenanceDetails({ target }: { readonly target: ProvenanceTarget }) {
     <>
       <RecordDetails record={record} />
       <details className="wb-cowork-provenance-panel__history">
-        <summary>{target.history.length} immutable {target.history.length === 1 ? "record" : "records"}</summary>
+        <summary>
+          {target.history.length} immutable{" "}
+          {target.history.length === 1 ? "record" : "records"}
+        </summary>
         <ol>
           {target.history.map((entry) => (
             <li key={entry.attestationId}>
               <RecordDetails record={entry} />
-              <p>{entry.supersedesId === null ? "Original record" : "Supersedes an earlier record"}</p>
+              <p>
+                {entry.supersedesId === null
+                  ? "Original record"
+                  : "Supersedes an earlier record"}
+              </p>
             </li>
           ))}
         </ol>
@@ -335,9 +405,12 @@ function ProvenanceDetails({ target }: { readonly target: ProvenanceTarget }) {
 
 function ProvenanceContents({
   load,
-  provider, editor, mutationBarrier,
+  provider,
+  editor,
+  mutationBarrier,
   readOnly,
   selectionAction,
+  inputProvenancePending = false,
 }: {
   readonly load: ProvenanceLoad;
   readonly provider: ProvenanceProvider;
@@ -345,6 +418,7 @@ function ProvenanceContents({
   readonly readOnly?: boolean;
   readonly mutationBarrier?: ProvenanceMutationBarrier;
   readonly selectionAction?: ProvenanceSelectionAction | null;
+  readonly inputProvenancePending?: boolean;
 }) {
   const view = load.state === "ready" ? load.data : undefined;
   const [filter, setFilter] = useState<ProvenanceFilter>("all");
@@ -385,7 +459,9 @@ function ProvenanceContents({
       <div className="wb-cowork-provenance-panel__unavailable" role="status">
         <h2>Provenance view unavailable</h2>
         <p>
-          {load.state === "unavailable" ? load.reason : "This server did not provide the provenance view needed to explain the document safely."}
+          {load.state === "unavailable"
+            ? load.reason
+            : "This server did not provide the provenance view needed to explain the document safely."}
         </p>
       </div>
     );
@@ -413,7 +489,9 @@ function ProvenanceContents({
   const reviewedCount = targets.filter(
     ({ target }) => effective(target)?.humanReview.status === "reviewed",
   ).length;
-  const issueCount = targets.filter((item) => isIssue(item, locallyDirty)).length;
+  const issueCount = targets.filter((item) =>
+    isIssue(item, locallyDirty),
+  ).length;
   const unrecorded =
     (editor?.hasText() ?? true) &&
     (locallyDirty ||
@@ -429,11 +507,18 @@ function ProvenanceContents({
           ? [target.span]
           : [],
       ),
-    ) ?? true);
-  const selected = targets.find((item) => targetId(item.target) === selectedId)?.target ?? null;
+    ) ??
+      true);
+  const selected =
+    targets.find((item) => targetId(item.target) === selectedId)?.target ??
+    null;
   const hasText = editor?.hasText() ?? true;
   const noRecordedProvenance =
-    !locallyDirty && hasText && targets.length === 0 && view.history.length === 0;
+    !inputProvenancePending &&
+    !locallyDirty &&
+    hasText &&
+    targets.length === 0 &&
+    view.history.length === 0;
   const markReviewed = async (target: ProvenanceTarget): Promise<void> => {
     if (mutationLock.current) return;
     const record = effective(target);
@@ -463,7 +548,10 @@ function ProvenanceContents({
           const refreshedItem = resolvePanelTargets(
             refreshed.data,
             editor,
-          ).find((candidate) => candidate.target.projectionId === target.projectionId);
+          ).find(
+            (candidate) =>
+              candidate.target.projectionId === target.projectionId,
+          );
           if (
             refreshed.data.currentStructuredHeadSha256 === null ||
             synchronized.structuredHeadSha256 !==
@@ -502,28 +590,65 @@ function ProvenanceContents({
   };
   return (
     <>
-      <dl className="wb-cowork-provenance-panel__summary" aria-label="Provenance summary">
-        <div><dt>Needs review</dt><dd>{needsReviewCount}</dd></div>
-        <div><dt>Reviewed</dt><dd>{reviewedCount}</dd></div>
-        <div><dt>Issues</dt><dd>{issueCount}</dd></div>
-        <div><dt>Unrecorded</dt><dd>{unrecorded ? "Yes" : "No"}</dd></div>
+      <dl
+        className="wb-cowork-provenance-panel__summary"
+        aria-label="Provenance summary"
+      >
+        <div>
+          <dt>Needs review</dt>
+          <dd>{needsReviewCount}</dd>
+        </div>
+        <div>
+          <dt>Reviewed</dt>
+          <dd>{reviewedCount}</dd>
+        </div>
+        <div>
+          <dt>Issues</dt>
+          <dd>{issueCount}</dd>
+        </div>
+        <div>
+          <dt>Unrecorded</dt>
+          <dd>
+            {inputProvenancePending ? "Updating…" : unrecorded ? "Yes" : "No"}
+          </dd>
+        </div>
       </dl>
-      <div className="wb-cowork-provenance-panel__filters" aria-label="Filter provenance" role="group">
-        {(["all", "needs_review", "ai_authored", "issues"] as const).map((item) => (
-          <button
-            key={item}
-            type="button"
-            aria-pressed={filter === item}
-            onClick={() => setFilter(item)}
-          >
-            {item.replace(/_/gu, " ").replace(/^./u, (letter: string) => letter.toUpperCase())}
-          </button>
-        ))}
+      <div
+        className="wb-cowork-provenance-panel__filters"
+        aria-label="Filter provenance"
+        role="group"
+      >
+        {(["all", "needs_review", "ai_authored", "issues"] as const).map(
+          (item) => (
+            <button
+              key={item}
+              type="button"
+              aria-pressed={filter === item}
+              onClick={() => setFilter(item)}
+            >
+              {item
+                .replace(/_/gu, " ")
+                .replace(/^./u, (letter: string) => letter.toUpperCase())}
+            </button>
+          ),
+        )}
       </div>
-      {error === null ? null : <p className="wb-cowork-provenance-panel__error" role="alert">{error}</p>}
-      {locallyDirty ? (
+      {error === null ? null : (
+        <p className="wb-cowork-provenance-panel__error" role="alert">
+          {error}
+        </p>
+      )}
+      {inputProvenancePending ? (
         <p className="wb-cowork-provenance-panel__reason" role="status">
-          Local edits are not yet represented by the latest provenance snapshot. Exact passages are reanchored for inspection; recording review waits for synchronization.
+          Recording provenance for recent typing… The editor has captured the
+          text; authorship and review will appear after the server confirms the
+          record.
+        </p>
+      ) : locallyDirty ? (
+        <p className="wb-cowork-provenance-panel__reason" role="status">
+          Local edits are not yet represented by the latest provenance snapshot.
+          Exact passages are reanchored for inspection; recording review waits
+          for synchronization.
         </p>
       ) : null}
       <p className="wb-cowork-provenance-panel__success" aria-live="polite">
@@ -533,165 +658,228 @@ function ProvenanceContents({
         <article className="wb-cowork-provenance-panel__unrecorded">
           <h3>No provenance has been recorded for this document</h3>
           <p>
-            New typing is recorded automatically. Select existing text to
-            record who wrote it and whether it was reviewed; its earlier source
-            will remain untracked.
+            New typing is recorded automatically. Select existing text to record
+            who wrote it and whether it was reviewed; its earlier source will
+            remain untracked.
           </p>
         </article>
-      ) : unrecorded && filter === "all" ? (
+      ) : !inputProvenancePending && unrecorded && filter === "all" ? (
         <article className="wb-cowork-provenance-panel__unrecorded">
           <h3>Some text has no current provenance record</h3>
-          <p>Unrecorded text is shown with the unknown pattern. It is not assumed to be human-authored.</p>
+          <p>
+            Unrecorded text is shown with the unknown pattern. It is not assumed
+            to be human-authored.
+          </p>
         </article>
       ) : null}
       {!hasText ? (
-        <p className="wb-cowork-provenance-panel__empty">There is no text to map yet.</p>
+        <p className="wb-cowork-provenance-panel__empty">
+          There is no text to map yet.
+        </p>
       ) : null}
       {visible.length === 0 ? (
         hasText && (!noRecordedProvenance || filter !== "all") ? (
-          <p className="wb-cowork-provenance-panel__empty">No provenance records match this filter.</p>
+          <p className="wb-cowork-provenance-panel__empty">
+            No provenance records match this filter.
+          </p>
         ) : null
       ) : (
         <ol className="wb-cowork-provenance-panel__list">
-          {visible.map(({ target, anchorResolution, peerConflictIds }, index) => {
-            const id = targetId(target);
-            const record = effective(target);
-            const quote =
-              target.span !== null
-                ? passageExcerpt(target.span.exact)
-                : target.target.kind === "document_version"
-                  ? "Whole document"
-                  : "Unavailable passage";
-            const active = selectedId === id;
-            return (
-              <li key={`${id}:${String(index)}`} data-state={peerConflictIds.length > 0 || target.resolution === "conflicted" || target.target.currentness !== "current" ? "issue" : "recorded"}>
-                <button
-                  type="button"
-                  ref={
-                    selectionAction?.targetIds[0] === id
-                      ? routedRowRef
-                      : undefined
+          {visible.map(
+            ({ target, anchorResolution, peerConflictIds }, index) => {
+              const id = targetId(target);
+              const record = effective(target);
+              const quote =
+                target.span !== null
+                  ? passageExcerpt(target.span.exact)
+                  : target.target.kind === "document_version"
+                    ? "Whole document"
+                    : "Unavailable passage";
+              const active = selectedId === id;
+              return (
+                <li
+                  key={`${id}:${String(index)}`}
+                  data-state={
+                    peerConflictIds.length > 0 ||
+                    target.resolution === "conflicted" ||
+                    target.target.currentness !== "current"
+                      ? "issue"
+                      : "recorded"
                   }
-                  className="wb-cowork-provenance-panel__item"
-                  aria-expanded={active}
-                  onClick={() => {
-                    setSelectedId(active ? null : id);
-                    if (anchorResolution.state === "unique") {
-                      editor?.focusTarget(id);
-                    }
-                  }}
                 >
-                  <span className="wb-cowork-provenance-panel__quote">{quote}</span>
-                  <span className="wb-cowork-provenance-panel__status">{peerConflictIds.length > 0 ? "Conflicts with overlapping passage" : locallyDirty && target.target.currentness === "current" ? target.span === null ? "Awaiting provenance refresh" : anchorResolution.state === "unique" ? "Reanchored for inspection" : statusLabel(target, anchorResolution.state) : statusLabel(target, anchorResolution.state)}</span>
-                </button>
-                {active ? (
-                  <div className="wb-cowork-provenance-panel__detail">
-                    <ProvenanceDetails target={target} />
-                    {peerConflictIds.length > 0 ? (
-                      <div className="wb-cowork-provenance-panel__conflict">
+                  <button
+                    type="button"
+                    ref={
+                      selectionAction?.targetIds[0] === id
+                        ? routedRowRef
+                        : undefined
+                    }
+                    className="wb-cowork-provenance-panel__item"
+                    aria-expanded={active}
+                    onClick={() => {
+                      setSelectedId(active ? null : id);
+                      if (anchorResolution.state === "unique") {
+                        editor?.focusTarget(id);
+                      }
+                    }}
+                  >
+                    <span className="wb-cowork-provenance-panel__quote">
+                      {quote}
+                    </span>
+                    <span className="wb-cowork-provenance-panel__status">
+                      {peerConflictIds.length > 0
+                        ? "Conflicts with overlapping passage"
+                        : locallyDirty &&
+                            target.target.currentness === "current"
+                          ? target.span === null
+                            ? "Awaiting provenance refresh"
+                            : anchorResolution.state === "unique"
+                              ? "Reanchored for inspection"
+                              : statusLabel(target, anchorResolution.state)
+                          : statusLabel(target, anchorResolution.state)}
+                    </span>
+                  </button>
+                  {active ? (
+                    <div className="wb-cowork-provenance-panel__detail">
+                      <ProvenanceDetails target={target} />
+                      {peerConflictIds.length > 0 ? (
+                        <div className="wb-cowork-provenance-panel__conflict">
+                          <p className="wb-cowork-provenance-panel__reason">
+                            Overlapping provenance records disagree on
+                            authorship, review, or source. Review recording is
+                            blocked until that conflict is resolved.
+                          </p>
+                          <ul>
+                            {peerConflictIds.map((peerId) => {
+                              const peer = targets.find(
+                                (candidate) =>
+                                  candidate.target.projectionId === peerId,
+                              )?.target;
+                              return peer === undefined ? null : (
+                                <li key={peerId}>
+                                  <strong>
+                                    {peer.span !== null
+                                      ? passageExcerpt(peer.span.exact)
+                                      : peer.target.kind === "document_version"
+                                        ? "Whole document"
+                                        : "Unavailable passage"}
+                                  </strong>
+                                  {peer.effectiveAttestations.map((leaf) => (
+                                    <RecordDetails
+                                      key={leaf.attestationId}
+                                      record={leaf}
+                                    />
+                                  ))}
+                                </li>
+                              );
+                            })}
+                          </ul>
+                        </div>
+                      ) : null}
+                      {anchorResolution.state === "unavailable" ? (
                         <p className="wb-cowork-provenance-panel__reason">
-                          Overlapping provenance records disagree on authorship, review, or source. Review recording is blocked until that conflict is resolved.
+                          The recorded passage target is unavailable. Its
+                          append-only history remains inspectable, but it cannot
+                          be shown or reviewed.
                         </p>
-                        <ul>
-                          {peerConflictIds.map((peerId) => {
-                            const peer = targets.find(
-                              (candidate) => candidate.target.projectionId === peerId,
-                            )?.target;
-                            return peer === undefined ? null : (
-                              <li key={peerId}>
-                                 <strong>{peer.span !== null ? passageExcerpt(peer.span.exact) : peer.target.kind === "document_version" ? "Whole document" : "Unavailable passage"}</strong>
-                                {peer.effectiveAttestations.map((leaf) => (
-                                  <RecordDetails key={leaf.attestationId} record={leaf} />
-                                ))}
-                              </li>
+                      ) : anchorResolution.state === "missing" ? (
+                        <p className="wb-cowork-provenance-panel__reason">
+                          The recorded passage is no longer present in this
+                          document.
+                        </p>
+                      ) : anchorResolution.state === "ambiguous" ? (
+                        <p className="wb-cowork-provenance-panel__reason">
+                          The recorded passage matches multiple locations, so
+                          Co-work will not choose one.
+                        </p>
+                      ) : null}
+                      {target.span !== null &&
+                      anchorResolution.state === "unique" ? (
+                        <button
+                          type="button"
+                          onClick={() => editor?.revealTarget(id)}
+                        >
+                          Show in document
+                        </button>
+                      ) : null}
+                      {record !== null &&
+                      (record.authorship.kind === "ai" ||
+                        record.authorship.kind === "mixed")
+                        ? (() => {
+                            const targetCanReview = canReview(
+                              target,
+                              anchorResolution.state,
+                              peerConflictIds.length > 0,
+                              locallyDirty,
                             );
-                          })}
-                        </ul>
-                      </div>
-                    ) : null}
-                    {anchorResolution.state === "unavailable" ? (
-                      <p className="wb-cowork-provenance-panel__reason">The recorded passage target is unavailable. Its append-only history remains inspectable, but it cannot be shown or reviewed.</p>
-                    ) : anchorResolution.state === "missing" ? (
-                      <p className="wb-cowork-provenance-panel__reason">The recorded passage is no longer present in this document.</p>
-                    ) : anchorResolution.state === "ambiguous" ? (
-                      <p className="wb-cowork-provenance-panel__reason">The recorded passage matches multiple locations, so Co-work will not choose one.</p>
-                    ) : null}
-                    {target.span !== null && anchorResolution.state === "unique" ? (
-                      <button type="button" onClick={() => editor?.revealTarget(id)}>
-                        Show in document
-                      </button>
-                    ) : null}
-                    {record !== null &&
-                    (record.authorship.kind === "ai" ||
-                      record.authorship.kind === "mixed") ? (() => {
-                        const targetCanReview = canReview(
-                          target,
-                          anchorResolution.state,
-                          peerConflictIds.length > 0,
-                          locallyDirty,
-                        );
-                        const reviewEnabled =
-                          targetCanReview &&
-                          view.currentStructuredHeadSha256 !== null &&
-                          readOnly !== true &&
-                          mutationBarrier !== undefined &&
-                          pendingId === null;
-                        const reason = pendingId === record.attestationId
-                          ? "Human review is being recorded."
-                          : pendingId !== null
-                            ? "Finish recording the current review before starting another."
-                          : peerConflictIds.length > 0
-                          ? "Overlapping provenance records disagree, so review cannot be recorded."
-                          : locallyDirty
-                            ? "Synchronize local edits and refresh provenance before recording review."
-                            : view.currentStructuredHeadSha256 === null && targetCanReview
-                              ? "No current structured document head is available, so review cannot be recorded."
-                              : readOnly === true && targetCanReview
-                                ? "This document is read-only, so review cannot be recorded."
-                                : mutationBarrier === undefined && targetCanReview
-                                  ? "The editor is not ready to record review safely."
-                                  : reviewBlockedReason(target);
-                        const reasonId = `wb-cowork-provenance-review-reason-${id}`;
-                        return (
-                          <div className="wb-cowork-provenance-panel__actions">
-                            <h4>Actions</h4>
-                            <button
-                              type="button"
-                              disabled={!reviewEnabled}
-                              aria-describedby={reviewEnabled ? undefined : reasonId}
-                              onClick={() => void markReviewed(target)}
-                            >
-                              {pendingId === record.attestationId
-                                ? "Recording…"
-                                : "Mark reviewed"}
-                            </button>
-                            {reviewEnabled ? (
-                              <p className="wb-cowork-provenance-panel__reason">
-                                Records that you reviewed this text. It does not
-                                change its authorship or assert that it is true.
-                              </p>
-                            ) : (
-                              <p
-                                id={reasonId}
-                                className="wb-cowork-provenance-panel__reason"
-                              >
-                                {reason}
-                              </p>
-                            )}
-                          </div>
-                        );
-                      })() : null}
-                  </div>
-                ) : null}
-              </li>
-            );
-          })}
+                            const reviewEnabled =
+                              targetCanReview &&
+                              view.currentStructuredHeadSha256 !== null &&
+                              readOnly !== true &&
+                              mutationBarrier !== undefined &&
+                              pendingId === null;
+                            const reason =
+                              pendingId === record.attestationId
+                                ? "Human review is being recorded."
+                                : pendingId !== null
+                                  ? "Finish recording the current review before starting another."
+                                  : peerConflictIds.length > 0
+                                    ? "Overlapping provenance records disagree, so review cannot be recorded."
+                                    : locallyDirty
+                                      ? "Synchronize local edits and refresh provenance before recording review."
+                                      : view.currentStructuredHeadSha256 ===
+                                            null && targetCanReview
+                                        ? "No current structured document head is available, so review cannot be recorded."
+                                        : readOnly === true && targetCanReview
+                                          ? "This document is read-only, so review cannot be recorded."
+                                          : mutationBarrier === undefined &&
+                                              targetCanReview
+                                            ? "The editor is not ready to record review safely."
+                                            : reviewBlockedReason(target);
+                            const reasonId = `wb-cowork-provenance-review-reason-${id}`;
+                            return (
+                              <div className="wb-cowork-provenance-panel__actions">
+                                <h4>Actions</h4>
+                                <button
+                                  type="button"
+                                  disabled={!reviewEnabled}
+                                  aria-describedby={
+                                    reviewEnabled ? undefined : reasonId
+                                  }
+                                  onClick={() => void markReviewed(target)}
+                                >
+                                  {pendingId === record.attestationId
+                                    ? "Recording…"
+                                    : "Mark reviewed"}
+                                </button>
+                                {reviewEnabled ? (
+                                  <p className="wb-cowork-provenance-panel__reason">
+                                    Records that you reviewed this text. It does
+                                    not change its authorship or assert that it
+                                    is true.
+                                  </p>
+                                ) : (
+                                  <p
+                                    id={reasonId}
+                                    className="wb-cowork-provenance-panel__reason"
+                                  >
+                                    {reason}
+                                  </p>
+                                )}
+                              </div>
+                            );
+                          })()
+                        : null}
+                    </div>
+                  ) : null}
+                </li>
+              );
+            },
+          )}
         </ol>
       )}
       <details className="wb-cowork-provenance-panel__global-history">
-        <summary>
-          Complete provenance history ({view.history.length})
-        </summary>
+        <summary>Complete provenance history ({view.history.length})</summary>
         {view.history.length === 0 ? (
           <p>No immutable provenance records have been recorded.</p>
         ) : (
@@ -709,7 +897,9 @@ function ProvenanceContents({
           </ol>
         )}
       </details>
-      {selected === null ? null : <span className="wb-visually-hidden">Provenance target selected</span>}
+      {selected === null ? null : (
+        <span className="wb-visually-hidden">Provenance target selected</span>
+      )}
     </>
   );
 }
@@ -760,10 +950,73 @@ export function ProvenancePanel(props: ProvenancePanelProps) {
     };
   }, [load, props.active, props.provider]);
   const content = useMemo(() => {
-    if (error !== null && data === null) return <div className="wb-cowork-provenance-panel__unavailable" role="alert"><h2>Provenance could not load</h2><p>{error}</p><button type="button" onClick={() => setReload((value) => value + 1)}>Retry</button></div>;
-    if (data === null) return <p className="wb-cowork-provenance-panel__empty" role="status">Loading provenance…</p>;
-    if (data.state === "unavailable") return <div className="wb-cowork-provenance-panel__unavailable" role="status"><h2>Provenance view unavailable</h2><p>{data.reason}</p><button type="button" onClick={() => setReload((value) => value + 1)}>Retry</button></div>;
-    return <>{error === null ? null : <p className="wb-cowork-provenance-panel__error" role="alert">{error} <button type="button" onClick={() => setReload((value) => value + 1)}>Retry</button></p>}<ProvenanceContents load={data} provider={props.provider} editor={props.editor} readOnly={props.readOnly} mutationBarrier={props.mutationBarrier} selectionAction={props.selectionAction} /></>;
-  }, [data, error, props.editor, props.mutationBarrier, props.provider, props.readOnly, props.selectionAction]);
-  return <section className="wb-cowork-provenance-panel" aria-label="Document provenance" ref={props.scrollContainerRef}>{content}</section>;
+    if (error !== null && data === null)
+      return (
+        <div className="wb-cowork-provenance-panel__unavailable" role="alert">
+          <h2>Provenance could not load</h2>
+          <p>{error}</p>
+          <button type="button" onClick={() => setReload((value) => value + 1)}>
+            Retry
+          </button>
+        </div>
+      );
+    if (data === null)
+      return (
+        <p className="wb-cowork-provenance-panel__empty" role="status">
+          Loading provenance…
+        </p>
+      );
+    if (data.state === "unavailable")
+      return (
+        <div className="wb-cowork-provenance-panel__unavailable" role="status">
+          <h2>Provenance view unavailable</h2>
+          <p>{data.reason}</p>
+          <button type="button" onClick={() => setReload((value) => value + 1)}>
+            Retry
+          </button>
+        </div>
+      );
+    return (
+      <>
+        {error === null ? null : (
+          <p className="wb-cowork-provenance-panel__error" role="alert">
+            {error}{" "}
+            <button
+              type="button"
+              onClick={() => setReload((value) => value + 1)}
+            >
+              Retry
+            </button>
+          </p>
+        )}
+        <ProvenanceContents
+          load={data}
+          provider={props.provider}
+          editor={props.editor}
+          readOnly={props.readOnly}
+          mutationBarrier={props.mutationBarrier}
+          selectionAction={props.selectionAction}
+          inputProvenancePending={props.inputProvenancePending}
+        />
+      </>
+    );
+  }, [
+    data,
+    error,
+    props.editor,
+    props.inputProvenancePending,
+    props.mutationBarrier,
+    props.provider,
+    props.readOnly,
+    props.selectionAction,
+  ]);
+  return (
+    <section
+      className="wb-cowork-provenance-panel"
+      aria-label="Document provenance"
+      ref={props.scrollContainerRef}
+    >
+      {content}
+    </section>
+  );
 }

--- a/dashboard-react/src/apps/cowork/provenance/view/contracts.ts
+++ b/dashboard-react/src/apps/cowork/provenance/view/contracts.ts
@@ -113,3 +113,20 @@ export interface ProvenanceMutationBarrier {
     }) => Promise<Result>,
   ): Promise<Result>;
 }
+
+/**
+ * A provenance-aware interpretation of one explicit editor selection.
+ *
+ * The floating affordance emits an intent rather than performing a mutation:
+ * stable Provenance detail owns review confirmation, while `record` is handed
+ * to the editor's durable provenance capture path. `requestId` distinguishes
+ * repeated clicks on the same still-selected passage.
+ */
+export interface ProvenanceSelectionAction {
+  readonly requestId: number;
+  readonly intent: "record" | "review" | "view" | "inspect";
+  readonly anchor: QuoteAnchor;
+  readonly from: number;
+  readonly to: number;
+  readonly targetIds: readonly string[];
+}

--- a/dashboard-react/src/apps/cowork/provenance/view/index.ts
+++ b/dashboard-react/src/apps/cowork/provenance/view/index.ts
@@ -9,6 +9,7 @@ export type {
   ProvenanceLoad,
   ProvenanceProvider,
   ProvenanceMutationBarrier,
+  ProvenanceSelectionAction,
   ProvenanceTarget,
   ProvenanceTargetResolution,
 } from "./contracts";

--- a/dashboard-react/src/apps/cowork/provenance/view/semantics.ts
+++ b/dashboard-react/src/apps/cowork/provenance/view/semantics.ts
@@ -58,16 +58,39 @@ const SOURCE_DETAIL_FIELDS = [
   ["ref", "Reference"],
   ["surface", "Surface"],
   ["sha256", "Digest"],
+  ["proposal_id", "Proposal"],
+  ["acceptance_gesture_id", "Acceptance gesture"],
+] as const;
+
+const PRODUCER_DETAIL_FIELDS = [
+  ["model", "Producer model"],
+  ["harness", "Producer harness"],
+  ["surface", "Producer surface"],
+  ["session_id", "Producer run"],
 ] as const;
 
 /** Whitelisted, bounded source fields only; never dumps arbitrary source metadata. */
 export const provenanceSourceDetails = (
   record: ProvenanceAttestation,
-): readonly { readonly label: string; readonly value: string }[] =>
-  SOURCE_DETAIL_FIELDS.flatMap(([field, label]) => {
+): readonly { readonly label: string; readonly value: string }[] => {
+  const direct = SOURCE_DETAIL_FIELDS.flatMap(([field, label]) => {
     const value = boundedText(record.source[field]);
     return value === null ? [] : [{ label, value }];
   });
+  const producer = record.source.producer;
+  const nested =
+    typeof producer === "object" &&
+    producer !== null &&
+    !Array.isArray(producer)
+      ? PRODUCER_DETAIL_FIELDS.flatMap(([field, label]) => {
+          const value = boundedText(
+            (producer as Readonly<Record<string, unknown>>)[field],
+          );
+          return value === null ? [] : [{ label, value }];
+        })
+      : [];
+  return [...direct, ...nested];
+};
 
 export const provenanceIdentityStatusLabel = (
   status: ProvenanceIdentityStatus,
@@ -77,7 +100,5 @@ export const provenanceIdentityStatusLabel = (
   return "claimed name; not account-verified";
 };
 
-export const provenancePersonDetail = (
-  person: ProvenanceContributor,
-): string =>
+export const provenancePersonDetail = (person: ProvenanceContributor): string =>
   `${person.label ?? person.ref ?? "Unnamed person"} (${provenanceIdentityStatusLabel(person.identityStatus)})`;

--- a/dashboard-react/src/apps/cowork/providers/CoworkHttpClient.test.ts
+++ b/dashboard-react/src/apps/cowork/providers/CoworkHttpClient.test.ts
@@ -41,6 +41,7 @@ const markdownImporter = {
 const pasteProvenanceRequest: CoworkPasteProvenanceRequest = {
   storeId: "store with space",
   documentId: "doc/with slash",
+  sourceKind: "paste",
   basisKind: "user_attestation",
   expectedStructuredHeadSha256: "a".repeat(64),
   anchor: {
@@ -113,6 +114,7 @@ describe("CoworkHttpClient document lifecycle contracts", () => {
       expect(JSON.parse(String(init.body))).toEqual({
         span: pasteProvenanceRequest.anchor,
         attestation: pasteProvenanceRequest.attestation,
+        source_kind: "paste",
         basis_kind: "user_attestation",
         expected_structured_head_sha256: "a".repeat(64),
         idempotency_key: "paste-provenance-key",

--- a/dashboard-react/src/apps/cowork/providers/CoworkHttpClient.ts
+++ b/dashboard-react/src/apps/cowork/providers/CoworkHttpClient.ts
@@ -1015,6 +1015,15 @@ export class CoworkHttpClient {
     const body = {
       span: request.anchor,
       attestation: request.attestation,
+      ...(request.expectedActorRef === undefined
+        ? {}
+        : { expected_actor_ref: request.expectedActorRef }),
+      ...(request.expectedActorIdentityStatus === undefined
+        ? {}
+        : {
+            expected_actor_identity_status: request.expectedActorIdentityStatus,
+          }),
+      source_kind: request.sourceKind,
       basis_kind: request.basisKind,
       expected_structured_head_sha256:
         request.expectedStructuredHeadSha256,
@@ -1049,8 +1058,7 @@ export class CoworkHttpClient {
     ) {
       throw new CoworkHttpError({
         code: "invalid_provenance_response",
-        message:
-          "Co-work could not confirm where the pasted text was recorded.",
+        message: "Co-work could not confirm where the passage was recorded.",
         retryable: true,
       });
     }

--- a/dashboard-react/src/apps/cowork/providers/CoworkHttpClient.ts
+++ b/dashboard-react/src/apps/cowork/providers/CoworkHttpClient.ts
@@ -13,6 +13,7 @@ import { buildEditorExtensions } from "../editor/extensions";
 import { HttpCoworkYdocTransport } from "../persistence/HttpCoworkYdocTransport";
 import { sha256Hex as sha256Bytes } from "../persistence/hashing";
 import type {
+  CoworkPasteProvenanceReceipt,
   CoworkPasteProvenanceRequest,
   CoworkProvenanceActorIdentity,
   CoworkProvenanceDetermination,
@@ -88,8 +89,9 @@ const normalizeImportDescriptor = (
     rawSuffixes.some(
       (suffix) => typeof suffix !== "string" || !IMPORT_SUFFIX.test(suffix),
     ) ||
-    new Set(rawSuffixes.map((suffix) => String(suffix).toLocaleLowerCase("en-US")))
-      .size !== rawSuffixes.length ||
+    new Set(
+      rawSuffixes.map((suffix) => String(suffix).toLocaleLowerCase("en-US")),
+    ).size !== rawSuffixes.length ||
     typeof maxSourceBytes !== "number" ||
     !Number.isSafeInteger(maxSourceBytes) ||
     maxSourceBytes <= 0
@@ -171,12 +173,17 @@ export interface CoworkInspectionResult {
   readonly candidate: CoworkFolderCandidate | null;
   readonly folder: CoworkFolderSummary | null;
   readonly owner: CoworkFolderSummary | null;
-  readonly boundaries: readonly (CoworkFolderCandidate & { readonly storeId: string | null })[];
+  readonly boundaries: readonly (CoworkFolderCandidate & {
+    readonly storeId: string | null;
+  })[];
   readonly reasonCode: string | null;
   readonly actions: readonly string[];
   readonly inspectionToken: string | null;
   readonly continuationToken: string | null;
-  readonly progress: { readonly visited: number; readonly complete: false } | null;
+  readonly progress: {
+    readonly visited: number;
+    readonly complete: false;
+  } | null;
   readonly retryAfterMs: number | null;
 }
 
@@ -203,7 +210,8 @@ export interface CoworkBootstrapPrepared {
   readonly sourceUrl: string;
   readonly ydocSchema: string;
   readonly expiresAt: string;
-  readonly state: "prepared" | "publishing" | "committed" | "cancelled" | "failed";
+  readonly state:
+    "prepared" | "publishing" | "committed" | "cancelled" | "failed";
   readonly result: CoworkDocumentSummary | null;
 }
 
@@ -218,12 +226,6 @@ export interface CoworkBootstrapMetadata {
   readonly expectedFileSha256?: string | null;
   readonly documentId?: string | null;
   readonly idempotencyKey: string;
-}
-
-export interface CoworkPasteProvenanceReceipt {
-  readonly attestationId: string;
-  readonly documentSpanId: string;
-  readonly targetStructuredHeadSha256: string;
 }
 
 export interface CoworkDriftSource {
@@ -290,7 +292,9 @@ export interface CoworkRetirementPrepared {
   readonly consequenceSha256: string;
 }
 
-const normalizeFolderPermissions = (value: unknown): CoworkFolderPermissions => {
+const normalizeFolderPermissions = (
+  value: unknown,
+): CoworkFolderPermissions => {
   const source = record(value);
   return {
     read: bool(source.read, true),
@@ -303,8 +307,12 @@ const normalizeFolderPermissions = (value: unknown): CoworkFolderPermissions => 
 
 export const normalizeFolderSummary = (value: unknown): CoworkFolderSummary => {
   const source = record(value);
-  const documentSurface = record(source.document_surface ?? source.documentSurface);
-  const classes = documentSurface.allowed_document_classes ?? documentSurface.allowedDocumentClasses;
+  const documentSurface = record(
+    source.document_surface ?? source.documentSurface,
+  );
+  const classes =
+    documentSurface.allowed_document_classes ??
+    documentSurface.allowedDocumentClasses;
   return {
     storeId: text(source.store_id ?? source.storeId),
     folderName: text(source.folder_name ?? source.folderName),
@@ -312,7 +320,9 @@ export const normalizeFolderSummary = (value: unknown): CoworkFolderSummary => {
     layout: text(source.layout, "wbuddy_cowork_v1"),
     reachable: bool(source.reachable, true),
     eligibility: text(source.eligibility, "eligible"),
-    ineligibleReason: nullableText(source.ineligible_reason ?? source.ineligibleReason),
+    ineligibleReason: nullableText(
+      source.ineligible_reason ?? source.ineligibleReason,
+    ),
     documentSurface: {
       enabled: bool(documentSurface.enabled, true),
       allowedDocumentClasses: Array.isArray(classes)
@@ -327,7 +337,9 @@ export const normalizeFolderSummary = (value: unknown): CoworkFolderSummary => {
   };
 };
 
-const normalizeDocumentPermissions = (value: unknown): CoworkDocumentPermissions => {
+const normalizeDocumentPermissions = (
+  value: unknown,
+): CoworkDocumentPermissions => {
   const source = record(value);
   return {
     open: bool(source.open, true),
@@ -338,7 +350,9 @@ const normalizeDocumentPermissions = (value: unknown): CoworkDocumentPermissions
   };
 };
 
-export const normalizeDocumentSummary = (value: unknown): CoworkDocumentSummary => {
+export const normalizeDocumentSummary = (
+  value: unknown,
+): CoworkDocumentSummary => {
   const source = record(value);
   const hashes = record(source.hashes);
   const readiness = record(source.readiness);
@@ -356,7 +370,8 @@ export const normalizeDocumentSummary = (value: unknown): CoworkDocumentSummary 
   const path = text(source.path);
   const suppliedTitle = text(source.title).trim();
   const pathParts = path.split(/[\\/]/u);
-  const fallbackTitle = pathParts[pathParts.length - 1] || path || "Untitled document";
+  const fallbackTitle =
+    pathParts[pathParts.length - 1] || path || "Untitled document";
   const hasSnakeCaseWriteback = Object.prototype.hasOwnProperty.call(
     source,
     "source_writeback",
@@ -375,7 +390,10 @@ export const normalizeDocumentSummary = (value: unknown): CoworkDocumentSummary 
     path,
     title: suppliedTitle.length > 0 ? suppliedTitle : fallbackTitle,
     profile: text(source.profile ?? source.document_class, "co_authored"),
-    documentClass: text(source.document_class ?? source.documentClass, "co_authored"),
+    documentClass: text(
+      source.document_class ?? source.documentClass,
+      "co_authored",
+    ),
     // Absence identifies a legacy payload from before this field existed.
     // Once a server supplies the field, accept only the exact known values
     // and fail closed for malformed or future values.
@@ -429,12 +447,18 @@ export const normalizeDocumentSummary = (value: unknown): CoworkDocumentSummary 
     ),
     driftState:
       rawDrift === "drifted" || rawDrift === "missing" ? rawDrift : "clean",
-    openProposalCount: count(source.open_proposal_count ?? source.openProposalCount),
+    openProposalCount: count(
+      source.open_proposal_count ?? source.openProposalCount,
+    ),
     openFlagCount: count(source.open_flag_count ?? source.openFlagCount),
     updatedAt: nullableText(source.updated_at ?? source.updatedAt),
-    permissions: normalizeDocumentPermissions(source.permissions ?? readiness.permissions),
+    permissions: normalizeDocumentPermissions(
+      source.permissions ?? readiness.permissions,
+    ),
     disabledReason: nullableText(
-      source.disabled_reason ?? source.disabledReason ?? readiness.disabled_reason,
+      source.disabled_reason ??
+        source.disabledReason ??
+        readiness.disabled_reason,
     ),
   };
 };
@@ -471,7 +495,9 @@ const normalizeReimportReceipt = (value: unknown): CoworkReimportReceipt => {
   };
 };
 
-const normalizeRetirementReceipt = (value: unknown): CoworkRetirementReceipt => {
+const normalizeRetirementReceipt = (
+  value: unknown,
+): CoworkRetirementReceipt => {
   const source = record(value);
   return {
     intentId: text(source.intent_id ?? source.intentId),
@@ -491,13 +517,13 @@ export class CoworkHttpClient {
     this.#fetch = fetchImpl;
   }
 
-  async #json(
-    url: string,
-    init: RequestInit = {},
-  ): Promise<JsonRecord> {
+  async #json(url: string, init: RequestInit = {}): Promise<JsonRecord> {
     let response: Response;
     try {
-      response = await this.#fetch(url, { credentials: "same-origin", ...init });
+      response = await this.#fetch(url, {
+        credentials: "same-origin",
+        ...init,
+      });
     } catch (error) {
       throw new CoworkHttpError(normalizeCoworkError(error));
     }
@@ -520,13 +546,11 @@ export class CoworkHttpClient {
     if (
       payload.kind !== "human" ||
       ref.length === 0 ||
-      (identityStatus !== "local_actor_ref" &&
-        identityStatus !== "account_ref")
+      (identityStatus !== "local_actor_ref" && identityStatus !== "account_ref")
     ) {
       throw new CoworkHttpError({
         code: "invalid_current_actor_response",
-        message:
-          "Co-work couldn’t bind this action to the current identity.",
+        message: "Co-work couldn’t bind this action to the current identity.",
         retryable: true,
       });
     }
@@ -537,7 +561,9 @@ export class CoworkHttpClient {
     };
   }
 
-  async listFolders(includeIneligible = false): Promise<CoworkFolderListResult> {
+  async listFolders(
+    includeIneligible = false,
+  ): Promise<CoworkFolderListResult> {
     const payload = await this.#json(
       `/api/truth/cowork/folders?include_ineligible=${includeIneligible ? "1" : "0"}`,
     );
@@ -546,9 +572,13 @@ export class CoworkHttpClient {
     return {
       readOnly: bool(payload.read_only ?? payload.readOnly),
       folders: Array.isArray(payload.folders)
-        ? payload.folders.map(normalizeFolderSummary).filter((folder) => folder.storeId.length > 0)
+        ? payload.folders
+            .map(normalizeFolderSummary)
+            .filter((folder) => folder.storeId.length > 0)
         : [],
-      diagnostics: Array.isArray(payload.diagnostics) ? payload.diagnostics : [],
+      diagnostics: Array.isArray(payload.diagnostics)
+        ? payload.diagnostics
+        : [],
       chooser: {
         available,
         kind: text(chooser.kind, "host"),
@@ -580,7 +610,9 @@ export class CoworkHttpClient {
       cancelled: bool(payload.cancelled),
       folderName: text(payload.folder_name ?? payload.folderName),
       folderPath: text(payload.folder_path ?? payload.folderPath),
-      selectionToken: nullableText(payload.selection_token ?? payload.selectionToken),
+      selectionToken: nullableText(
+        payload.selection_token ?? payload.selectionToken,
+      ),
     };
   }
 
@@ -589,14 +621,17 @@ export class CoworkHttpClient {
    * workflow uses chooseImportFile and its typed importer identity.
    */
   async chooseMarkdownFile(storeId: string): Promise<CoworkNativePathResult> {
-    const payload = await this.#json("/api/truth/cowork/files/choose-markdown", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        [COWORK_FOLDER_PICKER_INTENT_HEADER]: COWORK_MARKDOWN_PICKER_INTENT,
+    const payload = await this.#json(
+      "/api/truth/cowork/files/choose-markdown",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          [COWORK_FOLDER_PICKER_INTENT_HEADER]: COWORK_MARKDOWN_PICKER_INTENT,
+        },
+        body: JSON.stringify({ store_id: storeId }),
       },
-      body: JSON.stringify({ store_id: storeId }),
-    });
+    );
     return normalizeNativePathResult(payload, "Markdown");
   }
 
@@ -650,14 +685,17 @@ export class CoworkHttpClient {
   }
 
   async chooseLocation(storeId: string): Promise<CoworkNativePathResult> {
-    const payload = await this.#json("/api/truth/cowork/folders/choose-location", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        [COWORK_FOLDER_PICKER_INTENT_HEADER]: COWORK_LOCATION_PICKER_INTENT,
+    const payload = await this.#json(
+      "/api/truth/cowork/folders/choose-location",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          [COWORK_FOLDER_PICKER_INTENT_HEADER]: COWORK_LOCATION_PICKER_INTENT,
+        },
+        body: JSON.stringify({ store_id: storeId }),
       },
-      body: JSON.stringify({ store_id: storeId }),
-    });
+    );
     return normalizeNativePathResult(payload, "location");
   }
 
@@ -670,7 +708,9 @@ export class CoworkHttpClient {
       ...(input.selectionToken === undefined
         ? {}
         : { selection_token: input.selectionToken }),
-      ...(input.folderPath === undefined ? {} : { folder_path: input.folderPath }),
+      ...(input.folderPath === undefined
+        ? {}
+        : { folder_path: input.folderPath }),
       ...(input.continuationToken === undefined
         ? {}
         : { continuation_token: input.continuationToken }),
@@ -684,7 +724,9 @@ export class CoworkHttpClient {
     const folderName = text(payload.folder_name ?? rawCandidate.folder_name);
     const folderPath = text(payload.folder_path ?? rawCandidate.folder_path);
     const rawProgress = record(payload.progress);
-    const rawBoundaries = Array.isArray(payload.boundaries) ? payload.boundaries : [];
+    const rawBoundaries = Array.isArray(payload.boundaries)
+      ? payload.boundaries
+      : [];
     const rawFolder = payload.folder ?? payload.folder_summary;
     const rawActions = payload.available_actions ?? payload.actions;
     return {
@@ -693,8 +735,12 @@ export class CoworkHttpClient {
         folderName.length === 0 && folderPath.length === 0
           ? null
           : { folderName, folderPath },
-      folder: rawFolder === undefined ? null : normalizeFolderSummary(rawFolder),
-      owner: payload.owner === undefined ? null : normalizeFolderSummary(payload.owner),
+      folder:
+        rawFolder === undefined ? null : normalizeFolderSummary(rawFolder),
+      owner:
+        payload.owner === undefined
+          ? null
+          : normalizeFolderSummary(payload.owner),
       boundaries: rawBoundaries.map((entry) => {
         const boundary = record(entry);
         return {
@@ -709,7 +755,9 @@ export class CoworkHttpClient {
             (entry): entry is string => typeof entry === "string",
           )
         : [],
-      inspectionToken: nullableText(payload.inspection_token ?? payload.inspectionToken),
+      inspectionToken: nullableText(
+        payload.inspection_token ?? payload.inspectionToken,
+      ),
       continuationToken: nullableText(
         payload.continuation_token ?? payload.continuationToken,
       ),
@@ -753,7 +801,9 @@ export class CoworkHttpClient {
     return normalizeFolderSummary(payload.folder ?? payload);
   }
 
-  async listDocuments(storeId: string): Promise<readonly CoworkDocumentSummary[]> {
+  async listDocuments(
+    storeId: string,
+  ): Promise<readonly CoworkDocumentSummary[]> {
     const payload = await this.#json(
       `/api/truth/doc/list?store_id=${encodeURIComponent(storeId)}`,
     );
@@ -762,10 +812,15 @@ export class CoworkHttpClient {
       : Array.isArray(payload.documents)
         ? payload.documents
         : [];
-    return docs.map(normalizeDocumentSummary).filter((doc) => doc.documentId.length > 0);
+    return docs
+      .map(normalizeDocumentSummary)
+      .filter((doc) => doc.documentId.length > 0);
   }
 
-  async readDocument(storeId: string, documentId: string): Promise<CoworkDocumentSummary> {
+  async readDocument(
+    storeId: string,
+    documentId: string,
+  ): Promise<CoworkDocumentSummary> {
     const payload = await this.#json(
       `/api/truth/doc/${encodeURIComponent(documentId)}?store_id=${encodeURIComponent(storeId)}`,
     );
@@ -808,7 +863,9 @@ export class CoworkHttpClient {
       // reject a snapshot produced by bootstrapCoworkYdoc itself.
       const fidelity = ydoc.getMap<unknown>("wb-cowork:fidelity");
       if (fidelity.get("schema") !== "cowork-fidelity/v1") {
-        throw new Error("The Co-work fidelity schema is missing or unsupported.");
+        throw new Error(
+          "The Co-work fidelity schema is missing or unsupported.",
+        );
       }
       void ydoc.getXmlFragment("default");
       // Actually mount the document against the production ProseMirror schema. A Yjs update
@@ -836,9 +893,15 @@ export class CoworkHttpClient {
     query: string,
     cursor?: string,
   ): Promise<CoworkCandidatesResult> {
-    const params = new URLSearchParams({ store_id: storeId, query, limit: "50" });
+    const params = new URLSearchParams({
+      store_id: storeId,
+      query,
+      limit: "50",
+    });
     if (cursor !== undefined) params.set("cursor", cursor);
-    const payload = await this.#json(`/api/truth/doc/candidates?${params.toString()}`);
+    const payload = await this.#json(
+      `/api/truth/doc/candidates?${params.toString()}`,
+    );
     const entries = Array.isArray(payload.candidates) ? payload.candidates : [];
     return {
       candidates: entries.map((entry) => {
@@ -890,7 +953,10 @@ export class CoworkHttpClient {
     };
     form.append("metadata", JSON.stringify(wireMetadata));
     if (source !== undefined) {
-      form.append("source", new Blob([source as BlobPart], { type: "application/octet-stream" }));
+      form.append(
+        "source",
+        new Blob([source as BlobPart], { type: "application/octet-stream" }),
+      );
     }
     const authorityHeaders = await coworkHumanAuthorityHeaders(
       {
@@ -901,7 +967,8 @@ export class CoworkHttpClient {
           `bootstrap:${metadata.idempotencyKey || "new"}`,
         body: {
           metadata: wireMetadata,
-          source_sha256: source === undefined ? null : await sha256Bytes(source),
+          source_sha256:
+            source === undefined ? null : await sha256Bytes(source),
           source_byte_length: source?.byteLength ?? 0,
         },
       },
@@ -921,7 +988,10 @@ export class CoworkHttpClient {
       sourceUrl: text(payload.source_url),
       ydocSchema: text(payload.ydoc_schema),
       expiresAt: text(payload.expires_at),
-      state: text(payload.state, "prepared") as CoworkBootstrapPrepared["state"],
+      state: text(
+        payload.state,
+        "prepared",
+      ) as CoworkBootstrapPrepared["state"],
       result:
         payload.result === undefined || payload.result === null
           ? null
@@ -933,7 +1003,8 @@ export class CoworkHttpClient {
     const parsed = new URL(sourceUrl, "http://localhost");
     const storeId = parsed.searchParams.get("store_id") ?? "";
     const match = parsed.pathname.match(/\/bootstrap\/([^/]+)\/source$/u);
-    const bootstrapId = match === null ? "" : decodeURIComponent(match[1] ?? "");
+    const bootstrapId =
+      match === null ? "" : decodeURIComponent(match[1] ?? "");
     const authorityHeaders = await coworkHumanAuthorityHeaders(
       {
         operation: "bootstrap.source_read",
@@ -982,7 +1053,9 @@ export class CoworkHttpClient {
     );
     form.append(
       "projection",
-      new Blob([projection as BlobPart], { type: "text/markdown;charset=utf-8" }),
+      new Blob([projection as BlobPart], {
+        type: "text/markdown;charset=utf-8",
+      }),
     );
     const authorityHeaders = await coworkHumanAuthorityHeaders(
       {
@@ -1025,8 +1098,7 @@ export class CoworkHttpClient {
           }),
       source_kind: request.sourceKind,
       basis_kind: request.basisKind,
-      expected_structured_head_sha256:
-        request.expectedStructuredHeadSha256,
+      expected_structured_head_sha256: request.expectedStructuredHeadSha256,
       idempotency_key: request.idempotencyKey,
     };
     const authorityHeaders = await coworkHumanAuthorityHeaders(
@@ -1085,19 +1157,25 @@ export class CoworkHttpClient {
     );
   }
 
-  async inspectDrift(storeId: string, documentId: string): Promise<CoworkDriftInspection> {
+  async inspectDrift(
+    storeId: string,
+    documentId: string,
+  ): Promise<CoworkDriftInspection> {
     const payload = await this.#json(
       `/api/truth/doc/${encodeURIComponent(documentId)}/drift?store_id=${encodeURIComponent(storeId)}`,
     );
     const rawState = text(payload.state, "clean");
     return {
-      state: rawState === "drifted" || rawState === "missing" ? rawState : "clean",
+      state:
+        rawState === "drifted" || rawState === "missing" ? rawState : "clean",
       lastMaterializedSha256: text(payload.last_materialized_sha256),
       currentFileSha256: nullableText(payload.current_file_sha256),
       snapshotSha256: nullableText(payload.snapshot_sha256),
       structuredHeadSha256: nullableText(payload.structured_head_sha256),
       updateTailPresent: bool(payload.update_tail_present),
-      unmaterializedStructuredEdits: bool(payload.unmaterialized_structured_edits),
+      unmaterializedStructuredEdits: bool(
+        payload.unmaterialized_structured_edits,
+      ),
       baseline: normalizeDriftSource(payload.baseline),
       source: normalizeDriftSource(payload.source),
       diffAvailable: bool(payload.diff_available),
@@ -1113,7 +1191,9 @@ export class CoworkHttpClient {
       response = await this.#fetch(source.sourceUrl, {
         method: "GET",
         credentials: "same-origin",
-        ...(source.etag === null ? {} : { headers: { "If-Match": source.etag } }),
+        ...(source.etag === null
+          ? {}
+          : { headers: { "If-Match": source.etag } }),
       });
     } catch (error) {
       throw new CoworkHttpError(normalizeCoworkError(error));
@@ -1131,7 +1211,8 @@ export class CoworkHttpClient {
     if (source.etag !== null && etag !== null && etag !== source.etag) {
       throw new CoworkHttpError({
         code: "source_changed",
-        message: "The Markdown changed while Co-work was reading the comparison.",
+        message:
+          "The Markdown changed while Co-work was reading the comparison.",
         retryable: true,
       });
     }
@@ -1250,7 +1331,11 @@ export class CoworkHttpClient {
     return normalizeReimportReceipt(payload);
   }
 
-  async cancelReimport(storeId: string, documentId: string, intentId: string): Promise<void> {
+  async cancelReimport(
+    storeId: string,
+    documentId: string,
+    intentId: string,
+  ): Promise<void> {
     const authorityHeaders = await coworkHumanAuthorityHeaders(
       {
         operation: "reimport.cancel",

--- a/dashboard-react/src/apps/cowork/rail/CoworkRail.tsx
+++ b/dashboard-react/src/apps/cowork/rail/CoworkRail.tsx
@@ -5,7 +5,13 @@
  * uses the shared ConversationChat surface through a thin Co-work adapter.
  */
 
-import { useEffect, useRef, useState, type KeyboardEvent, type RefCallback } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type RefCallback,
+} from "react";
 
 import { HelpTarget, type HelpContent } from "../../../dashboard/help";
 import {
@@ -71,7 +77,8 @@ const TRUTH_TAB_HELP: HelpContent = {
 };
 
 const PROVENANCE_TAB_HELP: HelpContent = {
-  summary: "See how the text is attributed and whether human review is recorded.",
+  summary:
+    "See how the text is attributed and whether human review is recorded.",
   details:
     "The editor overlay keeps authorship, source, and human review separate. These records do not say whether the text is true.",
 };
@@ -94,6 +101,7 @@ export interface CoworkRailProps {
     readonly editor?: ProvenanceEditorIntegration;
     readonly mutationBarrier?: ProvenanceMutationBarrier;
     readonly selectionAction?: ProvenanceSelectionAction | null;
+    readonly inputProvenancePending?: boolean;
   };
   readonly chat: CoworkRailChat;
   /** Fired only for a present user click on the wide Chat tab. */
@@ -171,9 +179,7 @@ function CoworkConversationGate({
         label="Chat about this document"
         kind="loading"
         title={chat.kind === "loading" ? "Loading chat…" : "Starting chat…"}
-        detail={
-          chat.kind === "loading" ? "Checking for messages." : undefined
-        }
+        detail={chat.kind === "loading" ? "Checking for messages." : undefined}
         execution={execution}
         executionDisabled
       />
@@ -222,7 +228,9 @@ export function CoworkRail(props: CoworkRailProps) {
     );
   });
   const tab = useRailState(store, (state) => state.tab);
-  const tabRefs = useRef<Partial<Record<RailTab, HTMLButtonElement | null>>>({});
+  const tabRefs = useRef<Partial<Record<RailTab, HTMLButtonElement | null>>>(
+    {},
+  );
   const tabsRef = useRef<HTMLDivElement | null>(null);
   const reviewActive = tab === "review" && props.reviewVisible !== false;
   const provenanceActive =
@@ -240,9 +248,7 @@ export function CoworkRail(props: CoworkRailProps) {
   const unread =
     tab !== "chat" &&
     messages.length > seenCount &&
-    messages
-      .slice(seenCount)
-      .some((message) => message.author === "assistant");
+    messages.slice(seenCount).some((message) => message.author === "assistant");
 
   const selectRailTab = (next: RailTab): void => {
     if (tab === "review" && next !== "review") {
@@ -304,94 +310,96 @@ export function CoworkRail(props: CoworkRailProps) {
 
   return (
     <div className="wb-cowork-rail">
-      {props.showTabs !== false ? <div
-        ref={tabsRef}
-        className="wb-cowork-rail__tabs"
-        role="tablist"
-        aria-label="Co-work side panels"
-      >
-        <HelpTarget content={REVIEW_TAB_HELP} placement="bottom start">
-          <button
-            type="button"
-            ref={(element) => {
-              tabRefs.current.review = element;
-            }}
-            role="tab"
-            id="wb-cowork-rail-tab-review"
-            className="wb-cowork-rail__tab"
-            aria-selected={tab === "review"}
-            tabIndex={tab === "review" ? 0 : -1}
-            aria-controls="wb-cowork-rail-panel-review"
-            onClick={() => selectRailTab("review")}
-            onKeyDown={(event) => navigateTabs(event, "review")}
-          >
-            Review
-          </button>
-        </HelpTarget>
-        <HelpTarget content={PROVENANCE_TAB_HELP} placement="bottom">
-          <button
-            type="button"
-            ref={(element) => {
-              tabRefs.current.provenance = element;
-            }}
-            role="tab"
-            id="wb-cowork-rail-tab-provenance"
-            className="wb-cowork-rail__tab"
-            aria-selected={tab === "provenance"}
-            tabIndex={tab === "provenance" ? 0 : -1}
-            aria-controls="wb-cowork-rail-panel-provenance"
-            onClick={() => selectRailTab("provenance")}
-            onKeyDown={(event) => navigateTabs(event, "provenance")}
-          >
-            Provenance
-          </button>
-        </HelpTarget>
-        <HelpTarget content={TRUTH_TAB_HELP} placement="bottom">
-          <button
-            type="button"
-            ref={(element) => {
-              tabRefs.current.truth = element;
-            }}
-            role="tab"
-            id="wb-cowork-rail-tab-truth"
-            className="wb-cowork-rail__tab"
-            aria-selected={tab === "truth"}
-            tabIndex={tab === "truth" ? 0 : -1}
-            aria-controls="wb-cowork-rail-panel-truth"
-            onClick={() => selectRailTab("truth")}
-            onKeyDown={(event) => navigateTabs(event, "truth")}
-          >
-            Truth
-          </button>
-        </HelpTarget>
-        <HelpTarget content={CHAT_TAB_HELP} placement="bottom">
-          <button
-            type="button"
-            ref={(element) => {
-              tabRefs.current.chat = element;
-            }}
-            role="tab"
-            id="wb-cowork-rail-tab-chat"
-            className="wb-cowork-rail__tab"
-            aria-selected={tab === "chat"}
-            tabIndex={tab === "chat" ? 0 : -1}
-            aria-controls="wb-cowork-rail-panel-chat"
-            onClick={() => {
-              selectRailTab("chat");
-              revealRailTabs();
-              props.onChatSelected?.();
-            }}
-            onKeyDown={(event) => navigateTabs(event, "chat")}
-          >
-            Chat
-            {unread ? (
-              <span className="wb-cowork-rail__unread">
-                <span className="wb-visually-hidden">unread reply</span>
-              </span>
-            ) : null}
-          </button>
-        </HelpTarget>
-      </div> : null}
+      {props.showTabs !== false ? (
+        <div
+          ref={tabsRef}
+          className="wb-cowork-rail__tabs"
+          role="tablist"
+          aria-label="Co-work side panels"
+        >
+          <HelpTarget content={REVIEW_TAB_HELP} placement="bottom start">
+            <button
+              type="button"
+              ref={(element) => {
+                tabRefs.current.review = element;
+              }}
+              role="tab"
+              id="wb-cowork-rail-tab-review"
+              className="wb-cowork-rail__tab"
+              aria-selected={tab === "review"}
+              tabIndex={tab === "review" ? 0 : -1}
+              aria-controls="wb-cowork-rail-panel-review"
+              onClick={() => selectRailTab("review")}
+              onKeyDown={(event) => navigateTabs(event, "review")}
+            >
+              Review
+            </button>
+          </HelpTarget>
+          <HelpTarget content={PROVENANCE_TAB_HELP} placement="bottom">
+            <button
+              type="button"
+              ref={(element) => {
+                tabRefs.current.provenance = element;
+              }}
+              role="tab"
+              id="wb-cowork-rail-tab-provenance"
+              className="wb-cowork-rail__tab"
+              aria-selected={tab === "provenance"}
+              tabIndex={tab === "provenance" ? 0 : -1}
+              aria-controls="wb-cowork-rail-panel-provenance"
+              onClick={() => selectRailTab("provenance")}
+              onKeyDown={(event) => navigateTabs(event, "provenance")}
+            >
+              Provenance
+            </button>
+          </HelpTarget>
+          <HelpTarget content={TRUTH_TAB_HELP} placement="bottom">
+            <button
+              type="button"
+              ref={(element) => {
+                tabRefs.current.truth = element;
+              }}
+              role="tab"
+              id="wb-cowork-rail-tab-truth"
+              className="wb-cowork-rail__tab"
+              aria-selected={tab === "truth"}
+              tabIndex={tab === "truth" ? 0 : -1}
+              aria-controls="wb-cowork-rail-panel-truth"
+              onClick={() => selectRailTab("truth")}
+              onKeyDown={(event) => navigateTabs(event, "truth")}
+            >
+              Truth
+            </button>
+          </HelpTarget>
+          <HelpTarget content={CHAT_TAB_HELP} placement="bottom">
+            <button
+              type="button"
+              ref={(element) => {
+                tabRefs.current.chat = element;
+              }}
+              role="tab"
+              id="wb-cowork-rail-tab-chat"
+              className="wb-cowork-rail__tab"
+              aria-selected={tab === "chat"}
+              tabIndex={tab === "chat" ? 0 : -1}
+              aria-controls="wb-cowork-rail-panel-chat"
+              onClick={() => {
+                selectRailTab("chat");
+                revealRailTabs();
+                props.onChatSelected?.();
+              }}
+              onKeyDown={(event) => navigateTabs(event, "chat")}
+            >
+              Chat
+              {unread ? (
+                <span className="wb-cowork-rail__unread">
+                  <span className="wb-visually-hidden">unread reply</span>
+                </span>
+              ) : null}
+            </button>
+          </HelpTarget>
+        </div>
+      ) : null}
 
       <div
         role="tabpanel"
@@ -442,7 +450,9 @@ export function CoworkRail(props: CoworkRailProps) {
         hidden={tab !== "provenance"}
       >
         {props.provenance === undefined ? (
-          <p className="wb-cowork-rail__empty">Provenance is unavailable for this document.</p>
+          <p className="wb-cowork-rail__empty">
+            Provenance is unavailable for this document.
+          </p>
         ) : (
           <ProvenancePanel
             key={`${props.storeId ?? "unscoped"}:${props.documentId}`}
@@ -454,6 +464,7 @@ export function CoworkRail(props: CoworkRailProps) {
             editor={props.provenance.editor}
             mutationBarrier={props.provenance.mutationBarrier}
             selectionAction={props.provenance.selectionAction}
+            inputProvenancePending={props.provenance.inputProvenancePending}
             readOnly={props.readOnly}
           />
         )}

--- a/dashboard-react/src/apps/cowork/rail/CoworkRail.tsx
+++ b/dashboard-react/src/apps/cowork/rail/CoworkRail.tsx
@@ -41,6 +41,7 @@ import {
   type ProvenanceEditorIntegration,
   type ProvenanceProvider,
   type ProvenanceMutationBarrier,
+  type ProvenanceSelectionAction,
 } from "../provenance/view";
 import type { VerificationRecheckIntent } from "./contracts";
 import type { ReviewAnchorController, ReviewRailProvider } from "./provider";
@@ -92,6 +93,7 @@ export interface CoworkRailProps {
     readonly provider: ProvenanceProvider;
     readonly editor?: ProvenanceEditorIntegration;
     readonly mutationBarrier?: ProvenanceMutationBarrier;
+    readonly selectionAction?: ProvenanceSelectionAction | null;
   };
   readonly chat: CoworkRailChat;
   /** Fired only for a present user click on the wide Chat tab. */
@@ -451,6 +453,7 @@ export function CoworkRail(props: CoworkRailProps) {
             }
             editor={props.provenance.editor}
             mutationBarrier={props.provenance.mutationBarrier}
+            selectionAction={props.provenance.selectionAction}
             readOnly={props.readOnly}
           />
         )}

--- a/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.test.tsx
+++ b/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.test.tsx
@@ -31,6 +31,7 @@ import CoworkWorkspaceWidget, {
   reimportReceiptMatchesDocument,
 } from "../widget/CoworkWorkspaceWidget";
 import {
+  coworkProvenanceSelectionActionsActive,
   coworkEditorHelp,
   coworkExecutionSwitchConfirmation,
   resolveFixtureMode,
@@ -67,6 +68,23 @@ const presentation: WidgetPresentationContext = {
 const noopEmit: ComponentProps<typeof CoworkWorkspaceWidget>["emit"] = async (
   intent,
 ) => ({ intent_id: intent.intent_id, status: "accepted" });
+
+describe("Provenance selection actions", () => {
+  it("stay available in the visible editor pane on narrow workspaces", () => {
+    expect(
+      coworkProvenanceSelectionActionsActive("provenance", true, "editor"),
+    ).toBe(true);
+    expect(
+      coworkProvenanceSelectionActionsActive("provenance", true, "provenance"),
+    ).toBe(false);
+    expect(
+      coworkProvenanceSelectionActionsActive("provenance", false, "provenance"),
+    ).toBe(true);
+    expect(coworkProvenanceSelectionActionsActive("chat", true, "editor")).toBe(
+      false,
+    );
+  });
+});
 
 const DEMO_DOCUMENT: CoworkDocumentSummary = {
   documentId: "demo-doc",

--- a/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.tsx
+++ b/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.tsx
@@ -35,7 +35,10 @@ import {
   type CoworkDriftState,
   type CoworkViewModel,
 } from "../contracts";
-import type { CoworkPasteProvenanceRecorder } from "../provenance";
+import type {
+  CoworkPasteProvenanceRecorder,
+  ProvenanceSelectionAction,
+} from "../provenance";
 import { CoworkHttpClient } from "../providers/CoworkHttpClient";
 import type { CoworkSyncStatus } from "../persistence/CoworkYdocPersistence";
 import type {
@@ -78,6 +81,7 @@ import {
   createDemoChatProvider,
   isDirty,
   type CoworkRailChat,
+  type RailTab,
   type ReviewAnchorController,
   type VerificationRecheckIntent,
 } from "../rail";
@@ -448,6 +452,14 @@ export const healthFromModel = (
   };
 };
 
+export const coworkProvenanceSelectionActionsActive = (
+  activeRailTab: RailTab,
+  narrowWorkspace: boolean,
+  activePane: CoworkWorkspacePane,
+): boolean =>
+  activeRailTab === "provenance" &&
+  (!narrowWorkspace || activePane === "editor");
+
 export const healthFromDocument = (
   document: CoworkDocumentSummary,
 ): CoworkHealthView => ({
@@ -655,6 +667,8 @@ export function CoworkLiveWorkspace({
       ),
   );
   const activeRailTab = useRailState(railStore, (state) => state.tab);
+  const [provenanceSelectionAction, setProvenanceSelectionAction] =
+    useState<ProvenanceSelectionAction | null>(null);
   const truthStore = useMemo(
     () =>
       createPersistedTruthStore(
@@ -877,6 +891,7 @@ export function CoworkLiveWorkspace({
     [narrowWorkspace, railStore],
   );
   useEffect(() => setActivePane("editor"), [documentId]);
+  useEffect(() => setProvenanceSelectionAction(null), [documentId, storeId]);
   useEffect(() => {
     setArmedVerifyRecheck(null);
   }, [documentId, storeId]);
@@ -943,6 +958,17 @@ export function CoworkLiveWorkspace({
         }
       : {}),
   });
+  const handleProvenanceSelectionAction = useCallback(
+    (
+      action: ProvenanceSelectionAction & {
+        readonly intent: "review" | "view" | "inspect";
+      },
+    ): void => {
+      setProvenanceSelectionAction(action);
+      selectPane("provenance");
+    },
+    [selectPane],
+  );
   const provenanceEditor = useMemo<ProvenanceEditorIntegration>(
     () => ({
       resolveTarget: bridge.provenanceEditor.resolveTarget,
@@ -1348,7 +1374,27 @@ export function CoworkLiveWorkspace({
           />
         </>
       }
-      editor={<CoworkBridgeEditor {...bridge.editorProps} />}
+      editor={
+        <CoworkBridgeEditor
+          {...bridge.editorProps}
+          activeLens={
+            activeRailTab === "review"
+              ? "review"
+              : activeRailTab === "truth"
+                ? "truth"
+                : activeRailTab === "provenance"
+                  ? "provenance"
+                  : "neutral"
+          }
+          provenanceProvider={bridge.provenanceProvider}
+          provenanceSelectionActionsActive={coworkProvenanceSelectionActionsActive(
+            activeRailTab,
+            narrowWorkspace,
+            activePane,
+          )}
+          onProvenanceSelectionAction={handleProvenanceSelectionAction}
+        />
+      }
       rail={
         <CoworkChatTargetingProvider
           storeId={storeId}
@@ -1370,6 +1416,7 @@ export function CoworkLiveWorkspace({
               provider: bridge.provenanceProvider,
               editor: provenanceEditor,
               mutationBarrier: bridge.provenanceMutationBarrier,
+              selectionAction: provenanceSelectionAction,
             }}
             chat={chat}
             reviewAnchors={reviewAnchors}

--- a/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.tsx
+++ b/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.tsx
@@ -46,10 +46,7 @@ import type {
   CoworkMaterializationState,
   CoworkMaterializeReceipt,
 } from "../materialization/contracts";
-import {
-  CoworkBridgeEditor,
-  useCoworkBridge,
-} from "../bridge";
+import { CoworkBridgeEditor, useCoworkBridge } from "../bridge";
 import {
   CoworkChatAnnotations,
   CoworkChatTargetingProvider,
@@ -103,10 +100,7 @@ import {
 } from "../truth";
 import { ProvenanceHoverCard } from "../provenance";
 import type { ProvenanceEditorIntegration } from "../provenance";
-import {
-  HttpCoworkVerifyClient,
-  useCoworkVerifyExecution,
-} from "../verify";
+import { HttpCoworkVerifyClient, useCoworkVerifyExecution } from "../verify";
 import {
   EDITOR_DEFAULT_SIZE,
   EDITOR_MIN_SIZE,
@@ -216,11 +210,7 @@ interface CoworkHealthView {
 }
 
 type CoworkWorkspacePane =
-  | "editor"
-  | "review"
-  | "truth"
-  | "provenance"
-  | "chat";
+  "editor" | "review" | "truth" | "provenance" | "chat";
 const NARROW_WORKSPACE_QUERY = "(max-width: 760px)";
 
 const useNarrowWorkspace = (): boolean => {
@@ -265,7 +255,11 @@ function CoworkPaneTabs({
     refs.current[normalized]?.focus();
   };
   return (
-    <div className="wb-cowork__pane-tabs" role="tablist" aria-label="Co-work panes">
+    <div
+      className="wb-cowork__pane-tabs"
+      role="tablist"
+      aria-label="Co-work panes"
+    >
       {panes.map((pane, index) => (
         <button
           key={pane}
@@ -503,7 +497,10 @@ export function CoworkDemoWorkspace({
       health={healthFromModel(model)}
       editorScrollRef={editorScrollRef}
       editor={
-        <CoworkEditorPane documentId={documentId} seedMarkdown={DEMO_DOCUMENT_MARKDOWN} />
+        <CoworkEditorPane
+          documentId={documentId}
+          seedMarkdown={DEMO_DOCUMENT_MARKDOWN}
+        />
       }
       rail={
         <CoworkRail
@@ -541,7 +538,9 @@ export function CoworkScratchWorkspace({
   onLocalEdit,
 }: {
   readonly scratchId: string;
-  readonly onPromotionHandle?: (handle: CoworkScratchPromotionHandle | null) => void;
+  readonly onPromotionHandle?: (
+    handle: CoworkScratchPromotionHandle | null,
+  ) => void;
   readonly onSyncStatus?: (status: CoworkSyncStatus) => void;
   readonly onLocalEdit?: () => void;
 }) {
@@ -669,13 +668,9 @@ export function CoworkLiveWorkspace({
   const activeRailTab = useRailState(railStore, (state) => state.tab);
   const [provenanceSelectionAction, setProvenanceSelectionAction] =
     useState<ProvenanceSelectionAction | null>(null);
+  const [inputProvenancePending, setInputProvenancePending] = useState(false);
   const truthStore = useMemo(
-    () =>
-      createPersistedTruthStore(
-        window.localStorage,
-        storeId,
-        documentId,
-      ),
+    () => createPersistedTruthStore(window.localStorage, storeId, documentId),
     [documentId, storeId],
   );
   const conversation = useDocumentConversationBinding({
@@ -688,37 +683,32 @@ export function CoworkLiveWorkspace({
   }, [annotations, conversation.feedback]);
   const adoptExecutionRef = useRef(conversation.adoptExecution);
   adoptExecutionRef.current = conversation.adoptExecution;
-  const executionProvider = useMemo(
-    () => {
-      const providerWorkspaceIdentity = workspaceIdentity;
-      return createHttpChatExecutionProfileProvider({
-        targetId: workspaceIdentity,
-        loadUrl: coworkConversationEndpoint(documentId, storeId),
-        selectUrl: coworkConversationExecutionEndpoint(documentId, storeId),
-        authorizeSelect: (body) =>
-          coworkHumanAuthorityHeaders({
-            operation: "chat.execution_select",
-            storeId,
-            documentId,
-            body,
-          }),
-        onEnvelope: (envelope) => {
-          if (
-            workspaceIdentityRef.current !== providerWorkspaceIdentity
-          ) {
-            return;
-          }
-          adoptExecutionRef.current(
-            documentId,
-            storeId,
-            envelope.execution,
-            envelope.agent,
-          );
-        },
-      });
-    },
-    [documentId, storeId, workspaceIdentity],
-  );
+  const executionProvider = useMemo(() => {
+    const providerWorkspaceIdentity = workspaceIdentity;
+    return createHttpChatExecutionProfileProvider({
+      targetId: workspaceIdentity,
+      loadUrl: coworkConversationEndpoint(documentId, storeId),
+      selectUrl: coworkConversationExecutionEndpoint(documentId, storeId),
+      authorizeSelect: (body) =>
+        coworkHumanAuthorityHeaders({
+          operation: "chat.execution_select",
+          storeId,
+          documentId,
+          body,
+        }),
+      onEnvelope: (envelope) => {
+        if (workspaceIdentityRef.current !== providerWorkspaceIdentity) {
+          return;
+        }
+        adoptExecutionRef.current(
+          documentId,
+          storeId,
+          envelope.execution,
+          envelope.agent,
+        );
+      },
+    });
+  }, [documentId, storeId, workspaceIdentity]);
   useEffect(() => {
     if (conversation.execution !== undefined) {
       executionProvider.replaceSnapshot(conversation.execution);
@@ -733,10 +723,7 @@ export function CoworkLiveWorkspace({
     return {
       ...chatExecution,
       confirmSelection: (candidate: ChatExecutionSelectionCandidate) =>
-        coworkExecutionSwitchConfirmation(
-          conversation.agent.status,
-          candidate,
-        ),
+        coworkExecutionSwitchConfirmation(conversation.agent.status, candidate),
     };
   }, [chatExecution, conversation.agent.status]);
   const verifyExecution = useCoworkVerifyExecution(
@@ -776,10 +763,7 @@ export function CoworkLiveWorkspace({
   }, [conversation.ensure]);
   const automaticPreparationKeyRef = useRef<string | null>(null);
   const prepareChat = useCallback(async (): Promise<void> => {
-    if (
-      conversation.phase !== "idle" &&
-      conversation.phase !== "error"
-    ) {
+    if (conversation.phase !== "idle" && conversation.phase !== "error") {
       return;
     }
     // A present-user Chat selection authorizes a fresh bounded preparation
@@ -790,8 +774,7 @@ export function CoworkLiveWorkspace({
   useEffect(() => {
     if (railStore.getState().tab !== "chat" || conversation.ensuring) return;
     const needsPreparation =
-      conversation.phase === "idle" ||
-      conversation.phase === "error";
+      conversation.phase === "idle" || conversation.phase === "error";
     if (!needsPreparation) return;
     const attemptKey = [
       workspaceIdentity,
@@ -836,8 +819,7 @@ export function CoworkLiveWorkspace({
       return {
         kind: "error",
         draftStorageId: chatDraftStorageId,
-        error:
-          conversation.error ?? "Chat could not be loaded.",
+        error: conversation.error ?? "Chat could not be loaded.",
       };
     }
     return {
@@ -899,7 +881,7 @@ export function CoworkLiveWorkspace({
   const provenanceClient = useMemo(() => new CoworkHttpClient(), []);
   const defaultPasteProvenanceRecorder =
     useCallback<CoworkPasteProvenanceRecorder>(
-      (request) => provenanceClient.recordPasteProvenance(request).then(() => undefined),
+      (request) => provenanceClient.recordPasteProvenance(request),
       [provenanceClient],
     );
 
@@ -1095,14 +1077,18 @@ export function CoworkLiveWorkspace({
       captureAnalysisTarget: async (target) => {
         const controller = bridge.actionSnapshotController;
         if (controller === null) {
-          throw new Error("The editor is still preparing. Try again in a moment.");
+          throw new Error(
+            "The editor is still preparing. Try again in a moment.",
+          );
         }
         return controller.capture(target);
       },
       captureSelection: async (): Promise<TruthSelectionCapture> => {
         const controller = bridge.actionSnapshotController;
         if (controller === null) {
-          throw new Error("The editor is still preparing. Try again in a moment.");
+          throw new Error(
+            "The editor is still preparing. Try again in a moment.",
+          );
         }
         const capture = await controller.capture("current_selection");
         if (capture.target.selector.kind !== "text_quote") {
@@ -1134,7 +1120,9 @@ export function CoworkLiveWorkspace({
           connection.documentId !== documentId
         ) {
           if (onOpenTruthPassage === undefined) {
-            setPassageAnnouncement("That connected document could not be opened here.");
+            setPassageAnnouncement(
+              "That connected document could not be opened here.",
+            );
             return;
           }
           onOpenTruthPassage(connection);
@@ -1225,11 +1213,7 @@ export function CoworkLiveWorkspace({
       });
       bridge.reviewProvider.invalidate();
     };
-  }, [
-    bridge.reviewProvider,
-    onRunVerify,
-    verifyClient,
-  ]);
+  }, [bridge.reviewProvider, onRunVerify, verifyClient]);
   const resolvedAffirmRecheckTarget =
     useMemo<CoworkAffirmVerifyRecheckTargetHandler>(() => {
       if (onAffirmRecheckTarget !== undefined) {
@@ -1328,9 +1312,7 @@ export function CoworkLiveWorkspace({
       editorHelp={coworkEditorHelp(document)}
       showHealth={showHealth}
       editorTopBar={
-        <CoworkDocumentActionBar
-          controller={bridge.actionSnapshotController}
-        />
+        <CoworkDocumentActionBar controller={bridge.actionSnapshotController} />
       }
       workspaceBottomDock={
         <CoworkDocumentActionDock
@@ -1360,11 +1342,7 @@ export function CoworkLiveWorkspace({
               editorTabRef={editorPaneTabRef}
             />
           ) : null}
-          <p
-            className="wb-visually-hidden"
-            role="status"
-            aria-live="polite"
-          >
+          <p className="wb-visually-hidden" role="status" aria-live="polite">
             {passageAnnouncement}
           </p>
           <ProvenanceHoverCard
@@ -1393,6 +1371,7 @@ export function CoworkLiveWorkspace({
             activePane,
           )}
           onProvenanceSelectionAction={handleProvenanceSelectionAction}
+          onInputProvenancePendingChange={setInputProvenancePending}
         />
       }
       rail={
@@ -1417,6 +1396,7 @@ export function CoworkLiveWorkspace({
               editor: provenanceEditor,
               mutationBarrier: bridge.provenanceMutationBarrier,
               selectionAction: provenanceSelectionAction,
+              inputProvenancePending,
             }}
             chat={chat}
             reviewAnchors={reviewAnchors}
@@ -1432,9 +1412,7 @@ export function CoworkLiveWorkspace({
             chatAnnotations={annotations}
             chatExecution={presentedChatExecution}
             onScrollToChatAnchor={scrollToChatAnchor}
-            reviewVisible={
-              !narrowWorkspace || activePane === "review"
-            }
+            reviewVisible={!narrowWorkspace || activePane === "review"}
             truthVisible={!narrowWorkspace || activePane === "truth"}
             provenanceVisible={!narrowWorkspace || activePane === "provenance"}
             readOnly={readOnly}
@@ -1468,6 +1446,7 @@ export function resolveFixtureMode(
 ): CoworkFixtureMode {
   if (import.meta.env.DEV && override === "demo") return "demo";
   const wantLive = override === "live" || quality !== "demo";
-  if (wantLive && documentId !== undefined && storeId !== undefined) return "live";
+  if (wantLive && documentId !== undefined && storeId !== undefined)
+    return "live";
   return "empty";
 }

--- a/dashboard-react/src/apps/cowork/surface/styles.css
+++ b/dashboard-react/src/apps/cowork/surface/styles.css
@@ -484,7 +484,11 @@
   display: grid;
   place-items: center;
   padding: var(--wb-space-4);
-  background: color-mix(in srgb, var(--wb-color-surface-canvas) 35%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--wb-color-surface-canvas) 35%,
+    transparent
+  );
   backdrop-filter: blur(3px);
 }
 
@@ -862,8 +866,10 @@
   transform: translateX(-50%);
   inline-size: 1px;
   background: var(--wb-color-border-default);
-  transition: inline-size var(--wb-motion-duration-fast) var(--wb-motion-easing-standard),
-    background-color var(--wb-motion-duration-fast) var(--wb-motion-easing-standard);
+  transition:
+    inline-size var(--wb-motion-duration-fast) var(--wb-motion-easing-standard),
+    background-color var(--wb-motion-duration-fast)
+      var(--wb-motion-easing-standard);
 }
 
 .wb-cowork__rail-separator:hover::before,
@@ -949,7 +955,8 @@
    * className on an inner content element. Target the actual panel boundary and override
    * the library's inline display/flex sizing so exactly one peer pane occupies the viewport.
    */
-  .wb-cowork__body[data-narrow="true"] > [data-panel][data-pane-active="false"] {
+  .wb-cowork__body[data-narrow="true"]
+    > [data-panel][data-pane-active="false"] {
     display: none !important;
   }
 
@@ -1174,7 +1181,11 @@
 }
 
 .wb-cowork-provenance--human {
-  background: color-mix(in srgb, var(--wb-color-status-success) 9%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--wb-color-status-success) 9%,
+    transparent
+  );
   border-inline-start: 2px solid var(--wb-color-status-success);
 }
 
@@ -1206,23 +1217,45 @@
   border-inline-start-style: dashed;
 }
 
+/*
+ * Browser-local delivery state only. It intentionally avoids every authorship
+ * and review treatment until the server ledger returns an authoritative span.
+ */
+.wb-cowork-provenance--pending {
+  background: color-mix(in srgb, var(--wb-color-status-info) 9%, transparent);
+  border-inline-start: 2px dotted var(--wb-color-status-info);
+  outline: 1px dotted
+    color-mix(in srgb, var(--wb-color-status-info) 45%, transparent);
+  outline-offset: 1px;
+}
+
 .wb-cowork-provenance--review-reviewed {
   text-decoration: underline solid var(--wb-color-status-success) 2px;
   text-underline-offset: 3px;
 }
 
-.wb-cowork-provenance--review-not-reviewed:is(.wb-cowork-provenance--ai, .wb-cowork-provenance--mixed) {
+.wb-cowork-provenance--review-not-reviewed:is(
+  .wb-cowork-provenance--ai,
+  .wb-cowork-provenance--mixed
+) {
   text-decoration: underline dashed var(--wb-color-status-warning) 1.5px;
   text-underline-offset: 3px;
 }
 
-.wb-cowork-provenance--review-unknown:is(.wb-cowork-provenance--ai, .wb-cowork-provenance--mixed) {
+.wb-cowork-provenance--review-unknown:is(
+  .wb-cowork-provenance--ai,
+  .wb-cowork-provenance--mixed
+) {
   text-decoration: underline dotted var(--wb-color-text-secondary) 1.5px;
   text-underline-offset: 3px;
 }
 
 .wb-cowork-provenance--conflict {
-  background: color-mix(in srgb, var(--wb-color-status-danger) 12%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--wb-color-status-danger) 12%,
+    transparent
+  );
   border-inline-start: 3px double var(--wb-color-status-danger);
   text-decoration: underline wavy var(--wb-color-status-danger) 2px;
   text-underline-offset: 3px;

--- a/dashboard-react/src/apps/journal/providers/HttpJournalProvider.test.ts
+++ b/dashboard-react/src/apps/journal/providers/HttpJournalProvider.test.ts
@@ -156,6 +156,34 @@ function principal() {
 afterEach(() => resetLocalIdentityForTests());
 
 describe("HttpJournalProvider", () => {
+  it("binds the browser fetch receiver when no client is injected", async () => {
+    const browserFetch = vi.fn(async function (
+      this: typeof globalThis,
+      input: RequestInfo | URL,
+    ): Promise<Response> {
+      if (this !== globalThis) throw new TypeError("Illegal invocation");
+      const url = String(input);
+      if (url === "/api/local-identity/session/csrf") {
+        return json({ ok: true, authenticated: true, principal: principal(), csrf_token: "csrf" });
+      }
+      if (url === LEGACY_TODAY_ENDPOINT) return json(legacy);
+      if (url === JOURNAL_VIEW_ENDPOINT) return json(native);
+      throw new Error(`Unexpected ${url}`);
+    });
+    vi.stubGlobal("fetch", browserFetch);
+
+    try {
+      const provider = new HttpJournalProvider();
+      const snapshot = await provider.loadView(JOURNAL_VIEW_DEFINITION_ID, { reason: "mount" });
+
+      expect(snapshot.status).toBe("ready");
+      expect(browserFetch.mock.contexts.length).toBeGreaterThan(0);
+      expect(browserFetch.mock.contexts.every((context) => context === globalThis)).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("composes live capture and Running Notes with the authoritative Today timeline", async () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/dashboard-react/src/apps/journal/providers/HttpJournalProvider.ts
+++ b/dashboard-react/src/apps/journal/providers/HttpJournalProvider.ts
@@ -462,7 +462,7 @@ export class HttpJournalProvider implements ViewProvider {
   #last: HttpJournalViewSnapshot | undefined;
 
   constructor(options: HttpJournalProviderOptions = {}) {
-    this.#fetch = options.fetchImpl ?? fetch;
+    this.#fetch = options.fetchImpl ?? globalThis.fetch.bind(globalThis);
     this.#legacy = options.legacyProvider ?? new LegacyFlaskViewAdapter({ fetchImpl: this.#fetch });
     this.#clock = options.clock ?? (() => new Date().toISOString());
     this.#navigate = options.navigate ?? ((href) => window.location.assign(href));

--- a/dashboard-react/src/apps/journal/providers/LegacyFlaskViewAdapter.test.ts
+++ b/dashboard-react/src/apps/journal/providers/LegacyFlaskViewAdapter.test.ts
@@ -72,6 +72,30 @@ function modelOrThrow(model: LegacyJournalViewModel | null): LegacyJournalViewMo
 }
 
 describe("LegacyFlaskViewAdapter", () => {
+  it("binds the browser fetch receiver when no client is injected", async () => {
+    const browserFetch = vi.fn(async function (
+      this: typeof globalThis,
+      input: RequestInfo | URL,
+    ): Promise<Response> {
+      if (this !== globalThis) throw new TypeError("Illegal invocation");
+      expect(String(input)).toBe(LEGACY_TODAY_ENDPOINT);
+      return jsonResponse(READY_PAYLOAD);
+    });
+    vi.stubGlobal("fetch", browserFetch);
+
+    try {
+      const provider = new LegacyFlaskViewAdapter();
+      const snapshot = await provider.loadView(JOURNAL_VIEW_DEFINITION_ID, {
+        reason: "mount",
+      });
+
+      expect(snapshot.status).toBe("read-only");
+      expect(browserFetch.mock.contexts).toEqual([globalThis]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("uses the Work Buddy timezone carried by the live payload", async () => {
     const fetchImpl = vi.fn(async () => jsonResponse(READY_PAYLOAD));
     const provider = new LegacyFlaskViewAdapter({ fetchImpl });

--- a/dashboard-react/src/apps/journal/providers/LegacyFlaskViewAdapter.ts
+++ b/dashboard-react/src/apps/journal/providers/LegacyFlaskViewAdapter.ts
@@ -662,7 +662,7 @@ export class LegacyFlaskViewAdapter implements ViewProvider {
   #lastSnapshot: LegacyJournalViewSnapshot | undefined;
 
   constructor(options: LegacyFlaskViewAdapterOptions = {}) {
-    this.#fetch = options.fetchImpl ?? fetch;
+    this.#fetch = options.fetchImpl ?? globalThis.fetch.bind(globalThis);
     this.#timezoneOverride = options.timezone;
     this.#clock = options.clock ?? (() => new Date().toISOString());
   }

--- a/dashboard-react/src/main.tsx
+++ b/dashboard-react/src/main.tsx
@@ -17,7 +17,6 @@ import { DensityProvider } from "./theme/DensityProvider";
 import { ThemeProvider } from "./theme/ThemeProvider";
 import { TypographyScaleProvider } from "./theme/TypographyScaleProvider";
 import {
-  currentLocalIdentity,
   hasLocalIdentityBootstrap,
   initializeLocalIdentity,
   refreshLocalIdentity,
@@ -34,7 +33,11 @@ window.addEventListener("hashchange", () => {
   if (hasLocalIdentityBootstrap()) void refreshLocalIdentity();
 });
 const recoverFocusedLocalIdentity = (): void => {
-  if (!currentLocalIdentity().authenticated) void refreshLocalIdentity();
+  // The cookie can be renewed by a trusted launcher in another tab while
+  // this tab still holds an authenticated-but-stale CSRF token in memory.
+  // Always re-check the exact-Origin, cookie-bound session on foreground;
+  // refreshLocalIdentity coalesces focus + visibility events.
+  void refreshLocalIdentity();
 };
 window.addEventListener("focus", recoverFocusedLocalIdentity);
 document.addEventListener("visibilitychange", () => {

--- a/dashboard-react/src/security/humanAuthority.test.ts
+++ b/dashboard-react/src/security/humanAuthority.test.ts
@@ -24,33 +24,67 @@ const principal = {
 beforeEach(() => resetLocalIdentityForTests());
 
 describe("exact Co-work human authority", () => {
+  it("preserves multiline and repeated whitespace in the shared digest", async () => {
+    const canonical = canonicalHumanAuthorityJson({
+      body: {
+        span: {
+          exact: "Line  one\nLine\ttwo",
+          prefix: "\nBefore  ",
+          suffix: "\nAfter\t ",
+        },
+        note: "  keep   spacing  ",
+      },
+      document_id: "document-1",
+      operation: "provenance.attest",
+      store_id: "store-1",
+    });
+
+    await expect(sha256Hex(canonical)).resolves.toBe(
+      "8cc88685011214b1de6d2cd9ff347f372dc5da6e3595d33744b2795aeb8b75a2",
+    );
+    const normalized = canonicalHumanAuthorityJson({
+      body: {
+        span: {
+          exact: "Line one Line two",
+          prefix: "Before",
+          suffix: "After",
+        },
+        note: "keep spacing",
+      },
+      document_id: "document-1",
+      operation: "provenance.attest",
+      store_id: "store-1",
+    });
+    expect(await sha256Hex(normalized)).not.toBe(await sha256Hex(canonical));
+  });
+
   it("binds one server session gesture to the exact action, subject, and body", async () => {
     const fetchImpl = vi.fn(
       async (input: RequestInfo | URL, _init?: RequestInit) => {
-      if (String(input) === "/api/local-identity/session/csrf") {
+        if (String(input) === "/api/local-identity/session/csrf") {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              authenticated: true,
+              principal,
+              csrf_token: "wbc_exact",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
         return new Response(
           JSON.stringify({
             ok: true,
-            authenticated: true,
-            principal,
-            csrf_token: "wbc_exact",
+            gesture: {
+              token: "wbg_exact",
+              action: "cowork.verify.run",
+              subject_sha256: "a".repeat(64),
+              context_sha256: "b".repeat(64),
+              expires_at: 90,
+            },
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         );
-      }
-      return new Response(
-        JSON.stringify({
-          ok: true,
-          gesture: {
-            token: "wbg_exact",
-            action: "cowork.verify.run",
-            subject_sha256: "a".repeat(64),
-            context_sha256: "b".repeat(64),
-            expires_at: 90,
-          },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
       },
     );
     const body = {

--- a/dashboard-react/src/security/localIdentity.test.ts
+++ b/dashboard-react/src/security/localIdentity.test.ts
@@ -18,7 +18,7 @@ const principal = {
     kind: "human" as const,
     tenant_scope_id: "wts_test",
   },
-  origin: "http://127.0.0.1:5127",
+  origin: window.location.origin,
   audience: "work-buddy-dashboard",
   session_expires_at: 99,
   rotation_due_at: 50,
@@ -131,6 +131,227 @@ describe("local identity bootstrap", () => {
     expect(localIdentityHeaders()).toEqual({
       "X-WB-CSRF": "wbc_reconnected",
     });
+  });
+
+  it("refreshes cached authenticated state and coalesces foreground recovery", async () => {
+    let releaseRefresh!: () => void;
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    const fetchImpl = vi.fn(
+      async (input: RequestInfo | URL, _init?: RequestInit) => {
+        const url = String(input);
+        if (url === "/api/local-identity/bootstrap/redeem") {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              authenticated: true,
+              principal,
+              csrf_token: "wbc_initial",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        expect(url).toBe("/api/local-identity/session/csrf");
+        await refreshGate;
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            authenticated: true,
+            principal: { ...principal, session_expires_at: 199 },
+            csrf_token: "wbc_replaced_cookie",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      },
+    );
+    const location = {
+      hash: "#wb-bootstrap=wbb_secret",
+      origin: principal.origin,
+      pathname: "/app/cowork",
+      search: "?document_id=doc-1",
+    };
+    await initializeLocalIdentity({
+      fetchImpl,
+      location,
+      replaceState: vi.fn(() => {
+        location.hash = "";
+      }),
+    });
+
+    const first = refreshLocalIdentity({ fetchImpl, location });
+    const second = refreshLocalIdentity({ fetchImpl, location });
+    releaseRefresh();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.objectContaining({ authenticated: true }),
+      expect.objectContaining({ authenticated: true }),
+    ]);
+    expect(fetchImpl.mock.calls.map(([url]) => String(url))).toEqual([
+      "/api/local-identity/bootstrap/redeem",
+      "/api/local-identity/session/csrf",
+    ]);
+    expect(localIdentityHeaders()).toEqual({
+      "X-WB-CSRF": "wbc_replaced_cookie",
+    });
+  });
+
+  it("refreshes stale CSRF after a trusted cookie replacement and retries once", async () => {
+    const gesture = {
+      token: "wbg_recovered",
+      action: "sources.capture",
+      subject_sha256: "a".repeat(64),
+      context_sha256: "b".repeat(64),
+      expires_at: 90,
+    };
+    let gestureAttempts = 0;
+    const fetchImpl = vi.fn(
+      async (input: RequestInfo | URL, _init?: RequestInit) => {
+        const url = String(input);
+        if (url === "/api/local-identity/bootstrap/redeem") {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              authenticated: true,
+              principal,
+              csrf_token: "wbc_stale",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        if (url === "/api/local-identity/session/csrf") {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              authenticated: true,
+              principal: { ...principal, session_expires_at: 199 },
+              csrf_token: "wbc_current",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        expect(url).toBe("/api/local-identity/gestures");
+        gestureAttempts += 1;
+        if (gestureAttempts === 1) {
+          return new Response(
+            JSON.stringify({
+              ok: false,
+              error: { code: "csrf_mismatch", message: "CSRF is stale." },
+            }),
+            { status: 403, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return new Response(
+          JSON.stringify({ ok: true, gesture }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      },
+    );
+    await initializeLocalIdentity({
+      fetchImpl,
+      location: {
+        hash: "#wb-bootstrap=wbb_secret",
+        origin: principal.origin,
+        pathname: "/app/",
+        search: "",
+      },
+      replaceState: vi.fn(),
+    });
+
+    await expect(
+      issueHumanGesture(
+        {
+          action: "sources.capture",
+          subject: "journal:quick-capture",
+          contextSha256: "b".repeat(64),
+        },
+        fetchImpl,
+      ),
+    ).resolves.toEqual(gesture);
+
+    expect(fetchImpl.mock.calls.map(([url]) => String(url))).toEqual([
+      "/api/local-identity/bootstrap/redeem",
+      "/api/local-identity/gestures",
+      "/api/local-identity/session/csrf",
+      "/api/local-identity/gestures",
+    ]);
+    const retryHeaders = fetchImpl.mock.calls[3]?.[1]?.headers as Record<
+      string,
+      string
+    >;
+    expect(retryHeaders["X-WB-CSRF"]).toBe("wbc_current");
+  });
+
+  it("publishes unauthenticated state after absolute session expiry", async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/local-identity/bootstrap/redeem") {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            authenticated: true,
+            principal,
+            csrf_token: "wbc_expiring",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url === "/api/local-identity/session/csrf") {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            authenticated: false,
+            human_authority_available: false,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      expect(url).toBe("/api/local-identity/gestures");
+      return new Response(
+        JSON.stringify({
+          ok: false,
+          error: { code: "session_expired", message: "Session expired." },
+        }),
+        { status: 401, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    await initializeLocalIdentity({
+      fetchImpl,
+      location: {
+        hash: "#wb-bootstrap=wbb_secret",
+        origin: principal.origin,
+        pathname: "/app/",
+        search: "",
+      },
+      replaceState: vi.fn(),
+    });
+
+    await expect(
+      issueHumanGesture(
+        {
+          action: "sources.capture",
+          subject: "journal:quick-capture",
+          contextSha256: "b".repeat(64),
+        },
+        fetchImpl,
+      ),
+    ).rejects.toThrow("Session expired.");
+
+    expect(currentLocalIdentity()).toEqual({
+      authenticated: false,
+      reason: "Session expired.",
+    });
+    expect(() => localIdentityHeaders()).toThrow(
+      "An authenticated local session is required.",
+    );
+    expect(
+      fetchImpl.mock.calls.filter(
+        ([url]) => String(url) === "/api/local-identity/gestures",
+      ),
+    ).toHaveLength(1);
   });
 
   it("rotates an aging session once before issuing the bound gesture", async () => {

--- a/dashboard-react/src/security/localIdentity.ts
+++ b/dashboard-react/src/security/localIdentity.ts
@@ -284,10 +284,42 @@ export async function issueHumanGesture(
   input: { action: string; subject: string; contextSha256: string },
   fetchImpl: typeof fetch = window.fetch.bind(window),
 ): Promise<HumanGesture> {
-  let { response, payload } = await requestHumanGesture(input, fetchImpl);
-  if (response.status === 409 && payload.error?.code === "session_rotation_required") {
-    await rotateLocalIdentitySession(fetchImpl);
+  let response: Response;
+  let payload: Awaited<ReturnType<typeof requestHumanGesture>>["payload"];
+  let recoveredSession = false;
+  let rotatedSession = false;
+  while (true) {
     ({ response, payload } = await requestHumanGesture(input, fetchImpl));
+    if (
+      (response.status === 401 || response.status === 403) &&
+      !recoveredSession
+    ) {
+      // A trusted launcher can replace the cookie while an already-open tab
+      // still holds the prior CSRF token in memory. Recover that exact-Origin
+      // session once and retry the gesture; an absent/expired cookie publishes
+      // unauthenticated state instead of leaving a stale principal cached.
+      recoveredSession = true;
+      const recovered = await refreshLocalIdentity({ fetchImpl });
+      if (recovered.authenticated) continue;
+    }
+    if (
+      response.status === 409 &&
+      payload.error?.code === "session_rotation_required" &&
+      !rotatedSession
+    ) {
+      rotatedSession = true;
+      await rotateLocalIdentitySession(fetchImpl);
+      continue;
+    }
+    break;
+  }
+  if (response.status === 401 || response.status === 403) {
+    csrfToken = null;
+    publish({
+      authenticated: false,
+      reason:
+        payload.error?.message || "No authenticated local session.",
+    });
   }
   if (!response.ok || !payload.ok || !payload.gesture) {
     throw responseError(

--- a/dashboard-react/tests/live/cowork-live.spec.ts
+++ b/dashboard-react/tests/live/cowork-live.spec.ts
@@ -1169,10 +1169,6 @@ test.describe.serial("Co-work live lifecycle", () => {
     await editor.click();
     await page.keyboard.type("Test", { delay: 20 });
     await expect(editor).toHaveText("Test");
-    await page.keyboard.press("Shift+Home");
-    await expect
-      .poll(() => page.evaluate(() => window.getSelection()?.toString() ?? ""))
-      .toBe("Test");
 
     // Entering Provenance finalizes the active typing burst. The stable rail owns
     // inspection while the contextual editor action becomes provenance-specific.
@@ -1238,9 +1234,37 @@ test.describe.serial("Co-work live lifecycle", () => {
           review: "not_applicable",
         },
       ]);
-    await expect(
-      page.getByRole("button", { name: "View provenance", exact: true }),
-    ).toBeVisible({ timeout: 30_000 });
+    const decoratedPassage = editor.locator(
+      "[data-wb-decoration='provenance-overlay']",
+      { hasText: "Test" },
+    );
+    await expect(decoratedPassage).toBeVisible({ timeout: 30_000 });
+
+    // Select after the Provenance lens and its overlay are already active. This
+    // is the normal inspection gesture and exercises the selection-action and
+    // passive-hover lifecycles together.
+    const passageBox = await decoratedPassage.boundingBox();
+    expect(passageBox).not.toBeNull();
+    await page.mouse.move(
+      passageBox!.x + passageBox!.width - 1,
+      passageBox!.y + passageBox!.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      passageBox!.x + 1,
+      passageBox!.y + passageBox!.height / 2,
+      { steps: 8 },
+    );
+    await page.mouse.up();
+    await expect
+      .poll(() => page.evaluate(() => window.getSelection()?.toString() ?? ""))
+      .toBe("Test");
+    await expect(page.getByRole("tooltip")).toHaveCount(0);
+    const provenanceAction = page.getByRole("button", {
+      name: "View provenance",
+      exact: true,
+    });
+    await expect(provenanceAction).toBeVisible({ timeout: 5_000 });
   });
 
   test("Close Folder returns to the Folder launcher and can reopen it without a native picker", async ({

--- a/dashboard-react/tests/live/cowork-live.spec.ts
+++ b/dashboard-react/tests/live/cowork-live.spec.ts
@@ -1133,6 +1133,14 @@ test.describe.serial("Co-work live lifecycle", () => {
     page,
     request,
   }) => {
+    const existingParagraph =
+      "An existing paragraph makes the direct-entry selector cross a block boundary.";
+    const directEntry = "The party's rocking, yes";
+    const sourceRelativePath = "provenance-existing-paragraph.md";
+    const sourcePath = path.join(fixture.initialized.path, sourceRelativePath);
+    const sourceBytes = Buffer.from(`${existingParagraph}\n`, "utf-8");
+    await writeFile(sourcePath, sourceBytes);
+
     const bootstrap = await mintBrowserIdentityBootstrap(page);
     // Same-origin GET does not normally carry Origin, but bootstrap source reads
     // are human-authority actions. Mirror a trusted browser launch's exact
@@ -1157,18 +1165,98 @@ test.describe.serial("Co-work live lifecycle", () => {
       )
       .toBe(200);
 
-    await page.getByRole("button", { name: "New", exact: true }).click();
-    await expect(page.getByRole("heading", { name: "New document" })).toBeVisible();
-    await page.getByLabel("Title").fill("Provenance Working Note");
-    await page.getByRole("button", { name: "Create document" }).click();
+    await page.route(
+      "**/api/truth/cowork/files/choose-import",
+      async (route) => {
+        expect(route.request().headers()["x-work-buddy-intent"]).toBe(
+          "cowork-import-picker",
+        );
+        expect(route.request().postDataJSON()).toEqual({
+          store_id: fixture.initialized.store_id,
+        });
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            cancelled: false,
+            path: sourceRelativePath,
+            importer_id: "markdown/v1",
+            media_type: "text/markdown",
+            source_sha256: digest(sourceBytes),
+            importer: {
+              importer_id: "markdown/v1",
+              display_name: "Markdown",
+              source_format: "markdown",
+              media_type: "text/markdown",
+              suffixes: [".md", ".markdown"],
+              max_source_bytes: 16 * 1024 * 1024,
+            },
+          }),
+        });
+      },
+      { times: 1 },
+    );
+    await page.getByRole("button", { name: "From file", exact: true }).click();
+    await page.getByRole("button", { name: "Import", exact: true }).click();
     const editor = await waitForEditor(page);
     await expect(editor).toHaveAttribute("aria-readonly", "false");
-    await expect(editor).toHaveText("");
+    await expect(editor.locator("p")).toHaveCount(1);
+    await expect(editor.locator("p").first()).toHaveText(existingParagraph);
     const { documentId } = currentRouteIds(page);
 
+    const attestationResponses: number[] = [];
+    const attestationRequestFailures: string[] = [];
+    const attestationConsoleErrors: string[] = [];
+    page.on("response", (response) => {
+      const parsed = new URL(response.url());
+      if (
+        parsed.pathname ===
+          `/api/truth/doc/${documentId}/authorship-attestations` &&
+        response.request().method() === "POST"
+      ) {
+        attestationResponses.push(response.status());
+      }
+    });
+    page.on("requestfailed", (failed) => {
+      const parsed = new URL(failed.url());
+      if (
+        parsed.pathname ===
+          `/api/truth/doc/${documentId}/authorship-attestations`
+      ) {
+        attestationRequestFailures.push(
+          failed.failure()?.errorText ?? "unknown request failure",
+        );
+      }
+    });
+    page.on("console", (message) => {
+      if (
+        message.type() === "error" &&
+        message.text().includes("authorship-attestations")
+      ) {
+        attestationConsoleErrors.push(message.text());
+      }
+    });
+
     await editor.click();
-    await page.keyboard.type("Test", { delay: 20 });
-    await expect(editor).toHaveText("Test");
+    await page.keyboard.press(
+      process.platform === "darwin" ? "Meta+ArrowUp" : "Control+Home",
+    );
+    await page.keyboard.press("Enter");
+    await expect(editor.locator("p")).toHaveCount(2);
+    await expect(editor.locator("p").first()).toHaveText("");
+    await expect(editor.locator("p").nth(1)).toHaveText(existingParagraph);
+    await page.keyboard.press(
+      process.platform === "darwin" ? "Meta+ArrowUp" : "Control+Home",
+    );
+
+    // Create the block boundary before the direct-entry burst, then type the
+    // sentence through normal keyboard input. This gives the attestation a
+    // quote-anchor suffix beginning with `\n` without folding Enter into a
+    // second provenance capture.
+    await page.keyboard.type(directEntry, { delay: 20 });
+    await expect(editor.locator("p").first()).toHaveText(directEntry);
+    await expect(editor.locator("p").nth(1)).toHaveText(existingParagraph);
 
     // Entering Provenance finalizes the active typing burst. The stable rail owns
     // inspection while the contextual editor action becomes provenance-specific.
@@ -1185,7 +1273,7 @@ test.describe.serial("Co-work live lifecycle", () => {
         const payload = (await response.json()) as {
           provenance?: {
             spans?: readonly {
-              span?: { exact?: string } | null;
+              span?: { exact?: string; suffix?: string } | null;
               target?: { currentness?: string };
               effective_attestation?: {
                 source?: { kind?: string };
@@ -1206,6 +1294,8 @@ test.describe.serial("Co-work live lifecycle", () => {
           .filter((span) => span.target?.currentness === "current")
           .map((span) => ({
             exact: span.span?.exact,
+            suffixStartsWithBlockBoundary:
+              span.span?.suffix?.startsWith("\n") ?? false,
             source: span.effective_attestation?.source?.kind,
             basis: span.effective_attestation?.basis?.kind,
             authorship: span.effective_attestation?.authorship?.kind,
@@ -1221,7 +1311,8 @@ test.describe.serial("Co-work live lifecycle", () => {
       }, { timeout: 30_000 })
       .toEqual([
         {
-          exact: "Test",
+          exact: directEntry,
+          suffixStartsWithBlockBoundary: true,
           source: "direct_entry",
           basis: "automatic_direct_entry_attribution",
           authorship: "human",
@@ -1236,7 +1327,7 @@ test.describe.serial("Co-work live lifecycle", () => {
       ]);
     const decoratedPassage = editor.locator(
       "[data-wb-decoration='provenance-overlay']",
-      { hasText: "Test" },
+      { hasText: directEntry },
     );
     await expect(decoratedPassage).toBeVisible({ timeout: 30_000 });
 
@@ -1258,13 +1349,16 @@ test.describe.serial("Co-work live lifecycle", () => {
     await page.mouse.up();
     await expect
       .poll(() => page.evaluate(() => window.getSelection()?.toString() ?? ""))
-      .toBe("Test");
+      .toBe(directEntry);
     await expect(page.getByRole("tooltip")).toHaveCount(0);
     const provenanceAction = page.getByRole("button", {
       name: "View provenance",
       exact: true,
     });
     await expect(provenanceAction).toBeVisible({ timeout: 5_000 });
+    expect(attestationResponses).toEqual([201]);
+    expect(attestationRequestFailures).toEqual([]);
+    expect(attestationConsoleErrors).toEqual([]);
   });
 
   test("Close Folder returns to the Folder launcher and can reopen it without a native picker", async ({

--- a/dashboard-react/tests/live/cowork-live.spec.ts
+++ b/dashboard-react/tests/live/cowork-live.spec.ts
@@ -60,6 +60,10 @@ const expectedHarnessNonce = process.env.COWORK_LIVE_HARNESS_NONCE;
 if (expectedHarnessNonce === undefined) {
   throw new Error("COWORK_LIVE_HARNESS_NONCE is required");
 }
+const backendBaseURL = process.env.COWORK_LIVE_BACKEND_URL;
+if (backendBaseURL === undefined) {
+  throw new Error("COWORK_LIVE_BACKEND_URL is required");
+}
 
 const digest = (bytes: Uint8Array): string =>
   createHash("sha256").update(bytes).digest("hex");
@@ -103,6 +107,54 @@ const gotoCowork = async (page: Page, search = "?mode=launcher"): Promise<void> 
   await expect(page.getByRole("heading", { level: 1, name: "Co-work" })).toBeVisible({
     timeout: 60_000,
   });
+};
+
+const mintBrowserIdentityBootstrap = async (page: Page): Promise<string> => {
+  // The mint route exists only in the isolated live server. Calling it from the
+  // directly served throwaway browser page supplies the exact Origin that will
+  // redeem it. Human authority deliberately rejects Vite's proxy-marked requests.
+  await page.goto(`${backendBaseURL}/app/`, { waitUntil: "domcontentloaded" });
+  const result = await page.evaluate(async ({ nonce }) => {
+    const denied = await fetch("/api/_cowork-live/identity-bootstrap", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ origin: window.location.origin }),
+    });
+    const mismatched = await fetch("/api/_cowork-live/identity-bootstrap", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-WB-Cowork-Live-Control": nonce,
+      },
+      body: JSON.stringify({ origin: "http://127.0.0.1:1" }),
+    });
+    const allowed = await fetch("/api/_cowork-live/identity-bootstrap", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-WB-Cowork-Live-Control": nonce,
+      },
+      body: JSON.stringify({ origin: window.location.origin }),
+    });
+    return {
+      deniedStatus: denied.status,
+      mismatchedStatus: mismatched.status,
+      allowedStatus: allowed.status,
+      payload: (await allowed.json()) as {
+        ok?: boolean;
+        token?: string;
+        origin?: string;
+        error?: string;
+      },
+      origin: window.location.origin,
+    };
+  }, { nonce: expectedHarnessNonce });
+  expect(result.deniedStatus).toBe(403);
+  expect(result.mismatchedStatus).toBe(403);
+  expect(result.allowedStatus, JSON.stringify(result.payload)).toBe(200);
+  expect(result.payload).toMatchObject({ ok: true, origin: result.origin });
+  expect(result.payload.token).toMatch(/^wbb_/);
+  return result.payload.token!;
 };
 
 const chooseFolder = async (
@@ -1075,6 +1127,120 @@ test.describe.serial("Co-work live lifecycle", () => {
     await page.goBack({ waitUntil: "domcontentloaded" });
     await expect(await waitForEditor(page)).toHaveText("");
     expect(currentRouteIds(page).documentId).toBe(firstDocumentId);
+  });
+
+  test("AC-PROV: direct-entry provenance is durable and owns selection actions", async ({
+    page,
+    request,
+  }) => {
+    const bootstrap = await mintBrowserIdentityBootstrap(page);
+    // Same-origin GET does not normally carry Origin, but bootstrap source reads
+    // are human-authority actions. Mirror a trusted browser launch's exact
+    // loopback boundary across every request in this isolated page.
+    await page.setExtraHTTPHeaders({ Origin: new URL(backendBaseURL).origin });
+    await page.goto(
+      `${backendBaseURL}/app/cowork?store_id=${fixture.initialized.store_id}` +
+        `#wb-bootstrap=${encodeURIComponent(bootstrap)}`,
+      { waitUntil: "domcontentloaded" },
+    );
+    await expect(page.getByRole("heading", { level: 1, name: "Co-work" })).toBeVisible({
+      timeout: 60_000,
+    });
+    expect(new URL(page.url()).hash).not.toContain("wb-bootstrap");
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(async () =>
+            (await fetch("/api/truth/cowork/current-actor")).status,
+          ),
+        { timeout: 30_000 },
+      )
+      .toBe(200);
+
+    await page.getByRole("button", { name: "New", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "New document" })).toBeVisible();
+    await page.getByLabel("Title").fill("Provenance Working Note");
+    await page.getByRole("button", { name: "Create document" }).click();
+    const editor = await waitForEditor(page);
+    await expect(editor).toHaveAttribute("aria-readonly", "false");
+    await expect(editor).toHaveText("");
+    const { documentId } = currentRouteIds(page);
+
+    await editor.click();
+    await page.keyboard.type("Test", { delay: 20 });
+    await expect(editor).toHaveText("Test");
+    await page.keyboard.press("Shift+Home");
+    await expect
+      .poll(() => page.evaluate(() => window.getSelection()?.toString() ?? ""))
+      .toBe("Test");
+
+    // Entering Provenance finalizes the active typing burst. The stable rail owns
+    // inspection while the contextual editor action becomes provenance-specific.
+    await page.getByRole("tab", { name: "Provenance", exact: true }).click();
+    await expect(page.getByRole("button", { name: "Give feedback", exact: true })).toHaveCount(0);
+
+    const projectionUrl =
+      `${backendBaseURL}/api/truth/doc/${documentId}` +
+      `?store_id=${fixture.initialized.store_id}`;
+    await expect
+      .poll(async () => {
+        const response = await request.get(projectionUrl);
+        if (!response.ok()) return [{ status: response.status() }];
+        const payload = (await response.json()) as {
+          provenance?: {
+            spans?: readonly {
+              span?: { exact?: string } | null;
+              target?: { currentness?: string };
+              effective_attestation?: {
+                source?: { kind?: string };
+                basis?: { kind?: string };
+                authorship?: {
+                  kind?: string;
+                  contributors?: readonly {
+                    kind?: string;
+                    identity_status?: string;
+                  }[];
+                };
+                human_review?: { status?: string };
+              } | null;
+            }[];
+          };
+        };
+        return (payload.provenance?.spans ?? [])
+          .filter((span) => span.target?.currentness === "current")
+          .map((span) => ({
+            exact: span.span?.exact,
+            source: span.effective_attestation?.source?.kind,
+            basis: span.effective_attestation?.basis?.kind,
+            authorship: span.effective_attestation?.authorship?.kind,
+            contributors:
+              span.effective_attestation?.authorship?.contributors?.map(
+                (contributor) => ({
+                  kind: contributor.kind,
+                  identity_status: contributor.identity_status,
+                }),
+              ),
+            review: span.effective_attestation?.human_review?.status,
+          }));
+      }, { timeout: 30_000 })
+      .toEqual([
+        {
+          exact: "Test",
+          source: "direct_entry",
+          basis: "automatic_direct_entry_attribution",
+          authorship: "human",
+          contributors: [
+            {
+              kind: "human",
+              identity_status: "local_actor_ref",
+            },
+          ],
+          review: "not_applicable",
+        },
+      ]);
+    await expect(
+      page.getByRole("button", { name: "View provenance", exact: true }),
+    ).toBeVisible({ timeout: 30_000 });
   });
 
   test("Close Folder returns to the Folder launcher and can reopen it without a native picker", async ({

--- a/dashboard-react/tests/live/cowork_live_server.py
+++ b/dashboard-react/tests/live/cowork_live_server.py
@@ -40,6 +40,12 @@ from work_buddy.cowork import api as cowork_api  # noqa: E402
 from work_buddy.cowork import document_agent as document_agent  # noqa: E402
 from work_buddy.cowork.conversations import CONVERSATION_SOURCE  # noqa: E402
 from work_buddy.dashboard.service import app  # noqa: E402
+from work_buddy.security.local_identity import (  # noqa: E402
+    DEFAULT_AUDIENCE,
+    LocalIdentityError,
+    get_default_authority,
+    normalize_loopback_origin,
+)
 from work_buddy.truth import documents, proposals, ydoc_store  # noqa: E402
 from work_buddy.truth.anchors import CompositeSelector  # noqa: E402
 from work_buddy.truth.contracts import Actor  # noqa: E402
@@ -161,6 +167,45 @@ def _agent_state():
                 "conversation_ids": list(_agent_conversation_ids),
             }
         )
+
+
+@app.post("/api/_cowork-live/identity-bootstrap")
+def _identity_bootstrap():
+    """Mint one isolated, exact-Origin browser bootstrap for live UI coverage.
+
+    Production deliberately has no HTTP mint route. This nonce-gated route exists
+    only in the throwaway live-harness process, and its authority database is under
+    ``COWORK_LIVE_ROOT`` so teardown removes the token and resulting session.
+    """
+
+    if not _harness_control_allowed():
+        return jsonify({"ok": False, "error": "harness control denied"}), 403
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return jsonify({"ok": False, "error": "JSON object required"}), 400
+    requested_origin = str(payload.get("origin") or "")
+    observed_origin = str(request.headers.get("Origin") or "")
+    try:
+        normalized_requested = normalize_loopback_origin(requested_origin)
+        normalized_observed = normalize_loopback_origin(observed_origin)
+    except LocalIdentityError:
+        return jsonify({"ok": False, "error": "exact loopback origin required"}), 400
+    if normalized_requested != normalized_observed:
+        return jsonify({"ok": False, "error": "browser origin mismatch"}), 403
+    grant = get_default_authority().mint_bootstrap(
+        origin=normalized_observed,
+        audience=DEFAULT_AUDIENCE,
+    )
+    response = jsonify(
+        {
+            "ok": True,
+            "token": grant.token,
+            "origin": grant.origin,
+            "expires_at": grant.expires_at,
+        }
+    )
+    response.headers["Cache-Control"] = "no-store"
+    return response
 
 
 @app.after_request

--- a/knowledge/store/architecture/local-human-identity.md
+++ b/knowledge/store/architecture/local-human-identity.md
@@ -59,6 +59,14 @@ unauthenticated state if authority is still absent. These recovery paths do not
 mint authority in HTTP, extend the server's hard session or gesture TTLs, or
 weaken the direct-loopback, Origin, audience, CSRF, and exact-action checks.
 
+An informational actor-binding read may continue to identify the enrolled
+actor when an otherwise valid session has reached its rotation boundary. That
+read neither rotates the session nor authorizes a mutation. The next protected
+gesture request still receives the typed rotation requirement, rotates through
+the CSRF-protected session endpoint, and retries before the exact bound write
+can proceed. Expired, revoked, wrong-Origin, or otherwise invalid sessions
+remain unavailable to both reads and writes.
+
 Before a protected click, the browser requests a gesture for the exact action,
 subject, and canonical context digest. The domain mutation sends that one-use
 gesture and CSRF token; the backend consumes it and constructs the

--- a/knowledge/store/architecture/local-human-identity.md
+++ b/knowledge/store/architecture/local-human-identity.md
@@ -38,6 +38,24 @@ request logs or referrers. The browser removes the fragment synchronously and
 redeems it for an opaque HttpOnly Strict session cookie plus an in-memory CSRF
 token.
 
+Deliberate CLI and tray start/restart operations also use that trusted host
+boundary to recover dashboard tabs that survived a sidecar restart. After the
+dashboard is ready, the host mints a fresh one-use bootstrap and asks the
+browser integration to update an existing app tab in place while preserving
+its current route and query. Request/response nonces ensure that an unrelated
+tab export cannot be mistaken for a successful identity handoff. If no
+existing tab can be confirmed, recovery uses a fresh grant for the normal
+trusted browser-launch path rather than replaying a possibly consumed grant.
+
+An open tab consumes a newly delivered bootstrap on hash change. On window
+focus or return to visible state it always recovers the exact-Origin cookie
+session and refreshes the in-memory CSRF token, including when the tab still
+looks authenticated with a stale token. A protected gesture that receives
+401/403 performs the same recovery once before retrying, then publishes an
+unauthenticated state if authority is still absent. These recovery paths do not
+mint authority in HTTP, extend the server's hard session or gesture TTLs, or
+weaken the direct-loopback, Origin, audience, CSRF, and exact-action checks.
+
 Before a protected click, the browser requests a gesture for the exact action,
 subject, and canonical context digest. The domain mutation sends that one-use
 gesture and CSRF token; the backend consumes it and constructs the

--- a/knowledge/store/architecture/local-human-identity.md
+++ b/knowledge/store/architecture/local-human-identity.md
@@ -44,8 +44,11 @@ dashboard is ready, the host mints a fresh one-use bootstrap and asks the
 browser integration to update an existing app tab in place while preserving
 its current route and query. Request/response nonces ensure that an unrelated
 tab export cannot be mistaken for a successful identity handoff. If no
-existing tab can be confirmed, recovery uses a fresh grant for the normal
-trusted browser-launch path rather than replaying a possibly consumed grant.
+existing tab can be confirmed, including when a pre-update extension worker
+does not support that mutation, recovery uses a fresh grant for the normal
+trusted browser-launch path rather than replaying a possibly consumed grant or
+calling the older navigation mutation. This leaves any open Co-work document
+route intact while the new same-origin session becomes available to it.
 
 An open tab consumes a newly delivered bootstrap on hash change. On window
 focus or return to visible state it always recovers the exact-Origin cookie

--- a/knowledge/store/cowork.md
+++ b/knowledge/store/cowork.md
@@ -2,7 +2,7 @@
 name: Co-work
 kind: concept
 description: The human-and-agent surface for living documents, with durable editing, source-safe file import, explicit file writes, content provenance, proposal review, and first-class Truth observability and management.
-summary: A user opens an ordinary folder, Co-work inspects it without mutation, and a one-time confirmation discloses the .wbuddy support data before setup. An invariant toolbar owns New, From file, folder selection, document selection, and explicit folder closing. From file uses a format-neutral importer boundary with Markdown support today; it creates a managed Co-work document without rewriting the source artifact. Co-work keeps structured editing state durable through an offline-capable outbox, records frozen-target authorship and human-review attestations for imported and pasted text, binds each document to one durable conversation with exact feedback anchors, and routes agent contributions through human-reviewed proposals.
+summary: A user opens an ordinary folder, Co-work inspects it without mutation, and a one-time confirmation discloses the .wbuddy support data before setup. An invariant toolbar owns New, From file, folder selection, document selection, and explicit folder closing. From file uses a format-neutral importer boundary with Markdown support today; it creates a managed Co-work document without rewriting the source artifact. Co-work keeps structured editing state durable through an offline-capable outbox, records frozen-target authorship and human-review attestations for imported, pasted, directly entered, and accepted-proposal text, binds each document to one durable conversation with exact feedback anchors, and routes agent contributions through human-reviewed proposals.
 tags:
 - cowork
 - documents
@@ -324,6 +324,14 @@ structured head, and retries it unchanged until receipt. Yjs and the provenance
 record are not one atomic transaction; the journal makes the cross-store gap
 recoverable. A changed, absent, or ambiguous target remains visible for explicit
 recovery rather than being attached elsewhere.
+
+Local direct entry uses the same recovery stores but records only a contiguous
+typing burst observed at editor ingress. Until the authoritative receipt is
+visible, the exact passage says **Recording provenance…** rather than claiming
+authorship or reporting an empty ledger. If no actor was available at capture,
+the row becomes an explicit legacy/user-attested determination and automatically
+surfaces after identity recovery; deferring or reloading retains that one row.
+A later actor is never silently substituted as the capture-time author.
 
 The attestation says what the acting person reports about the content. It does
 not prove authorship, verify a claim, certify correctness, or approve the text.

--- a/knowledge/store/cowork/content-provenance.md
+++ b/knowledge/store/cowork/content-provenance.md
@@ -6,10 +6,12 @@ summary: >-
   Provenance is a first-class Co-work rail and view-only editor lens for source,
   authorship, human-review, attester, and basis records. File import targets an
   immutable document version; local direct entry and text-bearing paste target
-  exact spans. A
-  human review action appends a user-attested superseding record while
-  preserving source and authorship. Attestations report what a person says
-  about content; they do not verify authorship, correctness, or claims.
+  exact spans, with direct entry shown as pending delivery before its receipt.
+  Accepted agent proposals transactionally attribute only replacement text to
+  the producing run. A human review action appends a user-attested superseding
+  record while preserving source and authorship. Attestations report what a
+  person says about content; they do not verify authorship, correctness, or
+  claims.
 tags:
 - cowork
 - provenance
@@ -103,7 +105,10 @@ cover the passage's coverage-aware selection action; collapsing the selection
 restores ordinary hover behavior. The stable Provenance panel owns summary,
 filters, document-order items, frozen target and history details, and mutation
 controls. Missing data is visible as **No provenance recorded**, never inferred
-as human. Loading and failed refresh are separate from an empty record set.
+as human. Browser-local direct entry awaiting a ledger receipt is instead
+visible as **Recording provenance…** over only the pending passage; it is neither
+loading nor evidence of an unrecorded passage. Loading and failed refresh are
+separate from an empty record set.
 List-row activation opens detail and may apply compatible focus, but it does not
 scroll the editor. A uniquely resolved span has a separate **Show in document**
 action for one present-user reveal. The panel also exposes **Complete provenance
@@ -168,6 +173,35 @@ Only then does it post the append-only transition and repull authoritative
 state. Any drift fails closed; the editor is re-enabled only if the mounted
 document is still writable.
 
+## Accepted agent proposals
+
+When the user confirms an agent-run edit proposal and the sitting applies it,
+Co-work records provenance for the text contributed by that proposal in the
+same locked database transaction as the document materialization and sitting
+commit. The resulting exact-span attestation records AI authorship and
+`human_review=not_reviewed`; accepting an edit is a document-change decision,
+not a claim that the user reviewed the resulting prose. A later **Mark
+reviewed** action remains a separate append-only transition.
+
+The record uses `source=proposal_acceptance` and
+`basis=proposal_acceptance`. Its source detail binds the immutable proposal and
+canonical digest, the accepted replacement digest, the consumed human
+acceptance gesture, and the validated producing agent-run reference and
+producer metadata. The human actor who confirmed the proposal is the attester,
+while the producing run remains the attributed authoring activity. These roles
+are intentionally not collapsed.
+
+The target covers only text mechanically attributable to the accepted
+replacement. A replacement which does not preserve the original quote produces
+one exact AI-authored span. For insertion-style proposals whose replacement
+contains the original quote exactly once, Co-work excludes that preserved text
+and records the non-whitespace text inserted before and/or after it as separate
+exact spans. Deletions create no text span. If the original is repeated, the
+derived selector is invalid, or any inserted segment does not resolve uniquely
+in the exact committed projection, the entire sitting fails closed. The
+document change, acceptance gesture, proposal status, and provenance rows
+therefore cannot commit independently.
+
 ## Direct entry and manual repair
 
 Ordinary local typing is captured at the editor ingress rather than inferred
@@ -184,6 +218,20 @@ the capture-time enrolled local actor, review `not_applicable`, and
 `basis=automatic_direct_entry_attribution`. The capture-time actor is never
 replaced by whichever identity happens to exist after a crash or reload. A
 changed or unavailable actor requires an explicit honest determination.
+
+Between synchronous capture and the authoritative server receipt, the
+Provenance lens projects the uniquely resolved exact local capture range as
+**Recording provenance…**. This pending decoration is delivery state only. It
+does not provisionally assert authorship, review, contributor, reviewer, or
+attester facts, even when the capture already carries a frozen actor binding.
+The stable panel exposes the same pending state and does not announce that the
+passage has no provenance. As soon as authoritative recorded coverage is
+present, that ledger projection wins for the overlapping range even if local
+outbox cleanup has not completed; removing the pending row later cannot make a
+server receipt disappear. The client retains the frozen outbox row and pending
+treatment until a fresh history entry matches the server receipt's attestation
+ID, document-span ID, and structured head. A missing, stale, misbound, or failed
+refresh therefore remains visibly pending and safely retryable.
 
 Typing observed without a capture-time actor, or whose actor changes before
 the automatic request can be frozen, is not discarded. Its exact selector

--- a/knowledge/store/cowork/content-provenance.md
+++ b/knowledge/store/cowork/content-provenance.md
@@ -5,7 +5,8 @@ description: Frozen-target, append-only attestations that keep content source, a
 summary: >-
   Provenance is a first-class Co-work rail and view-only editor lens for source,
   authorship, human-review, attester, and basis records. File import targets an
-  immutable document version; text-bearing paste targets an exact span. A
+  immutable document version; local direct entry and text-bearing paste target
+  exact spans. A
   human review action appends a user-attested superseding record while
   preserving source and authorship. Attestations report what a person says
   about content; they do not verify authorship, correctness, or claims.
@@ -36,8 +37,8 @@ Co-work records four related facts without collapsing them:
 - **Human review** is reviewed, not reviewed, not applicable, or unknown.
   Reviewed content can name its human reviewers.
 - **Attester and basis** say who supplied the information and whether it came
-  from a user attestation, automatic short-text attribution, proposal
-  acceptance, migration, or legacy data.
+  from a user attestation, automatic short-text attribution, automatic
+  direct-entry attribution, proposal acceptance, migration, or legacy data.
 
 An authorship and human-review attestation is a report, not a verification
 result. Saying that a person reviewed AI-written text does not mean the text was
@@ -53,13 +54,13 @@ it:
 
 - **From file** targets the immutable document version created by the import and
   records that version's structured-head hash.
-- **Pasted text** creates an exact quote-anchored document span and binds the
-  attestation to that span and one expected structured-head digest. The client
-  first persists the inserted edit, then freezes that digest into the request;
-  the server records the attestation only if its locked current head still
-  matches.
+- **Pasted or locally typed text** creates an exact quote-anchored document span
+  and binds the attestation to that span and one expected structured-head
+  digest. The client first persists the inserted edit, then freezes that digest
+  into the request; the server records the attestation only if its locked
+  current head still matches.
 
-Before sending or replaying a paste request, the client requires the complete
+Before sending or replaying a span-provenance request, the client requires the complete
 `exact`, `prefix`, and `suffix` quote anchor to resolve to exactly one passage in
 the currently hydrated editor. An absent or ambiguous passage becomes a stale
 target instead of being silently attached elsewhere. The server also binds an
@@ -105,6 +106,15 @@ scroll the editor. A uniquely resolved span has a separate **Show in document**
 action for one present-user reveal. The panel also exposes **Complete provenance
 history**, so old or malformed records without safe current geometry remain
 inspectable without receiving a guessed range.
+
+The generic **Give feedback** selection bubble belongs to the other lenses and
+is suppressed in Provenance. A selected passage instead gets exactly one
+coverage-aware action: **Record provenance** when uncovered, **Review provenance**
+when it exactly matches one eligible AI/mixed span, **View provenance** for one
+healthy record, or **Inspect provenance** for stale, ambiguous, conflicting, or
+multiple coverage. Review provenance only opens the stable target detail; its
+guarded append remains in the panel. Recording pre-existing text uses an
+explicit determination and keeps its source labeled **Untracked / legacy**.
 
 Provenance has a dedicated typed provider and panel projection. It can share the
 authoritative open-document snapshot source with other rails, but it does not
@@ -154,6 +164,35 @@ head, eligibility, unique exact-span resolution, and incompatible peer overlap.
 Only then does it post the append-only transition and repull authoritative
 state. Any drift fails closed; the editor is re-enabled only if the mounted
 document is still writable.
+
+## Direct entry and manual repair
+
+Ordinary local typing is captured at the editor ingress rather than inferred
+later from an opaque Yjs update. Each evolving contiguous same-block burst is
+synchronously staged before asynchronous IndexedDB work, updated through
+backspace and correction, and closed at a quiescent persistence or interaction
+boundary. Paste/drop, undo/redo, remote/applied Yjs, seed/system work,
+formatting-only changes, and disjoint edits do not inherit the assertion. A
+fully deleted burst produces no provenance record.
+
+After the Yjs edit is durable, the client freezes one exact selector and
+structured head. The server records `source=direct_entry`, human authorship by
+the capture-time enrolled local actor, review `not_applicable`, and
+`basis=automatic_direct_entry_attribution`. The capture-time actor is never
+replaced by whichever identity happens to exist after a crash or reload. A
+changed or unavailable actor requires an explicit honest determination.
+
+The synchronous recovery journal retains the newest coalesced burst over an
+older unfrozen `capturing` row. It never overwrites a ready or frozen request.
+Closing the page leaves an unfinished capture recoverable rather than trying to
+resolve it after the editor has disappeared. Once frozen, retry is the same
+immutable logical request.
+
+Text that predates this path cannot be safely attributed retroactively. In the
+Provenance lens the user can select that text and choose **Record provenance**;
+the shared determination creates an exact span with `source=legacy` and
+`basis=user_attestation`. Product copy calls that source **Untracked / legacy**
+instead of pretending the selection proves how the text entered Co-work.
 
 ## From file
 
@@ -255,8 +294,8 @@ clipboard content; its record carries
 `basis=automatic_short_text_attribution` so downstream readers can distinguish
 it from an explicit user determination.
 
-The browser keeps pending paste records in a document-scoped IndexedDB FIFO
-outbox.
+The browser keeps pending paste and direct-entry records in a document-scoped
+IndexedDB FIFO outbox.
 Before the asynchronous outbox write, it synchronously stages the capture in a
 small local-storage recovery journal; hydration reconciles staged captures into
 the outbox and deduplicates them by idempotency key. Once a determination is
@@ -282,14 +321,14 @@ plus a one-time gesture bound to the exact action, subject, and request context.
 The server derives the Truth actor from that authority; it does not accept a
 client-supplied human actor.
 
-The server revalidates the frozen binding when an import, paste, or review
-attestation is recorded. If the acting identity changed, the determination is
-rejected instead of being reassigned. For queued pastes, the browser refetches
-the current actor, clears stale frozen requests, rotates their idempotency keys,
-and changes every pending determination to unknown authorship with an explicit
-user-attestation basis. Nothing is resent until the user makes a fresh
-determination, including a short paste originally eligible for automatic
-attribution.
+The server revalidates the frozen binding when an import, paste, direct-entry,
+manual-selection, or review attestation is recorded. If the acting identity
+changed, the determination is rejected instead of being reassigned. A queued
+paste can be reset to unknown authorship for a fresh explicit determination.
+A direct-entry capture instead retains its capture-time determination and is
+never rewritten to whichever actor happens to be current after a crash or
+reload. Nothing is resent under a changed actor without a fresh honest user
+decision.
 
 The enrolled local actor ref is durable within this installation and stronger
 than an arbitrary request header, but it is not a verified remote multi-user
@@ -306,14 +345,14 @@ same authorship, reviewer, attester, and frozen-target fields.
 
 ## Storage and portability
 
-Truth schema v8 stores these facts in the append-only
-`document_provenance_attestations` table. Truth export format v8 includes the
+Truth schema v10 stores these facts in the append-only
+`document_provenance_attestations` table. Truth export format v10 includes the
 records, validates their target links and canonical hashes on import, and
 preserves supersession history. It also includes exact retained import-source
 blobs when available while accepting that historical imports can carry only a
 source hash. Existing detached imports from before provenance attestations
 receive a deterministic migration-backfill attestation with unknown authorship,
 unknown human-review status, and a system attester; migration does not invent a
-human or AI author. The managed Markdown projection, browser paste outbox, and
+human or AI author. The managed Markdown projection, browser input-provenance outbox, and
 editor decorations remain supporting projections or delivery state; the
 append-only Truth record is the provenance authority after receipt.

--- a/knowledge/store/cowork/content-provenance.md
+++ b/knowledge/store/cowork/content-provenance.md
@@ -97,7 +97,10 @@ ambiguous, or conflicting targets, not ordinary AI authorship or an explicit
 not-reviewed state. Every meaning is repeated as text in the hover explanation
 and stable panel so color is never the only channel.
 
-Hover is explanatory and passive. The stable Provenance panel owns summary,
+Hover is explanatory and passive. While the editor has an expanded text
+selection, the passive hover card is dismissed and suppressed so it cannot
+cover the passage's coverage-aware selection action; collapsing the selection
+restores ordinary hover behavior. The stable Provenance panel owns summary,
 filters, document-order items, frozen target and history details, and mutation
 controls. Missing data is visible as **No provenance recorded**, never inferred
 as human. Loading and failed refresh are separate from an empty record set.
@@ -181,6 +184,18 @@ the capture-time enrolled local actor, review `not_applicable`, and
 `basis=automatic_direct_entry_attribution`. The capture-time actor is never
 replaced by whichever identity happens to exist after a crash or reload. A
 changed or unavailable actor requires an explicit honest determination.
+
+Typing observed without a capture-time actor, or whose actor changes before
+the automatic request can be frozen, is not discarded. Its exact selector
+stays durable in the document outbox as `source=legacy`,
+`basis=user_attestation`, and `status=awaiting_determination`, with no actor
+attached. After a trusted identity session is available, selecting that same
+passage reuses the pending row and asks for an explicit attribution; it never
+creates an overlapping automatic claim. A later actor is never retroactively
+claimed as the author. Conversely, when a capture already has an immutable
+actor and only the current browser session is temporarily unavailable, the
+actor-bound capture remains pending for trusted session recovery rather than
+being downgraded or dropped.
 
 The synchronous recovery journal retains the newest coalesced burst over an
 older unfrozen `capturing` row. It never overwrites a ready or frozen request.

--- a/knowledge/store/cowork/content-provenance.md
+++ b/knowledge/store/cowork/content-provenance.md
@@ -6,7 +6,8 @@ summary: >-
   Provenance is a first-class Co-work rail and view-only editor lens for source,
   authorship, human-review, attester, and basis records. File import targets an
   immutable document version; local direct entry and text-bearing paste target
-  exact spans, with direct entry shown as pending delivery before its receipt.
+  exact spans, with direct entry shown as pending delivery before its receipt
+  and actorless captures retained for explicit attribution after recovery.
   Accepted agent proposals transactionally attribute only replacement text to
   the producing run. A human review action appends a user-attested superseding
   record while preserving source and authorship. Attestations report what a
@@ -237,13 +238,18 @@ Typing observed without a capture-time actor, or whose actor changes before
 the automatic request can be frozen, is not discarded. Its exact selector
 stays durable in the document outbox as `source=legacy`,
 `basis=user_attestation`, and `status=awaiting_determination`, with no actor
-attached. After a trusted identity session is available, selecting that same
-passage reuses the pending row and asks for an explicit attribution; it never
-creates an overlapping automatic claim. A later actor is never retroactively
-claimed as the author. Conversely, when a capture already has an immutable
-actor and only the current browser session is temporarily unavailable, the
-actor-bound capture remains pending for trusted session recovery rather than
-being downgraded or dropped.
+attached. After a trusted identity session is available, Co-work surfaces
+**Recent typing needs attribution** and requires the user to choose authorship
+and review explicitly. **Keep for later** closes the prompt without deleting or
+duplicating the durable row, and **Review pending attribution** reopens it.
+Reloading must rediscover the same recovery row even after an in-progress form
+edit. Selecting that same exact passage through the manual action also reuses
+the row rather than creating an overlapping claim. A later actor is never
+retroactively claimed as the author merely because identity recovered; that
+actor supplies the explicit attestation. Conversely, when a capture already
+has an immutable actor and only the current browser session is temporarily
+unavailable, the actor-bound capture remains pending for trusted session
+recovery rather than being downgraded or dropped.
 
 The synchronous recovery journal retains the newest coalesced burst over an
 older unfrozen `capturing` row. It never overwrites a ready or frozen request.

--- a/knowledge/store/cowork/verify-and-cothink-surfaces.md
+++ b/knowledge/store/cowork/verify-and-cothink-surfaces.md
@@ -105,6 +105,14 @@ authoritative read into:
 Configuration and item mutations invalidate the provider. Truth SSE events are
 also invalidation nudges; they never replace the authoritative repull.
 
+During the short-lived marker boundary of a client compaction, this read stays
+available rather than turning the entire document projection into a transient
+server error. It reports `initialization_state=recovery_required`,
+`disabled_reason=compaction_recovery_required`, and no current structured head;
+Verify is disabled until recovery completes. Durable run, result, and Co-think
+history remains readable, but every frozen item is conservatively projected as
+not current until the authoritative head can be read again.
+
 The run-detail HTTP read adds the content-minimized coordination lifecycle,
 request bindings, candidate-proof lineage, and consequence references used by
 inspection. It never returns raw worker output or private candidate prose.

--- a/knowledge/store/operations/wb-cli.md
+++ b/knowledge/store/operations/wb-cli.md
@@ -73,11 +73,14 @@ app and has the trusted host mint a fresh one-use dashboard bootstrap. The
 browser extension first updates an existing app tab without activating it and
 preserves that tab's document route and query; a correlated response prevents
 unrelated shared Chrome output from being reported as success. If no handoff
-is confirmed, Work Buddy uses a fresh grant with the normal browser launch so
-it never silently leaves the tab with a stale identity session or replays a
-possibly consumed credential. Sidecar lifecycle success remains separate from
-this best-effort browser handoff: CLI writes an explicit reconnect warning and
-tray results include `identity_reconnect` when recovery cannot be confirmed.
+is confirmed—including when an already-running older extension worker does not
+support the path-preserving mutation—Work Buddy uses a fresh grant with the
+normal browser launch. It never falls back through the older navigation
+mutation, which could replace a live Co-work document route with the app root,
+and it never replays a possibly consumed credential. Sidecar lifecycle success
+remains separate from this best-effort browser handoff: CLI writes an explicit
+reconnect warning and tray results include `identity_reconnect` when recovery
+cannot be confirmed.
 
 ## When to use
 

--- a/knowledge/store/operations/wb-cli.md
+++ b/knowledge/store/operations/wb-cli.md
@@ -48,9 +48,9 @@ Installed as a console script (`wbuddy`) via pyproject, also runnable as `python
 
 ## Verbs
 
-- `wbuddy start [--foreground]` -- start the sidecar. Detached by default (no console window), `--foreground` runs it in the current terminal. Idempotent for a healthy sidecar: an already-running (or still-booting) sidecar is reported, not duplicated, while a wedged one is taken over.
+- `wbuddy start [--foreground]` -- start the sidecar. Detached by default (no console window), `--foreground` runs it in the current terminal. Idempotent for a healthy sidecar: an already-running (or still-booting) sidecar is reported, not duplicated, while a wedged one is taken over. A successful detached start then attempts the trusted dashboard-identity recovery described below.
 - `wbuddy stop` -- stop the running sidecar and its child services.
-- `wbuddy restart` -- stop then start.
+- `wbuddy restart` -- stop then start, then attempt trusted dashboard-identity recovery after the app is ready.
 - `wbuddy status [--json]` -- sidecar liveness, uptime, and per-service health, read from the sidecar state file. Distinguishes booting from wedged; exits non-zero when not running or wedged. Also reports the daemon's dispatch loop: a phase busy past ~2 minutes prints as busy with the running job's name (scheduled work is queued behind it, supervision unaffected), otherwise the time since the last completed dispatch cycle.
 - `wbuddy doctor [<component>] [--json]` -- render the setup wizard's status, or one component's diagnosis: bootstrap, requirements, health.
 - `wbuddy setup` -- run bootstrap checks, print the gateway MCP config, and point to the selected harness's generated `wb-setup` command or skill for interactive feature selection.
@@ -67,6 +67,17 @@ Installed as a console script (`wbuddy`) via pyproject, also runnable as `python
 - `wbuddy autostart {enable,disable,status}` -- manage login auto-start of the detached sidecar (Windows Task Scheduler `WB-Sidecar`, Linux systemd `--user` unit, macOS launchd agent), via `work_buddy/autostart/`.
 - `wbuddy tray {enable,disable,status,run}` -- manage the system-tray icon (needs the `tray` extra). `enable` sets `tray.enabled`, registers the `WB-Tray` login item, and starts the tray; `disable` reverses all three; `status` reports enabled/registered/running; `run` is the foreground login-item entry point. The tray is a separate process and login item, NOT a sidecar-supervised service -- see services/tray.
 - `wbuddy truth {capture,propose,query,confirm,migrate} [--store ...] [--json]` -- discover or select a canonical scoped local Truth Store at `.wbuddy/cowork` and use the frozen consumer surface directly. `capture` records immutable evidence and an optional quote span, `propose` writes a profile-valid claim, `query` exposes current/as-of/review/conflict views, and `confirm` requires a local-human interactive TTY or an existing human gesture. `migrate` upgrades the schema of one selected store or every registered store. Detected agent sessions cannot mint an interactive human gesture.
+
+For detached CLI and tray start/restart, identity recovery waits for the React
+app and has the trusted host mint a fresh one-use dashboard bootstrap. The
+browser extension first updates an existing app tab without activating it and
+preserves that tab's document route and query; a correlated response prevents
+unrelated shared Chrome output from being reported as success. If no handoff
+is confirmed, Work Buddy uses a fresh grant with the normal browser launch so
+it never silently leaves the tab with a stale identity session or replays a
+possibly consumed credential. Sidecar lifecycle success remains separate from
+this best-effort browser handoff: CLI writes an explicit reconnect warning and
+tray results include `identity_reconnect` when recovery cannot be confirmed.
 
 ## When to use
 

--- a/tests/unit/cowork/test_api_routes.py
+++ b/tests/unit/cowork/test_api_routes.py
@@ -820,6 +820,7 @@ def test_paste_authorship_attestation_targets_exact_structured_head(
         }
     ]
     assert listed[0]["basis"]["kind"] == "automatic_short_text_attribution"
+    assert listed[0]["source"] == {"kind": "paste", "format": "plain_text"}
 
     replay = client.post(
         url,
@@ -846,6 +847,286 @@ def test_paste_authorship_attestation_targets_exact_structured_head(
     assert opened.get_json()["authorship_attestations"] == listed
 
 
+def test_direct_entry_authorship_projects_from_the_exact_current_head(
+    client,
+    seeded,
+):
+    document = seeded["document"]
+    head = ydoc_store.current_structured_head(
+        seeded["store"],
+        document_id=document.id,
+        snapshot_sha256=seeded["snapshot_sha256"],
+    )
+    url = _url(
+        f"/api/truth/doc/{document.id}/authorship-attestations",
+        seeded["store_id"],
+    )
+    body = {
+        "span": {"exact": DOC_QUOTE, "prefix": "", "suffix": ""},
+        "attestation": {
+            "schema": "cowork-authorship-attestation/v1",
+            "authorship": {
+                "kind": "human",
+                "contributors": [
+                    {
+                        "kind": "current_user",
+                        "ref": "reviewer-kaden",
+                        "identity_status": "local_actor_ref",
+                    }
+                ],
+            },
+            "human_review": {"status": "not_applicable", "reviewers": []},
+        },
+        "source_kind": "direct_entry",
+        "basis_kind": "automatic_direct_entry_attribution",
+        "expected_actor_ref": "reviewer-kaden",
+        "expected_actor_identity_status": "local_actor_ref",
+        "expected_structured_head_sha256": head,
+        "idempotency_key": "direct-entry-route-0001",
+    }
+
+    recorded = client.post(url, json=body)
+    replay = client.post(url, json=body)
+
+    assert recorded.status_code == replay.status_code == 201
+    receipt = recorded.get_json()
+    assert replay.get_json() == receipt
+    listed = provenance.list_attestations(seeded["store"], document.id)
+    assert len(listed) == 1
+    assert listed[0]["source"] == {
+        "kind": "direct_entry",
+        "format": "plain_text",
+    }
+    assert listed[0]["basis"] == {
+        "kind": "automatic_direct_entry_attribution",
+        "ref": None,
+    }
+    assert listed[0]["authorship"]["contributors"] == [
+        {
+            "kind": "human",
+            "ref": "reviewer-kaden",
+            "identity_status": "local_actor_ref",
+        }
+    ]
+
+    opened = client.get(_url(f"/api/truth/doc/{document.id}", seeded["store_id"]))
+    assert opened.status_code == 200
+    view = opened.get_json()["provenance"]
+    assert view["current_structured_head_sha256"] == head
+    assert view["summary"]["current_span_count"] == 1
+    assert view["spans"][0]["effective_attestation"] == listed[0]
+
+
+def test_unrecorded_selection_can_be_explicitly_attested_as_legacy_reviewed(
+    client,
+    seeded,
+):
+    document = seeded["document"]
+    head = ydoc_store.current_structured_head(
+        seeded["store"],
+        document_id=document.id,
+        snapshot_sha256=seeded["snapshot_sha256"],
+    )
+    response = client.post(
+        _url(
+            f"/api/truth/doc/{document.id}/authorship-attestations",
+            seeded["store_id"],
+        ),
+        json={
+            "span": {"exact": DOC_QUOTE, "prefix": "", "suffix": ""},
+            "attestation": {
+                "schema": "cowork-authorship-attestation/v1",
+                "authorship": {"kind": "ai", "contributors": []},
+                "human_review": {
+                    "status": "reviewed",
+                    "reviewers": [
+                        {
+                            "kind": "current_user",
+                            "ref": "reviewer-kaden",
+                            "identity_status": "local_actor_ref",
+                        }
+                    ],
+                },
+            },
+            "source_kind": "legacy",
+            "basis_kind": "user_attestation",
+            "expected_actor_ref": "reviewer-kaden",
+            "expected_actor_identity_status": "local_actor_ref",
+            "expected_structured_head_sha256": head,
+            "idempotency_key": "legacy-selection-review-0001",
+        },
+    )
+
+    assert response.status_code == 201
+    projected = client.get(
+        _url(f"/api/truth/doc/{document.id}", seeded["store_id"])
+    ).get_json()["provenance"]
+    effective = projected["spans"][0]["effective_attestation"]
+    assert effective["source"]["kind"] == "legacy"
+    assert effective["basis"]["kind"] == "user_attestation"
+    assert effective["authorship"]["kind"] == "ai"
+    assert effective["human_review"]["status"] == "reviewed"
+    assert effective["human_review"]["reviewers"][0]["ref"] == "reviewer-kaden"
+
+
+def test_legacy_attestation_replay_rejects_a_changed_acting_identity(
+    client,
+    seeded,
+):
+    document = seeded["document"]
+    head = ydoc_store.current_structured_head(
+        seeded["store"],
+        document_id=document.id,
+        snapshot_sha256=seeded["snapshot_sha256"],
+    )
+    response = client.post(
+        _url(
+            f"/api/truth/doc/{document.id}/authorship-attestations",
+            seeded["store_id"],
+        ),
+        json={
+            "span": {"exact": DOC_QUOTE, "prefix": "", "suffix": ""},
+            "attestation": {
+                "schema": "cowork-authorship-attestation/v1",
+                "authorship": {"kind": "ai", "contributors": []},
+                "human_review": {"status": "not_reviewed", "reviewers": []},
+            },
+            "source_kind": "legacy",
+            "basis_kind": "user_attestation",
+            "expected_actor_ref": "different-capture-time-actor",
+            "expected_actor_identity_status": "local_actor_ref",
+            "expected_structured_head_sha256": head,
+            "idempotency_key": "legacy-selection-actor-change-0001",
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.get_json()["error"]["code"] == "provenance_actor_changed"
+    assert provenance.list_attestations(seeded["store"], document.id) == []
+
+
+@pytest.mark.parametrize("source_kind", ["direct_entry", "legacy"])
+def test_new_span_sources_require_a_capture_time_actor_binding(
+    client,
+    seeded,
+    source_kind,
+):
+    document = seeded["document"]
+    response = client.post(
+        _url(
+            f"/api/truth/doc/{document.id}/authorship-attestations",
+            seeded["store_id"],
+        ),
+        json={
+            "span": {"exact": DOC_QUOTE, "prefix": "", "suffix": ""},
+            "attestation": {
+                "schema": "cowork-authorship-attestation/v1",
+                "authorship": {"kind": "human", "contributors": []},
+                "human_review": {"status": "not_applicable", "reviewers": []},
+            },
+            "source_kind": source_kind,
+            "basis_kind": (
+                "automatic_direct_entry_attribution"
+                if source_kind == "direct_entry"
+                else "user_attestation"
+            ),
+            "expected_structured_head_sha256": "0" * 64,
+            "idempotency_key": f"missing-capture-actor-{source_kind}-0001",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == (
+        "expected_actor_ref and expected_actor_identity_status are required"
+    )
+    assert provenance.list_attestations(seeded["store"], document.id) == []
+
+
+@pytest.mark.parametrize(
+    ("source_kind", "basis_kind"),
+    [
+        ("direct_entry", "user_attestation"),
+        ("direct_entry", "automatic_short_text_attribution"),
+        ("paste", "automatic_direct_entry_attribution"),
+        ("legacy", "automatic_direct_entry_attribution"),
+        ("legacy", "automatic_short_text_attribution"),
+    ],
+)
+def test_span_authorship_route_rejects_invented_source_basis_pairs(
+    client,
+    seeded,
+    source_kind,
+    basis_kind,
+):
+    document = seeded["document"]
+    response = client.post(
+        _url(
+            f"/api/truth/doc/{document.id}/authorship-attestations",
+            seeded["store_id"],
+        ),
+        json={
+            "span": {"exact": DOC_QUOTE, "prefix": "", "suffix": ""},
+            "attestation": {
+                "schema": "cowork-authorship-attestation/v1",
+                "authorship": {"kind": "unknown", "contributors": []},
+                "human_review": {"status": "not_applicable", "reviewers": []},
+            },
+            "source_kind": source_kind,
+            "basis_kind": basis_kind,
+            "expected_structured_head_sha256": "0" * 64,
+            "idempotency_key": "invalid-source-basis-pair-0001",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == (
+        "source_kind and basis_kind are not an allowed pair"
+    )
+    assert provenance.list_attestations(seeded["store"], document.id) == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_error"),
+    [
+        ("source_kind", "not-a-source", "source_kind is invalid"),
+        ("basis_kind", ["user_attestation"], "basis_kind is invalid"),
+    ],
+)
+def test_span_authorship_route_rejects_explicit_invalid_source_metadata(
+    client,
+    seeded,
+    field,
+    value,
+    expected_error,
+):
+    document = seeded["document"]
+    body = {
+        "span": {"exact": DOC_QUOTE, "prefix": "", "suffix": ""},
+        "attestation": {
+            "schema": "cowork-authorship-attestation/v1",
+            "authorship": {"kind": "unknown", "contributors": []},
+            "human_review": {"status": "not_applicable", "reviewers": []},
+        },
+        "source_kind": "paste",
+        "basis_kind": "user_attestation",
+        "expected_structured_head_sha256": "0" * 64,
+        "idempotency_key": "invalid-source-metadata-0001",
+    }
+    body[field] = value
+
+    response = client.post(
+        _url(
+            f"/api/truth/doc/{document.id}/authorship-attestations",
+            seeded["store_id"],
+        ),
+        json=body,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == expected_error
+    assert provenance.list_attestations(seeded["store"], document.id) == []
+
+
 def test_paste_authorship_attestation_rejects_stale_structured_head(
     client,
     seeded,
@@ -866,6 +1147,7 @@ def test_paste_authorship_attestation_rejects_stale_structured_head(
                     "reviewers": [],
                 },
             },
+            "source_kind": "paste",
             "expected_structured_head_sha256": "0" * 64,
             "idempotency_key": "paste-route-stale-0001",
         },
@@ -1136,6 +1418,7 @@ def test_automatic_paste_attribution_is_server_constrained(
         json={
             "span": {"exact": exact, "prefix": "", "suffix": ""},
             "attestation": attestation,
+            "source_kind": "paste",
             "basis_kind": "automatic_short_text_attribution",
             "expected_structured_head_sha256": head,
             "idempotency_key": "automatic-paste-guard-0001",

--- a/tests/unit/cowork/test_api_routes.py
+++ b/tests/unit/cowork/test_api_routes.py
@@ -241,6 +241,48 @@ def test_get_returns_open_proposals_and_hashes(client, seeded, make_proposal):
     assert entry["kind"] == "edit"
 
 
+def test_get_projects_compaction_boundary_as_typed_recovery_state(
+    client,
+    seeded,
+):
+    store = seeded["store"]
+    document = seeded["document"]
+    current_head = ydoc_store.current_structured_head(
+        store,
+        document_id=document.id,
+        snapshot_sha256=document.ydoc_snapshot_sha256,
+    )
+    replacement_snapshot = b"YDOC-COMPACTION-IN-FLIGHT"
+    with ydoc_store.document_lock(store, document.id):
+        replacement = ydoc_store.prepare_snapshot_replacement_locked(
+            store,
+            document_id=document.id,
+            snapshot=replacement_snapshot,
+            expected_new_snapshot_sha256=sha256_bytes(replacement_snapshot),
+            expected_current_snapshot_sha256=document.ydoc_snapshot_sha256,
+            expected_current_structured_head_sha256=current_head,
+        )
+
+    try:
+        response = client.get(
+            _url(f"/api/truth/doc/{document.id}", store.store_id)
+        )
+    finally:
+        with ydoc_store.document_lock(store, document.id):
+            ydoc_store.abort_snapshot_replacement_locked(
+                store,
+                document_id=document.id,
+                expected_snapshot_sha256=replacement.snapshot_sha256,
+            )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["initialization_state"] == "recovery_required"
+    assert payload["disabled_reason"] == "compaction_recovery_required"
+    assert payload["structured_head_sha256"] is None
+    assert payload["capabilities"]["cowork_verify"]["enabled"] is False
+
+
 def test_get_uses_live_structured_head_not_materialized_baseline_for_applicability(
     client, seeded
 ):
@@ -755,6 +797,24 @@ def test_current_actor_exposes_the_binding_provenance_clients_must_freeze(
         "ref": "reviewer-kaden",
         "identity_status": "local_actor_ref",
     }
+
+
+def test_current_actor_read_allows_a_valid_rotation_due_session(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[dict[str, object]] = []
+
+    def authenticate(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(actor=SimpleNamespace(canonical_id=HUMAN.ref))
+
+    monkeypatch.setattr(api, "authenticate_request_session", authenticate)
+
+    response = client.get("/api/truth/cowork/current-actor")
+
+    assert response.status_code == 200
+    assert calls == [{"allow_rotation_due": True}]
 
 
 def test_paste_authorship_attestation_targets_exact_structured_head(

--- a/tests/unit/cowork/test_lifecycle_hardening.py
+++ b/tests/unit/cowork/test_lifecycle_hardening.py
@@ -12,6 +12,7 @@ from work_buddy.cowork import (
     bootstrap,
     conversations,
     materialization,
+    provenance,
     reimport,
     retirement,
     sitting_lifecycle,
@@ -174,6 +175,31 @@ def test_sitting_prepare_is_pure_and_commit_is_atomic_and_idempotent(store_ctx):
     assert refreshed.ydoc_snapshot_sha256 == sha256_bytes(new_snapshot)
     assert refreshed.content_sha256 == sha256_bytes(rendered)
     assert (store_ctx["root"] / document.path).read_bytes() == rendered
+    initial_attestations = store.list_document_provenance_attestations(
+        document.id
+    )
+    assert len(initial_attestations) == 1
+    assert receipt["results"][0]["provenance_attestation_ids"] == [
+        initial_attestations[0].id
+    ]
+    pure_replacement = initial_attestations[0]
+    assert pure_replacement.authorship_kind == "ai"
+    assert pure_replacement.review_status == "not_reviewed"
+    with store._read_connection() as conn:
+        pure_replacement_span = store._get_document_span_locked(
+            conn,
+            pure_replacement.document_span_id,
+        )
+    assert pure_replacement_span is not None
+    assert pure_replacement_span.quote_exact == "Replacement sentence."
+    projected = provenance.project_attestations(
+        store,
+        document.id,
+        current_structured_head_sha256=receipt["structured_head_sha256"],
+    )
+    assert projected["spans"][0]["span"]["exact"] == (
+        "Replacement sentence."
+    )
 
     repeated, events = sitting_lifecycle.commit_sitting(
         store,
@@ -188,6 +214,358 @@ def test_sitting_prepare_is_pure_and_commit_is_atomic_and_idempotent(store_ctx):
     assert canonical_json(repeated) == canonical_json(receipt)
     assert events == receipt["post_commit_events"]
     assert _gesture_count(store) == 1
+    assert (
+        store.list_document_provenance_attestations(document.id)
+        == initial_attestations
+    )
+
+
+def test_confirmed_agent_insertion_records_only_new_text_in_provenance_get(
+    store_ctx,
+    client,
+):
+    store = store_ctx["store"]
+    document, _source, _old_snapshot = _ready(
+        store_ctx,
+        path="docs/proposal-provenance.md",
+        key="proposal-provenance-ready-0001",
+    )
+    old_head = ydoc_store.current_structured_head(
+        store,
+        document_id=document.id,
+        snapshot_sha256=document.ydoc_snapshot_sha256,
+    )
+    claim = store.propose_claim(
+        proposition="The inserted sentence demonstrates AI provenance.",
+        claim_kind="fact",
+        actor=AGENT,
+    ).claim
+    ai_text = "This sentence was generated to demonstrate AI provenance."
+    replacement = f"{ai_text}\n\nOriginal sentence."
+    proposal = proposals.propose_edit(
+        store,
+        document_id=document.id,
+        base_content_sha256=document.content_sha256,
+        base_structured_head_sha256=old_head,
+        selector=CompositeSelector(exact="Original sentence."),
+        quote_exact="Original sentence.",
+        replacement=replacement,
+        rationale="Demonstrate accepted AI-authored provenance.",
+        tldr="Insert an AI provenance demonstration.",
+        claim_refs=[{"claim": claim.id, "role": "instantiation"}],
+        actor=AGENT,
+    )
+    intent, created = sitting_lifecycle.prepare_sitting(
+        store,
+        document_id=document.id,
+        actor=HUMAN,
+        items=[
+            {
+                "proposal_id": proposal.id,
+                "verb": "confirm",
+                "canonical_sha256": proposal.canonical_sha256,
+            }
+        ],
+        expected_file_sha256=document.content_sha256,
+        expected_structured_head_sha256=old_head,
+        idempotency_key="proposal-provenance-sitting-0001",
+    )
+    assert created is True
+
+    rendered = f"# Lifecycle\n\n{replacement}\n".encode()
+    new_snapshot = b"YDOC:" + rendered
+    receipt, events = sitting_lifecycle.commit_sitting(
+        store,
+        document_id=document.id,
+        intent_id=intent.id,
+        actor=HUMAN,
+        snapshot=new_snapshot,
+        snapshot_sha256=sha256_bytes(new_snapshot),
+        rendered_markdown=rendered.decode(),
+        rendered_sha256=sha256_bytes(rendered),
+    )
+
+    result = receipt["results"][0]
+    assert result["result"] == "applied"
+    assert len(result["provenance_attestation_ids"]) == 1
+    assert any(
+        event["event_type"] == "truth.doc_provenance_attested"
+        for event in events
+    )
+    rows = store.list_document_provenance_attestations(document.id)
+    assert len(rows) == 1
+    attestation = rows[0]
+    assert attestation.id == result["provenance_attestation_ids"][0]
+    assert attestation.target_structured_head_sha256 == receipt[
+        "structured_head_sha256"
+    ]
+    assert attestation.authorship_kind == "ai"
+    assert attestation.review_status == "not_reviewed"
+    assert json.loads(attestation.human_reviewers_json) == []
+    assert attestation.source_kind == "proposal_acceptance"
+    assert attestation.basis_kind == "proposal_acceptance"
+    assert attestation.basis_ref == result["gesture_id"]
+    source = json.loads(attestation.source_json)
+    assert source["proposal_id"] == proposal.id
+    assert source["acceptance_gesture_id"] == result["gesture_id"]
+    assert source["producer"] == {
+        "kind": "agent_run",
+        "ref": AGENT.ref,
+        "model": "test-model",
+        "harness": "pytest",
+        "surface": "cowork",
+        "session_id": "session-1",
+    }
+
+    with store._read_connection() as conn:
+        exact_span = store._get_document_span_locked(
+            conn,
+            attestation.document_span_id,
+        )
+        expression_spans = conn.execute(
+            "SELECT s.quote_exact, s.author_kind, s.author_ref "
+            "FROM expressions e JOIN document_spans s "
+            "ON s.id = e.document_span_id"
+        ).fetchall()
+    assert exact_span is not None
+    assert exact_span.quote_exact == ai_text
+    assert exact_span.author_kind == "agent_run"
+    assert exact_span.author_ref == AGENT.ref
+    # The expression may cover the complete accepted passage, but the
+    # preserved original is never exposed as wholly AI-authored provenance.
+    assert [dict(row) for row in expression_spans] == [
+        {
+            "quote_exact": replacement,
+            "author_kind": "unknown",
+            "author_ref": None,
+        }
+    ]
+
+    response = client.get(
+        f"/api/truth/doc/{document.id}?store_id={store.store_id}"
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["provenance"]["summary"]["ai_unreviewed_count"] == 1
+    assert len(payload["provenance"]["spans"]) == 1
+    target = payload["provenance"]["spans"][0]
+    assert target["target"]["currentness"] == "current"
+    assert target["span"]["exact"] == ai_text
+    assert target["effective_attestation"]["attestation_id"] == attestation.id
+    assert target["effective_attestation"]["authorship"] == {
+        "kind": "ai",
+        "contributors": [],
+    }
+    assert target["effective_attestation"]["human_review"] == {
+        "status": "not_reviewed",
+        "reviewers": [],
+    }
+    legacy_quotes = {
+        entry["quote"] for entry in payload["provenance_spans"]
+    }
+    assert legacy_quotes == {ai_text}
+
+
+def test_confirmed_sandwich_insertion_records_two_ai_only_segments(store_ctx):
+    store = store_ctx["store"]
+    document, _source, _old_snapshot = _ready(
+        store_ctx,
+        path="docs/sandwich-proposal-provenance.md",
+        key="sandwich-proposal-provenance-ready-0001",
+    )
+    old_head = ydoc_store.current_structured_head(
+        store,
+        document_id=document.id,
+        snapshot_sha256=document.ydoc_snapshot_sha256,
+    )
+    prefix = "AI-authored preface."
+    suffix = "AI-authored follow-up."
+    replacement = f"{prefix}\n\nOriginal sentence.\n\n{suffix}"
+    proposal = _proposal(
+        store,
+        document,
+        old_head,
+        replacement=replacement,
+    )
+    intent, _created = sitting_lifecycle.prepare_sitting(
+        store,
+        document_id=document.id,
+        actor=HUMAN,
+        items=[
+            {
+                "proposal_id": proposal.id,
+                "verb": "confirm",
+                "canonical_sha256": proposal.canonical_sha256,
+            }
+        ],
+        expected_file_sha256=document.content_sha256,
+        expected_structured_head_sha256=old_head,
+        idempotency_key="sandwich-proposal-provenance-sitting-0001",
+    )
+    rendered = f"# Lifecycle\n\n{replacement}\n".encode()
+    new_snapshot = b"YDOC:" + rendered
+    receipt, _events = sitting_lifecycle.commit_sitting(
+        store,
+        document_id=document.id,
+        intent_id=intent.id,
+        actor=HUMAN,
+        snapshot=new_snapshot,
+        snapshot_sha256=sha256_bytes(new_snapshot),
+        rendered_markdown=rendered.decode(),
+        rendered_sha256=sha256_bytes(rendered),
+    )
+
+    result = receipt["results"][0]
+    rows = store.list_document_provenance_attestations(document.id)
+    assert result["provenance_attestation_ids"] == [row.id for row in rows]
+    assert len(rows) == 2
+    assert {
+        row.target_structured_head_sha256 for row in rows
+    } == {receipt["structured_head_sha256"]}
+    assert {row.basis_ref for row in rows} == {result["gesture_id"]}
+    assert [
+        json.loads(row.source_json)["segment_index"] for row in rows
+    ] == [0, 1]
+    assert {
+        json.loads(row.source_json)["segment_count"] for row in rows
+    } == {2}
+    with store._read_connection() as conn:
+        exacts = [
+            store._get_document_span_locked(conn, row.document_span_id).quote_exact
+            for row in rows
+        ]
+    assert exacts == [prefix, suffix]
+    assert "Original sentence." not in exacts
+
+    projected = provenance.project_attestations(
+        store,
+        document.id,
+        current_structured_head_sha256=receipt["structured_head_sha256"],
+    )
+    projected_segments = sorted(
+        projected["spans"],
+        key=lambda target: target["effective_attestation"]["source"][
+            "segment_index"
+        ],
+    )
+    assert [target["span"]["exact"] for target in projected_segments] == [
+        prefix,
+        suffix,
+    ]
+
+
+def test_edit_confirm_human_amendment_does_not_claim_ai_authorship(store_ctx):
+    store = store_ctx["store"]
+    document, _source, _old_snapshot = _ready(
+        store_ctx,
+        path="docs/amended-proposal-provenance.md",
+        key="amended-proposal-provenance-ready-0001",
+    )
+    old_head = ydoc_store.current_structured_head(
+        store,
+        document_id=document.id,
+        snapshot_sha256=document.ydoc_snapshot_sha256,
+    )
+    proposal = _proposal(store, document, old_head)
+    human_amendment = "The human supplied this final sentence."
+    intent, _created = sitting_lifecycle.prepare_sitting(
+        store,
+        document_id=document.id,
+        actor=HUMAN,
+        items=[
+            {
+                "proposal_id": proposal.id,
+                "verb": "edit_confirm",
+                "canonical_sha256": proposal.canonical_sha256,
+                "amend_content": human_amendment,
+            }
+        ],
+        expected_file_sha256=document.content_sha256,
+        expected_structured_head_sha256=old_head,
+        idempotency_key="amended-proposal-provenance-sitting-0001",
+    )
+    rendered = f"# Lifecycle\n\n{human_amendment}\n".encode()
+    new_snapshot = b"YDOC:" + rendered
+    receipt, _events = sitting_lifecycle.commit_sitting(
+        store,
+        document_id=document.id,
+        intent_id=intent.id,
+        actor=HUMAN,
+        snapshot=new_snapshot,
+        snapshot_sha256=sha256_bytes(new_snapshot),
+        rendered_markdown=rendered.decode(),
+        rendered_sha256=sha256_bytes(rendered),
+    )
+
+    result = receipt["results"][0]
+    assert result["result"] == "applied"
+    assert "provenance_attestation_ids" not in result
+    assert store.list_document_provenance_attestations(document.id) == ()
+
+
+def test_ambiguous_preserved_quote_rolls_back_acceptance_and_provenance(
+    store_ctx,
+):
+    store = store_ctx["store"]
+    document, source, old_snapshot = _ready(
+        store_ctx,
+        path="docs/ambiguous-proposal-provenance.md",
+        key="ambiguous-proposal-provenance-ready-0001",
+    )
+    old_head = ydoc_store.current_structured_head(
+        store,
+        document_id=document.id,
+        snapshot_sha256=document.ydoc_snapshot_sha256,
+    )
+    replacement = (
+        "AI preface. Original sentence. AI bridge. Original sentence."
+    )
+    proposal = _proposal(
+        store,
+        document,
+        old_head,
+        replacement=replacement,
+    )
+    intent, _created = sitting_lifecycle.prepare_sitting(
+        store,
+        document_id=document.id,
+        actor=HUMAN,
+        items=[
+            {
+                "proposal_id": proposal.id,
+                "verb": "confirm",
+                "canonical_sha256": proposal.canonical_sha256,
+            }
+        ],
+        expected_file_sha256=document.content_sha256,
+        expected_structured_head_sha256=old_head,
+        idempotency_key="ambiguous-proposal-provenance-sitting-0001",
+    )
+    rendered = f"# Lifecycle\n\n{replacement}\n".encode()
+    new_snapshot = b"YDOC:" + rendered
+
+    with pytest.raises(
+        sitting_lifecycle.SittingError,
+        match="cannot be identified without guessing",
+    ) as failure:
+        sitting_lifecycle.commit_sitting(
+            store,
+            document_id=document.id,
+            intent_id=intent.id,
+            actor=HUMAN,
+            snapshot=new_snapshot,
+            snapshot_sha256=sha256_bytes(new_snapshot),
+            rendered_markdown=rendered.decode(),
+            rendered_sha256=sha256_bytes(rendered),
+        )
+
+    assert failure.value.code == "proposal_provenance_unsafe"
+    assert proposals.latest_proposal_status(store, proposal.id).status == "open"
+    assert _gesture_count(store) == 0
+    assert store.list_document_provenance_attestations(document.id) == ()
+    refreshed = documents.get_document(store, document.id)
+    assert refreshed.ydoc_snapshot_sha256 == sha256_bytes(old_snapshot)
+    assert (store_ctx["root"] / document.path).read_bytes() == source
 
 
 def test_detached_sitting_replaces_exact_durable_update_tail(store_ctx):

--- a/tests/unit/cowork/test_lifecycle_hardening.py
+++ b/tests/unit/cowork/test_lifecycle_hardening.py
@@ -220,6 +220,162 @@ def test_sitting_prepare_is_pure_and_commit_is_atomic_and_idempotent(store_ctx):
     )
 
 
+def test_confirmed_duplicate_replacement_uses_frozen_application_position(
+    store_ctx,
+):
+    store = store_ctx["store"]
+    source = b"# Lifecycle\n\nTarget phrase.\n\nShared replacement.\n"
+    document, _source, _old_snapshot = _ready(
+        store_ctx,
+        source=source,
+        path="docs/duplicate-proposal-provenance.md",
+        key="duplicate-proposal-provenance-ready-0001",
+    )
+    old_head = ydoc_store.current_structured_head(
+        store,
+        document_id=document.id,
+        snapshot_sha256=document.ydoc_snapshot_sha256,
+    )
+    original = "Target phrase."
+    replacement = "Shared replacement."
+    start = source.decode().index(original)
+    proposal = proposals.propose_edit(
+        store,
+        document_id=document.id,
+        base_content_sha256=document.content_sha256,
+        base_structured_head_sha256=old_head,
+        selector=CompositeSelector(
+            exact=original,
+            start=start,
+            end=start + len(original),
+        ),
+        quote_exact=original,
+        replacement=replacement,
+        rationale="Exercise position-bound proposal provenance.",
+        tldr="Use the repeated wording.",
+        actor=AGENT,
+    )
+    intent, _created = sitting_lifecycle.prepare_sitting(
+        store,
+        document_id=document.id,
+        actor=HUMAN,
+        items=[
+            {
+                "proposal_id": proposal.id,
+                "verb": "confirm",
+                "canonical_sha256": proposal.canonical_sha256,
+            }
+        ],
+        expected_file_sha256=document.content_sha256,
+        expected_structured_head_sha256=old_head,
+        idempotency_key="duplicate-proposal-provenance-sitting-0001",
+    )
+    rendered = source.decode().replace(original, replacement, 1).encode()
+    new_snapshot = b"YDOC:" + rendered
+    receipt, _events = sitting_lifecycle.commit_sitting(
+        store,
+        document_id=document.id,
+        intent_id=intent.id,
+        actor=HUMAN,
+        snapshot=new_snapshot,
+        snapshot_sha256=sha256_bytes(new_snapshot),
+        rendered_markdown=rendered.decode(),
+        rendered_sha256=sha256_bytes(rendered),
+    )
+
+    assert receipt["results"][0]["result"] == "applied"
+    rows = store.list_document_provenance_attestations(document.id)
+    assert len(rows) == 1
+    with store._read_connection() as conn:
+        span = store._get_document_span_locked(
+            conn,
+            rows[0].document_span_id,
+        )
+    assert span is not None
+    selector = CompositeSelector.from_json(span.selector_json)
+    assert selector.exact == replacement
+    assert (selector.start, selector.end) == (
+        start,
+        start + len(replacement),
+    )
+    assert rendered.decode().find(replacement) == start
+    assert rendered.decode().rfind(replacement) > start
+
+
+def test_confirmed_duplicate_replacement_at_wrong_position_rolls_back(
+    store_ctx,
+):
+    store = store_ctx["store"]
+    source = b"# Lifecycle\n\nTarget phrase.\n\nShared replacement.\n"
+    document, _source, old_snapshot = _ready(
+        store_ctx,
+        source=source,
+        path="docs/misplaced-proposal-provenance.md",
+        key="misplaced-proposal-provenance-ready-0001",
+    )
+    old_head = ydoc_store.current_structured_head(
+        store,
+        document_id=document.id,
+        snapshot_sha256=document.ydoc_snapshot_sha256,
+    )
+    original = "Target phrase."
+    replacement = "Shared replacement."
+    start = source.decode().index(original)
+    proposal = proposals.propose_edit(
+        store,
+        document_id=document.id,
+        base_content_sha256=document.content_sha256,
+        base_structured_head_sha256=old_head,
+        selector=CompositeSelector(
+            exact=original,
+            start=start,
+            end=start + len(original),
+        ),
+        quote_exact=original,
+        replacement=replacement,
+        rationale="Exercise position-bound proposal provenance.",
+        tldr="Use the repeated wording.",
+        actor=AGENT,
+    )
+    intent, _created = sitting_lifecycle.prepare_sitting(
+        store,
+        document_id=document.id,
+        actor=HUMAN,
+        items=[
+            {
+                "proposal_id": proposal.id,
+                "verb": "confirm",
+                "canonical_sha256": proposal.canonical_sha256,
+            }
+        ],
+        expected_file_sha256=document.content_sha256,
+        expected_structured_head_sha256=old_head,
+        idempotency_key="misplaced-proposal-provenance-sitting-0001",
+    )
+    # The replacement exists, but only at the pre-existing second occurrence;
+    # accepting this payload must never attribute that unrelated text to AI.
+    malicious_snapshot = b"YDOC:MISPLACED:" + source
+    with pytest.raises(sitting_lifecycle.SittingError) as failure:
+        sitting_lifecycle.commit_sitting(
+            store,
+            document_id=document.id,
+            intent_id=intent.id,
+            actor=HUMAN,
+            snapshot=malicious_snapshot,
+            snapshot_sha256=sha256_bytes(malicious_snapshot),
+            rendered_markdown=source.decode(),
+            rendered_sha256=sha256_bytes(source),
+        )
+
+    assert failure.value.code == "proposal_provenance_unsafe"
+    assert proposals.latest_proposal_status(store, proposal.id).status == "open"
+    assert _gesture_count(store) == 0
+    assert store.list_document_provenance_attestations(document.id) == ()
+    refreshed = documents.get_document(store, document.id)
+    assert refreshed.ydoc_snapshot_sha256 == sha256_bytes(old_snapshot)
+    assert (store_ctx["root"] / document.path).read_bytes() == source
+
+
 def test_confirmed_agent_insertion_records_only_new_text_in_provenance_get(
     store_ctx,
     client,

--- a/tests/unit/cowork/test_proposal_applicability.py
+++ b/tests/unit/cowork/test_proposal_applicability.py
@@ -47,6 +47,36 @@ def test_matching_structured_head_wins_over_materialized_baseline(seeded):
     assert result.reason == "same_structured_head"
 
 
+def test_matching_structured_head_carries_resolved_application_position(seeded):
+    document = seeded["document"]
+    text = "First repeated phrase. Later, repeated phrase."
+    start = text.index("repeated phrase")
+    proposal = SimpleNamespace(
+        base_content_sha256="a" * 64,
+        base_structured_head_sha256="b" * 64,
+        selector_json=CompositeSelector(
+            exact="repeated phrase",
+            start=start,
+            end=start + len("repeated phrase"),
+        ).to_json(),
+    )
+
+    result = assess_proposal_applicability(
+        proposal,
+        document,
+        structured_head_sha256="b" * 64,
+        current_projection=_projection(text),
+    )
+
+    assert result.status == "applicable"
+    assert result.reason == "same_structured_head"
+    assert (result.resolved_start, result.resolved_end) == (
+        start,
+        start + len("repeated phrase"),
+    )
+    assert result.current_projection_sha256 == "c" * 64
+
+
 def test_unrelated_document_change_reanchors_the_original_target(seeded):
     document = seeded["document"]
     proposal = _proposal(

--- a/tests/unit/cowork/test_provenance_attestations.py
+++ b/tests/unit/cowork/test_provenance_attestations.py
@@ -9,9 +9,9 @@ from pathlib import Path
 import pytest
 
 from work_buddy.cowork import bootstrap, provenance
-from work_buddy.truth import documents, ydoc_store
+from work_buddy.truth import documents, export as truth_export, ydoc_store
 from work_buddy.truth.contracts import Actor, InvariantViolation
-from work_buddy.truth.export import export_store, import_store
+from work_buddy.truth.export import FORMAT_VERSION, export_store, import_store
 from work_buddy.truth.identity import sha256_bytes
 from work_buddy.truth.queries import integrity_findings
 
@@ -505,6 +505,48 @@ def test_paste_idempotency_key_is_bound_to_the_exact_selector(store_ctx):
         )
 
 
+@pytest.mark.parametrize(
+    ("source_kind", "basis_kind"),
+    [
+        ("direct_entry", "user_attestation"),
+        ("direct_entry", "automatic_short_text_attribution"),
+        ("paste", "automatic_direct_entry_attribution"),
+        ("legacy", "automatic_direct_entry_attribution"),
+    ],
+)
+def test_span_attestation_rejects_unsupported_source_basis_pairs(
+    store_ctx,
+    source_kind,
+    basis_kind,
+):
+    store = store_ctx["store"]
+    document, version, _intent, _source = _import_ready(store_ctx)
+    history_before = store.list_document_provenance_attestations(document.id)
+    with pytest.raises(InvariantViolation, match="allowed provenance pair"):
+        provenance.record_span_attestation(
+            store,
+            document_id=document.id,
+            exact="durable provenance",
+            prefix="A ",
+            suffix=" target.",
+            attestation=_attestation(authorship="human", review="not_applicable"),
+            actor=HUMAN,
+            idempotency_key=f"invalid-source-basis-{source_kind}-{basis_kind}",
+            source={"kind": source_kind, "format": "plain_text"},
+            basis_kind=basis_kind,
+            expected_structured_head_sha256=version.structured_head_sha256,
+        )
+    assert store.list_document_provenance_attestations(document.id) == history_before
+    with store.connect() as conn:
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM document_spans WHERE document_id = ?",
+                (document.id,),
+            ).fetchone()[0]
+            == 0
+        )
+
+
 @pytest.mark.parametrize("authorship", ["ai", "mixed"])
 def test_human_review_supersedes_effective_ai_without_rewriting_source(
     store_ctx,
@@ -524,7 +566,7 @@ def test_human_review_supersedes_effective_ai_without_rewriting_source(
         ),
         actor=HUMAN,
         idempotency_key=f"review-origin-{authorship}-0001",
-        basis_kind="automatic_short_text_attribution",
+        basis_kind="user_attestation",
         expected_structured_head_sha256=version.structured_head_sha256,
     )
 
@@ -559,7 +601,7 @@ def test_human_review_supersedes_effective_ai_without_rewriting_source(
             "ref": HUMAN.ref,
         }
     ]
-    assert original.basis_kind == "automatic_short_text_attribution"
+    assert original.basis_kind == "user_attestation"
     assert reviewed.basis_kind == "user_attestation"
     assert reviewed.basis_ref == original.id
     assert reviewed.supersedes_id == original.id
@@ -572,13 +614,73 @@ def test_human_review_supersedes_effective_ai_without_rewriting_source(
     target = projection["spans"][0]
     assert target["resolution"] == "resolved"
     assert target["effective_attestation"]["attestation_id"] == reviewed.id
-    assert target["history"][0]["basis"]["kind"] == (
-        "automatic_short_text_attribution"
-    )
+    assert target["history"][0]["basis"]["kind"] == "user_attestation"
     assert target["history"][1]["basis"] == {
         "kind": "user_attestation",
         "ref": original.id,
     }
+
+
+def test_human_review_of_proposal_acceptance_round_trips(
+    store_ctx,
+    tmp_path: Path,
+):
+    store = store_ctx["store"]
+    document, initial_version, _intent, _source = _import_ready(store_ctx)
+    _document, version, _event = documents.commit_document_version(
+        store,
+        document_id=document.id,
+        kind="materialized",
+        projection_sha256=initial_version.projection_sha256,
+        ydoc_snapshot_sha256=initial_version.ydoc_snapshot_sha256,
+        structured_head_sha256=initial_version.structured_head_sha256,
+        actor=HUMAN,
+    )
+    proposal_id = "bb" * 16
+    original = provenance.record_document_attestation(
+        store,
+        document_id=document.id,
+        document_version_id=version.id,
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        source={"kind": "proposal_acceptance", "proposal_id": proposal_id},
+        actor=HUMAN,
+        idempotency_key="proposal-acceptance-origin-0001",
+        basis_kind="proposal_acceptance",
+        basis_ref=proposal_id,
+    )
+
+    reviewed = provenance.record_human_review(
+        store,
+        document_id=document.id,
+        attestation_id=original.id,
+        actor=HUMAN,
+        idempotency_key="proposal-acceptance-review-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+
+    assert original.source_kind == "proposal_acceptance"
+    assert original.basis_kind == "proposal_acceptance"
+    assert reviewed.source_kind == "proposal_acceptance"
+    assert reviewed.basis_kind == "user_attestation"
+    assert reviewed.basis_ref == original.id
+    assert reviewed.supersedes_id == original.id
+
+    exported = export_store(store)
+    target = tmp_path / "proposal-review-restored"
+    target.mkdir()
+    restored = import_store(
+        exported.path,
+        target,
+        registry=_EmptyRegistry(),
+    ).store
+    restored_rows = restored.list_document_provenance_attestations(document.id)
+    assert restored_rows == store.list_document_provenance_attestations(document.id)
+    assert any(
+        row.id == reviewed.id
+        and row.source_kind == "proposal_acceptance"
+        and row.basis_kind == "user_attestation"
+        for row in restored_rows
+    )
 
 
 def test_human_review_rejects_non_ai_stale_and_already_superseded_targets(
@@ -1093,24 +1195,62 @@ def test_effective_projection_mixed_target_heads_are_order_independent(
 def test_provenance_round_trips_and_integrity_detects_canonical_tampering(
     store_ctx,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     store = store_ctx["store"]
-    document, _version, _intent, _source = _import_ready(
+    document, version, _intent, _source = _import_ready(
         store_ctx,
         attestation=_attestation(authorship="ai", review="not_reviewed"),
     )
+    direct, _span_id = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="durable provenance",
+        prefix="A ",
+        suffix=" target.",
+        attestation=_attestation(authorship="human", review="not_applicable"),
+        actor=HUMAN,
+        idempotency_key="direct-entry-round-trip-0001",
+        source={"kind": "direct_entry", "format": "plain_text"},
+        basis_kind="automatic_direct_entry_attribution",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    assert direct.source_kind == "direct_entry"
+    assert direct.basis_kind == "automatic_direct_entry_attribution"
     assert [finding for finding in integrity_findings(store) if finding.severity == "error"] == []
 
     exported = export_store(store)
+    header = json.loads(exported.path.read_text(encoding="utf-8").splitlines()[0])
+    assert header["format_version"] == FORMAT_VERSION == 10
+    v9_target = tmp_path / "v9-reader"
+    v9_target.mkdir()
+    with monkeypatch.context() as v9_reader:
+        v9_reader.setattr(truth_export, "FORMAT_VERSION", 9)
+        with pytest.raises(
+            truth_export.TruthImportError,
+            match="newer than supported v9",
+        ):
+            import_store(
+                exported.path,
+                v9_target,
+                registry=_EmptyRegistry(),
+            )
     target = tmp_path / "restored"
     target.mkdir()
-    restored = import_store(
+    imported = import_store(
         exported.path,
         target,
         registry=_EmptyRegistry(),
-    ).store
+    )
+    assert imported.source_format_version == 10
+    restored = imported.store
     restored_rows = restored.list_document_provenance_attestations(document.id)
     assert restored_rows == store.list_document_provenance_attestations(document.id)
+    assert any(
+        row.source_kind == "direct_entry"
+        and row.basis_kind == "automatic_direct_entry_attribution"
+        for row in restored_rows
+    )
     assert [finding for finding in integrity_findings(restored) if finding.severity == "error"] == []
 
     with restored.connect() as conn:

--- a/tests/unit/cowork/test_verify_orchestration.py
+++ b/tests/unit/cowork/test_verify_orchestration.py
@@ -8,6 +8,7 @@ import sqlite3
 from copy import deepcopy
 from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -17,7 +18,11 @@ from work_buddy.agent_execution.models import (
     AgentSpawnOutcome,
     AgentSpawnRequest,
 )
-from work_buddy.cowork import verify_orchestration, verify_runtime
+from work_buddy.cowork import (
+    verify_orchestration,
+    verify_projection,
+    verify_runtime,
+)
 from work_buddy.cowork.execution_identity import CoworkVerifyRole
 from work_buddy.cowork.verify import (
     ActionSnapshot,
@@ -144,6 +149,81 @@ def _ready_document(
         at=NOW,
     )
     return document, projection, snapshot
+
+
+def test_verify_result_is_non_current_while_compaction_recovery_is_pending(
+    store_ctx: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    document, _projection, _snapshot = _ready_document(store_ctx)
+    store = store_ctx["store"]
+
+    def compaction_in_flight(*_args, **_kwargs):
+        raise ydoc_store.CompactionRecoveryRequired("compaction in flight")
+
+    result = SimpleNamespace(
+        id="result-in-flight",
+        evaluation_run_id="run-in-flight",
+        check_execution_id="execution-in-flight",
+        criterion_definition_version_id="criterion-in-flight",
+        result_kind="finding",
+        message="A recorded result.",
+        payload_json="{}",
+        canonical_sha256="1" * 64,
+        created_at=NOW,
+    )
+    records = {
+        EvaluationResult: result,
+        CheckExecution: SimpleNamespace(
+            check_definition_version_id="check-in-flight"
+        ),
+        CriterionDefinitionVersion: SimpleNamespace(
+            title="Clarity",
+            description="The document is clear.",
+        ),
+        CheckDefinitionVersion: SimpleNamespace(
+            title="Clarity check",
+            mechanism="deterministic",
+            limitations_json="[]",
+        ),
+        ActionSnapshot: SimpleNamespace(
+            target_kind="document",
+            structured_head_sha256="2" * 64,
+        ),
+    }
+
+    monkeypatch.setattr(
+        ydoc_store,
+        "current_structured_head",
+        compaction_in_flight,
+    )
+    monkeypatch.setattr(
+        verify_projection,
+        "surfaced_results",
+        lambda *_args, **_kwargs: (
+            {
+                "id": result.id,
+                "action_snapshot_id": "action-in-flight",
+                "evidence_selector": {"exact": "A recorded result."},
+                "disposition": {"decision": "surface"},
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        verify_projection.verify_store,
+        "get_record",
+        lambda _store, record_type, _record_id, **_kwargs: records[record_type],
+    )
+    monkeypatch.setattr(
+        verify_projection.verify_store,
+        "list_records",
+        lambda *_args, **_kwargs: (),
+    )
+
+    projected = result_projection(store, document)
+
+    assert len(projected) == 1
+    assert projected[0]["current_version"] is False
 
 
 def _capture(

--- a/tests/unit/sources/test_store.py
+++ b/tests/unit/sources/test_store.py
@@ -18,6 +18,12 @@ from work_buddy.sources import (
     resolve_source,
 )
 from work_buddy.sources.errors import InvalidSourceRequest, SourceSchemaTooNew
+from work_buddy.sources.migrations import (
+    SOURCES_MIGRATIONS,
+    _m001_sources_schema,
+    _m002_recoverable_exports,
+)
+from work_buddy.storage.migrations import Migration, MigrationRunner
 
 
 def _capture(store: SourceStore, tenant_id: str, content: str | bytes = "alpha"):
@@ -38,6 +44,36 @@ def test_store_identity_persists_and_future_schema_fails_closed(tmp_path: Path) 
     conn.close()
     with pytest.raises(SourceSchemaTooNew):
         SourceStore.open(root)
+
+
+def test_recoverable_export_migration_hash_remains_frozen_during_v3_upgrade(
+    tmp_path: Path,
+) -> None:
+    conn = sqlite3.connect(tmp_path / "sources-v2.db")
+    v2_runner = MigrationRunner(
+        "sources",
+        [
+            Migration(1, "retained source foundation", _m001_sources_schema),
+            Migration(2, "recoverable issued-copy exports", _m002_recoverable_exports),
+        ],
+    )
+    v2_runner.run(conn)
+
+    frozen_hash = "0621fdb22cc3dddc78a8fee3b24ba70e9ba93d7827f5df78928f6158fa32e3f6"
+    assert conn.execute(
+        "SELECT code_hash FROM _migration_history WHERE version = 2"
+    ).fetchone()[0] == frozen_hash
+
+    SOURCES_MIGRATIONS.run(conn)
+
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 3
+    assert conn.execute(
+        "SELECT code_hash FROM _migration_history WHERE version = 2"
+    ).fetchone()[0] == frozen_hash
+    assert conn.execute(
+        "SELECT COUNT(*) FROM _migration_history WHERE version = 3"
+    ).fetchone()[0] == 1
+    conn.close()
 
 
 def test_exact_inline_and_blob_representations_are_immutable(

--- a/tests/unit/test_chrome_collector_mutations.py
+++ b/tests/unit/test_chrome_collector_mutations.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import json
+import os
+from types import SimpleNamespace
+
 from work_buddy.collectors import chrome_collector
 
 
@@ -36,4 +40,165 @@ def test_focus_or_create_normalizes_app_base_and_requests_path_preservation(
             "target_hash": "#wb-bootstrap=wbb_test",
             "preserve_path": True,
         },
+    }
+
+
+def test_focus_existing_uses_non_creating_mutation(monkeypatch):
+    seen = {}
+
+    def fake_request(mutation, timeout_seconds=15, **params):
+        seen.update(
+            mutation=mutation,
+            timeout_seconds=timeout_seconds,
+            params=params,
+        )
+        return {"status": "ok", "details": {"found": True}}
+
+    monkeypatch.setattr(chrome_collector, "_request_mutation", fake_request)
+
+    result = chrome_collector.focus_existing_tab(
+        "http://127.0.0.1:5127/app/",
+        target_hash="#wb-bootstrap=wbb_test",
+        timeout_seconds=10,
+    )
+
+    assert result == {"status": "ok", "details": {"found": True}}
+    assert seen == {
+        "mutation": "focus_existing_tab",
+        "timeout_seconds": 10,
+        "params": {
+            "url": "http://127.0.0.1:5127/app",
+            "target_hash": "#wb-bootstrap=wbb_test",
+        },
+    }
+
+
+def test_mutation_ignores_unrelated_shared_output_until_nonce_matches(
+    tmp_path,
+    monkeypatch,
+):
+    request_file = tmp_path / "request.json"
+    output_file = tmp_path / "tabs.json"
+    output_file.write_text(json.dumps({"request_id": "older"}), encoding="utf-8")
+    stamp = output_file.stat().st_mtime
+    monkeypatch.setattr(chrome_collector, "_REQUEST_FILE", request_file)
+    monkeypatch.setattr(chrome_collector, "_TABS_FILE", output_file)
+    monkeypatch.setattr(
+        chrome_collector.uuid,
+        "uuid4",
+        lambda: SimpleNamespace(hex="request-1"),
+    )
+    sleeps = 0
+
+    def advance_response(_seconds):
+        nonlocal sleeps
+        sleeps += 1
+        if sleeps == 1:
+            payload = {"request_id": "unrelated", "mutation_result": {}}
+        else:
+            payload = {
+                "request_id": "request-1",
+                "mutation_result": {
+                    "status": "ok",
+                    "details": {"found": True},
+                },
+            }
+        output_file.write_text(json.dumps(payload), encoding="utf-8")
+        os.utime(output_file, (stamp + sleeps, stamp + sleeps))
+
+    monkeypatch.setattr(chrome_collector.time, "sleep", advance_response)
+
+    result = chrome_collector._request_mutation(
+        "focus_existing_tab",
+        timeout_seconds=1,
+        url="http://127.0.0.1:5127/app",
+    )
+
+    assert result == {"status": "ok", "details": {"found": True}}
+    request = json.loads(request_file.read_text(encoding="utf-8"))
+    assert request["request_id"] == "request-1"
+    assert not output_file.exists()
+
+
+def test_snapshot_timeout_does_not_delete_a_newer_request(tmp_path, monkeypatch):
+    request_file = tmp_path / "request.json"
+    output_file = tmp_path / "tabs.json"
+    monkeypatch.setattr(chrome_collector, "_REQUEST_FILE", request_file)
+    monkeypatch.setattr(chrome_collector, "_TABS_FILE", output_file)
+    monkeypatch.setattr(
+        chrome_collector.uuid,
+        "uuid4",
+        lambda: SimpleNamespace(hex="snapshot-1"),
+    )
+    monotonic = iter([0.0, 0.0, 2.0])
+    monkeypatch.setattr(
+        chrome_collector.time,
+        "time",
+        lambda: next(monotonic, 2.0),
+    )
+
+    def replace_with_newer_request(_seconds):
+        request_file.write_text(
+            json.dumps({"request_id": "newer-request"}),
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(chrome_collector.time, "sleep", replace_with_newer_request)
+
+    assert chrome_collector.request_tabs(timeout_seconds=1) is None
+    assert json.loads(request_file.read_text(encoding="utf-8")) == {
+        "request_id": "newer-request"
+    }
+
+
+def test_snapshot_accepts_an_idless_extension_response(
+    tmp_path,
+    monkeypatch,
+):
+    request_file = tmp_path / "request.json"
+    output_file = tmp_path / "tabs.json"
+    output_file.write_text("{}", encoding="utf-8")
+    stamp = output_file.stat().st_mtime
+    monkeypatch.setattr(chrome_collector, "_REQUEST_FILE", request_file)
+    monkeypatch.setattr(chrome_collector, "_TABS_FILE", output_file)
+
+    def idless_worker_response(_seconds):
+        output_file.write_text(json.dumps({"tabs": [{"tabId": 1}]}), encoding="utf-8")
+        os.utime(output_file, (stamp + 1, stamp + 1))
+
+    monkeypatch.setattr(chrome_collector.time, "sleep", idless_worker_response)
+
+    assert chrome_collector.request_tabs(timeout_seconds=1) == {
+        "tabs": [{"tabId": 1}]
+    }
+
+
+def test_content_timeout_does_not_delete_a_newer_request(tmp_path, monkeypatch):
+    request_file = tmp_path / "request.json"
+    output_file = tmp_path / "tabs.json"
+    monkeypatch.setattr(chrome_collector, "_REQUEST_FILE", request_file)
+    monkeypatch.setattr(chrome_collector, "_TABS_FILE", output_file)
+    monkeypatch.setattr(
+        chrome_collector.uuid,
+        "uuid4",
+        lambda: SimpleNamespace(hex="content-1"),
+    )
+    monotonic = iter([0.0, 0.0, 2.0])
+    monkeypatch.setattr(
+        chrome_collector.time,
+        "time",
+        lambda: next(monotonic, 2.0),
+    )
+
+    def replace_with_newer_request(_seconds):
+        request_file.write_text(
+            json.dumps({"request_id": "newer-request"}),
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(chrome_collector.time, "sleep", replace_with_newer_request)
+
+    assert chrome_collector.request_content([42], timeout_seconds=1) is None
+    assert json.loads(request_file.read_text(encoding="utf-8")) == {
+        "request_id": "newer-request"
     }

--- a/tests/unit/test_chrome_native_host.py
+++ b/tests/unit/test_chrome_native_host.py
@@ -1,0 +1,91 @@
+"""Native-host request correlation for trusted dashboard tab handoffs."""
+
+from __future__ import annotations
+
+import json
+
+from work_buddy.chrome_native_host import host
+
+
+def test_check_passes_identity_handoff_fields_to_extension(tmp_path, monkeypatch):
+    request_file = tmp_path / "request.json"
+    request_file.write_text(
+        json.dumps(
+            {
+                "request_id": "request-1",
+                "request_action": "mutate",
+                "mutation": "focus_or_create_tab",
+                "url": "http://127.0.0.1:5127/app",
+                "target_hash": "#wb-bootstrap=secret",
+                "preserve_path": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    responses = []
+    monkeypatch.setattr(host, "REQUEST_FILE", request_file)
+    monkeypatch.setattr(host, "write_message", responses.append)
+
+    host.handle_check()
+
+    assert responses == [
+        {
+            "status": "ok",
+            "requested": True,
+            "request_id": "request-1",
+            "request_action": "mutate",
+            "mutation": "focus_or_create_tab",
+            "url": "http://127.0.0.1:5127/app",
+            "target_hash": "#wb-bootstrap=secret",
+            "preserve_path": True,
+        }
+    ]
+
+
+def test_stale_export_does_not_delete_newer_request(tmp_path, monkeypatch):
+    request_file = tmp_path / "request.json"
+    output_file = tmp_path / "output.json"
+    request_file.write_text(
+        json.dumps({"request_id": "new-request"}),
+        encoding="utf-8",
+    )
+    responses = []
+    monkeypatch.setattr(host, "REQUEST_FILE", request_file)
+    monkeypatch.setattr(host, "OUTPUT_FILE", output_file)
+    monkeypatch.setattr(host, "write_message", responses.append)
+
+    host.handle_export(
+        {
+            "action": "export",
+            "request_id": "stale-request",
+            "mutation_result": {"status": "ok"},
+        }
+    )
+
+    assert request_file.exists()
+    assert json.loads(output_file.read_text(encoding="utf-8"))["request_id"] == (
+        "stale-request"
+    )
+    assert responses[0]["status"] == "ok"
+
+
+def test_correlated_export_removes_its_request(tmp_path, monkeypatch):
+    request_file = tmp_path / "request.json"
+    output_file = tmp_path / "output.json"
+    request_file.write_text(
+        json.dumps({"request_id": "request-1"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(host, "REQUEST_FILE", request_file)
+    monkeypatch.setattr(host, "OUTPUT_FILE", output_file)
+    monkeypatch.setattr(host, "write_message", lambda _response: None)
+
+    host.handle_export(
+        {
+            "action": "export",
+            "request_id": "request-1",
+            "mutation_result": {"status": "ok"},
+        }
+    )
+
+    assert not request_file.exists()

--- a/tests/unit/test_local_identity.py
+++ b/tests/unit/test_local_identity.py
@@ -237,6 +237,28 @@ def test_csrf_rotation_revocation_and_expiry(
     assert revoked.value.code == "session_unavailable"
 
 
+def test_rotation_due_session_remains_valid_only_when_a_read_allows_it(
+    authority: tuple[LocalIdentityAuthority, Clock],
+) -> None:
+    service, clock = authority
+    session = _session(service)
+    clock.advance(_policy().session_rotation_seconds + 1)
+
+    principal = service.authenticate_session(
+        cookie_token=session.cookie_token,
+        boundary=_boundary(),
+        allow_rotation_due=True,
+    )
+
+    assert principal.actor == service.enrolled_actor()
+    with pytest.raises(LocalIdentityError) as protected:
+        service.authenticate_session(
+            cookie_token=session.cookie_token,
+            boundary=_boundary(),
+        )
+    assert protected.value.code == "session_rotation_required"
+
+
 def test_session_and_gesture_expiry_are_enforced(
     authority: tuple[LocalIdentityAuthority, Clock],
 ) -> None:

--- a/tests/unit/test_local_identity.py
+++ b/tests/unit/test_local_identity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import sqlite3
 from pathlib import Path
 
@@ -673,6 +674,45 @@ def test_dashboard_human_authority_helper_fails_closed_remotely(
     assert response.json == {"ok": False, "code": "loopback_required"}
 
 
+def test_cowork_mutation_context_matches_browser_exact_whitespace_digest() -> None:
+    from work_buddy.cowork import api as cowork_api
+
+    body = {
+        "span": {
+            "exact": "Line  one\nLine\ttwo",
+            "prefix": "\nBefore  ",
+            "suffix": "\nAfter\t ",
+        },
+        "note": "  keep   spacing  ",
+    }
+    digest = cowork_api.cowork_mutation_context_sha256(
+        operation="provenance.attest",
+        store_id="store-1",
+        document_id="document-1",
+        body=body,
+    )
+
+    # Fixed against canonicalHumanAuthorityJson in the dashboard client. The
+    # bytes inside strings are part of the authority boundary, not semantic
+    # prose to normalize.
+    assert digest == "8cc88685011214b1de6d2cd9ff347f372dc5da6e3595d33744b2795aeb8b75a2"
+    normalized = cowork_api.cowork_mutation_context_sha256(
+        operation="provenance.attest",
+        store_id="store-1",
+        document_id="document-1",
+        body={
+            **body,
+            "span": {
+                "exact": "Line one Line two",
+                "prefix": "Before",
+                "suffix": "After",
+            },
+            "note": "keep spacing",
+        },
+    )
+    assert normalized != digest
+
+
 def test_cowork_action_rejects_absent_mismatched_replayed_and_remote_gestures(
     authority: tuple[LocalIdentityAuthority, Clock],
     monkeypatch: pytest.MonkeyPatch,
@@ -773,6 +813,155 @@ def test_cowork_action_rejects_absent_mismatched_replayed_and_remote_gestures(
     )
     assert remote.status_code == 403
     assert remote.json["code"] == "loopback_required"
+
+
+def test_direct_entry_route_accepts_multiline_anchor_and_consumes_gesture(
+    authority: tuple[LocalIdentityAuthority, Clock],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from work_buddy.cowork import api as cowork_api
+    from work_buddy.cowork import provenance
+    from work_buddy.truth import documents, ydoc_store
+    from work_buddy.truth.contracts import Actor
+    from work_buddy.truth.identity import sha256_bytes
+    from work_buddy.truth.registry import TruthStoreRegistry
+    from work_buddy.truth.store import TruthStore
+
+    service, _ = authority
+    monkeypatch.setattr(local_identity_api, "_authority", lambda: service)
+    monkeypatch.setattr(cowork_api, "_emit", lambda *_args, **_kwargs: None)
+
+    root = tmp_path / "cowork-authority-scope"
+    root.mkdir()
+    store = TruthStore.create(
+        root,
+        {
+            "store_id": "1" * 32,
+            "profile": "cowork-authority-test",
+            "title": "Throwaway Co-work authority test store",
+            "allowed_claim_kinds": ["fact", "preference"],
+            "required_fields": {},
+            "gate": {
+                "rejected_content": "retain",
+                "confirmation_surfaces": ["dashboard"],
+                "block_materialize_on_flags": False,
+            },
+            "projection": "none",
+            "export_committed": True,
+            "document_surface": {
+                "enabled": True,
+                "allowed_document_classes": ["co_authored"],
+                "feedback_capture": True,
+            },
+        },
+    )
+    registry = TruthStoreRegistry(tmp_path / "truth-registry.db")
+    registry.register(store)
+    monkeypatch.setattr(cowork_api, "_registry", lambda: registry)
+
+    actor_ref = service.enrolled_actor().canonical_id
+    actor = Actor("human", actor_ref)
+    snapshot = b"throwaway-multiline-authority-snapshot"
+    snapshot_sha256 = ydoc_store.write_snapshot(store, snapshot=snapshot)
+    document = documents.register_document(
+        store,
+        path="docs/throwaway-multiline-authority.md",
+        title="Throwaway multiline authority",
+        document_class="co_authored",
+        content_sha256=sha256_bytes(b"throwaway multiline authority body"),
+        ydoc_snapshot_sha256=snapshot_sha256,
+        actor=actor,
+    )
+    head = ydoc_store.current_structured_head(
+        store,
+        document_id=document.id,
+        snapshot_sha256=snapshot_sha256,
+    )
+    body = {
+        "span": {
+            "exact": "Typed  line",
+            "prefix": "",
+            "suffix": "\nOver  several\tdays, the next paragraph.",
+        },
+        "attestation": {
+            "schema": "cowork-authorship-attestation/v1",
+            "authorship": {
+                "kind": "human",
+                "contributors": [
+                    {
+                        "kind": "current_user",
+                        "ref": actor_ref,
+                        "identity_status": "local_actor_ref",
+                    }
+                ],
+            },
+            "human_review": {"status": "not_applicable", "reviewers": []},
+        },
+        "source_kind": "direct_entry",
+        "basis_kind": "automatic_direct_entry_attribution",
+        "expected_actor_ref": actor_ref,
+        "expected_actor_identity_status": "local_actor_ref",
+        "expected_structured_head_sha256": head,
+        "idempotency_key": "direct-entry-multiline-authority-0001",
+    }
+
+    session = _session(service)
+    action = "cowork.provenance.attest"
+    subject = f"cowork-document:{store.store_id}:{document.id}"
+    context_sha256 = cowork_api.cowork_mutation_context_sha256(
+        operation="provenance.attest",
+        store_id=store.store_id,
+        document_id=document.id,
+        body=body,
+    )
+    _, gesture = service.issue_gesture(
+        cookie_token=session.cookie_token,
+        csrf_token=session.csrf_token,
+        boundary=_boundary(),
+        action=action,
+        subject=subject,
+        context_sha256=context_sha256,
+    )
+
+    app = Flask("cowork-direct-entry-authority-test")
+    app.config.update(TESTING=True)
+    cowork_api.register_routes(app)
+    client = app.test_client()
+    client.set_cookie(
+        SESSION_COOKIE_NAME,
+        session.cookie_token,
+        domain="127.0.0.1",
+    )
+    headers = {
+        "Origin": "http://127.0.0.1:5127",
+        "Host": "127.0.0.1:5127",
+        "X-WB-CSRF": session.csrf_token,
+        "X-WB-Gesture": gesture.token,
+    }
+    url = (
+        f"/api/truth/doc/{document.id}/authorship-attestations"
+        f"?store_id={store.store_id}"
+    )
+
+    accepted = client.post(url, json=body, headers=headers)
+
+    assert accepted.status_code == 201
+    listed = provenance.list_attestations(store, document.id)
+    assert len(listed) == 1
+    assert listed[0]["source"]["kind"] == "direct_entry"
+    with store.connect() as conn:
+        span = conn.execute(
+            "SELECT selector_json FROM document_spans WHERE id = ?",
+            (listed[0]["scope"]["document_span_id"],),
+        ).fetchone()
+    selector = json.loads(span["selector_json"])[0]
+    assert selector["prefix"] == ""
+    assert selector["suffix"] == "\nOver  several\tdays, the next paragraph."
+
+    replay = client.post(url, json=body, headers=headers)
+    assert replay.status_code == 409
+    assert replay.get_json()["error"]["code"] == "gesture_replayed"
 
 
 def test_host_launch_places_one_time_grant_only_in_fragment(

--- a/tests/unit/test_tray_actions.py
+++ b/tests/unit/test_tray_actions.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from unittest.mock import Mock
-
 import pytest
 
 from work_buddy.tray import actions
@@ -60,13 +58,10 @@ class TestOpenDashboard:
             lambda app_url, *, next_hash="": "#wb-bootstrap=wbb_test",
         )
 
-        def fake_focus(
-            url, target_hash="", preserve_path=False, timeout_seconds=15
-        ):
+        def fake_focus(url, target_hash="", timeout_seconds=15):
             seen.update(
                 url=url,
                 target_hash=target_hash,
-                preserve_path=preserve_path,
                 timeout_seconds=timeout_seconds,
             )
             return {
@@ -75,7 +70,7 @@ class TestOpenDashboard:
             }
 
         monkeypatch.setattr(
-            "work_buddy.collectors.chrome_collector.focus_or_create_tab",
+            "work_buddy.collectors.chrome_collector.focus_existing_tab",
             fake_focus,
         )
         monkeypatch.setattr(
@@ -88,7 +83,6 @@ class TestOpenDashboard:
         assert seen == {
             "url": "http://127.0.0.1:5127/app/",
             "target_hash": "#wb-bootstrap=wbb_test",
-            "preserve_path": True,
             "timeout_seconds": 10,
         }
 
@@ -101,7 +95,7 @@ class TestOpenDashboard:
             lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("broken")),
         )
         monkeypatch.setattr(
-            "work_buddy.collectors.chrome_collector.focus_or_create_tab",
+            "work_buddy.collectors.chrome_collector.focus_existing_tab",
             lambda *args, **kwargs: pytest.fail("extension launch must not run"),
         )
         monkeypatch.setattr(
@@ -124,7 +118,7 @@ class TestOpenDashboard:
             lambda app_url, *, next_hash="": "#wb-bootstrap=wbb_test",
         )
         monkeypatch.setattr(
-            "work_buddy.collectors.chrome_collector.focus_or_create_tab",
+            "work_buddy.collectors.chrome_collector.focus_existing_tab",
             lambda *args, **kwargs: {"status": "error", "details": {}},
         )
         opened = {}
@@ -272,10 +266,6 @@ class TestIdentityReconnect:
             "work_buddy.collectors.chrome_collector.focus_existing_tab",
             lambda *args, **kwargs: {},
         )
-        monkeypatch.setattr(
-            "work_buddy.collectors.chrome_collector.focus_or_create_tab",
-            lambda *args, **kwargs: {},
-        )
         monkeypatch.setattr("webbrowser.open", lambda _url: False)
 
         result = actions.reconnect_dashboard_identity()
@@ -307,10 +297,6 @@ class TestIdentityReconnect:
             "work_buddy.collectors.chrome_collector.focus_existing_tab",
             lambda *args, **kwargs: None,
         )
-        monkeypatch.setattr(
-            "work_buddy.collectors.chrome_collector.focus_or_create_tab",
-            lambda *args, **kwargs: None,
-        )
         opened = {}
         monkeypatch.setattr(
             "webbrowser.open",
@@ -324,9 +310,8 @@ class TestIdentityReconnect:
         assert minted == [
             "#wb-bootstrap=wbb_1",
             "#wb-bootstrap=wbb_2",
-            "#wb-bootstrap=wbb_3",
         ]
-        assert opened["url"].endswith("/app/#wb-bootstrap=wbb_3")
+        assert opened["url"].endswith("/app/#wb-bootstrap=wbb_2")
 
     def test_confirmed_missing_tab_continues_to_create_a_trusted_session(
         self,
@@ -347,22 +332,23 @@ class TestIdentityReconnect:
                 "details": {"found": False, "created": False, "focused": False},
             },
         )
-        fallback = Mock(
-            return_value={
-                "status": "ok",
-                "details": {"created": True, "focused": False},
-            }
-        )
         monkeypatch.setattr(
             "work_buddy.collectors.chrome_collector.focus_or_create_tab",
-            fallback,
+            lambda *args, **kwargs: pytest.fail(
+                "an older worker must not navigate an existing document tab"
+            ),
+        )
+        opened = {}
+        monkeypatch.setattr(
+            "webbrowser.open",
+            lambda url: opened.setdefault("url", url),
         )
 
         result = actions.reconnect_dashboard_identity()
 
         assert result["ok"] is True
         assert result["reconnected"] is True
-        fallback.assert_called_once()
+        assert opened["url"].endswith("/app/#wb-bootstrap=wbb_test")
 
     def test_falls_back_when_focus_existing_tab_is_unsupported(self, monkeypatch):
         monkeypatch.setattr(
@@ -380,37 +366,20 @@ class TestIdentityReconnect:
                 "details": {"error": "Unknown mutation: focus_existing_tab"},
             },
         )
-        seen = {}
-
-        def prior_worker_focus(
-            url,
-            target_hash="",
-            preserve_path=False,
-            timeout_seconds=15,
-        ):
-            seen.update(
-                url=url,
-                target_hash=target_hash,
-                preserve_path=preserve_path,
-                timeout_seconds=timeout_seconds,
-            )
-            return {
-                "status": "ok",
-                "details": {"created": False, "focused": True},
-            }
-
         monkeypatch.setattr(
             "work_buddy.collectors.chrome_collector.focus_or_create_tab",
-            prior_worker_focus,
+            lambda *args, **kwargs: pytest.fail(
+                "an unsupported worker must not receive the bootstrap fallback"
+            ),
+        )
+        opened = {}
+        monkeypatch.setattr(
+            "webbrowser.open",
+            lambda url: opened.setdefault("url", url),
         )
 
         result = actions.reconnect_dashboard_identity()
 
         assert result["ok"] is True
         assert result["reconnected"] is True
-        assert seen == {
-            "url": "http://127.0.0.1:5127/app/",
-            "target_hash": "#wb-bootstrap=wbb_test",
-            "preserve_path": True,
-            "timeout_seconds": 10,
-        }
+        assert opened["url"].endswith("/app/#wb-bootstrap=wbb_test")

--- a/tests/unit/test_tray_actions.py
+++ b/tests/unit/test_tray_actions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import pytest
 
 from work_buddy.tray import actions
@@ -24,7 +26,10 @@ class TestOpenDashboard:
             seen["url"] = url
             seen["hash"] = target_hash
             seen["preserve_path"] = preserve_path
-            return {"created": False, "focused": True}
+            return {
+                "status": "ok",
+                "details": {"created": False, "focused": True},
+            }
 
         import work_buddy.collectors.chrome_collector as cc
 
@@ -35,7 +40,14 @@ class TestOpenDashboard:
         monkeypatch.setattr(webbrowser, "open", lambda *a, **k: pytest.fail("fallback used"))
 
         res = actions.open_dashboard(actions.ACTIVITY_HASH)
-        assert res == {"ok": True, "via": "extension", "result": {"created": False, "focused": True}}
+        assert res == {
+            "ok": True,
+            "via": "extension",
+            "result": {
+                "status": "ok",
+                "details": {"created": False, "focused": True},
+            },
+        }
         assert seen["url"] == "http://127.0.0.1:5127"
         assert seen["hash"] == "#tab=settings&st=activity"
         assert seen["preserve_path"] is False
@@ -57,7 +69,10 @@ class TestOpenDashboard:
                 preserve_path=preserve_path,
                 timeout_seconds=timeout_seconds,
             )
-            return {"created": False, "focused": True}
+            return {
+                "status": "ok",
+                "details": {"created": False, "focused": True},
+            }
 
         monkeypatch.setattr(
             "work_buddy.collectors.chrome_collector.focus_or_create_tab",
@@ -76,6 +91,53 @@ class TestOpenDashboard:
             "preserve_path": True,
             "timeout_seconds": 10,
         }
+
+    def test_app_launch_fails_closed_when_bootstrap_cannot_be_minted(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            "work_buddy.dashboard.local_identity_launch.bootstrap_fragment_for_dashboard",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("broken")),
+        )
+        monkeypatch.setattr(
+            "work_buddy.collectors.chrome_collector.focus_or_create_tab",
+            lambda *args, **kwargs: pytest.fail("extension launch must not run"),
+        )
+        monkeypatch.setattr(
+            "webbrowser.open",
+            lambda *args, **kwargs: pytest.fail("browser launch must not run"),
+        )
+
+        result = actions.open_dashboard(app=True)
+
+        assert result["ok"] is False
+        assert result["identity_bootstrap"] is False
+        assert "trusted local dashboard session" in result["detail"]
+
+    def test_unconfirmed_extension_result_falls_back_with_bootstrap(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            "work_buddy.dashboard.local_identity_launch.bootstrap_fragment_for_dashboard",
+            lambda app_url, *, next_hash="": "#wb-bootstrap=wbb_test",
+        )
+        monkeypatch.setattr(
+            "work_buddy.collectors.chrome_collector.focus_or_create_tab",
+            lambda *args, **kwargs: {"status": "error", "details": {}},
+        )
+        opened = {}
+        monkeypatch.setattr(
+            "webbrowser.open",
+            lambda url: opened.setdefault("url", url),
+        )
+
+        result = actions.open_dashboard(app=True)
+
+        assert result["ok"] is True
+        assert result["via"] == "webbrowser"
+        assert opened["url"].endswith("/app/#wb-bootstrap=wbb_test")
 
     def test_falls_back_when_extension_times_out(self, monkeypatch):
         import work_buddy.collectors.chrome_collector as cc
@@ -123,3 +185,232 @@ class TestRestartAction:
         res = actions.restart_sidecar()
         assert res["stopped"] is False
         assert started["called"] is False  # never tried to start after a failed stop
+
+    def test_successful_restart_reconnects_an_existing_dashboard_tab(
+        self,
+        monkeypatch,
+    ):
+        from work_buddy.cli import lifecycle
+
+        monkeypatch.setattr(
+            lifecycle,
+            "stop_sidecar",
+            lambda: {"was_running": True, "stopped": True, "detail": "stopped"},
+        )
+        monkeypatch.setattr(
+            lifecycle,
+            "start_sidecar",
+            lambda: {"started": True, "pid": 42, "detail": "started"},
+        )
+        monkeypatch.setattr(actions.time, "sleep", lambda _seconds: None)
+        monkeypatch.setattr(
+            actions,
+            "reconnect_dashboard_identity",
+            lambda: {
+                "ok": True,
+                "reconnected": True,
+                "detail": "reconnected",
+            },
+        )
+
+        result = actions.restart_sidecar()
+
+        assert result["identity_reconnect"]["reconnected"] is True
+
+
+class TestIdentityReconnect:
+    def test_delivers_host_minted_grant_to_existing_tab(self, monkeypatch):
+        seen = {}
+        monkeypatch.setattr(
+            "work_buddy.cli.commands._wait_for_dashboard_app",
+            lambda _url: True,
+        )
+        monkeypatch.setattr(
+            "work_buddy.dashboard.local_identity_launch.bootstrap_fragment_for_dashboard",
+            lambda app_url, *, next_hash="": "#wb-bootstrap=wbb_test",
+        )
+
+        def fake_focus(url, target_hash="", timeout_seconds=15):
+            seen.update(
+                url=url,
+                target_hash=target_hash,
+                timeout_seconds=timeout_seconds,
+            )
+            return {
+                "status": "ok",
+                "details": {"found": True, "created": False, "focused": False},
+            }
+
+        monkeypatch.setattr(
+            "work_buddy.collectors.chrome_collector.focus_existing_tab",
+            fake_focus,
+        )
+
+        result = actions.reconnect_dashboard_identity()
+
+        assert result["ok"] is True
+        assert result["reconnected"] is True
+        assert seen == {
+            "url": "http://127.0.0.1:5127/app/",
+            "target_hash": "#wb-bootstrap=wbb_test",
+            "timeout_seconds": 10,
+        }
+
+    def test_does_not_claim_reconnect_without_correlated_confirmation(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            "work_buddy.cli.commands._wait_for_dashboard_app",
+            lambda _url: True,
+        )
+        monkeypatch.setattr(
+            "work_buddy.dashboard.local_identity_launch.bootstrap_fragment_for_dashboard",
+            lambda app_url, *, next_hash="": "#wb-bootstrap=wbb_test",
+        )
+        monkeypatch.setattr(
+            "work_buddy.collectors.chrome_collector.focus_existing_tab",
+            lambda *args, **kwargs: {},
+        )
+        monkeypatch.setattr(
+            "work_buddy.collectors.chrome_collector.focus_or_create_tab",
+            lambda *args, **kwargs: {},
+        )
+        monkeypatch.setattr("webbrowser.open", lambda _url: False)
+
+        result = actions.reconnect_dashboard_identity()
+
+        assert result["ok"] is False
+        assert result["reconnected"] is False
+        assert "Neither the browser extension" in result["detail"]
+
+    def test_uses_fresh_browser_grant_when_extension_is_unavailable(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            "work_buddy.cli.commands._wait_for_dashboard_app",
+            lambda _url: True,
+        )
+        minted = []
+
+        def mint(app_url, *, next_hash=""):
+            token = f"#wb-bootstrap=wbb_{len(minted) + 1}"
+            minted.append(token)
+            return token
+
+        monkeypatch.setattr(
+            "work_buddy.dashboard.local_identity_launch.bootstrap_fragment_for_dashboard",
+            mint,
+        )
+        monkeypatch.setattr(
+            "work_buddy.collectors.chrome_collector.focus_existing_tab",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "work_buddy.collectors.chrome_collector.focus_or_create_tab",
+            lambda *args, **kwargs: None,
+        )
+        opened = {}
+        monkeypatch.setattr(
+            "webbrowser.open",
+            lambda url: opened.setdefault("url", url),
+        )
+
+        result = actions.reconnect_dashboard_identity()
+
+        assert result["ok"] is True
+        assert result["reconnected"] is True
+        assert minted == [
+            "#wb-bootstrap=wbb_1",
+            "#wb-bootstrap=wbb_2",
+            "#wb-bootstrap=wbb_3",
+        ]
+        assert opened["url"].endswith("/app/#wb-bootstrap=wbb_3")
+
+    def test_confirmed_missing_tab_continues_to_create_a_trusted_session(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            "work_buddy.cli.commands._wait_for_dashboard_app",
+            lambda _url: True,
+        )
+        monkeypatch.setattr(
+            "work_buddy.dashboard.local_identity_launch.bootstrap_fragment_for_dashboard",
+            lambda app_url, *, next_hash="": "#wb-bootstrap=wbb_test",
+        )
+        monkeypatch.setattr(
+            "work_buddy.collectors.chrome_collector.focus_existing_tab",
+            lambda *args, **kwargs: {
+                "status": "ok",
+                "details": {"found": False, "created": False, "focused": False},
+            },
+        )
+        fallback = Mock(
+            return_value={
+                "status": "ok",
+                "details": {"created": True, "focused": False},
+            }
+        )
+        monkeypatch.setattr(
+            "work_buddy.collectors.chrome_collector.focus_or_create_tab",
+            fallback,
+        )
+
+        result = actions.reconnect_dashboard_identity()
+
+        assert result["ok"] is True
+        assert result["reconnected"] is True
+        fallback.assert_called_once()
+
+    def test_falls_back_when_focus_existing_tab_is_unsupported(self, monkeypatch):
+        monkeypatch.setattr(
+            "work_buddy.cli.commands._wait_for_dashboard_app",
+            lambda _url: True,
+        )
+        monkeypatch.setattr(
+            "work_buddy.dashboard.local_identity_launch.bootstrap_fragment_for_dashboard",
+            lambda app_url, *, next_hash="": "#wb-bootstrap=wbb_test",
+        )
+        monkeypatch.setattr(
+            "work_buddy.collectors.chrome_collector.focus_existing_tab",
+            lambda *args, **kwargs: {
+                "status": "error",
+                "details": {"error": "Unknown mutation: focus_existing_tab"},
+            },
+        )
+        seen = {}
+
+        def prior_worker_focus(
+            url,
+            target_hash="",
+            preserve_path=False,
+            timeout_seconds=15,
+        ):
+            seen.update(
+                url=url,
+                target_hash=target_hash,
+                preserve_path=preserve_path,
+                timeout_seconds=timeout_seconds,
+            )
+            return {
+                "status": "ok",
+                "details": {"created": False, "focused": True},
+            }
+
+        monkeypatch.setattr(
+            "work_buddy.collectors.chrome_collector.focus_or_create_tab",
+            prior_worker_focus,
+        )
+
+        result = actions.reconnect_dashboard_identity()
+
+        assert result["ok"] is True
+        assert result["reconnected"] is True
+        assert seen == {
+            "url": "http://127.0.0.1:5127/app/",
+            "target_hash": "#wb-bootstrap=wbb_test",
+            "preserve_path": True,
+            "timeout_seconds": 10,
+        }

--- a/tests/unit/test_wb_cli.py
+++ b/tests/unit/test_wb_cli.py
@@ -7,6 +7,7 @@ sidecar plumbing mocked (no real process spawn or kill).
 
 from __future__ import annotations
 
+import inspect
 import json
 import time
 from unittest.mock import Mock
@@ -155,6 +156,16 @@ def test_launch_does_not_open_a_dead_dashboard(capsys, monkeypatch):
     monkeypatch.setattr(commands, "_wait_for_dashboard_app", lambda url: False)
     assert dispatch.main(["launch"]) == 1
     assert "did not become ready" in capsys.readouterr().err
+
+
+def test_dashboard_startup_timeout_covers_slow_managed_imports():
+    assert commands.DASHBOARD_STARTUP_TIMEOUT_SECONDS == 120.0
+    assert (
+        inspect.signature(commands._wait_for_dashboard_app)
+        .parameters["timeout_seconds"]
+        .default
+        == commands.DASHBOARD_STARTUP_TIMEOUT_SECONDS
+    )
 
 
 def test_launch_operation_returns_open_failure(monkeypatch):

--- a/tests/unit/test_wb_cli.py
+++ b/tests/unit/test_wb_cli.py
@@ -68,6 +68,53 @@ def test_unknown_command_is_usage_error():
     assert dispatch.main(["bogus"]) == 2
 
 
+def test_start_recovers_identity_for_an_existing_dashboard_tab(
+    capsys,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        lifecycle,
+        "start_sidecar",
+        lambda **kwargs: {
+            "started": True,
+            "already_running": False,
+            "pid": 42,
+            "detail": "started",
+        },
+    )
+    monkeypatch.setattr(commands, "_ensure_tray", lambda: None)
+    monkeypatch.setattr(commands, "_print_dashboard_url", lambda prefix="": None)
+    recovered = Mock()
+    monkeypatch.setattr(commands, "_reconnect_open_dashboard_identity", recovered)
+
+    assert dispatch.main(["start"]) == 0
+
+    recovered.assert_called_once_with()
+    assert "Sidecar started" in capsys.readouterr().out
+
+
+def test_restart_recovers_identity_after_dashboard_returns(capsys, monkeypatch):
+    monkeypatch.setattr(
+        lifecycle,
+        "stop_sidecar",
+        lambda: {"was_running": True, "stopped": True, "detail": "stopped"},
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "start_sidecar",
+        lambda: {"started": True, "pid": 84, "detail": "started"},
+    )
+    monkeypatch.setattr(commands.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(commands, "_ensure_tray", lambda: None)
+    recovered = Mock()
+    monkeypatch.setattr(commands, "_reconnect_open_dashboard_identity", recovered)
+
+    assert dispatch.main(["restart"]) == 0
+
+    recovered.assert_called_once_with()
+    assert "Sidecar restarted" in capsys.readouterr().out
+
+
 def test_launch_starts_waits_and_opens_react_app(capsys, monkeypatch):
     monkeypatch.setattr(
         lifecycle,

--- a/tests/unit/truth/test_export_v3.py
+++ b/tests/unit/truth/test_export_v3.py
@@ -18,12 +18,16 @@ from work_buddy.truth.export import (
     export_store,
     import_store,
 )
-from work_buddy.truth.identity import new_id, sha256_bytes, sha256_text
+from work_buddy.truth.identity import canonical_json, new_id, sha256_bytes, sha256_text
 from work_buddy.truth.migrations import REDACTED_SELECTOR_JSON
 from work_buddy.truth.proposals import proposal_canonical_sha256
+from work_buddy.truth.provenance import (
+    attestation_canonical_payload,
+    attestation_canonical_sha256,
+)
 from work_buddy.truth.queries import integrity_findings
 from work_buddy.truth.redact import policy_basis_ref
-from work_buddy.truth.store import TruthStore
+from work_buddy.truth.store import DocumentProvenanceAttestationRecord, TruthStore
 
 
 NOW = "2026-07-17T16:00:00.000+00:00"
@@ -220,7 +224,7 @@ def test_document_surface_round_trips_lossless_including_ydoc_blob(
 
     exported = export_store(source)
     objects = _objects(exported.path.read_bytes())
-    assert objects[0]["format_version"] == FORMAT_VERSION == 9
+    assert objects[0]["format_version"] == FORMAT_VERSION == 10
 
     record_types = {
         item["record_type"]
@@ -478,6 +482,63 @@ def _seeded_objects(tmp_path: Path) -> list[dict[str, Any]]:
     return _objects(export_store(source).path.read_bytes())
 
 
+def _append_valid_span_provenance(
+    store: TruthStore,
+) -> DocumentProvenanceAttestationRecord:
+    contributors = [
+        {
+            "kind": "human",
+            "ref": HUMAN.ref,
+            "identity_status": "local_actor_ref",
+        }
+    ]
+    source = {"kind": "paste", "format": "plain_text"}
+    target_head = sha256_text("frozen structured head")
+    canonical = attestation_canonical_sha256(
+        document_id=DOC_ID,
+        target_kind="document_span",
+        document_version_id=None,
+        document_span_id=SPAN_ID,
+        target_structured_head_sha256=target_head,
+        authorship_kind="human",
+        human_contributors=contributors,
+        review_status="not_applicable",
+        human_reviewers=[],
+        source_kind="paste",
+        source=source,
+        basis_kind="user_attestation",
+        basis_ref=None,
+        supersedes_id=None,
+        attested_by_kind=HUMAN.kind,
+        attested_by_ref=HUMAN.ref,
+        attested_by_meta=None,
+    )
+    record = DocumentProvenanceAttestationRecord(
+        id="aa" * 16,
+        document_id=DOC_ID,
+        target_kind="document_span",
+        document_version_id=None,
+        document_span_id=SPAN_ID,
+        target_structured_head_sha256=target_head,
+        authorship_kind="human",
+        human_contributors_json=canonical_json(contributors),
+        review_status="not_applicable",
+        human_reviewers_json="[]",
+        source_kind="paste",
+        source_json=canonical_json(source),
+        basis_kind="user_attestation",
+        basis_ref=None,
+        supersedes_id=None,
+        idempotency_key="portable-provenance-pair-0001",
+        canonical_sha256=canonical,
+        created_at=NOW,
+        attested_by_kind=HUMAN.kind,
+        attested_by_ref=HUMAN.ref,
+        attested_by_meta_json=None,
+    )
+    return store.append_document_provenance_attestation(record)
+
+
 def _canonical_line(value: dict[str, Any]) -> bytes:
     return (
         json.dumps(
@@ -504,6 +565,67 @@ def _repack(objects: list[dict[str, Any]]) -> bytes:
     footer["last_seq"] = data[-1]["seq"] if data else 0
     footer["stream_sha256"] = sha256_bytes(prefix)
     return prefix + _canonical_line(footer)
+
+
+@pytest.mark.parametrize(
+    ("source_kind", "basis_kind"),
+    [
+        ("direct_entry", "user_attestation"),
+        ("paste", "automatic_direct_entry_attribution"),
+    ],
+)
+def test_import_rejects_canonically_rehashed_invalid_provenance_pair(
+    tmp_path: Path,
+    source_kind: str,
+    basis_kind: str,
+) -> None:
+    source = _create_store(tmp_path / "source", store_id="ba" * 16)
+    _write_blob(source, SNAPSHOT_SHA, SNAPSHOT_BYTES)
+    _insert_document(source)
+    _append_valid_span_provenance(source)
+    objects = _objects(export_store(source).path.read_bytes())
+    item = next(
+        value
+        for value in objects
+        if value["record_type"] == "document_provenance_attestation"
+    )
+    row = item["record"]
+    original_canonical = row["canonical_sha256"]
+    payload = attestation_canonical_payload(
+        document_id=row["document_id"],
+        target_kind=row["target_kind"],
+        document_version_id=row["document_version_id"],
+        document_span_id=row["document_span_id"],
+        target_structured_head_sha256=row["target_structured_head_sha256"],
+        authorship_kind=row["authorship_kind"],
+        human_contributors=row["human_contributors_json"],
+        review_status=row["review_status"],
+        human_reviewers=row["human_reviewers_json"],
+        source_kind=row["source_kind"],
+        source=row["source_json"],
+        basis_kind=row["basis_kind"],
+        basis_ref=row["basis_ref"],
+        supersedes_id=row["supersedes_id"],
+        attested_by_kind=row["attested_by_kind"],
+        attested_by_ref=row["attested_by_ref"],
+        attested_by_meta=row["attested_by_meta_json"],
+    )
+
+    forged_source = json.loads(row["source_json"])
+    forged_source["kind"] = source_kind
+    row["source_kind"] = source_kind
+    row["source_json"] = canonical_json(forged_source)
+    row["basis_kind"] = basis_kind
+    payload["source"] = forged_source
+    payload["basis"]["kind"] = basis_kind
+    row["canonical_sha256"] = sha256_text(canonical_json(payload))
+    assert row["canonical_sha256"] != original_canonical
+
+    target = tmp_path / "target"
+    target.mkdir()
+    with pytest.raises(TruthImportError, match="allowed provenance pair"):
+        import_store(_repack(objects), target, registry=FakeRegistry())
+    assert list(target.iterdir()) == []
 
 
 def test_v3_stream_upcasts_proposal_structured_base_to_null(tmp_path: Path) -> None:

--- a/tests/unit/truth/test_provenance_schema_v10.py
+++ b/tests/unit/truth/test_provenance_schema_v10.py
@@ -1,0 +1,179 @@
+"""Schema-v10 direct-entry provenance basis migration."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from work_buddy.cowork import provenance
+from work_buddy.truth import documents, migrations, ydoc_store
+from work_buddy.truth.contracts import Actor
+from work_buddy.truth.identity import new_id
+from work_buddy.truth.store import TruthStore
+
+
+HUMAN = Actor("human", "schema-v10-user")
+
+
+def _profile() -> dict[str, object]:
+    return {
+        "store_id": new_id(),
+        "profile": "provenance-schema-v10",
+        "title": "Provenance schema v10",
+        "allowed_claim_kinds": ["fact", "preference"],
+        "required_fields": {},
+        "gate": {
+            "rejected_content": "redact",
+            "confirmation_surfaces": ["dashboard"],
+            "block_materialize_on_flags": False,
+        },
+        "projection": "none",
+        "export_committed": True,
+        "document_surface": {
+            "enabled": True,
+            "allowed_document_classes": ["co_authored", "generated"],
+            "feedback_capture": True,
+        },
+    }
+
+
+def _attestation(*, authorship: str, review: str) -> dict[str, object]:
+    contributors = (
+        [
+            {
+                "kind": "current_user",
+                "ref": HUMAN.ref,
+                "identity_status": "local_actor_ref",
+            }
+        ]
+        if authorship in {"human", "mixed"}
+        else []
+    )
+    reviewers = (
+        [
+            {
+                "kind": "current_user",
+                "ref": HUMAN.ref,
+                "identity_status": "local_actor_ref",
+            }
+        ]
+        if review == "reviewed"
+        else []
+    )
+    return {
+        "schema": provenance.INPUT_ATTESTATION_SCHEMA,
+        "authorship": {"kind": authorship, "contributors": contributors},
+        "human_review": {
+            "status": review,
+            "reviewers": reviewers,
+        },
+    }
+
+
+def test_v10_migration_preserves_lineage_and_admits_direct_entry_basis(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    current_runner = migrations.TRUTH_MIGRATIONS
+    v9_runner = migrations._TruthMigrationRunner(
+        "truth",
+        migrations=list(current_runner.migrations[:9]),
+    )
+    monkeypatch.setattr(migrations, "TRUTH_MIGRATIONS", v9_runner)
+
+    root = tmp_path / "v9-store"
+    root.mkdir()
+    store = TruthStore.create(root, _profile())
+    snapshot = b"schema-v10-opaque-ydoc-snapshot"
+    snapshot_sha256 = ydoc_store.write_snapshot(store, snapshot=snapshot)
+    head = ydoc_store.structured_head_from_segments(snapshot, ())
+    document, _version, _created = documents.register_ready_document(
+        store,
+        path="docs/schema-v10.md",
+        title="Schema v10",
+        document_class="co_authored",
+        projection_bytes=b"# Schema v10\n\nExisting AI text.\n",
+        ydoc_snapshot_sha256=snapshot_sha256,
+        structured_head_sha256=head,
+        actor=HUMAN,
+        mode="create",
+    )
+    original, span_id = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="Existing AI text.",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="schema-v9-origin-0001",
+        source={"kind": "paste", "format": "plain_text"},
+        basis_kind="user_attestation",
+        expected_structured_head_sha256=head,
+    )
+    successor = provenance.record_human_review(
+        store,
+        document_id=document.id,
+        attestation_id=original.id,
+        actor=HUMAN,
+        idempotency_key="schema-v9-review-0001",
+        expected_structured_head_sha256=head,
+    )
+    before = store.list_document_provenance_attestations(document.id)
+    assert before == (original, successor)
+    assert successor.supersedes_id == original.id
+    with store.connect() as conn:
+        assert migrations.current_version(conn) == 9
+
+    monkeypatch.setattr(migrations, "TRUTH_MIGRATIONS", current_runner)
+    migrated = TruthStore.open(store.paths.sidecar)
+    after = migrated.list_document_provenance_attestations(document.id)
+
+    assert after == before
+    assert [row.id for row in after] == [original.id, successor.id]
+    assert [row.idempotency_key for row in after] == [
+        "schema-v9-origin-0001",
+        "schema-v9-review-0001",
+    ]
+    assert [row.canonical_sha256 for row in after] == [
+        original.canonical_sha256,
+        successor.canonical_sha256,
+    ]
+    assert after[1].supersedes_id == after[0].id
+    with migrated.connect() as conn:
+        assert migrations.current_version(conn) == 10
+        assert conn.execute(
+            "SELECT schema_version FROM store_info"
+        ).fetchone()[0] == 10
+        table_sql = conn.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'document_provenance_attestations'"
+        ).fetchone()[0]
+        assert "automatic_direct_entry_attribution" in table_sql
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(
+                "UPDATE document_provenance_attestations SET basis_ref = 'changed' "
+                "WHERE id = ?",
+                (original.id,),
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(
+                "DELETE FROM document_provenance_attestations WHERE id = ?",
+                (successor.id,),
+            )
+
+    direct, direct_span_id = provenance.record_span_attestation(
+        migrated,
+        document_id=document.id,
+        exact="Schema v10",
+        attestation=_attestation(authorship="human", review="not_applicable"),
+        actor=HUMAN,
+        idempotency_key="schema-v10-direct-entry-0001",
+        source={"kind": "direct_entry", "format": "plain_text"},
+        basis_kind="automatic_direct_entry_attribution",
+        expected_structured_head_sha256=head,
+    )
+    assert direct.document_span_id == direct_span_id
+    assert direct_span_id != span_id
+    assert direct.source_kind == "direct_entry"
+    assert direct.basis_kind == "automatic_direct_entry_attribution"

--- a/tests/unit/truth/test_source_provenance_schema_v9.py
+++ b/tests/unit/truth/test_source_provenance_schema_v9.py
@@ -239,7 +239,7 @@ def test_v9_records_round_trip_without_promoting_legacy_authorship(tmp_path: Pat
 
     exported = export_store(store)
     header = json.loads(exported.path.read_text(encoding="utf-8").splitlines()[0])
-    assert header["format_version"] == FORMAT_VERSION == 9
+    assert header["format_version"] == FORMAT_VERSION == 10
     target = tmp_path / "target"
     target.mkdir()
     restored = import_store(

--- a/work_buddy/chrome_native_host/host.py
+++ b/work_buddy/chrome_native_host/host.py
@@ -82,9 +82,23 @@ def handle_check() -> None:
     if requested:
         params = _read_request_params()
         # Pass through all known request parameters to the extension
-        for key in ("since", "until", "request_action", "tab_ids", "max_chars",
-                    "mutation", "title", "color", "group_id", "window_id", "index",
-                    "url", "target_hash"):
+        for key in (
+            "request_id",
+            "since",
+            "until",
+            "request_action",
+            "tab_ids",
+            "max_chars",
+            "mutation",
+            "title",
+            "color",
+            "group_id",
+            "window_id",
+            "index",
+            "url",
+            "target_hash",
+            "preserve_path",
+        ):
             if params.get(key) is not None:
                 response[key] = params[key]
 
@@ -152,9 +166,19 @@ def handle_export(message: dict) -> None:
     )
     temp_file.replace(OUTPUT_FILE)
 
-    # Clean up request file
+    # Clean up only the request that produced this response.  A stale native
+    # host reply must never erase a newer browser-launch request that happens
+    # to share the same filesystem rendezvous.
     if REQUEST_FILE.exists():
-        REQUEST_FILE.unlink()
+        current = _read_request_params()
+        current_id = current.get("request_id")
+        response_id = message.get("request_id")
+        if (current_id is None and response_id is None) or (
+            isinstance(current_id, str)
+            and isinstance(response_id, str)
+            and current_id == response_id
+        ):
+            REQUEST_FILE.unlink()
 
     write_message({
         "status": "ok",

--- a/work_buddy/cli/commands.py
+++ b/work_buddy/cli/commands.py
@@ -63,6 +63,7 @@ def cmd_start(args) -> int:
         print(f"Sidecar started (pid={res['pid']}).")
     _print_dashboard_url(prefix="Dashboard: ")
     _ensure_tray()
+    _reconnect_open_dashboard_identity()
     return EXIT_OK
 
 
@@ -89,6 +90,7 @@ def cmd_restart(args) -> int:
     if start["started"]:
         print(f"Sidecar restarted (pid={start['pid']}).")
         _ensure_tray()
+        _reconnect_open_dashboard_identity()
         return EXIT_OK
     _err(start["detail"])
     return EXIT_FAIL
@@ -108,6 +110,25 @@ def _ensure_tray() -> None:
             print(f"Tray: {res.get('detail')}")
     except Exception:
         pass
+
+
+def _reconnect_open_dashboard_identity() -> None:
+    """Best-effort, truthful recovery for a tab surviving start/restart.
+
+    The lifecycle command itself remains successful when no extension is
+    installed, but it must not imply that the browser's stronger identity
+    boundary was restored when the trusted handoff was not acknowledged.
+    """
+
+    try:
+        from work_buddy.tray.actions import reconnect_dashboard_identity
+
+        result = reconnect_dashboard_identity()
+    except Exception as exc:
+        _err(f"Dashboard identity reconnect failed: {exc}")
+        return
+    if not result.get("ok"):
+        _err(f"Dashboard identity reconnect: {result.get('detail', 'failed')}")
 
 
 def cmd_status(args) -> int:

--- a/work_buddy/cli/commands.py
+++ b/work_buddy/cli/commands.py
@@ -689,7 +689,14 @@ def dashboard_app_url(*, local: bool = False) -> str:
     return f"{base.rstrip('/')}/app/"
 
 
-def _wait_for_dashboard_app(url: str, *, timeout_seconds: float = 30.0) -> bool:
+DASHBOARD_STARTUP_TIMEOUT_SECONDS = 120.0
+
+
+def _wait_for_dashboard_app(
+    url: str,
+    *,
+    timeout_seconds: float = DASHBOARD_STARTUP_TIMEOUT_SECONDS,
+) -> bool:
     """Wait until the React dashboard document is actually ready to open."""
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
@@ -747,7 +754,7 @@ def launch_dashboard_app() -> dict:
         return {
             "ok": False,
             "detail": (
-                "Dashboard app did not become ready within 30 seconds. "
+                "Dashboard app did not become ready within 120 seconds. "
                 "Run 'wbuddy status' and try again."
             ),
         }

--- a/work_buddy/collectors/chrome_collector.py
+++ b/work_buddy/collectors/chrome_collector.py
@@ -11,6 +11,7 @@ Two request modes:
 
 import json
 import time
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -20,6 +21,19 @@ from work_buddy.paths import resolve
 
 _REQUEST_FILE = resolve("cache/chrome-request")
 _TABS_FILE = resolve("cache/chrome-tabs")
+
+
+def _remove_request_if_owned(request_id: str) -> None:
+    """Remove only the still-current request written by this caller."""
+
+    if not _REQUEST_FILE.exists():
+        return
+    try:
+        pending = json.loads(_REQUEST_FILE.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return
+    if pending.get("request_id") == request_id:
+        _REQUEST_FILE.unlink(missing_ok=True)
 
 
 def request_tabs(
@@ -38,8 +52,12 @@ def request_tabs(
     """
     old_mtime = _TABS_FILE.stat().st_mtime if _TABS_FILE.exists() else 0
 
-    # Write request file as JSON with optional time range
-    request_data = {"requested_at": datetime.now(timezone.utc).isoformat()}
+    # Write request file as JSON with optional time range.
+    request_id = uuid.uuid4().hex
+    request_data = {
+        "request_id": request_id,
+        "requested_at": datetime.now(timezone.utc).isoformat(),
+    }
     if since:
         request_data["since"] = since
     if until:
@@ -58,14 +76,22 @@ def request_tabs(
                 try:
                     with open(_TABS_FILE, encoding="utf-8") as f:
                         data = json.load(f)
+                    response_id = data.get("request_id")
+                    # Pre-1.3 extension workers did not echo request IDs. Reads
+                    # remain backwards compatible; when an ID is present it
+                    # must match so a newer correlated response cannot cross
+                    # requests.
+                    if response_id is not None and response_id != request_id:
+                        old_mtime = new_mtime
+                        continue
                     _TABS_FILE.unlink(missing_ok=True)
                     return data
                 except (json.JSONDecodeError, OSError):
-                    return None
+                    old_mtime = new_mtime
+                    continue
         time.sleep(0.5)
 
-    if _REQUEST_FILE.exists():
-        _REQUEST_FILE.unlink()
+    _remove_request_if_owned(request_id)
     return None
 
 
@@ -86,7 +112,9 @@ def request_content(
     """
     old_mtime = _TABS_FILE.stat().st_mtime if _TABS_FILE.exists() else 0
 
+    request_id = uuid.uuid4().hex
     request_data = {
+        "request_id": request_id,
         "requested_at": datetime.now(timezone.utc).isoformat(),
         "request_action": "get_content",
         "tab_ids": tab_ids,
@@ -106,14 +134,18 @@ def request_content(
                 try:
                     with open(_TABS_FILE, encoding="utf-8") as f:
                         data = json.load(f)
+                    response_id = data.get("request_id")
+                    if response_id is not None and response_id != request_id:
+                        old_mtime = new_mtime
+                        continue
                     _TABS_FILE.unlink(missing_ok=True)
                     return data.get("tab_contents", [])
                 except (json.JSONDecodeError, OSError):
-                    return None
+                    old_mtime = new_mtime
+                    continue
         time.sleep(0.5)
 
-    if _REQUEST_FILE.exists():
-        _REQUEST_FILE.unlink()
+    _remove_request_if_owned(request_id)
     return None
 
 
@@ -286,8 +318,10 @@ def _request_mutation(
         Mutation result dict, or None if Chrome doesn't respond.
     """
     old_mtime = _TABS_FILE.stat().st_mtime if _TABS_FILE.exists() else 0
+    request_id = uuid.uuid4().hex
 
     request_data = {
+        "request_id": request_id,
         "requested_at": datetime.now(timezone.utc).isoformat(),
         "request_action": "mutate",
         "mutation": mutation,
@@ -304,17 +338,32 @@ def _request_mutation(
         if _TABS_FILE.exists():
             new_mtime = _TABS_FILE.stat().st_mtime
             if new_mtime > old_mtime:
+                old_mtime = new_mtime
                 try:
                     with open(_TABS_FILE, encoding="utf-8") as f:
                         data = json.load(f)
+                    # The snapshot file is shared with periodic/on-demand tab
+                    # exports.  Only a response carrying our nonce proves that
+                    # this launch mutation was actually handled; accepting an
+                    # unrelated write here can strand a one-use identity grant
+                    # while the caller falsely reports a successful reconnect.
+                    response_id = data.get("request_id")
+                    identity_handoff = mutation in {
+                        "focus_existing_tab",
+                        "focus_or_create_tab",
+                    }
+                    if response_id != request_id and (
+                        identity_handoff or response_id is not None
+                    ):
+                        continue
                     _TABS_FILE.unlink(missing_ok=True)
-                    return data.get("mutation_result", {})
+                    result = data.get("mutation_result")
+                    return result if isinstance(result, dict) else None
                 except (json.JSONDecodeError, OSError):
-                    return None
+                    continue
         time.sleep(0.5)
 
-    if _REQUEST_FILE.exists():
-        _REQUEST_FILE.unlink()
+    _remove_request_if_owned(request_id)
     return None
 
 
@@ -407,4 +456,27 @@ def focus_or_create_tab(
         url=match_url,
         target_hash=target_hash,
         preserve_path=preserve_path,
+    )
+
+
+def focus_existing_tab(
+    url: str,
+    target_hash: str = "",
+    timeout_seconds: int = 15,
+) -> dict | None:
+    """Deliver a fragment to an existing dashboard tab without opening one.
+
+    This is the quiet trusted-host recovery path used by deliberate sidecar
+    start/restart operations.  The extension preserves the tab's path/query,
+    does not activate it, and reports ``found=false`` when no matching app tab
+    exists.  A new mutation name makes older extensions fail closed instead of
+    accidentally creating a browser tab while interpreting newer options.
+    """
+
+    match_url = url.rstrip("/") or url
+    return _request_mutation(
+        "focus_existing_tab",
+        timeout_seconds,
+        url=match_url,
+        target_hash=target_hash,
     )

--- a/work_buddy/cowork/api.py
+++ b/work_buddy/cowork/api.py
@@ -70,7 +70,7 @@ from work_buddy.truth.anchors import CompositeSelector
 from work_buddy.truth.contracts import Actor, InvariantViolation
 from work_buddy.truth.events import emit_truth_event
 from work_buddy.truth.expressions import ensure_document_span
-from work_buddy.truth.identity import canonical_json, parse_truth_uri, sha256_text
+from work_buddy.truth.identity import parse_truth_uri, sha256_text
 from work_buddy.truth.registry import TruthStoreRegistry
 from work_buddy.truth.store import DocumentRecord, TruthStore
 
@@ -122,14 +122,22 @@ def cowork_mutation_context_sha256(
 ) -> str:
     """Canonical exact-body digest shared by Co-work gesture-gated routes."""
 
+    # Do not use Truth's semantic ``canonical_json`` here: it deliberately
+    # collapses whitespace inside strings. Human authority binds the bytes of
+    # the request values, including the newlines in quote-anchor context, and
+    # mirrors canonicalHumanAuthorityJson in the browser.
     return sha256_text(
-        canonical_json(
+        json.dumps(
             {
                 "body": {} if body is None else dict(body),
                 "document_id": document_id,
                 "operation": operation,
                 "store_id": store_id,
-            }
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
         )
     )
 

--- a/work_buddy/cowork/api.py
+++ b/work_buddy/cowork/api.py
@@ -172,7 +172,11 @@ def _local_identity_error(exc: LocalIdentityError):
 def api_cowork_current_actor():
     """Expose the immutable identity binding used by provenance ``Me`` values."""
     try:
-        principal = authenticate_request_session()
+        # This is an informational read, not a protected human action.  Keep
+        # the actor binding available when a valid session has reached its
+        # rotation boundary; the subsequent gesture-gated mutation still
+        # requires and performs rotation before it can proceed.
+        principal = authenticate_request_session(allow_rotation_due=True)
     except LocalIdentityError as exc:
         return _local_identity_error(exc)
     return jsonify(

--- a/work_buddy/cowork/api.py
+++ b/work_buddy/cowork/api.py
@@ -82,7 +82,6 @@ cowork_blueprint = Blueprint("cowork", __name__)
 # dashboard surface must NOT reuse it: a real dashboard user threads through
 # instead (I17). Kept here only to document the boundary it must not cross.
 _MCP_HUMAN_REF = "work-buddy-user"
-_AUTOMATIC_PASTE_MAX_CHARS = 599
 _PROVENANCE_EXACT_MAX_CHARS = 1_000_000
 _PROVENANCE_CONTEXT_MAX_CHARS = 2_048
 
@@ -1821,6 +1820,11 @@ def api_doc_authorship_attestation(document_id: str):
     expected_head = body.get("expected_structured_head_sha256")
     idempotency_key = body.get("idempotency_key")
     basis_kind = body.get("basis_kind", "user_attestation")
+    # Compatibility: this endpoint was paste-only before source_kind existed.
+    # Older/cached clients therefore mean paste when the field is omitted.
+    source_kind = body.get("source_kind", "paste")
+    expected_actor_ref = body.get("expected_actor_ref")
+    expected_actor_identity_status = body.get("expected_actor_identity_status")
     if not isinstance(span, dict):
         return _fail("span must be an object", 400)
     exact = span.get("exact")
@@ -1843,11 +1847,30 @@ def api_doc_authorship_attestation(document_id: str):
         return _fail("expected_structured_head_sha256 is required", 400)
     if not isinstance(idempotency_key, str) or not idempotency_key:
         return _fail("idempotency_key is required", 400)
-    if basis_kind not in {
-        "automatic_short_text_attribution",
-        "user_attestation",
+    if not isinstance(source_kind, str) or source_kind not in {
+        "paste",
+        "direct_entry",
+        "legacy",
     }:
+        return _fail("source_kind is invalid", 400)
+    if not isinstance(basis_kind, str):
         return _fail("basis_kind is invalid", 400)
+    if (source_kind, basis_kind) not in provenance.SPAN_SOURCE_BASIS_PAIRS:
+        return _fail("source_kind and basis_kind are not an allowed pair", 400)
+    expects_actor = (
+        source_kind in {"direct_entry", "legacy"}
+        or expected_actor_ref is not None
+        or expected_actor_identity_status is not None
+    )
+    if expects_actor and (
+        not isinstance(expected_actor_ref, str)
+        or not expected_actor_ref
+        or expected_actor_identity_status not in {"local_actor_ref", "account_ref"}
+    ):
+        return _fail(
+            "expected_actor_ref and expected_actor_identity_status are required",
+            400,
+        )
 
     try:
         _authority_context, actor = _require_human_action(
@@ -1859,18 +1882,34 @@ def api_doc_authorship_attestation(document_id: str):
     except LocalIdentityError as exc:
         return _local_identity_error(exc)
     try:
+        if expects_actor:
+            acting_binding = provenance.actor_binding(actor)
+            if (
+                acting_binding["ref"] != expected_actor_ref
+                or acting_binding["identity_status"]
+                != expected_actor_identity_status
+            ):
+                raise provenance.ProvenanceActorBindingError(
+                    "The acting identity changed after provenance was captured."
+                )
         normalized_attestation = provenance.normalize_attestation(
             attestation,
             actor=actor,
         )
-        if basis_kind == "automatic_short_text_attribution":
+        if basis_kind in {
+            "automatic_short_text_attribution",
+            "automatic_direct_entry_attribution",
+        }:
             expected_contributor = {
                 "kind": "human",
                 "ref": actor.ref,
             }
             contributors = normalized_attestation["authorship"]["contributors"]
             if (
-                len(exact) > _AUTOMATIC_PASTE_MAX_CHARS
+                (
+                    basis_kind == "automatic_short_text_attribution"
+                    and len(exact) > provenance.AUTOMATIC_SHORT_TEXT_MAX_CHARS
+                )
                 or normalized_attestation["authorship"]["kind"] != "human"
                 or len(contributors) != 1
                 or contributors[0].get("kind") != expected_contributor["kind"]
@@ -1879,11 +1918,14 @@ def api_doc_authorship_attestation(document_id: str):
                 != "not_applicable"
                 or normalized_attestation["human_review"]["reviewers"]
             ):
-                return _fail(
+                message = (
                     "automatic short-text attribution is only available for "
-                    "short text authored by the acting user",
-                    400,
+                    "short text authored by the acting user"
+                    if basis_kind == "automatic_short_text_attribution"
+                    else "automatic direct-entry attribution is only available "
+                    "for text authored by the acting user"
                 )
+                return _fail(message, 400)
         from work_buddy.consent import user_initiated
 
         with user_initiated("dashboard.cowork.provenance_attestation"):
@@ -1896,7 +1938,7 @@ def api_doc_authorship_attestation(document_id: str):
                 attestation=attestation,
                 actor=actor,
                 idempotency_key=idempotency_key,
-                source={"kind": "paste", "format": "plain_text"},
+                source={"kind": source_kind, "format": "plain_text"},
                 basis_kind=basis_kind,
                 expected_structured_head_sha256=expected_head,
             )

--- a/work_buddy/cowork/proposal_applicability.py
+++ b/work_buddy/cowork/proposal_applicability.py
@@ -156,6 +156,31 @@ def load_current_projection(
     )
 
 
+def _supplemental_application_context(
+    proposal: Any,
+    current_projection: CurrentProjection | None,
+) -> tuple[int | None, int | None, str | None]:
+    """Resolve a position when available without changing same-state gating."""
+
+    if current_projection is None:
+        return None, None, None
+    try:
+        resolved = reanchor(
+            current_projection.text,
+            CompositeSelector.from_json(proposal.selector_json),
+        )
+    except AnchorError:
+        # A matching structured head or materialized baseline remains the
+        # authoritative applicability proof.  Resolution is supplemental
+        # context for exact post-apply provenance, not a new gate.
+        return None, None, current_projection.projection_sha256
+    return (
+        resolved.start,
+        resolved.end,
+        current_projection.projection_sha256,
+    )
+
+
 def assess_proposal_applicability(
     proposal: Any,
     document: DocumentRecord,
@@ -178,15 +203,27 @@ def assess_proposal_applicability(
         and structured_head_sha256 is not None
         and proposal_head == structured_head_sha256
     ):
+        resolved_start, resolved_end, current_projection_sha256 = (
+            _supplemental_application_context(proposal, current_projection)
+        )
         return ProposalApplicability(
             status="applicable",
             reason="same_structured_head",
+            resolved_start=resolved_start,
+            resolved_end=resolved_end,
+            current_projection_sha256=current_projection_sha256,
             current_structured_head_sha256=structured_head_sha256,
         )
     if proposal_head is None and proposal.base_content_sha256 == document.content_sha256:
+        resolved_start, resolved_end, current_projection_sha256 = (
+            _supplemental_application_context(proposal, current_projection)
+        )
         return ProposalApplicability(
             status="applicable",
             reason="same_materialized_baseline",
+            resolved_start=resolved_start,
+            resolved_end=resolved_end,
+            current_projection_sha256=current_projection_sha256,
             current_structured_head_sha256=structured_head_sha256,
         )
     if current_projection is None:

--- a/work_buddy/cowork/provenance.py
+++ b/work_buddy/cowork/provenance.py
@@ -777,6 +777,8 @@ def _proposal_projection_candidates(rendered_projection: str) -> tuple[str, ...]
 
 def _proposal_acceptance_segment_selectors(
     proposal: ProposalRecord,
+    *,
+    post_apply_start: int | None = None,
 ) -> tuple[CompositeSelector, ...]:
     """Return only the text the proposing agent added or replaced.
 
@@ -788,6 +790,14 @@ def _proposal_acceptance_segment_selectors(
     so the operation fails closed instead of guessing.
     """
 
+    if post_apply_start is not None and (
+        isinstance(post_apply_start, bool)
+        or not isinstance(post_apply_start, int)
+        or post_apply_start < 0
+    ):
+        raise ProposalAcceptanceProvenanceError(
+            "The accepted proposal has an invalid application position."
+        )
     if proposal.replacement in {None, ""}:
         return ()
     if proposal.quote_exact is None:
@@ -847,6 +857,16 @@ def _proposal_acceptance_segment_selectors(
                 exact=exact,
                 prefix=prefix,
                 suffix=suffix,
+                start=(
+                    None
+                    if post_apply_start is None
+                    else post_apply_start + start
+                ),
+                end=(
+                    None
+                    if post_apply_start is None
+                    else post_apply_start + end
+                ),
             )
         )
     return tuple(selectors)
@@ -861,6 +881,7 @@ def record_proposal_acceptance_attestations_locked(
     actor: Actor,
     target_structured_head_sha256: str,
     rendered_projection: str,
+    post_apply_start: int | None = None,
     at: str | None = None,
 ) -> tuple[DocumentProvenanceAttestationRecord, ...]:
     """Atomically attribute a confirmed agent proposal on its resulting head.
@@ -940,7 +961,10 @@ def record_proposal_acceptance_attestations_locked(
     except InvariantViolation as exc:
         raise ProposalAcceptanceProvenanceError(str(exc)) from exc
 
-    selectors = _proposal_acceptance_segment_selectors(proposal)
+    selectors = _proposal_acceptance_segment_selectors(
+        proposal,
+        post_apply_start=post_apply_start,
+    )
     # Prove every derived selector against the exact projection that produced
     # target_head before appending any rows. This makes a multi-segment
     # insertion all-or-nothing even for callers that catch this typed error.
@@ -951,19 +975,32 @@ def record_proposal_acceptance_attestations_locked(
             rendered_projection
         ):
             try:
-                resolved = reanchor(projection_candidate, selector)
-                break
+                candidate = reanchor(projection_candidate, selector)
             except Exception as exc:  # noqa: BLE001 - try visible Markdown
                 last_error = exc
+                continue
+            if candidate.exact != selector.exact:
+                last_error = ProposalAcceptanceProvenanceError(
+                    "The accepted AI-authored span changed before provenance "
+                    "was recorded."
+                )
+                continue
+            if selector.has_position and (
+                candidate.start != selector.start
+                or candidate.end != selector.end
+            ):
+                last_error = ProposalAcceptanceProvenanceError(
+                    "The accepted AI-authored span is not at its committed "
+                    "application position."
+                )
+                continue
+            resolved = candidate
+            break
         if resolved is None:
             raise ProposalAcceptanceProvenanceError(
                 "The accepted AI-authored span could not be resolved uniquely "
                 "in the committed document."
             ) from last_error
-        if resolved.exact != selector.exact:
-            raise ProposalAcceptanceProvenanceError(
-                "The accepted AI-authored span changed before provenance was recorded."
-            )
 
     normalized_attestation = {
         "authorship": {"kind": "ai", "contributors": []},

--- a/work_buddy/cowork/provenance.py
+++ b/work_buddy/cowork/provenance.py
@@ -21,6 +21,7 @@ from work_buddy.truth.provenance import (
     PROVENANCE_BASIS_KINDS,
     PROVENANCE_REVIEW_STATUSES,
     PROVENANCE_SOURCE_KINDS,
+    PROVENANCE_SPAN_SOURCE_BASIS_PAIRS,
     attestation_canonical_sha256,
     normalize_source,
 )
@@ -41,6 +42,8 @@ INPUT_ATTESTATION_SCHEMA = "cowork-authorship-attestation/v1"
 CURRENT_USER_IDENTITY_STATUSES = frozenset(
     {"local_actor_ref", "account_ref"}
 )
+SPAN_SOURCE_BASIS_PAIRS = PROVENANCE_SPAN_SOURCE_BASIS_PAIRS
+AUTOMATIC_SHORT_TEXT_MAX_CHARS = 599
 
 
 class ProvenanceActorBindingError(InvariantViolation):
@@ -550,7 +553,12 @@ def record_span_attestation(
     expected_structured_head_sha256: str | None = None,
     at: str | None = None,
 ) -> tuple[DocumentProvenanceAttestationRecord, str]:
-    """Anchor one pasted range and attest its authorship and review state."""
+    """Anchor one exact range and attest its authorship and review state.
+
+    The source/basis pair is deliberately closed.  In particular, a caller
+    cannot describe selected legacy text as direct entry or use a generic user
+    attestation to manufacture the stronger direct-entry observation.
+    """
 
     if actor.kind != "human" or not actor.ref:
         raise InvariantViolation("provenance attestation requires a human actor")
@@ -559,6 +567,33 @@ def record_span_attestation(
     key = _idempotency_key(idempotency_key)
     document_ref = _valid_record_id(document_id, "document_id")
     source_value = source or {"kind": "paste", "format": "plain_text"}
+    normalized_source = _source(source_value)
+    source_basis = (normalized_source["kind"], basis_kind)
+    if source_basis not in SPAN_SOURCE_BASIS_PAIRS:
+        raise InvariantViolation(
+            "source.kind and basis_kind are not an allowed provenance pair"
+        )
+    if basis_kind in {
+        "automatic_short_text_attribution",
+        "automatic_direct_entry_attribution",
+    }:
+        current_actor = actor_binding(actor)
+        if (
+            normalized["authorship"]["kind"] != "human"
+            or normalized["authorship"]["contributors"] != [current_actor]
+            or normalized["human_review"]
+            != {"status": "not_applicable", "reviewers": []}
+        ):
+            raise InvariantViolation(
+                "automatic attribution requires text authored by the acting user"
+            )
+        if (
+            basis_kind == "automatic_short_text_attribution"
+            and len(exact) > AUTOMATIC_SHORT_TEXT_MAX_CHARS
+        ):
+            raise InvariantViolation(
+                "automatic short-text attribution exceeds the size limit"
+            )
     expected_head = (
         None
         if expected_structured_head_sha256 is None
@@ -628,7 +663,7 @@ def record_span_attestation(
                         conn,
                         document_id=document.id,
                         attestation=attestation,
-                        source=source_value,
+                        source=normalized_source,
                         actor=actor,
                         idempotency_key=key,
                         target_kind="document_span",
@@ -686,7 +721,7 @@ def record_span_attestation(
                     conn,
                     document_id=document.id,
                     attestation=attestation,
-                    source=source_value,
+                    source=normalized_source,
                     actor=actor,
                     idempotency_key=key,
                     target_kind="document_span",
@@ -1340,12 +1375,14 @@ def record_human_review(
 
 __all__ = [
     "ATTESTATION_SCHEMA",
+    "AUTOMATIC_SHORT_TEXT_MAX_CHARS",
     "AUTHORSHIP_KINDS",
     "CURRENT_USER_IDENTITY_STATUSES",
     "ProvenanceActorBindingError",
     "ProvenanceConflictError",
     "ProvenanceReviewError",
     "REVIEW_STATUSES",
+    "SPAN_SOURCE_BASIS_PAIRS",
     "actor_binding",
     "list_attestations",
     "normalize_attestation",

--- a/work_buddy/cowork/provenance.py
+++ b/work_buddy/cowork/provenance.py
@@ -11,8 +11,12 @@ from typing import Any
 from work_buddy.cowork.lifecycle_lock import document_lifecycle_lock
 from work_buddy.cowork.policy import document_surface_allowed
 from work_buddy.truth import documents, ydoc_store
-from work_buddy.truth.anchors import CompositeSelector, serialize_selector
-from work_buddy.truth.contracts import Actor, InvariantViolation
+from work_buddy.truth.anchors import CompositeSelector, reanchor, serialize_selector
+from work_buddy.truth.contracts import (
+    Actor,
+    InvariantViolation,
+    validate_agent_producer_meta,
+)
 from work_buddy.truth.expressions import _ensure_document_span_locked
 from work_buddy.truth.identity import canonical_json, sha256_text
 from work_buddy.truth.provenance import (
@@ -27,6 +31,7 @@ from work_buddy.truth.provenance import (
 )
 from work_buddy.truth.store import (
     DocumentProvenanceAttestationRecord,
+    ProposalRecord,
     TruthStore,
     _timestamp,
     _valid_digest,
@@ -77,6 +82,15 @@ class ProvenanceConflictError(InvariantViolation):
         self.details = {
             "existing_attestation_id": existing_attestation_id,
         }
+
+
+class ProposalAcceptanceProvenanceError(InvariantViolation):
+    """An accepted edit cannot be attributed without guessing.
+
+    This error is deliberately narrower than a generic malformed attestation.
+    The two-phase sitting path turns it into a transaction-wide conflict so an
+    accepted AI edit and its provenance can never commit independently.
+    """
 
 
 class ProvenanceReviewError(InvariantViolation):
@@ -736,6 +750,311 @@ def record_span_attestation(
                 return event, span.id
 
 
+_PROPOSAL_ACCEPTANCE_CONTEXT_MAX_CHARS = 2_048
+_COMMONMARK_ESCAPED_PUNCTUATION_RE = re.compile(
+    r"\\([!\"#$%&'()*+,\-./:;<=>?@\[\\\]^_`{|}~])"
+)
+
+
+def _proposal_projection_candidates(rendered_projection: str) -> tuple[str, ...]:
+    """Return conservative server views of a serialized Markdown projection.
+
+    A proposal replacement is inserted as literal editor text. The canonical
+    Markdown serializer may therefore backslash-escape punctuation (``*`` ->
+    ``\\*``), while the provenance selector must continue to name the visible
+    text. Validate the exact serialized projection first, then the one
+    CommonMark-safe unescape the browser's canonical parser will expose.
+    """
+
+    visible_punctuation = _COMMONMARK_ESCAPED_PUNCTUATION_RE.sub(
+        r"\1",
+        rendered_projection,
+    )
+    if visible_punctuation == rendered_projection:
+        return (rendered_projection,)
+    return rendered_projection, visible_punctuation
+
+
+def _proposal_acceptance_segment_selectors(
+    proposal: ProposalRecord,
+) -> tuple[CompositeSelector, ...]:
+    """Return only the text the proposing agent added or replaced.
+
+    A common insertion proposal replaces ``original`` with
+    ``new text + original``. Treating the complete replacement as AI-authored
+    would silently relabel the preserved original. When the original occurs
+    exactly once, the text on either side is mechanically attributable to the
+    proposal. Multiple occurrences cannot identify which copy is preserved,
+    so the operation fails closed instead of guessing.
+    """
+
+    if proposal.replacement in {None, ""}:
+        return ()
+    if proposal.quote_exact is None:
+        raise ProposalAcceptanceProvenanceError(
+            "The accepted proposal no longer carries its original quote."
+        )
+    try:
+        original_selector = CompositeSelector.from_json(proposal.selector_json)
+    except Exception as exc:  # noqa: BLE001 - corrupt anchors fail closed
+        raise ProposalAcceptanceProvenanceError(
+            "The accepted proposal has an invalid quote anchor."
+        ) from exc
+    if original_selector.exact != proposal.quote_exact:
+        raise ProposalAcceptanceProvenanceError(
+            "The accepted proposal quote does not match its frozen anchor."
+        )
+
+    replacement = proposal.replacement
+    original = proposal.quote_exact
+    occurrences: list[int] = []
+    cursor = replacement.find(original)
+    while cursor >= 0:
+        occurrences.append(cursor)
+        cursor = replacement.find(original, cursor + 1)
+    if len(occurrences) > 1:
+        raise ProposalAcceptanceProvenanceError(
+            "The accepted replacement repeats the original quote, so its "
+            "AI-authored insertion cannot be identified without guessing."
+        )
+
+    ranges = (
+        ((0, len(replacement)),)
+        if not occurrences
+        else (
+            (0, occurrences[0]),
+            (occurrences[0] + len(original), len(replacement)),
+        )
+    )
+    selectors: list[CompositeSelector] = []
+    for raw_start, raw_end in ranges:
+        raw = replacement[raw_start:raw_end]
+        if not raw.strip():
+            continue
+        leading = len(raw) - len(raw.lstrip())
+        trailing = len(raw) - len(raw.rstrip())
+        start = raw_start + leading
+        end = raw_end - trailing
+        exact = replacement[start:end]
+        prefix = (original_selector.prefix + replacement[:start])[
+            -_PROPOSAL_ACCEPTANCE_CONTEXT_MAX_CHARS:
+        ]
+        suffix = (replacement[end:] + original_selector.suffix)[
+            :_PROPOSAL_ACCEPTANCE_CONTEXT_MAX_CHARS
+        ]
+        selectors.append(
+            CompositeSelector(
+                exact=exact,
+                prefix=prefix,
+                suffix=suffix,
+            )
+        )
+    return tuple(selectors)
+
+
+def record_proposal_acceptance_attestations_locked(
+    store: TruthStore,
+    conn: sqlite3.Connection,
+    *,
+    proposal: ProposalRecord,
+    gesture_id: str,
+    actor: Actor,
+    target_structured_head_sha256: str,
+    rendered_projection: str,
+    at: str | None = None,
+) -> tuple[DocumentProvenanceAttestationRecord, ...]:
+    """Atomically attribute a confirmed agent proposal on its resulting head.
+
+    The human confirmation is the basis for recording AI authorship; it is not
+    itself a human review of the resulting prose. The immutable proposal keeps
+    the producing agent-run identity, while the attestation's human actor and
+    consumed gesture preserve who accepted the edit.
+    """
+
+    if actor.kind != "human" or not actor.ref:
+        raise ProposalAcceptanceProvenanceError(
+            "Proposal acceptance provenance requires a human actor."
+        )
+    if proposal.created_by_kind != "agent_run" or not str(
+        proposal.created_by_ref or ""
+    ).strip():
+        return ()
+    if not isinstance(rendered_projection, str):
+        raise ProposalAcceptanceProvenanceError(
+            "The accepted document projection is unavailable."
+        )
+    target_head = _valid_digest(
+        target_structured_head_sha256,
+        "target_structured_head_sha256",
+    )
+    if proposal.document_id != _valid_record_id(
+        proposal.document_id,
+        "proposal.document_id",
+    ):
+        raise ProposalAcceptanceProvenanceError(
+            "The accepted proposal has an invalid document target."
+        )
+    document = store._get_document_locked(conn, proposal.document_id)
+    if document is None:
+        raise ProposalAcceptanceProvenanceError(
+            "The accepted proposal's document is unavailable."
+        )
+
+    gesture_ref = _valid_record_id(gesture_id, "gesture_id")
+    gesture = store._get_gesture_locked(conn, gesture_ref)
+    if (
+        gesture is None
+        or gesture.subject_ref != proposal.id
+        or gesture.kind != "confirm"
+        or gesture.actor_ref != actor.ref
+        or gesture.payload_sha256 != proposal.canonical_sha256
+        or gesture.consumed_at is None
+    ):
+        raise ProposalAcceptanceProvenanceError(
+            "The proposal acceptance gesture is missing or does not match the edit."
+        )
+    latest = store._latest_proposal_status_locked(conn, proposal.id)
+    if (
+        latest is None
+        or latest.status != "applied"
+        or latest.decision != "confirm"
+        or latest.basis_kind != "gesture"
+        or latest.basis_ref != gesture.id
+    ):
+        raise ProposalAcceptanceProvenanceError(
+            "The proposal is not bound to the confirmed acceptance gesture."
+        )
+
+    try:
+        producer_meta = json.loads(proposal.meta_json or "{}")
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ProposalAcceptanceProvenanceError(
+            "The accepted proposal has invalid producer metadata."
+        ) from exc
+    if not isinstance(producer_meta, Mapping):
+        raise ProposalAcceptanceProvenanceError(
+            "The accepted proposal has invalid producer metadata."
+        )
+    try:
+        validate_agent_producer_meta(producer_meta)
+    except InvariantViolation as exc:
+        raise ProposalAcceptanceProvenanceError(str(exc)) from exc
+
+    selectors = _proposal_acceptance_segment_selectors(proposal)
+    # Prove every derived selector against the exact projection that produced
+    # target_head before appending any rows. This makes a multi-segment
+    # insertion all-or-nothing even for callers that catch this typed error.
+    for selector in selectors:
+        resolved = None
+        last_error: Exception | None = None
+        for projection_candidate in _proposal_projection_candidates(
+            rendered_projection
+        ):
+            try:
+                resolved = reanchor(projection_candidate, selector)
+                break
+            except Exception as exc:  # noqa: BLE001 - try visible Markdown
+                last_error = exc
+        if resolved is None:
+            raise ProposalAcceptanceProvenanceError(
+                "The accepted AI-authored span could not be resolved uniquely "
+                "in the committed document."
+            ) from last_error
+        if resolved.exact != selector.exact:
+            raise ProposalAcceptanceProvenanceError(
+                "The accepted AI-authored span changed before provenance was recorded."
+            )
+
+    normalized_attestation = {
+        "authorship": {"kind": "ai", "contributors": []},
+        "human_review": {"status": "not_reviewed", "reviewers": []},
+    }
+    producer = {
+        "kind": "agent_run",
+        "ref": str(proposal.created_by_ref),
+        **dict(producer_meta),
+    }
+    records: list[DocumentProvenanceAttestationRecord] = []
+    for index, selector in enumerate(selectors):
+        key = f"proposal-acceptance:{proposal.id}:{index:04d}"
+        identifier = _attestation_id(
+            store_id=store.store_id,
+            document_id=proposal.document_id,
+            actor_ref=actor.ref,
+            idempotency_key=key,
+        )
+        existing = store._get_document_provenance_attestation_locked(
+            conn,
+            identifier,
+        )
+        if existing is None:
+            span = _ensure_document_span_locked(
+                store,
+                conn,
+                document_id=proposal.document_id,
+                selector=selector,
+                quote_exact=selector.exact,
+                actor=actor,
+                author_kind="agent_run",
+                author_ref=proposal.created_by_ref,
+                at=at,
+                reuse_existing=False,
+            )
+            span_id = span.id
+        else:
+            if existing.document_span_id is None:
+                raise ProposalAcceptanceProvenanceError(
+                    "Proposal acceptance idempotency points to a non-span target."
+                )
+            span = store._get_document_span_locked(
+                conn,
+                existing.document_span_id,
+            )
+            if (
+                span is None
+                or span.document_id != proposal.document_id
+                or span.quote_exact != selector.exact
+                or span.selector_json != serialize_selector(selector)
+            ):
+                raise ProposalAcceptanceProvenanceError(
+                    "Proposal acceptance idempotency points to another span."
+                )
+            span_id = existing.document_span_id
+
+        source = {
+            "kind": "proposal_acceptance",
+            "proposal_id": proposal.id,
+            "proposal_canonical_sha256": proposal.canonical_sha256,
+            "accepted_replacement_sha256": sha256_text(
+                proposal.replacement or ""
+            ),
+            "acceptance_gesture_id": gesture.id,
+            "segment_index": index,
+            "segment_count": len(selectors),
+            "producer": producer,
+        }
+        record = _record_attestation_locked(
+            store,
+            conn,
+            document_id=proposal.document_id,
+            attestation={},
+            normalized_attestation=normalized_attestation,
+            source=source,
+            actor=actor,
+            idempotency_key=key,
+            target_kind="document_span",
+            document_version_id=None,
+            document_span_id=span_id,
+            target_structured_head_sha256=target_head,
+            basis_kind="proposal_acceptance",
+            basis_ref=gesture.id,
+            supersedes_id=None,
+            at=at,
+        )
+        records.append(record)
+    return tuple(records)
+
+
 def portable_attestation(
     row: DocumentProvenanceAttestationRecord,
 ) -> dict[str, Any]:
@@ -1381,6 +1700,7 @@ __all__ = [
     "ProvenanceActorBindingError",
     "ProvenanceConflictError",
     "ProvenanceReviewError",
+    "ProposalAcceptanceProvenanceError",
     "REVIEW_STATUSES",
     "SPAN_SOURCE_BASIS_PAIRS",
     "actor_binding",
@@ -1390,5 +1710,6 @@ __all__ = [
     "project_attestations",
     "record_document_attestation",
     "record_human_review",
+    "record_proposal_acceptance_attestations_locked",
     "record_span_attestation",
 ]

--- a/work_buddy/cowork/sitting_lifecycle.py
+++ b/work_buddy/cowork/sitting_lifecycle.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping
 
-from work_buddy.cowork import materialization, sittings
+from work_buddy.cowork import materialization, provenance, sittings
 from work_buddy.cowork.lifecycle_state import inspect_lifecycle_state
 from work_buddy.cowork.policy import document_surface_allowed
 from work_buddy.cowork.proposal_applicability import (
@@ -544,6 +544,61 @@ def commit_sitting(
             results, events = _commit_decisions(
                 store, document, actor, current_intent, conn, at=str(projection_receipt["materialized_at"])
             )
+            result_by_proposal = {
+                str(result.get("proposal_id")): result for result in results
+            }
+            for entry in current_intent.admitted:
+                item = entry["item"]
+                if item.get("verb") != "confirm":
+                    continue
+                proposal_id = str(item["proposal_id"])
+                result = result_by_proposal.get(proposal_id)
+                if result is None or result.get("result") != "applied":
+                    continue
+                accepted = proposals.get_proposal(
+                    store,
+                    proposal_id,
+                    conn=conn,
+                )
+                try:
+                    attestations = (
+                        provenance.record_proposal_acceptance_attestations_locked(
+                            store,
+                            conn,
+                            proposal=accepted,
+                            gesture_id=str(result["gesture_id"]),
+                            actor=actor,
+                            target_structured_head_sha256=str(
+                                projection_receipt["structured_head_sha256"]
+                            ),
+                            rendered_projection=rendered_markdown,
+                            at=str(projection_receipt["materialized_at"]),
+                        )
+                    )
+                except provenance.ProposalAcceptanceProvenanceError as exc:
+                    raise SittingError(
+                        "proposal_provenance_unsafe",
+                        str(exc),
+                        status=409,
+                    ) from exc
+                result["provenance_attestation_ids"] = [
+                    attestation.id for attestation in attestations
+                ]
+                events.extend(
+                    (
+                        "truth.doc_provenance_attested",
+                        {
+                            "document_id": document.id,
+                            "attestation_id": attestation.id,
+                            "document_span_id": attestation.document_span_id,
+                            "target_structured_head_sha256": (
+                                attestation.target_structured_head_sha256
+                            ),
+                            "basis_kind": attestation.basis_kind,
+                        },
+                    )
+                    for attestation in attestations
+                )
             record_review_application(
                 store,
                 application_id=current_intent.id,

--- a/work_buddy/cowork/sitting_lifecycle.py
+++ b/work_buddy/cowork/sitting_lifecycle.py
@@ -18,8 +18,14 @@ from work_buddy.cowork.proposal_applicability import (
 )
 from work_buddy.cowork.verify_coordination import record_review_application
 from work_buddy.truth import documents, proposals, ydoc_store
-from work_buddy.truth.contracts import Actor, InvariantViolation
-from work_buddy.truth.identity import canonical_json, new_id, sha256_text
+from work_buddy.truth.anchors import CompositeSelector, reanchor
+from work_buddy.truth.contracts import Actor, AnchorError, InvariantViolation
+from work_buddy.truth.identity import (
+    canonical_json,
+    new_id,
+    sha256_bytes,
+    sha256_text,
+)
 from work_buddy.truth.store import DocumentRecord, TruthStore, _valid_digest
 
 
@@ -409,6 +415,123 @@ def _commit_decisions(
     return [result for _, result in ordered], events
 
 
+def _post_apply_starts(
+    store: TruthStore,
+    intent: SittingIntent,
+    results: list[dict[str, Any]],
+    conn: sqlite3.Connection,
+) -> dict[str, int]:
+    """Map applied proposals to their exact starts in the committed projection.
+
+    Applicability is resolved against the pre-apply structured head during
+    prepare.  Carrying those server-frozen ranges through every accepted edit
+    lets provenance distinguish an inserted/replacement string from identical
+    text already elsewhere in the document.  If any applied edit lacks a
+    positional proof, callers retain the quote/context-only fail-closed path.
+    """
+
+    result_by_proposal = {
+        str(result.get("proposal_id")): result for result in results
+    }
+    edits: list[tuple[str, int, int, str]] = []
+    for entry in intent.admitted:
+        item = entry["item"]
+        proposal_id = str(item["proposal_id"])
+        result = result_by_proposal.get(proposal_id)
+        if result is None or result.get("result") != "applied":
+            continue
+        proof = item.get("_applicability")
+        if not isinstance(proof, Mapping) or proof.get("status") != "applicable":
+            return {}
+        if (
+            proof.get("current_structured_head_sha256")
+            != intent.expected_structured_head_sha256
+        ):
+            return {}
+        start = proof.get("resolved_start")
+        end = proof.get("resolved_end")
+        range_is_valid = not (
+            isinstance(start, bool)
+            or isinstance(end, bool)
+            or not isinstance(start, int)
+            or not isinstance(end, int)
+            or start < 0
+            or end <= start
+        )
+        proposal = proposals.get_proposal(store, proposal_id, conn=conn)
+        if not range_is_valid:
+            # Same-state applicability remains valid even when no canonical
+            # projection receipt is available to enrich its wire proof.  In
+            # that case, recover only a frozen TextPositionSelector that can
+            # be verified against the proposal's immutable base blob.
+            reason = proof.get("reason")
+            base_is_bound = (
+                reason == "same_structured_head"
+                and proposal.base_structured_head_sha256
+                == intent.expected_structured_head_sha256
+                and proposal.base_content_sha256
+                == intent.expected_file_sha256
+            ) or (
+                reason == "same_materialized_baseline"
+                and proposal.base_structured_head_sha256 is None
+                and proposal.base_content_sha256
+                == intent.expected_file_sha256
+            )
+            try:
+                selector = CompositeSelector.from_json(proposal.selector_json)
+            except AnchorError:
+                selector = None
+            base_path = store.resolve_blob_path(
+                f"blobs/{proposal.base_content_sha256}"
+            )
+            try:
+                base_bytes = base_path.read_bytes()
+                base_text = base_bytes.decode("utf-8")
+            except (OSError, UnicodeDecodeError):
+                base_text = None
+                base_bytes = b""
+            if (
+                not base_is_bound
+                or selector is None
+                or not selector.has_position
+                or base_text is None
+                or sha256_bytes(base_bytes) != proposal.base_content_sha256
+            ):
+                return {}
+            try:
+                resolved = reanchor(
+                    base_text,
+                    selector,
+                    expected_snapshot_sha256=proposal.base_content_sha256,
+                )
+            except AnchorError:
+                return {}
+            start = resolved.start
+            end = resolved.end
+        if item.get("verb") == "confirm":
+            replacement = proposal.replacement
+        else:
+            replacement = item.get("amend_content")
+        if not isinstance(replacement, str):
+            return {}
+        edits.append((proposal_id, start, end, replacement))
+
+    ordered = sorted(edits, key=lambda edit: (edit[1], edit[2], edit[0]))
+    if any(left[2] > right[1] for left, right in zip(ordered, ordered[1:])):
+        raise SittingError(
+            "proposal_provenance_unsafe",
+            "Accepted proposal application ranges overlap.",
+            status=409,
+        )
+
+    shift = 0
+    starts: dict[str, int] = {}
+    for proposal_id, start, end, replacement in ordered:
+        starts[proposal_id] = start + shift
+        shift += len(replacement) - (end - start)
+    return starts
+
+
 def _routing_deliveries(intent: SittingIntent) -> list[dict[str, Any]]:
     return [
         {
@@ -547,6 +670,12 @@ def commit_sitting(
             result_by_proposal = {
                 str(result.get("proposal_id")): result for result in results
             }
+            post_apply_starts = _post_apply_starts(
+                store,
+                current_intent,
+                results,
+                conn,
+            )
             for entry in current_intent.admitted:
                 item = entry["item"]
                 if item.get("verb") != "confirm":
@@ -572,6 +701,7 @@ def commit_sitting(
                                 projection_receipt["structured_head_sha256"]
                             ),
                             rendered_projection=rendered_markdown,
+                            post_apply_start=post_apply_starts.get(proposal_id),
                             at=str(projection_receipt["materialized_at"]),
                         )
                     )

--- a/work_buddy/cowork/verify_orchestration.py
+++ b/work_buddy/cowork/verify_orchestration.py
@@ -4540,18 +4540,26 @@ def run_status_projection(
         raise VerifyOrchestrationError(
             "run projection document binding is invalid"
         )
-    current_head = (
-        None
-        if document.ydoc_snapshot_sha256 is None
-        else __import__(
+    current_head = None
+    if document.ydoc_snapshot_sha256 is not None:
+        ydoc_module = __import__(
             "work_buddy.truth.ydoc_store",
-            fromlist=["current_structured_head"],
-        ).current_structured_head(
-            store,
-            document_id=document_id,
-            snapshot_sha256=document.ydoc_snapshot_sha256,
+            fromlist=[
+                "CompactionRecoveryRequired",
+                "current_structured_head",
+            ],
         )
-    )
+        try:
+            current_head = ydoc_module.current_structured_head(
+                store,
+                document_id=document_id,
+                snapshot_sha256=document.ydoc_snapshot_sha256,
+            )
+        except ydoc_module.CompactionRecoveryRequired:
+            # Readiness owns the typed recovery state. Run history remains
+            # readable at this short-lived compaction boundary, but no frozen
+            # run may be presented as current until the head is available.
+            current_head = None
     summaries: list[dict[str, Any]] = []
     for run in verify_store.list_records(store, EvaluationRun, conn=conn):
         action = verify_store.get_record(

--- a/work_buddy/cowork/verify_projection.py
+++ b/work_buddy/cowork/verify_projection.py
@@ -47,11 +47,20 @@ _DISPOSITION_VIEW = {
 def _current_head(store: TruthStore, document: DocumentRecord) -> str | None:
     if document.ydoc_snapshot_sha256 is None:
         return None
-    return ydoc_store.current_structured_head(
-        store,
-        document_id=document.id,
-        snapshot_sha256=document.ydoc_snapshot_sha256,
-    )
+    try:
+        return ydoc_store.current_structured_head(
+            store,
+            document_id=document.id,
+            snapshot_sha256=document.ydoc_snapshot_sha256,
+        )
+    except ydoc_store.CompactionRecoveryRequired:
+        # A client compaction publishes a short-lived recovery marker before
+        # advancing the durable snapshot pointer and rotating the update log.
+        # Readiness projects that boundary as ``recovery_required``.  Verify is
+        # an additive read projection, so it must preserve the typed document
+        # response and conservatively mark recorded results non-current rather
+        # than turn the whole R2 read into a transient 500.
+        return None
 
 
 def _quote_anchor(evidence: object) -> dict[str, str] | None:

--- a/work_buddy/dashboard/local_identity_api.py
+++ b/work_buddy/dashboard/local_identity_api.py
@@ -296,7 +296,10 @@ def issue_gesture():
 
 
 def authenticate_request_session(
-    *, authority: LocalIdentityAuthority | None = None, require_csrf: bool = False
+    *,
+    authority: LocalIdentityAuthority | None = None,
+    require_csrf: bool = False,
+    allow_rotation_due: bool = False,
 ) -> LocalPrincipal:
     """Migration seam for a route that needs the canonical local principal."""
 
@@ -306,6 +309,7 @@ def authenticate_request_session(
         csrf_token=_csrf_token() if require_csrf else None,
         require_csrf=require_csrf,
         boundary=boundary_for_request(),
+        allow_rotation_due=allow_rotation_due,
     )
 
 

--- a/work_buddy/sources/migrations.py
+++ b/work_buddy/sources/migrations.py
@@ -538,7 +538,7 @@ def _m002_recoverable_exports(conn: sqlite3.Connection) -> None:
     )
     conn.execute(
         "UPDATE source_store_info SET schema_version = ? WHERE singleton = 1",
-        (2,),
+        (SCHEMA_VERSION,),
     )
 
 

--- a/work_buddy/tray/actions.py
+++ b/work_buddy/tray/actions.py
@@ -101,7 +101,8 @@ def reconnect_dashboard_identity(*, wait_until_ready: bool = True) -> dict:
     asks the registered extension to update an existing app tab in place. If
     no tab exists or the extension cannot prove the handoff, the normal OS
     browser launch opens one; the operation never silently assumes provenance
-    is available.
+    is available or asks an older extension worker to navigate an existing
+    document tab.
     """
 
     from work_buddy.cli.commands import dashboard_app_url, _wait_for_dashboard_app
@@ -117,33 +118,13 @@ def reconnect_dashboard_identity(*, wait_until_ready: bool = True) -> dict:
     if mint_error is not None:
         return {"ok": False, "reconnected": False, "detail": mint_error}
     try:
-        from work_buddy.collectors.chrome_collector import (
-            focus_existing_tab,
-            focus_or_create_tab,
-        )
+        from work_buddy.collectors.chrome_collector import focus_existing_tab
 
         response = focus_existing_tab(
             base,
             target_hash=launch_hash,
             timeout_seconds=10,
         )
-        if not _dashboard_handoff_happened(response):
-            # An already-installed unpacked extension may still be running the
-            # pre-update service worker, which reports the new mutation as
-            # unknown.  Fall back to the older, already-shipped operation. It
-            # now receives preserve_path end-to-end, so an existing document
-            # route/query survives; if no tab exists it creates the normal app
-            # window, which is preferable to silently leaving the user able to
-            # edit without provenance.
-            launch_hash, mint_error = _mint_dashboard_bootstrap(base)
-            if mint_error is not None:
-                return {"ok": False, "reconnected": False, "detail": mint_error}
-            response = focus_or_create_tab(
-                base,
-                target_hash=launch_hash,
-                preserve_path=True,
-                timeout_seconds=10,
-            )
     except Exception as exc:
         logger.warning("Dashboard identity handoff failed: %s", exc)
         response = None
@@ -197,14 +178,16 @@ def reconnect_dashboard_identity(*, wait_until_ready: bool = True) -> dict:
 def open_dashboard(target_hash: str = "", *, app: bool = False) -> dict:
     """Focus an existing dashboard tab/window (or create one), smartly.
 
-    Primary path: the Chrome extension's ``focus_or_create_tab`` (reuse the
-    live tab, deep-link via ``target_hash``). Fallback when the extension is
-    absent or times out: a plain ``webbrowser.open``. Never raises; returns a
-    small dict describing what happened.
+    Primary path: the Chrome extension focuses a matching live tab and applies
+    ``target_hash``. Fallback when the extension is absent, outdated, reports
+    no matching app tab, or times out: a plain ``webbrowser.open``. Never
+    raises; returns a small dict describing what happened.
 
-    App launches preserve an existing React route and query while delivering
-    only the one-time bootstrap fragment. Legacy dashboard deep-links retain
-    their existing navigation behavior.
+    App launches use only the path-preserving ``focus_existing_tab`` mutation.
+    They never fall back to the older extension mutation, because pre-update
+    service workers ignore ``preserve_path`` and can replace a Co-work document
+    route with the app root. Legacy dashboard deep-links retain their existing
+    navigation behavior.
     """
     from work_buddy.cli.commands import dashboard_app_url, dashboard_local_url
 
@@ -224,28 +207,43 @@ def open_dashboard(target_hash: str = "", *, app: bool = False) -> dict:
             }
         identity_bootstrap = True
     try:
-        from work_buddy.collectors.chrome_collector import focus_or_create_tab
+        if app:
+            from work_buddy.collectors.chrome_collector import focus_existing_tab
 
-        res = focus_or_create_tab(
-            base,
-            target_hash=launch_hash,
-            preserve_path=app,
-            timeout_seconds=10,
-        )
+            res = focus_existing_tab(
+                base,
+                target_hash=launch_hash,
+                timeout_seconds=10,
+            )
+        else:
+            from work_buddy.collectors.chrome_collector import focus_or_create_tab
+
+            res = focus_or_create_tab(
+                base,
+                target_hash=launch_hash,
+                preserve_path=False,
+                timeout_seconds=10,
+            )
         if _successful_extension_mutation(res):
-            result = {
-                "ok": True,
-                "via": "extension",
-                "result": res,
-            }
-            if app:
-                result["identity_bootstrap"] = identity_bootstrap
-            return result
+            if app and not _dashboard_handoff_happened(res):
+                logger.info(
+                    "No existing app tab accepted the identity handoff; "
+                    "falling back to webbrowser"
+                )
+            else:
+                result = {
+                    "ok": True,
+                    "via": "extension",
+                    "result": res,
+                }
+                if app:
+                    result["identity_bootstrap"] = identity_bootstrap
+                return result
         logger.info(
-            "focus_or_create_tab was not confirmed; falling back to webbrowser"
+            "Dashboard extension handoff was not confirmed; falling back to webbrowser"
         )
     except Exception as exc:
-        logger.warning("focus_or_create_tab failed (%s); falling back", exc)
+        logger.warning("Dashboard extension handoff failed (%s); falling back", exc)
 
     import webbrowser
 

--- a/work_buddy/tray/actions.py
+++ b/work_buddy/tray/actions.py
@@ -8,6 +8,7 @@ the windowless tray). The Qt layer runs these on a worker thread.
 from __future__ import annotations
 
 import time
+from collections.abc import Mapping
 
 from work_buddy.logging_config import get_logger
 
@@ -22,7 +23,8 @@ ACTIVITY_HASH = "#tab=settings&st=activity"
 def start_sidecar() -> dict:
     from work_buddy.cli import lifecycle
 
-    return lifecycle.start_sidecar()
+    result = lifecycle.start_sidecar()
+    return _with_identity_reconnect(result)
 
 
 def stop_sidecar() -> dict:
@@ -39,7 +41,157 @@ def restart_sidecar() -> dict:
     if stop["was_running"] and not stop["stopped"]:
         return stop
     time.sleep(0.5)
-    return lifecycle.start_sidecar()
+    return _with_identity_reconnect(lifecycle.start_sidecar())
+
+
+def _with_identity_reconnect(result: dict) -> dict:
+    """Attach the truthful reconnect outcome after a deliberate tray start."""
+
+    if not result.get("started"):
+        return result
+    recovered = reconnect_dashboard_identity()
+    combined = dict(result)
+    combined["identity_reconnect"] = recovered
+    if not recovered.get("ok"):
+        logger.warning("Dashboard identity reconnect failed: %s", recovered["detail"])
+    return combined
+
+
+def _mint_dashboard_bootstrap(
+    base: str,
+    *,
+    next_hash: str = "",
+) -> tuple[str, str | None]:
+    try:
+        from work_buddy.dashboard.local_identity_launch import (
+            bootstrap_fragment_for_dashboard,
+        )
+
+        return bootstrap_fragment_for_dashboard(base, next_hash=next_hash), None
+    except Exception as exc:
+        logger.warning("Could not mint dashboard identity bootstrap: %s", exc)
+        return "", (
+            "Could not create a trusted local dashboard session. "
+            "No unauthenticated dashboard launch was attempted."
+        )
+
+
+def _successful_extension_mutation(value: object) -> bool:
+    if not isinstance(value, Mapping) or value.get("status") != "ok":
+        return False
+    details = value.get("details")
+    return isinstance(details, Mapping) and not details.get("error")
+
+
+def _dashboard_handoff_happened(value: object) -> bool:
+    if not _successful_extension_mutation(value):
+        return False
+    details = value["details"]
+    return (
+        details.get("found") is True
+        or details.get("created") is True
+        or details.get("focused") is True
+    )
+
+
+def reconnect_dashboard_identity(*, wait_until_ready: bool = True) -> dict:
+    """Deliver a trusted bootstrap to a running or newly opened React tab.
+
+    The trusted host process, never HTTP, mints each one-use grant. It first
+    asks the registered extension to update an existing app tab in place. If
+    no tab exists or the extension cannot prove the handoff, the normal OS
+    browser launch opens one; the operation never silently assumes provenance
+    is available.
+    """
+
+    from work_buddy.cli.commands import dashboard_app_url, _wait_for_dashboard_app
+
+    base = dashboard_app_url(local=True)
+    if wait_until_ready and not _wait_for_dashboard_app(base):
+        return {
+            "ok": False,
+            "reconnected": False,
+            "detail": "Dashboard did not become ready for identity reconnect.",
+        }
+    launch_hash, mint_error = _mint_dashboard_bootstrap(base)
+    if mint_error is not None:
+        return {"ok": False, "reconnected": False, "detail": mint_error}
+    try:
+        from work_buddy.collectors.chrome_collector import (
+            focus_existing_tab,
+            focus_or_create_tab,
+        )
+
+        response = focus_existing_tab(
+            base,
+            target_hash=launch_hash,
+            timeout_seconds=10,
+        )
+        if not _dashboard_handoff_happened(response):
+            # An already-installed unpacked extension may still be running the
+            # pre-update service worker, which reports the new mutation as
+            # unknown.  Fall back to the older, already-shipped operation. It
+            # now receives preserve_path end-to-end, so an existing document
+            # route/query survives; if no tab exists it creates the normal app
+            # window, which is preferable to silently leaving the user able to
+            # edit without provenance.
+            launch_hash, mint_error = _mint_dashboard_bootstrap(base)
+            if mint_error is not None:
+                return {"ok": False, "reconnected": False, "detail": mint_error}
+            response = focus_or_create_tab(
+                base,
+                target_hash=launch_hash,
+                preserve_path=True,
+                timeout_seconds=10,
+            )
+    except Exception as exc:
+        logger.warning("Dashboard identity handoff failed: %s", exc)
+        response = None
+    if not _dashboard_handoff_happened(response):
+        # The extension may be absent, or an unpacked pre-update worker may
+        # have performed the handoff without the new response nonce. Mint a
+        # fresh one-use grant (the previous one may already be consumed) and
+        # use the same OS browser launch boundary as `wbuddy launch`.
+        launch_hash, mint_error = _mint_dashboard_bootstrap(base)
+        if mint_error is not None:
+            return {"ok": False, "reconnected": False, "detail": mint_error}
+        import webbrowser
+
+        try:
+            opened = webbrowser.open(base + launch_hash)
+        except Exception as exc:
+            logger.warning("Trusted dashboard reconnect launch failed: %s", exc)
+            opened = False
+        if opened is False:
+            return {
+                "ok": False,
+                "reconnected": False,
+                "detail": (
+                    "Neither the browser extension nor the OS browser accepted "
+                    "the trusted identity handoff."
+                ),
+            }
+        return {
+            "ok": True,
+            "reconnected": True,
+            "detail": "Opened a trusted dashboard session.",
+        }
+    details = response["details"]
+    found = details.get("found") is True or (
+        details.get("created") is False and details.get("focused") is True
+    )
+    created = details.get("created") is True
+    return {
+        "ok": True,
+        "reconnected": found or created,
+        "detail": (
+            "Reconnected the open dashboard tab."
+            if found
+            else "Opened a trusted dashboard session."
+            if created
+            else "No open dashboard tab needed reconnecting."
+        ),
+    }
 
 
 def open_dashboard(target_hash: str = "", *, app: bool = False) -> dict:
@@ -60,20 +212,17 @@ def open_dashboard(target_hash: str = "", *, app: bool = False) -> dict:
     identity_bootstrap = False
     launch_hash = target_hash
     if app:
-        try:
-            from work_buddy.dashboard.local_identity_launch import (
-                bootstrap_fragment_for_dashboard,
-            )
-
-            launch_hash = bootstrap_fragment_for_dashboard(
-                base,
-                next_hash=target_hash,
-            )
-            identity_bootstrap = True
-        except Exception as exc:
-            # Keep the pre-existing observability UI reachable during migration.
-            # New human-authority writes still fail closed without a session.
-            logger.warning("Could not mint dashboard identity bootstrap: %s", exc)
+        launch_hash, mint_error = _mint_dashboard_bootstrap(
+            base,
+            next_hash=target_hash,
+        )
+        if mint_error is not None:
+            return {
+                "ok": False,
+                "identity_bootstrap": False,
+                "detail": mint_error,
+            }
+        identity_bootstrap = True
     try:
         from work_buddy.collectors.chrome_collector import focus_or_create_tab
 
@@ -83,7 +232,7 @@ def open_dashboard(target_hash: str = "", *, app: bool = False) -> dict:
             preserve_path=app,
             timeout_seconds=10,
         )
-        if res is not None:
+        if _successful_extension_mutation(res):
             result = {
                 "ok": True,
                 "via": "extension",
@@ -92,14 +241,40 @@ def open_dashboard(target_hash: str = "", *, app: bool = False) -> dict:
             if app:
                 result["identity_bootstrap"] = identity_bootstrap
             return result
-        logger.info("focus_or_create_tab timed out; falling back to webbrowser")
+        logger.info(
+            "focus_or_create_tab was not confirmed; falling back to webbrowser"
+        )
     except Exception as exc:
         logger.warning("focus_or_create_tab failed (%s); falling back", exc)
 
     import webbrowser
 
+    if app and identity_bootstrap:
+        # The extension can consume a one-use grant even when its response is
+        # lost or comes from a pre-correlation worker. Never replay that grant
+        # through the OS-browser fallback.
+        launch_hash, mint_error = _mint_dashboard_bootstrap(
+            base,
+            next_hash=target_hash,
+        )
+        if mint_error is not None:
+            return {
+                "ok": False,
+                "identity_bootstrap": False,
+                "detail": mint_error,
+            }
     url = base + launch_hash if launch_hash else base
-    webbrowser.open(url)
+    try:
+        opened = webbrowser.open(url)
+    except Exception as exc:
+        logger.warning("webbrowser dashboard launch failed: %s", exc)
+        opened = False
+    if opened is False:
+        return {
+            "ok": False,
+            "identity_bootstrap": identity_bootstrap,
+            "detail": "The browser did not accept the trusted dashboard launch.",
+        }
     # Do not return/log the bearer-bearing launch URL.  The fragment is removed
     # by React before redemption, but it is still a short-lived credential.
     result = {

--- a/work_buddy/truth/export.py
+++ b/work_buddy/truth/export.py
@@ -59,7 +59,7 @@ from work_buddy.truth.store import TruthStore
 
 
 FORMAT_NAME = "work-buddy.truth-ledger"
-FORMAT_VERSION = 9
+FORMAT_VERSION = 10
 OLDEST_FORMAT_VERSION = 1
 _IMPORT_STAGING_PREFIX = ".wbuddy-cowork-import-"
 

--- a/work_buddy/truth/migrations.py
+++ b/work_buddy/truth/migrations.py
@@ -22,7 +22,7 @@ from work_buddy.storage.migrations import (
 
 logger = get_logger(__name__)
 
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 # Redacted spans retain their immutable identity/hash but not their quote or
 # quote context.  Keep the selector valid JSON (and valid for the existing
@@ -2198,6 +2198,131 @@ def _m009_source_backed_truth_provenance(conn: sqlite3.Connection) -> None:
     install_truth_hindsight_projection_schema(conn)
 
 
+def _m010_direct_entry_provenance_basis(conn: sqlite3.Connection) -> None:
+    """Admit honest automatic attribution for text typed in Co-work.
+
+    SQLite cannot widen a CHECK constraint in place. Rebuild only the
+    append-only provenance table, preserving every row and its insertion
+    order; indexes and immutability triggers are then restored verbatim.
+    """
+
+    conn.execute(
+        """
+        CREATE TABLE document_provenance_attestations_v10 (
+            id                            TEXT PRIMARY KEY,
+            document_id                   TEXT NOT NULL REFERENCES documents(id),
+            target_kind                   TEXT NOT NULL CHECK(
+                target_kind IN ('document_version', 'document_span')
+            ),
+            document_version_id           TEXT REFERENCES document_versions(id),
+            document_span_id              TEXT REFERENCES document_spans(id),
+            target_structured_head_sha256 TEXT NOT NULL,
+            authorship_kind               TEXT NOT NULL CHECK(
+                authorship_kind IN ('human', 'ai', 'mixed', 'unknown')
+            ),
+            human_contributors_json       TEXT NOT NULL,
+            review_status                 TEXT NOT NULL CHECK(
+                review_status IN (
+                    'reviewed', 'not_reviewed', 'not_applicable', 'unknown'
+                )
+            ),
+            human_reviewers_json          TEXT NOT NULL,
+            source_kind                   TEXT NOT NULL CHECK(
+                source_kind IN (
+                    'file_import', 'paste', 'direct_entry',
+                    'proposal_acceptance', 'legacy'
+                )
+            ),
+            source_json                   TEXT NOT NULL,
+            basis_kind                    TEXT NOT NULL CHECK(
+                basis_kind IN (
+                    'user_attestation', 'automatic_short_text_attribution',
+                    'automatic_direct_entry_attribution',
+                    'proposal_acceptance', 'migration_backfill', 'legacy'
+                )
+            ),
+            basis_ref                     TEXT,
+            supersedes_id                 TEXT
+                REFERENCES document_provenance_attestations_v10(id),
+            idempotency_key               TEXT NOT NULL,
+            canonical_sha256              TEXT NOT NULL UNIQUE,
+            created_at                    TEXT NOT NULL,
+            attested_by_kind              TEXT NOT NULL,
+            attested_by_ref               TEXT,
+            attested_by_meta_json         TEXT,
+            CHECK (
+                (
+                    target_kind = 'document_version'
+                    AND document_version_id IS NOT NULL
+                    AND document_span_id IS NULL
+                )
+                OR
+                (
+                    target_kind = 'document_span'
+                    AND document_span_id IS NOT NULL
+                    AND document_version_id IS NULL
+                )
+            )
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO document_provenance_attestations_v10 (
+            id, document_id, target_kind, document_version_id,
+            document_span_id, target_structured_head_sha256, authorship_kind,
+            human_contributors_json, review_status, human_reviewers_json,
+            source_kind, source_json, basis_kind, basis_ref, supersedes_id,
+            idempotency_key, canonical_sha256, created_at, attested_by_kind,
+            attested_by_ref, attested_by_meta_json
+        )
+        SELECT
+            id, document_id, target_kind, document_version_id,
+            document_span_id, target_structured_head_sha256, authorship_kind,
+            human_contributors_json, review_status, human_reviewers_json,
+            source_kind, source_json, basis_kind, basis_ref, supersedes_id,
+            idempotency_key, canonical_sha256, created_at, attested_by_kind,
+            attested_by_ref, attested_by_meta_json
+        FROM document_provenance_attestations
+        ORDER BY rowid
+        """
+    )
+    conn.execute("DROP TABLE document_provenance_attestations")
+    conn.execute(
+        "ALTER TABLE document_provenance_attestations_v10 "
+        "RENAME TO document_provenance_attestations"
+    )
+    for statement in (
+        "CREATE INDEX idx_document_provenance_document "
+        "ON document_provenance_attestations(document_id, created_at, id)",
+        "CREATE INDEX idx_document_provenance_version "
+        "ON document_provenance_attestations(document_version_id)",
+        "CREATE INDEX idx_document_provenance_span "
+        "ON document_provenance_attestations(document_span_id)",
+        "CREATE INDEX idx_document_provenance_supersedes "
+        "ON document_provenance_attestations(supersedes_id)",
+        "CREATE UNIQUE INDEX uq_document_provenance_idempotency "
+        "ON document_provenance_attestations("
+        "document_id, attested_by_kind, ifnull(attested_by_ref, ''), "
+        "idempotency_key)",
+        """
+        CREATE TRIGGER document_provenance_attestations_append_only_update
+        BEFORE UPDATE ON document_provenance_attestations
+        BEGIN
+            SELECT RAISE(ABORT, 'append-only');
+        END
+        """,
+        """
+        CREATE TRIGGER document_provenance_attestations_append_only_delete
+        BEFORE DELETE ON document_provenance_attestations
+        BEGIN
+            SELECT RAISE(ABORT, 'append-only');
+        END
+        """,
+    ):
+        conn.execute(statement)
+
+
 def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
     row = conn.execute(
         "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
@@ -2318,6 +2443,11 @@ TRUTH_MIGRATIONS = _TruthMigrationRunner(
             9,
             "source-backed Truth receipts and outcome-aware provenance",
             _m009_source_backed_truth_provenance,
+        ),
+        Migration(
+            10,
+            "automatic direct-entry provenance attribution",
+            _m010_direct_entry_provenance_basis,
         ),
     ],
 )

--- a/work_buddy/truth/proposals.py
+++ b/work_buddy/truth/proposals.py
@@ -649,6 +649,16 @@ def _mint_expressions_locked(
         proposal.created_by_kind == "agent_run"
         and bool(str(proposal.created_by_ref or "").strip())
     )
+    # An insertion proposal often carries the untouched quote inside its
+    # replacement (for example, ``new preface + original``). The expression
+    # may legitimately cover that complete passage, but the complete passage
+    # is not wholly AI-authored. The Co-work proposal-acceptance provenance
+    # path records only the mechanically derived inserted segments.
+    preserves_original = bool(
+        proposal.quote_exact
+        and proposal.replacement is not None
+        and proposal.quote_exact in proposal.replacement
+    )
     span = _ensure_document_span_locked(
         store,
         conn,
@@ -656,8 +666,16 @@ def _mint_expressions_locked(
         selector=accepted_selector,
         quote_exact=proposal.replacement,
         actor=actor,
-        author_kind="agent_run" if authored_by_agent else "unknown",
-        author_ref=proposal.created_by_ref if authored_by_agent else None,
+        author_kind=(
+            "agent_run"
+            if authored_by_agent and not preserves_original
+            else "unknown"
+        ),
+        author_ref=(
+            proposal.created_by_ref
+            if authored_by_agent and not preserves_original
+            else None
+        ),
         at=at,
         # An accepted edit needs its own durable authorship/acceptance row even
         # if an identical quote was previously anchored for another purpose.

--- a/work_buddy/truth/provenance.py
+++ b/work_buddy/truth/provenance.py
@@ -35,9 +35,31 @@ PROVENANCE_BASIS_KINDS = frozenset(
     {
         "user_attestation",
         "automatic_short_text_attribution",
+        "automatic_direct_entry_attribution",
         "proposal_acceptance",
         "migration_backfill",
         "legacy",
+    }
+)
+PROVENANCE_SOURCE_BASIS_PAIRS = frozenset(
+    {
+        ("file_import", "user_attestation"),
+        ("file_import", "migration_backfill"),
+        ("paste", "user_attestation"),
+        ("paste", "automatic_short_text_attribution"),
+        ("direct_entry", "automatic_direct_entry_attribution"),
+        ("proposal_acceptance", "proposal_acceptance"),
+        ("proposal_acceptance", "user_attestation"),
+        ("legacy", "user_attestation"),
+        ("legacy", "legacy"),
+    }
+)
+PROVENANCE_SPAN_SOURCE_BASIS_PAIRS = frozenset(
+    {
+        ("paste", "automatic_short_text_attribution"),
+        ("paste", "user_attestation"),
+        ("direct_entry", "automatic_direct_entry_attribution"),
+        ("legacy", "user_attestation"),
     }
 )
 PERSON_IDENTITY_STATUSES = frozenset(
@@ -296,6 +318,10 @@ def validate_attestation_components(
         raise InvariantViolation(
             f"basis_kind must be one of {sorted(PROVENANCE_BASIS_KINDS)}"
         )
+    if (source_kind, basis_kind) not in PROVENANCE_SOURCE_BASIS_PAIRS:
+        raise InvariantViolation(
+            "source_kind and basis_kind are not an allowed provenance pair"
+        )
     _optional_text(basis_ref, "basis_ref", maximum=2_048)
 
     if attested_by_kind not in VALID_ACTOR_KINDS:
@@ -413,7 +439,9 @@ __all__ = [
     "PROVENANCE_AUTHORSHIP_KINDS",
     "PROVENANCE_BASIS_KINDS",
     "PROVENANCE_REVIEW_STATUSES",
+    "PROVENANCE_SOURCE_BASIS_PAIRS",
     "PROVENANCE_SOURCE_KINDS",
+    "PROVENANCE_SPAN_SOURCE_BASIS_PAIRS",
     "PROVENANCE_TARGET_KINDS",
     "attestation_canonical_payload",
     "attestation_canonical_sha256",


### PR DESCRIPTION
## Summary

- Capture ordinary local typing as durable `direct_entry` provenance bound to the capture-time local actor and an exact structured-document head.
- Add provenance-specific selection actions—Record, Review, View, and Inspect—and suppress the generic Give feedback affordance while the Provenance lens is active.
- Let users explicitly record provenance for older text without falsely claiming how it entered Co-work; those records remain labeled Untracked / legacy.
- Harden the cross-store outbox, crash/reload recovery, immutable retries, actor changes, source/basis validation, schema migration, and portable export/import.

## Root cause

The editor only created provenance records for imports and paste transactions. Ordinary local typing flowed into Yjs and merely invalidated the pulled overlay; it never created an attestation, so newly typed text correctly appeared as unrecorded. The selection feedback affordance was also mounted independently of the active lens, which is why Provenance still offered Give feedback.

## User impact

New local typing now records exact human direct-entry provenance automatically at a stable persistence boundary. Corrections, deletion, cursor jumps, page teardown, ambiguous network responses, and identity changes fail safely without silently reassigning authorship. Pre-existing text is not retroactively invented as direct entry; it can be selected and explicitly recorded with honest legacy source semantics.

## Validation

- [x] 178 affected frontend Vitest tests
- [x] 47 final backend provenance/export/schema tests
- [x] Isolated live Playwright journey: type `Test` → open Provenance → exactly one current human `direct_entry` span, View provenance visible, Give feedback absent
- [x] TypeScript typecheck
- [x] Production dashboard and document-kernel build
- [x] Python compileall
- [x] Knowledge-store validation and index rebuild
- [x] `git diff --check`

The knowledge validator still reports the repository's existing 43 advisory warnings; this change introduces no new validation failures or warnings.

## Follow-up amendment

Production validation against a long-lived Co-work tab exposed two separate integration failures that unit fixtures had masked:

- The tab had no trusted local identity session, so Yjs edits persisted while current-actor resolution stopped and actorless direct-entry captures were discarded.
- The passive provenance hover card opened above the contextual selection control and covered it during a real mouse drag.

This follow-up:

- restores trusted local identity to surviving dashboard tabs on deliberate CLI/tray Start and Restart through a host-minted, route-preserving, response-correlated handoff;
- refreshes stale in-memory CSRF state on foreground and retries one rejected gesture after exact-Origin session recovery, without extending or weakening the hard local authority boundary;
- retains actorless or actor-changed typing as an exact explicit legacy attribution task instead of deleting it or assigning it to a later actor;
- prevents passive hover from covering Provenance selection actions and exercises the real mouse-selection path;
- raises the GitHub Actions test timeout from 15 to 30 minutes after the prior run was canceled at 90% with no test failure.

### Follow-up validation

- [x] 63 affected frontend Vitest tests
- [x] 89 focused Python identity/Chrome/native-host/tray/CLI tests
- [x] Isolated production-build Playwright journey with real mouse selection; `ok=true`, cleanup succeeded
- [x] TypeScript typecheck and production build
- [x] Chrome syntax, Python compileall, and workflow YAML assertion
- [x] Knowledge validation/rebuild and diff hygiene

## Runtime deployment amendment

A final local-runtime diagnosis showed that the dashboard bundle was current, but two lifecycle details could still make the fix appear absent:

- managed startup on this machine can take longer than the former 30-second dashboard readiness window, causing identity reconnect to give up while the dashboard was still starting;
- an already-running pre-update Chrome extension worker does not understand the path-preserving identity mutation, and the compatibility fallback could navigate a live Co-work document tab to the app root.

This amendment:

- raises the local dashboard readiness window to 120 seconds so Start/Restart waits through slow managed imports;
- never sends trusted app handoffs through the older navigation mutation; unsupported workers now open a fresh trusted root tab and leave existing document routes untouched;
- documents the compatibility boundary and preserves truthful reconnect failures.

### Runtime validation

- [x] Rebuilt the production dashboard and restarted the sidecar and tray
- [x] Real restart completed in 32 seconds; all five services reached healthy
- [x] Existing Journal routes remained unchanged with the old installed extension worker, while a separate trusted root tab was opened
- [x] 90 focused CLI/tray/native-host/Chrome/local-identity tests
- [x] Python compilation, knowledge validation/rebuild, and diff hygiene

## Journal runtime amendment

Live Journal validation found two independent pre-existing defects:

- both Journal HTTP providers stored browser-native `fetch` unbound, so Chrome invoked it with the provider object as its receiver and threw `Illegal invocation`;
- Sources migration v2 had been edited in place when v3 was added, so existing Sources databases failed their migration hash audit and `/api/journal/view` returned 500.

This amendment binds only the default browser fetch client (injected test clients stay untouched), restores the exact frozen v2 migration source, and leaves the v3 schema work in its own step.

### Journal validation

- [x] Browser-receiver regressions for native and legacy Journal providers
- [x] 19 focused provider tests and 64 complete Journal tests
- [x] Focused Sources/export migration tests
- [x] TypeScript typecheck and production dashboard build
- [x] Live `/api/journal/view` HTTP 200; Sources v2→v3 upgrade with v2 hash preserved
- [x] Live Journal render with zero browser console errors

## Exact authority and actor-readiness amendment

Live validation against the reported top-of-document sentence and its 409 responses exposed three coupled failures:

- the browser hashed quote-anchor strings byte-for-byte, while the Flask authority helper semantically collapsed whitespace, so a selector suffix beginning with a block-boundary newline produced `gesture_binding_mismatch` before provenance storage;
- the editor discarded that rejected direct-entry capture, turning a recoverable authority error into a terminal-looking “No provenance recorded” state;
- the editor could accept keystrokes while capture-time actor lookup was still loading, splitting one sentence into an actorless prefix and an actor-bound tail. Adjacent actor transitions could also overlap one boundary character.

This amendment:

- makes the browser and server share exact deterministic JSON hashing that preserves newlines, tabs, repeated spaces, and Unicode while keeping every session, Origin, CSRF, gesture, and target check intact;
- retains the immutable direct-entry request after non-target authority failures and replays the same idempotency key on explicit retry; target conflicts alone use a fresh, re-resolved target;
- keeps the editor non-editable only while actor lookup is in flight, then records the whole subsequent typing burst under the resolved actor;
- maps sealed/displaced actor ranges inward so adjacent actor spans cannot overlap.

### Exact failure-path validation

- [x] Shared fixed browser/Python digest vector with multiline and repeated-whitespace sensitivity
- [x] Real authenticated Flask route: multiline direct-entry selector returns 201, persists exact bytes, and consumes the gesture
- [x] 52 focused frontend authority/editor/outbox tests
- [x] 33/33 mounted editor provenance tests, including delayed actor resolution and adjacent actor-transition races
- [x] Production dashboard/document-kernel build and TypeScript typecheck
- [x] Isolated production Playwright journey: normal keyboard input of `The party's rocking, yes` above an existing paragraph; exactly one full current human `direct_entry` span, newline-prefixed suffix, one 201, no failed request or relevant console error, `View provenance` visible, and cleanup succeeded
- [x] Independent settled-diff release audit and diff hygiene


## Live hover refresh amendment

Post-restart tracing proved that trusted identity recovery, direct-entry storage, and the authoritative provenance projection were all current, while an already-open hover card could still display its pre-save “No provenance recorded” snapshot. The card only reread decoration metadata on pointer, focus, or selection events, so an asynchronous projection refresh under a stationary pointer left the visible explanation stale.

This amendment observes active provenance-decoration changes and re-resolves replacement nodes at the current pointer position. The tooltip now updates from unrecorded to the recorded authorship/source without requiring pointer movement or a reload.

### Hover refresh validation

- [x] Stationary-pointer regression: unrecorded decoration is asynchronously replaced by current human/direct-entry provenance and the open card updates
- [x] Focused hover-card tests (4/4)
- [x] TypeScript typecheck and production dashboard/document-kernel build
- [x] Fresh live document projection renders the accepted current direct-entry span in both the panel and editor overlay
- [x] Diff hygiene


## Pending-delivery and accepted-AI amendment

Live use confirmed that direct-entry capture was succeeding, but the overlay briefly described new text as having no provenance while its durable write, attestation, and authoritative repull were still in flight. It also exposed a separate ledger gap: accepting an agent-authored proposal changed the document without creating a record in the detailed Provenance view.

This amendment:

- projects only the exact locally captured passage as **Recording provenance…** while delivery is pending, without making provisional authorship, review, contributor, reviewer, or attester claims;
- keeps the frozen outbox request pending until refreshed history matches the receipt's attestation ID, span ID, and structured head, so stale, misbound, or failed refreshes cannot reintroduce a false **No provenance recorded** state;
- gives authoritative recorded coverage precedence immediately when it arrives;
- records accepted agent proposals transactionally as exact `ai` / `not_reviewed` provenance with `proposal_acceptance` source and basis, preserving the producing run and human acceptance gesture;
- attributes only agent-created replacement segments, never preserved human text, and rolls the entire sitting back when attribution cannot be derived safely;
- exposes bounded producer/model/run details in the Provenance panel.

Acceptance remains distinct from human review: accepted AI text is still shown as AI-authored and not reviewed until the user explicitly marks it reviewed.

### Pending and accepted-AI validation

- [x] 70 focused frontend tests, including delayed/missing/misbound/rejected authoritative refreshes
- [x] 165 backend lifecycle/proposal/provenance/API regressions, including replacement, sandwich insertion, replay, human amendment, and atomic rollback
- [x] TypeScript typecheck and production dashboard/document-kernel build
- [x] Python compilation
- [x] Knowledge validation/rebuild and diff hygiene


## Position-bound accepted-provenance amendment

The first complete CI run exposed a duplicate-text edge in two durable Verify flows: the accepted AI replacement also existed as unrelated human text elsewhere in the document. The provenance recorder retained quote/context but had discarded the proposal's already-validated application position, so strict reanchoring correctly rejected the result as ambiguous.

This amendment carries the server-resolved pre-apply range through all accepted edit deltas and binds each derived AI-only segment to its exact committed position. It does not choose the first textual match or relax unique reanchoring. Missing, overlapping, stale, or mismatched position proofs still fail closed and roll back the sitting atomically.

### Position-binding validation

- [x] Both CI failures reproduced and fixed (2/2)
- [x] Lifecycle hardening (25/25)
- [x] Durable Verify dispatch (12/12)
- [x] Provenance and proposal-applicability coverage (31/31)
- [x] Duplicate wording attributes only the edited occurrence
- [x] Wrong-position payload leaves proposal open and commits no gesture, attestation, snapshot, or file change
- [x] Python compilation, independent safety audit, and diff hygiene


### Identity-rotation and reload-recovery follow-up

- Fixed a rotation-boundary regression where the read-only current-actor lookup returned `session_rotation_required` after 30 minutes, preventing direct-entry capture from resolving an otherwise valid actor. Informational actor reads now remain available while gesture-gated writes retain mandatory session rotation.
- Fixed a transient document-read 500 during Y.Doc compaction. Co-work now returns the typed `recovery_required` state and conservatively marks Verify/Co-think history non-current until the head is readable again.
- Added explicit recovery for typing captured while actor resolution was unavailable. The durable row now surfaces `Recent typing needs attribution`, survives dismissal, form edits, and Ctrl+R, and records exactly once with the original row and idempotency key after confirmation; no later actor is inferred automatically.
- Regression coverage: 139 backend tests, 55 focused frontend tests, TypeScript typecheck, production dashboard build, and documentation validation all pass.
