### PR TITLE
fix(cowork): POST protected staged source reads

### DIFF
--- a/dashboard-react/src/apps/cowork/documents/CoworkDocumentLifecycleDialog.test.tsx
+++ b/dashboard-react/src/apps/cowork/documents/CoworkDocumentLifecycleDialog.test.tsx
@@ -2,6 +2,10 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
+vi.mock("../../../security/humanAuthority", () => ({
+  coworkHumanAuthorityHeaders: vi.fn(async () => ({})),
+}));
+
 import type { CoworkFolderSummary } from "../contracts";
 import { sha256Hex } from "../persistence/hashing";
 import { CoworkHttpClient } from "../providers/CoworkHttpClient";
@@ -104,7 +108,8 @@ describe("CoworkDocumentLifecycleDialog idempotent recovery", () => {
           normalized_path: "retry-document.md",
           source_sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           source_byte_length: 0,
-          source_url: "/bootstrap-1/source",
+          source_url:
+            "/api/truth/doc/bootstrap/bootstrap-1/source?store_id=store-1",
           ydoc_schema: "yjs-v1",
           expires_at: "2026-07-22T13:00:00.000Z",
         };
@@ -133,7 +138,10 @@ describe("CoworkDocumentLifecycleDialog idempotent recovery", () => {
           { status: committed ? 200 : 201, headers: { "Content-Type": "application/json" } },
         );
       }
-      if (url === "/bootstrap-1/source") {
+      if (
+        url ===
+        "/api/truth/doc/bootstrap/bootstrap-1/source?store_id=store-1"
+      ) {
         sourceReads += 1;
         return new Response(new Uint8Array(0), { status: 200 });
       }
@@ -221,7 +229,8 @@ describe("CoworkDocumentLifecycleDialog idempotent recovery", () => {
             normalized_path: repairDocument.path,
             source_sha256: sourceSha,
             source_byte_length: source.byteLength,
-            source_url: "/bootstrap-repair/source",
+            source_url:
+              "/api/truth/doc/bootstrap/bootstrap-repair/source?store_id=store-1",
             ydoc_schema: "yjs-v1",
             expires_at: "2026-07-22T20:00:00Z",
             state: "prepared",
@@ -229,7 +238,10 @@ describe("CoworkDocumentLifecycleDialog idempotent recovery", () => {
           { status: 201, headers: { "Content-Type": "application/json" } },
         );
       }
-      if (url === "/bootstrap-repair/source") {
+      if (
+        url ===
+        "/api/truth/doc/bootstrap/bootstrap-repair/source?store_id=store-1"
+      ) {
         return new Response(source as BodyInit, { status: 200 });
       }
       if (url.startsWith("/api/truth/doc/bootstrap/bootstrap-repair?")) {
@@ -274,7 +286,7 @@ describe("CoworkDocumentLifecycleDialog idempotent recovery", () => {
     );
     expect(requests).toEqual([
       "/api/truth/doc/bootstrap?store_id=store-1",
-      "/bootstrap-repair/source",
+      "/api/truth/doc/bootstrap/bootstrap-repair/source?store_id=store-1",
       "/api/truth/doc/bootstrap/bootstrap-repair?store_id=store-1",
     ]);
   }, 20_000);
@@ -342,7 +354,8 @@ describe("CoworkDocumentLifecycleDialog idempotent recovery", () => {
             source_sha256:
               "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             source_byte_length: 0,
-            source_url: "/bootstrap-create/source",
+            source_url:
+              "/api/truth/doc/bootstrap/bootstrap-create/source?store_id=store-1",
             ydoc_schema: "yjs-v1",
             expires_at: "2026-07-22T20:00:00Z",
             state: "prepared",
@@ -350,7 +363,12 @@ describe("CoworkDocumentLifecycleDialog idempotent recovery", () => {
           { status: 201, headers: { "Content-Type": "application/json" } },
         );
       }
-      if (url === "/bootstrap-create/source") return new Response(new Uint8Array(0));
+      if (
+        url ===
+        "/api/truth/doc/bootstrap/bootstrap-create/source?store_id=store-1"
+      ) {
+        return new Response(new Uint8Array(0));
+      }
       if (url.startsWith("/api/truth/doc/bootstrap/bootstrap-create?")) {
         return new Response(
           JSON.stringify({
@@ -468,7 +486,8 @@ describe("CoworkDocumentLifecycleDialog idempotent recovery", () => {
             normalized_path: "drafts/imported-source.md",
             source_sha256: sourceSha256,
             source_byte_length: source.byteLength,
-            source_url: "/bootstrap-import/source",
+            source_url:
+              "/api/truth/doc/bootstrap/bootstrap-import/source?store_id=store-1",
             ydoc_schema: "yjs-v1",
             expires_at: "2026-07-22T20:00:00Z",
             state: "prepared",
@@ -476,7 +495,10 @@ describe("CoworkDocumentLifecycleDialog idempotent recovery", () => {
           { status: 201, headers: { "Content-Type": "application/json" } },
         );
       }
-      if (url === "/bootstrap-import/source") {
+      if (
+        url ===
+        "/api/truth/doc/bootstrap/bootstrap-import/source?store_id=store-1"
+      ) {
         return new Response(source, { status: 200 });
       }
       if (url.startsWith("/api/truth/doc/bootstrap/bootstrap-import?")) {

--- a/dashboard-react/src/apps/cowork/documents/CoworkReimportDialog.test.tsx
+++ b/dashboard-react/src/apps/cowork/documents/CoworkReimportDialog.test.tsx
@@ -4,6 +4,10 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
 
+vi.mock("../../../security/humanAuthority", () => ({
+  coworkHumanAuthorityHeaders: vi.fn(async () => ({})),
+}));
+
 import type { CoworkDocumentSummary } from "../contracts";
 import { buildEditorExtensions } from "../editor/extensions";
 import { serializeCoworkEditorMarkdown } from "../editor/serializeCoworkMarkdown";

--- a/dashboard-react/src/apps/cowork/providers/CoworkHttpClient.test.ts
+++ b/dashboard-react/src/apps/cowork/providers/CoworkHttpClient.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../security/humanAuthority", () => ({
-  coworkHumanAuthorityHeaders: vi.fn(async () => ({})),
+  coworkHumanAuthorityHeaders: vi.fn(async () => ({
+    "X-WB-CSRF": "test-csrf-token",
+    "X-WB-Gesture": "test-gesture-token",
+  })),
 }));
 
+import { coworkHumanAuthorityHeaders } from "../../../security/humanAuthority";
 import type { CoworkPasteProvenanceRequest } from "../provenance";
 import {
   COWORK_FOLDER_PICKER_INTENT,
@@ -473,6 +477,93 @@ describe("CoworkHttpClient document lifecycle contracts", () => {
     ).toBe("never");
   });
 
+  it("posts the exact bootstrap source body with human authority and no caching", async () => {
+    vi.mocked(coworkHumanAuthorityHeaders).mockClear();
+    const source = new TextEncoder().encode("# Imported source\n");
+    const sourceUrl =
+      "/api/truth/doc/bootstrap/bootstrap-1/source?store_id=store%20one";
+    const fetchImpl = vi.fn(
+      async (input: RequestInfo | URL, init: RequestInit = {}) => {
+        expect(String(input)).toBe(sourceUrl);
+        expect(init).toMatchObject({
+          method: "POST",
+          credentials: "same-origin",
+          cache: "no-store",
+          body: JSON.stringify({ bootstrap_id: "bootstrap-1" }),
+        });
+        const headers = new Headers(init.headers);
+        expect(headers.get("Content-Type")).toBe("application/json");
+        expect(headers.get("X-WB-CSRF")).toBe("test-csrf-token");
+        expect(headers.get("X-WB-Gesture")).toBe("test-gesture-token");
+        return new Response(source, { status: 200 });
+      },
+    );
+    const client = new CoworkHttpClient(fetchImpl as typeof fetch);
+
+    expect(Array.from(await client.readBootstrapSource(sourceUrl))).toEqual(
+      Array.from(source),
+    );
+    expect(coworkHumanAuthorityHeaders).toHaveBeenCalledOnce();
+    expect(coworkHumanAuthorityHeaders).toHaveBeenLastCalledWith(
+      {
+        operation: "bootstrap.source_read",
+        storeId: "store one",
+        documentId: "bootstrap-1",
+        body: { bootstrap_id: "bootstrap-1" },
+      },
+      fetchImpl,
+    );
+  });
+
+  it("rejects a noncanonical bootstrap source URL before minting authority", async () => {
+    vi.mocked(coworkHumanAuthorityHeaders).mockClear();
+    const fetchImpl = vi.fn();
+    const client = new CoworkHttpClient(fetchImpl as typeof fetch);
+
+    for (const sourceUrl of [
+      "https://attacker.example/api/truth/doc/bootstrap/bootstrap-1/source?store_id=store-1",
+      "/bootstrap/bootstrap-1/source?store_id=store-1",
+    ]) {
+      await expect(client.readBootstrapSource(sourceUrl)).rejects.toMatchObject({
+        apiError: {
+          code: "invalid_bootstrap_source_url",
+          retryable: false,
+        },
+      });
+    }
+    expect(coworkHumanAuthorityHeaders).not.toHaveBeenCalled();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("preserves a structured bootstrap source-read error", async () => {
+    const client = new CoworkHttpClient(
+      vi.fn(async () =>
+        json(
+          {
+            error: {
+              code: "bootstrap_expired",
+              message: "The prepared import expired.",
+              retryable: false,
+            },
+          },
+          410,
+        ),
+      ) as typeof fetch,
+    );
+
+    await expect(
+      client.readBootstrapSource(
+        "/api/truth/doc/bootstrap/bootstrap-1/source?store_id=store-1",
+      ),
+    ).rejects.toMatchObject({
+      apiError: {
+        code: "bootstrap_expired",
+        retryable: false,
+        status: 410,
+      },
+    });
+  });
+
   it("uses prepare, exact staged source, and multipart commit for re-import", async () => {
     const requests: Array<{ readonly url: string; readonly init: RequestInit }> = [];
     const source = new TextEncoder().encode("# External source\n");
@@ -496,7 +587,16 @@ describe("CoworkHttpClient document lifecycle contracts", () => {
         });
       }
       if (url.endsWith("/reimport/reimport-1/source?store_id=store-1")) {
-        expect(init).toMatchObject({ method: "GET", credentials: "same-origin" });
+        expect(init).toMatchObject({
+          method: "POST",
+          credentials: "same-origin",
+          cache: "no-store",
+          body: JSON.stringify({ intent_id: "reimport-1" }),
+        });
+        const headers = new Headers(init.headers);
+        expect(headers.get("Content-Type")).toBe("application/json");
+        expect(headers.get("X-WB-CSRF")).toBe("test-csrf-token");
+        expect(headers.get("X-WB-Gesture")).toBe("test-gesture-token");
         return new Response(source, { status: 200 });
       }
       if (url.endsWith("/reimport/reimport-1/commit?store_id=store-1")) {
@@ -533,6 +633,15 @@ describe("CoworkHttpClient document lifecycle contracts", () => {
         await client.readReimportSource("store-1", "doc-1", prepared.intentId),
       ),
     ).toEqual(Array.from(source));
+    expect(coworkHumanAuthorityHeaders).toHaveBeenLastCalledWith(
+      {
+        operation: "reimport.source_read",
+        storeId: "store-1",
+        documentId: "doc-1",
+        body: { intent_id: "reimport-1" },
+      },
+      fetchImpl,
+    );
     const receipt = await client.commitReimport(
       "store-1",
       "doc-1",
@@ -546,6 +655,33 @@ describe("CoworkHttpClient document lifecycle contracts", () => {
       staledProposalIds: ["proposal-1"],
     });
     expect(requests).toHaveLength(3);
+  });
+
+  it("preserves a structured re-import source-read error", async () => {
+    const client = new CoworkHttpClient(
+      vi.fn(async () =>
+        json(
+          {
+            error: {
+              code: "reimport_source_changed",
+              message: "The staged source changed.",
+              retryable: true,
+            },
+          },
+          409,
+        ),
+      ) as typeof fetch,
+    );
+
+    await expect(
+      client.readReimportSource("store-1", "doc-1", "reimport-1"),
+    ).rejects.toMatchObject({
+      apiError: {
+        code: "reimport_source_changed",
+        retryable: true,
+        status: 409,
+      },
+    });
   });
 
   it("uses the same retirement route for server-prepared consequence and commit", async () => {

--- a/dashboard-react/src/apps/cowork/providers/CoworkHttpClient.ts
+++ b/dashboard-react/src/apps/cowork/providers/CoworkHttpClient.ts
@@ -1000,24 +1000,60 @@ export class CoworkHttpClient {
   }
 
   async readBootstrapSource(sourceUrl: string): Promise<Uint8Array> {
-    const parsed = new URL(sourceUrl, "http://localhost");
+    let parsed: URL;
+    try {
+      parsed = new URL(sourceUrl, "http://localhost");
+    } catch {
+      throw new CoworkHttpError({
+        code: "invalid_bootstrap_source_url",
+        message: "Co-work returned an invalid staged-source address.",
+        retryable: false,
+      });
+    }
     const storeId = parsed.searchParams.get("store_id") ?? "";
-    const match = parsed.pathname.match(/\/bootstrap\/([^/]+)\/source$/u);
-    const bootstrapId =
-      match === null ? "" : decodeURIComponent(match[1] ?? "");
+    const match = parsed.pathname.match(
+      /^\/api\/truth\/doc\/bootstrap\/([^/]+)\/source$/u,
+    );
+    let bootstrapId = "";
+    try {
+      bootstrapId = match === null ? "" : decodeURIComponent(match[1] ?? "");
+    } catch {
+      // The contract check below maps malformed path encoding to a typed error.
+    }
+    const queryEntries = Array.from(parsed.searchParams.entries());
+    if (
+      !sourceUrl.startsWith("/") ||
+      sourceUrl.startsWith("//") ||
+      parsed.origin !== "http://localhost" ||
+      match === null ||
+      bootstrapId.length === 0 ||
+      storeId.length === 0 ||
+      queryEntries.length !== 1 ||
+      queryEntries[0]?.[0] !== "store_id" ||
+      parsed.hash.length !== 0
+    ) {
+      throw new CoworkHttpError({
+        code: "invalid_bootstrap_source_url",
+        message: "Co-work returned an invalid staged-source address.",
+        retryable: false,
+      });
+    }
+    const body = { bootstrap_id: bootstrapId };
     const authorityHeaders = await coworkHumanAuthorityHeaders(
       {
         operation: "bootstrap.source_read",
         storeId,
         documentId: bootstrapId,
-        body: { bootstrap_id: bootstrapId },
+        body,
       },
       this.#fetch,
     );
     const response = await this.#fetch(sourceUrl, {
-      method: "GET",
+      method: "POST",
       credentials: "same-origin",
-      headers: authorityHeaders,
+      cache: "no-store",
+      headers: { "Content-Type": "application/json", ...authorityHeaders },
+      body: JSON.stringify(body),
     });
     if (!response.ok) {
       let payload: unknown = {};
@@ -1265,21 +1301,24 @@ export class CoworkHttpClient {
     intentId: string,
   ): Promise<Uint8Array> {
     const url = `/api/truth/doc/${encodeURIComponent(documentId)}/reimport/${encodeURIComponent(intentId)}/source?store_id=${encodeURIComponent(storeId)}`;
+    const body = { intent_id: intentId };
     const authorityHeaders = await coworkHumanAuthorityHeaders(
       {
         operation: "reimport.source_read",
         storeId,
         documentId,
-        body: { intent_id: intentId },
+        body,
       },
       this.#fetch,
     );
     let response: Response;
     try {
       response = await this.#fetch(url, {
-        method: "GET",
+        method: "POST",
         credentials: "same-origin",
-        headers: authorityHeaders,
+        cache: "no-store",
+        headers: { "Content-Type": "application/json", ...authorityHeaders },
+        body: JSON.stringify(body),
       });
     } catch (error) {
       throw new CoworkHttpError(normalizeCoworkError(error));

--- a/dashboard-react/src/security/humanAuthority.ts
+++ b/dashboard-react/src/security/humanAuthority.ts
@@ -1,4 +1,4 @@
-/** Exact-body local human-authority headers for application mutations. */
+/** Exact-body local human-authority headers for protected application actions. */
 
 import {
   initializeLocalIdentity,

--- a/dashboard-react/tests/live/cowork-live.spec.ts
+++ b/dashboard-react/tests/live/cowork-live.spec.ts
@@ -157,6 +157,31 @@ const mintBrowserIdentityBootstrap = async (page: Page): Promise<string> => {
   return result.payload.token!;
 };
 
+const gotoAuthenticatedCowork = async (
+  page: Page,
+  search = "?mode=launcher",
+): Promise<void> => {
+  const bootstrap = await mintBrowserIdentityBootstrap(page);
+  await page.goto(
+    `${backendBaseURL}/app/cowork${search}` +
+      `#wb-bootstrap=${encodeURIComponent(bootstrap)}`,
+    { waitUntil: "domcontentloaded" },
+  );
+  await expect(page.getByRole("heading", { level: 1, name: "Co-work" })).toBeVisible({
+    timeout: 60_000,
+  });
+  expect(new URL(page.url()).hash).not.toContain("wb-bootstrap");
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(async () =>
+          (await fetch("/api/truth/cowork/current-actor")).status,
+        ),
+      { timeout: 30_000 },
+    )
+    .toBe(200);
+};
+
 const chooseFolder = async (
   page: Page,
   folder: { readonly name: string; readonly path: string },
@@ -1141,29 +1166,10 @@ test.describe.serial("Co-work live lifecycle", () => {
     const sourceBytes = Buffer.from(`${existingParagraph}\n`, "utf-8");
     await writeFile(sourcePath, sourceBytes);
 
-    const bootstrap = await mintBrowserIdentityBootstrap(page);
-    // Same-origin GET does not normally carry Origin, but bootstrap source reads
-    // are human-authority actions. Mirror a trusted browser launch's exact
-    // loopback boundary across every request in this isolated page.
-    await page.setExtraHTTPHeaders({ Origin: new URL(backendBaseURL).origin });
-    await page.goto(
-      `${backendBaseURL}/app/cowork?store_id=${fixture.initialized.store_id}` +
-        `#wb-bootstrap=${encodeURIComponent(bootstrap)}`,
-      { waitUntil: "domcontentloaded" },
+    await gotoAuthenticatedCowork(
+      page,
+      `?store_id=${fixture.initialized.store_id}`,
     );
-    await expect(page.getByRole("heading", { level: 1, name: "Co-work" })).toBeVisible({
-      timeout: 60_000,
-    });
-    expect(new URL(page.url()).hash).not.toContain("wb-bootstrap");
-    await expect
-      .poll(
-        async () =>
-          page.evaluate(async () =>
-            (await fetch("/api/truth/cowork/current-actor")).status,
-          ),
-        { timeout: 30_000 },
-      )
-      .toBe(200);
 
     await page.route(
       "**/api/truth/cowork/files/choose-import",
@@ -1197,8 +1203,29 @@ test.describe.serial("Co-work live lifecycle", () => {
       },
       { times: 1 },
     );
+    // Observe rather than route this request: the browser must supply its natural
+    // exact Origin, which same-origin GET would omit.
+    const bootstrapSourceRead = page.waitForRequest(
+      (candidate) =>
+        /^\/api\/truth\/doc\/bootstrap\/[^/]+\/source$/.test(
+          new URL(candidate.url()).pathname,
+        ),
+      { timeout: 30_000 },
+    );
     await page.getByRole("button", { name: "From file", exact: true }).click();
     await page.getByRole("button", { name: "Import", exact: true }).click();
+    const bootstrapSourceRequest = await bootstrapSourceRead;
+    const bootstrapSourceMatch = new URL(bootstrapSourceRequest.url()).pathname.match(
+      /^\/api\/truth\/doc\/bootstrap\/([^/]+)\/source$/,
+    );
+    expect(bootstrapSourceRequest.method()).toBe("POST");
+    expect((await bootstrapSourceRequest.allHeaders())["origin"]).toBe(
+      new URL(backendBaseURL).origin,
+    );
+    expect(bootstrapSourceMatch).not.toBeNull();
+    expect(bootstrapSourceRequest.postDataJSON()).toEqual({
+      bootstrap_id: decodeURIComponent(bootstrapSourceMatch![1]),
+    });
     const editor = await waitForEditor(page);
     await expect(editor).toHaveAttribute("aria-readonly", "false");
     await expect(editor.locator("p")).toHaveCount(1);
@@ -1714,7 +1741,7 @@ test.describe.serial("Co-work live lifecycle", () => {
     page,
     request,
   }) => {
-    await gotoCowork(
+    await gotoAuthenticatedCowork(
       page,
       `?store_id=${ordinaryStoreId}&document_id=${importedDocumentId}`,
     );
@@ -1752,7 +1779,30 @@ test.describe.serial("Co-work live lifecycle", () => {
         new URL(response.url()).pathname.includes(`/reimport/`),
       { timeout: 30_000 },
     );
+    const reimportSourceRead = page.waitForRequest(
+      (candidate) => {
+        const pathname = new URL(candidate.url()).pathname;
+        return (
+          pathname.startsWith(
+            `/api/truth/doc/${encodeURIComponent(importedDocumentId)}/reimport/`,
+          ) && pathname.endsWith("/source")
+        );
+      },
+      { timeout: 30_000 },
+    );
     await page.getByRole("button", { name: "Replace Co-work document" }).click();
+    const reimportSourceRequest = await reimportSourceRead;
+    const reimportSourceMatch = new URL(reimportSourceRequest.url()).pathname.match(
+      /\/reimport\/([^/]+)\/source$/,
+    );
+    expect(reimportSourceRequest.method()).toBe("POST");
+    expect((await reimportSourceRequest.allHeaders())["origin"]).toBe(
+      new URL(backendBaseURL).origin,
+    );
+    expect(reimportSourceMatch).not.toBeNull();
+    expect(reimportSourceRequest.postDataJSON()).toEqual({
+      intent_id: decodeURIComponent(reimportSourceMatch![1]),
+    });
     const commitResponse = await committed;
     const commitBody = await commitResponse.text();
     expect(commitResponse.ok(), commitBody).toBe(true);

--- a/knowledge/store/architecture/local-human-identity.md
+++ b/knowledge/store/architecture/local-human-identity.md
@@ -1,7 +1,7 @@
 ---
 name: Local human identity boundary
 kind: concept
-description: Persistent installation-qualified actor, loopback session, Origin/CSRF, and exact one-use gesture boundary for protected local dashboard writes.
+description: Persistent installation-qualified actor, loopback session, Origin/CSRF, and exact one-use gesture boundary for protected local dashboard actions.
 summary: Work Buddy can prove that an enrolled local profile submitted a specific request through a bound loopback dashboard session. This is stronger than caller headers but deliberately does not prove physical presence, sole composition, or authorship.
 entry_points:
 - work_buddy.security.local_identity
@@ -26,7 +26,9 @@ requires:
 dev_notes: |-
   Protected routes must call the server verifier with the exact action, subject, and canonical context SHA-256. They derive the canonical actor from the consumed session/gesture and ignore caller-selected actor fields and legacy `X-WB-User-Ref`.
 
-  v1 is direct-loopback only. Reverse-proxied/Tailscale requests cannot make human-authority writes until a separate authenticated remote principal provider exists. Do not weaken this by treating same-origin alone as authentication.
+  A browser endpoint that consumes human authority must not use GET or HEAD, even when its domain result is a read. Chromium normally omits `Origin` on same-origin safe-method requests, so the exact-Origin verifier cannot authenticate them. The shared request gate rejects safe methods before consuming a gesture. Use a non-safe POST with the exact JSON request context bound into the gesture, validate any route/body target IDs for equality, and return `Cache-Control: no-store` for protected staged bytes.
+
+  v1 is direct-loopback only. Reverse-proxied/Tailscale requests cannot perform human-authority actions until a separate authenticated remote principal provider exists. Do not weaken this by treating same-origin alone as authentication.
 ---
 
 # Local human identity boundary

--- a/knowledge/store/cowork.md
+++ b/knowledge/store/cowork.md
@@ -91,6 +91,14 @@ requires its exact Co-work intent header, rejects cross-site browser provenance
 or a mismatched Origin, and the dashboard denies framing so another site cannot
 place the controls in a clickjacking frame.
 
+Bootstrap and re-import stage source bytes behind human authority. Their source
+retrieval routes are therefore non-safe POSTs, not GETs or HEADs: the JSON body
+repeats the staged intent ID, must exactly match the route target, and is bound
+into the one-use gesture context. Successful staged-byte responses are
+`no-store`. This method choice is a security invariant because Chromium does
+not normally send `Origin` on same-origin GET or HEAD requests, while the
+authority verifier must require the exact loopback Origin.
+
 ## Working with folders and documents
 
 With no folder open, the toolbar's **folder** control opens the native picker

--- a/tests/unit/cowork/test_api_routes.py
+++ b/tests/unit/cowork/test_api_routes.py
@@ -17,7 +17,7 @@ import pytest
 
 from work_buddy.conversations import store as conversation_store
 from work_buddy.conversations.execution import EXECUTION_METADATA_KEY
-from work_buddy.cowork import api, transport
+from work_buddy.cowork import api, reimport_api, transport
 from work_buddy.cowork import conversations, document_agent, provenance
 from work_buddy.truth import documents, expressions, proposals, ydoc_store
 from work_buddy.truth.anchors import CompositeSelector
@@ -1819,7 +1819,7 @@ def test_drift_reports_out_of_band_edit(client, store_ctx):
     assert drifted["current_file_sha256"] == sha256_bytes(drifted_body.encode("utf-8"))
 
 
-def test_reimport_records_change_set(client, store_ctx):
+def test_reimport_records_change_set(client, store_ctx, monkeypatch):
     ready, _source = _bootstrap_ready(
         client,
         store_ctx,
@@ -1839,15 +1839,46 @@ def test_reimport_records_change_set(client, store_ctx):
     )
     assert prepare.status_code == 201
     intent = prepare.get_json()
-    source = client.get(
-        _url(
-            f"/api/truth/doc/{ready['document_id']}/reimport/"
-            f"{intent['intent_id']}/source",
-            store_ctx["store_id"],
-        )
+    source_url = _url(
+        f"/api/truth/doc/{ready['document_id']}/reimport/"
+        f"{intent['intent_id']}/source",
+        store_ctx["store_id"],
     )
+    authority_calls: list[dict] = []
+
+    def capture_authority(**kwargs):
+        authority_calls.append(kwargs)
+        return HUMAN
+
+    monkeypatch.setattr(reimport_api, "_human_actor", capture_authority)
+
+    assert client.get(source_url).status_code == 405
+
+    missing_body = client.post(source_url)
+    assert missing_body.status_code == 400
+    assert missing_body.get_json()["error"]["code"] == "invalid_request"
+
+    mismatched_body = client.post(
+        source_url,
+        json={"intent_id": "another-intent"},
+    )
+    assert mismatched_body.status_code == 400
+    assert mismatched_body.get_json()["error"]["code"] == "intent_id_mismatch"
+    assert authority_calls == []
+
+    source_body = {"intent_id": intent["intent_id"]}
+    source = client.post(source_url, json=source_body)
     assert source.status_code == 200
     assert source.data == drifted_body.encode("utf-8")
+    assert source.headers["Cache-Control"] == "no-store"
+    assert authority_calls == [
+        {
+            "operation": "reimport.source_read",
+            "store_id": store_ctx["store_id"],
+            "document_id": ready["document_id"],
+            "body": source_body,
+        }
+    ]
 
     replacement_snapshot = b"YDOC:" + drifted_body.encode("utf-8")
     commit = client.put(

--- a/tests/unit/cowork/test_lifecycle_api.py
+++ b/tests/unit/cowork/test_lifecycle_api.py
@@ -9,6 +9,7 @@ from flask import Flask
 
 from work_buddy.cowork import api as cowork_api
 from work_buddy.cowork import bootstrap, bootstrap_api, materialization_api
+from work_buddy.truth.contracts import Actor
 from work_buddy.truth.identity import sha256_bytes
 
 
@@ -51,10 +52,46 @@ def test_bootstrap_binary_http_round_trip(store_ctx, monkeypatch):
     )
     assert prepared.status_code == 201
     intent = prepared.get_json()
-    staged = client.get(intent["source_url"].replace("store_id=test", "store_id=test"))
+    source_url = intent["source_url"].replace("store_id=test", "store_id=test")
+    authority_calls: list[dict] = []
+
+    def capture_authority(**kwargs):
+        authority_calls.append(kwargs)
+        return Actor("human", "reviewer-kaden")
+
+    monkeypatch.setattr(bootstrap_api, "_human_actor", capture_authority)
+
+    assert client.get(source_url).status_code == 405
+
+    missing_body = client.post(source_url)
+    assert missing_body.status_code == 400
+    assert missing_body.get_json()["error"]["code"] == "invalid_request"
+
+    mismatched_body = client.post(
+        source_url,
+        json={"bootstrap_id": "another-bootstrap"},
+    )
+    assert mismatched_body.status_code == 400
+    assert (
+        mismatched_body.get_json()["error"]["code"]
+        == "bootstrap_id_mismatch"
+    )
+    assert authority_calls == []
+
+    source_body = {"bootstrap_id": intent["bootstrap_id"]}
+    staged = client.post(source_url, json=source_body)
     assert staged.status_code == 200
     assert staged.data == source
+    assert staged.headers["Cache-Control"] == "no-store"
     assert staged.headers["X-WB-BOM"] == "utf-8"
+    assert authority_calls == [
+        {
+            "operation": "bootstrap.source_read",
+            "store_id": store_ctx["store"].store_id,
+            "document_id": intent["bootstrap_id"],
+            "body": source_body,
+        }
+    ]
 
     snapshot = b"opaque-browser-ydoc"
     committed = client.put(

--- a/tests/unit/test_local_identity.py
+++ b/tests/unit/test_local_identity.py
@@ -696,6 +696,69 @@ def test_dashboard_human_authority_helper_fails_closed_remotely(
     assert response.json == {"ok": False, "code": "loopback_required"}
 
 
+@pytest.mark.parametrize("method", ["GET", "HEAD", "OPTIONS", "TRACE"])
+def test_dashboard_human_authority_helper_rejects_safe_method_before_consuming_gesture(
+    authority: tuple[LocalIdentityAuthority, Clock],
+    monkeypatch: pytest.MonkeyPatch,
+    method: str,
+) -> None:
+    service, _ = authority
+    monkeypatch.setattr(local_identity_api, "_authority", lambda: service)
+    app = Flask("local-identity-safe-method-test")
+    context_digest = hashlib.sha256(b"protected read context").hexdigest()
+    session = _session(service)
+    _, gesture = service.issue_gesture(
+        cookie_token=session.cookie_token,
+        csrf_token=session.csrf_token,
+        boundary=_boundary(),
+        action="cowork.bootstrap.source_read",
+        subject="cowork-document:store-1:bootstrap-1",
+        context_sha256=context_digest,
+    )
+
+    @app.route(
+        "/protected",
+        methods=["GET", "HEAD", "OPTIONS", "POST", "TRACE"],
+        provide_automatic_options=False,
+    )
+    def protected():
+        try:
+            local_identity_api.require_human_authority_request(
+                action="cowork.bootstrap.source_read",
+                subject="cowork-document:store-1:bootstrap-1",
+                context_sha256=context_digest,
+            )
+        except LocalIdentityError as exc:
+            return {"ok": False, "code": exc.code}, exc.status
+        return {"ok": True}, 200
+
+    client = app.test_client()
+    client.set_cookie(
+        SESSION_COOKIE_NAME,
+        session.cookie_token,
+        domain="127.0.0.1",
+    )
+    headers = {
+        "Origin": "http://127.0.0.1:5127",
+        "Host": "127.0.0.1:5127",
+        "X-WB-CSRF": session.csrf_token,
+        "X-WB-Gesture": gesture.token,
+    }
+
+    rejected = client.open("/protected", method=method, headers=headers)
+    assert rejected.status_code == 405
+    if method != "HEAD":
+        assert rejected.json == {
+            "ok": False,
+            "code": "human_authority_method_not_allowed",
+        }
+
+    # The central method gate runs before the one-use gesture is consumed.
+    accepted = client.post("/protected", headers=headers)
+    assert accepted.status_code == 200
+    assert accepted.json == {"ok": True}
+
+
 def test_cowork_mutation_context_matches_browser_exact_whitespace_digest() -> None:
     from work_buddy.cowork import api as cowork_api
 
@@ -835,6 +898,275 @@ def test_cowork_action_rejects_absent_mismatched_replayed_and_remote_gestures(
     )
     assert remote.status_code == 403
     assert remote.json["code"] == "loopback_required"
+
+
+def test_bootstrap_source_post_requires_origin_and_accepts_exact_human_authority(
+    authority: tuple[LocalIdentityAuthority, Clock],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from work_buddy.cowork import api as cowork_api
+    from work_buddy.cowork import bootstrap, bootstrap_api
+    from work_buddy.truth.contracts import Actor
+    from work_buddy.truth.identity import sha256_bytes
+    from work_buddy.truth.registry import TruthStoreRegistry
+    from work_buddy.truth.store import TruthStore
+
+    service, _ = authority
+    monkeypatch.setattr(local_identity_api, "_authority", lambda: service)
+
+    root = tmp_path / "cowork-source-read-authority"
+    root.mkdir()
+    store = TruthStore.create(
+        root,
+        {
+            "store_id": "2" * 32,
+            "profile": "cowork-source-read-authority-test",
+            "title": "Throwaway Co-work source-read authority test store",
+            "allowed_claim_kinds": ["fact", "preference"],
+            "required_fields": {},
+            "gate": {
+                "rejected_content": "retain",
+                "confirmation_surfaces": ["dashboard"],
+                "block_materialize_on_flags": False,
+            },
+            "projection": "none",
+            "export_committed": True,
+            "document_surface": {
+                "enabled": True,
+                "allowed_document_classes": ["co_authored"],
+                "feedback_capture": True,
+            },
+        },
+    )
+    registry = TruthStoreRegistry(tmp_path / "truth-registry-source-read.db")
+    registry.register(store)
+    monkeypatch.setattr(cowork_api, "_registry", lambda: registry)
+
+    source = b"# Throwaway protected source\n\nExact staged bytes.\n"
+    actor = Actor("human", service.enrolled_actor().canonical_id)
+    intent, created = bootstrap.prepare_bootstrap(
+        store,
+        metadata={
+            "mode": "create",
+            "path": "docs/throwaway-protected-source.md",
+            "title": "Throwaway protected source",
+            "initial_source_sha256": sha256_bytes(source),
+            "idempotency_key": "source-read-authority-0001",
+        },
+        source=source,
+        actor=actor,
+    )
+    assert created is True
+
+    app = Flask("cowork-bootstrap-source-authority-test")
+    app.config.update(TESTING=True)
+    bootstrap_api.register_bootstrap_routes(app)
+    client = app.test_client()
+    session = _session(service)
+    client.set_cookie(
+        SESSION_COOKIE_NAME,
+        session.cookie_token,
+        domain="127.0.0.1",
+    )
+
+    body = {"bootstrap_id": intent.id}
+    action = "cowork.bootstrap.source_read"
+    subject = f"cowork-document:{store.store_id}:{intent.id}"
+    context_sha256 = cowork_api.cowork_mutation_context_sha256(
+        operation="bootstrap.source_read",
+        store_id=store.store_id,
+        document_id=intent.id,
+        body=body,
+    )
+
+    def gesture_token() -> str:
+        _, gesture = service.issue_gesture(
+            cookie_token=session.cookie_token,
+            csrf_token=session.csrf_token,
+            boundary=_boundary(),
+            action=action,
+            subject=subject,
+            context_sha256=context_sha256,
+        )
+        return gesture.token
+
+    url = (
+        f"/api/truth/doc/bootstrap/{intent.id}/source"
+        f"?store_id={store.store_id}"
+    )
+    base_headers = {
+        "Host": "127.0.0.1:5127",
+        "X-WB-CSRF": session.csrf_token,
+    }
+    missing_origin = client.post(
+        url,
+        json=body,
+        headers={**base_headers, "X-WB-Gesture": gesture_token()},
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+    assert missing_origin.status_code == 403
+    assert missing_origin.get_json()["error"]["code"] == "origin_required"
+
+    accepted = client.post(
+        url,
+        json=body,
+        headers={
+            **base_headers,
+            "Origin": "http://127.0.0.1:5127",
+            "X-WB-Gesture": gesture_token(),
+        },
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+    assert accepted.status_code == 200
+    assert accepted.data == source
+    assert accepted.headers["Cache-Control"] == "no-store"
+
+
+def test_reimport_source_post_requires_origin_and_accepts_exact_human_authority(
+    authority: tuple[LocalIdentityAuthority, Clock],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from work_buddy.cowork import api as cowork_api
+    from work_buddy.cowork import bootstrap, reimport, reimport_api
+    from work_buddy.truth.contracts import Actor
+    from work_buddy.truth.identity import sha256_bytes
+    from work_buddy.truth.registry import TruthStoreRegistry
+    from work_buddy.truth.store import TruthStore
+
+    service, _ = authority
+    monkeypatch.setattr(local_identity_api, "_authority", lambda: service)
+
+    root = tmp_path / "cowork-reimport-source-read-authority"
+    root.mkdir()
+    store = TruthStore.create(
+        root,
+        {
+            "store_id": "3" * 32,
+            "profile": "cowork-reimport-source-read-authority-test",
+            "title": "Throwaway Co-work re-import authority test store",
+            "allowed_claim_kinds": ["fact", "preference"],
+            "required_fields": {},
+            "gate": {
+                "rejected_content": "retain",
+                "confirmation_surfaces": ["dashboard"],
+                "block_materialize_on_flags": False,
+            },
+            "projection": "none",
+            "export_committed": True,
+            "document_surface": {
+                "enabled": True,
+                "allowed_document_classes": ["co_authored"],
+                "feedback_capture": True,
+            },
+        },
+    )
+    registry = TruthStoreRegistry(tmp_path / "truth-registry-reimport-source-read.db")
+    registry.register(store)
+    monkeypatch.setattr(cowork_api, "_registry", lambda: registry)
+
+    actor = Actor("human", service.enrolled_actor().canonical_id)
+    initial_source = b"# Original source\n\nBefore external drift.\n"
+    bootstrap_intent, created = bootstrap.prepare_bootstrap(
+        store,
+        metadata={
+            "mode": "create",
+            "path": "docs/throwaway-protected-reimport.md",
+            "title": "Throwaway protected re-import",
+            "initial_source_sha256": sha256_bytes(initial_source),
+            "idempotency_key": "reimport-source-authority-bootstrap-0001",
+        },
+        source=initial_source,
+        actor=actor,
+    )
+    assert created is True
+    snapshot = b"YDOC-INITIALIZED:" + sha256_bytes(initial_source).encode("ascii")
+    ready = bootstrap.commit_bootstrap(
+        store,
+        bootstrap_id=bootstrap_intent.id,
+        snapshot=snapshot,
+        source_sha256=bootstrap_intent.source_sha256,
+        snapshot_sha256=sha256_bytes(snapshot),
+        ydoc_schema=bootstrap.YDOC_SCHEMA,
+        actor=actor,
+    )
+    document_id = ready["document_id"]
+
+    external_source = b"# External replacement\n\nExact staged replacement bytes.\n"
+    (root / "docs" / "throwaway-protected-reimport.md").write_bytes(
+        external_source
+    )
+    intent, prepared = reimport.prepare_reimport(
+        store,
+        document_id=document_id,
+        actor=actor,
+        idempotency_key="reimport-source-authority-0001",
+    )
+    assert prepared is True
+
+    app = Flask("cowork-reimport-source-authority-test")
+    app.config.update(TESTING=True)
+    reimport_api.register_reimport_routes(app)
+    client = app.test_client()
+    session = _session(service)
+    client.set_cookie(
+        SESSION_COOKIE_NAME,
+        session.cookie_token,
+        domain="127.0.0.1",
+    )
+
+    body = {"intent_id": intent.id}
+    action = "cowork.reimport.source_read"
+    subject = f"cowork-document:{store.store_id}:{document_id}"
+    context_sha256 = cowork_api.cowork_mutation_context_sha256(
+        operation="reimport.source_read",
+        store_id=store.store_id,
+        document_id=document_id,
+        body=body,
+    )
+
+    def gesture_token() -> str:
+        _, gesture = service.issue_gesture(
+            cookie_token=session.cookie_token,
+            csrf_token=session.csrf_token,
+            boundary=_boundary(),
+            action=action,
+            subject=subject,
+            context_sha256=context_sha256,
+        )
+        return gesture.token
+
+    url = (
+        f"/api/truth/doc/{document_id}/reimport/{intent.id}/source"
+        f"?store_id={store.store_id}"
+    )
+    base_headers = {
+        "Host": "127.0.0.1:5127",
+        "X-WB-CSRF": session.csrf_token,
+    }
+    missing_origin = client.post(
+        url,
+        json=body,
+        headers={**base_headers, "X-WB-Gesture": gesture_token()},
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+    assert missing_origin.status_code == 403
+    assert missing_origin.get_json()["error"]["code"] == "origin_required"
+
+    accepted = client.post(
+        url,
+        json=body,
+        headers={
+            **base_headers,
+            "Origin": "http://127.0.0.1:5127",
+            "X-WB-Gesture": gesture_token(),
+        },
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+    assert accepted.status_code == 200
+    assert accepted.data == external_source
+    assert accepted.headers["Cache-Control"] == "no-store"
 
 
 def test_direct_entry_route_accepts_multiline_anchor_and_consumes_gesture(

--- a/work_buddy/cowork/bootstrap_api.py
+++ b/work_buddy/cowork/bootstrap_api.py
@@ -170,15 +170,26 @@ def api_bootstrap_prepare():
         return _error(bootstrap.BootstrapError("invalid_request", str(exc)))
 
 
-@bootstrap_blueprint.get("/api/truth/doc/bootstrap/<bootstrap_id>/source")
+@bootstrap_blueprint.post("/api/truth/doc/bootstrap/<bootstrap_id>/source")
 def api_bootstrap_source(bootstrap_id: str):
     try:
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            raise bootstrap.BootstrapError(
+                "invalid_request",
+                "bootstrap source read requires a JSON object",
+            )
+        if body.get("bootstrap_id") != bootstrap_id:
+            raise bootstrap.BootstrapError(
+                "bootstrap_id_mismatch",
+                "bootstrap_id must match the route target",
+            )
         store = _store()
         actor = _human_actor(
             operation="bootstrap.source_read",
             store_id=store.store_id,
             document_id=bootstrap_id,
-            body={"bootstrap_id": bootstrap_id},
+            body=body,
         )
         intent, payload = bootstrap.read_staged_source(
             store, bootstrap_id=bootstrap_id, actor=actor
@@ -186,6 +197,7 @@ def api_bootstrap_source(bootstrap_id: str):
         media_type = intent.source_media_type or "text/markdown"
         response = Response(payload, mimetype=media_type)
         response.headers["ETag"] = f'"{intent.source_sha256}"'
+        response.headers["Cache-Control"] = "no-store"
         response.headers["X-WB-Source-Sha256"] = intent.source_sha256
         response.headers["X-WB-Source-Byte-Length"] = str(len(payload))
         if intent.importer_id is not None:

--- a/work_buddy/cowork/reimport_api.py
+++ b/work_buddy/cowork/reimport_api.py
@@ -120,9 +120,19 @@ def api_prepare_reimport(document_id: str):
         return _error(reimport.ReimportError("invalid_request", str(exc)))
 
 
-@reimport_blueprint.get("/api/truth/doc/<document_id>/reimport/<intent_id>/source")
+@reimport_blueprint.post("/api/truth/doc/<document_id>/reimport/<intent_id>/source")
 def api_reimport_source(document_id: str, intent_id: str):
     try:
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            raise reimport.ReimportError(
+                "invalid_request", "Request body must be a JSON object."
+            )
+        if body.get("intent_id") != intent_id:
+            raise reimport.ReimportError(
+                "intent_id_mismatch",
+                "intent_id must match the route target.",
+            )
         store = _store()
         intent, data = reimport.read_reimport_source(
             store,
@@ -131,7 +141,7 @@ def api_reimport_source(document_id: str, intent_id: str):
                 operation="reimport.source_read",
                 store_id=store.store_id,
                 document_id=document_id,
-                body={"intent_id": intent_id},
+                body=body,
             ),
         )
         if intent.document_id != document_id:
@@ -142,6 +152,7 @@ def api_reimport_source(document_id: str, intent_id: str):
             )
         response = Response(data, mimetype="application/octet-stream")
         response.headers["ETag"] = f'"{intent.expected_file_sha256}"'
+        response.headers["Cache-Control"] = "no-store"
         response.headers["X-WB-Source-Sha256"] = intent.expected_file_sha256
         response.headers["X-WB-Source-Byte-Length"] = str(len(data))
         response.headers["X-WB-Source-Encoding"] = "utf-8"

--- a/work_buddy/dashboard/local_identity_api.py
+++ b/work_buddy/dashboard/local_identity_api.py
@@ -320,12 +320,18 @@ def require_human_authority_request(
     context_sha256: str,
     authority: LocalIdentityAuthority | None = None,
 ) -> HumanAuthorityContext:
-    """Hard gate for a human-authority domain mutation.
+    """Hard gate for a protected human-authority domain action.
 
     The actor is always read from server enrollment/session state.  Request
     headers such as ``X-WB-User-Ref`` and actor-shaped JSON fields are ignored.
     """
 
+    if request.method in {"GET", "HEAD", "OPTIONS", "TRACE"}:
+        raise LocalIdentityError(
+            "human_authority_method_not_allowed",
+            "Protected human-authority actions must use a non-safe HTTP method.",
+            status=405,
+        )
     service = authority or _authority()
     return service.authorize_human_mutation(
         cookie_token=_cookie_token(),


### PR DESCRIPTION
## Summary
- switch authority-protected bootstrap and re-import staged source reads from GET to exact-context POST so Chromium supplies the required loopback `Origin`
- reject safe methods before consuming one-use gestures, validate canonical staged-source targets and route/body identity, and mark returned bytes `no-store`
- update the Co-work and local-human-identity contracts with unit, frontend, compatibility, and live Chromium coverage

## Root cause
Chromium normally omits `Origin` on same-origin GET requests. These endpoints were domain reads but consumed human authority, whose verifier deliberately requires an exact loopback Origin, so valid Co-work imports failed with `An exact loopback Origin is required.`

## Test plan
- [x] `uv run --no-sync pytest tests/unit/test_local_identity.py tests/unit/cowork/test_lifecycle_api.py tests/unit/cowork/test_api_routes.py -q --tb=short` (108 passed before the added invariant cases)
- [x] `uv run --no-sync pytest tests/unit/test_local_identity.py -q --tb=short` (35 passed with the added cases)
- [x] `uv run --no-sync pytest tests/unit/tasks/test_api.py -q --tb=short` (12 passed)
- [x] focused Co-work Vitest suite (58 passed)
- [x] focused Tasks/Co-work provider Vitest suite (58 passed)
- [x] TypeScript typecheck
- [x] production frontend build
- [x] scoped live Chromium `AC-PROV` regression (1 passed; cleanup succeeded)
- [x] knowledge-store rebuild and validation (507 units, 0 errors; no warnings introduced)