### PR TITLE
fix(cowork): unblock provenance selection review

### DIFF
--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.pasteProvenance.test.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.pasteProvenance.test.tsx
@@ -375,6 +375,27 @@ describe("CoworkBridgeEditor paste provenance", () => {
       await entered;
       await waitFor(() => expect(pendingChanges).toContain(true));
 
+      const unrelated = resolveCoworkPasteAnchor(mounted.editor.state.doc, {
+        exact: "after",
+        prefix: "Before ",
+        suffix: "",
+      });
+      expect(unrelated.kind).toBe("unique");
+      if (unrelated.kind === "unique") {
+        act(() => {
+          mounted.editor.commands.setTextSelection({
+            from: unrelated.from,
+            to: unrelated.to,
+          });
+        });
+      }
+      expect(
+        await screen.findByRole("button", { name: "Record provenance" }),
+      ).toBeEnabled();
+      expect(
+        screen.queryByRole("button", { name: /Recording recent typing/u }),
+      ).toBeNull();
+
       releaseRecorder();
       await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
       await waitFor(() => {
@@ -390,6 +411,313 @@ describe("CoworkBridgeEditor paste provenance", () => {
       mounted.unmount();
     }
   }, 30_000);
+
+  it("blocks duplicate manual recording only for an overlapping volatile typing capture", async () => {
+    const memoryBacking =
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore();
+    let failWrites = true;
+    const failingBacking: CoworkPasteProvenanceOutboxBackingStore = {
+      durable: false,
+      read: (key) => memoryBacking.read(key),
+      mutate: (key, mutation) =>
+        failWrites
+          ? Promise.reject(new Error("injected outbox write failure"))
+          : memoryBacking.mutate(key, mutation),
+    };
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `volatile-direct-entry-${String(Date.now())}`,
+      failingBacking,
+    );
+    const recorder = vi.fn<CoworkPasteProvenanceRecorder>();
+    const mounted = await mountPasteEditor(recorder, {
+      outbox,
+      activeLens: "neutral",
+      provenanceProvider: provenanceProvider(),
+    });
+
+    try {
+      act(() => mounted.editor.commands.insertContentAt(1, "Pending text"));
+      mounted.setActiveLens("provenance");
+      await screen.findByRole("button", { name: "Retry provenance storage" });
+      failWrites = false;
+
+      const pending = resolveCoworkPasteAnchor(mounted.editor.state.doc, {
+        exact: "Pending text",
+        prefix: "",
+        suffix: "Before ",
+      });
+      expect(pending.kind).toBe("unique");
+      if (pending.kind === "unique") {
+        act(() => {
+          mounted.editor.commands.setTextSelection({
+            from: pending.from,
+            to: pending.to,
+          });
+        });
+      }
+      await userEvent.click(
+        await screen.findByRole("button", { name: "Record provenance" }),
+      );
+      const dialog = await screen.findByRole("dialog", {
+        name: "Record provenance",
+      });
+      await userEvent.click(
+        within(dialog).getByRole("button", { name: "Record provenance" }),
+      );
+
+      expect(
+        await within(dialog).findByText(
+          /Provenance delivery is already pending for this selection/u,
+        ),
+      ).toBeVisible();
+      expect(recorder).toHaveBeenCalledOnce();
+      expect(recorder.mock.calls[0]?.[0].sourceKind).toBe("direct_entry");
+    } finally {
+      mounted.unmount();
+    }
+  }, 30_000);
+
+  it("finalizes a volatile typing capture when provenance storage is retried", async () => {
+    const memoryBacking =
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore();
+    let failWrites = true;
+    const failingBacking: CoworkPasteProvenanceOutboxBackingStore = {
+      durable: false,
+      read: (key) => memoryBacking.read(key),
+      mutate: (key, mutation) =>
+        failWrites
+          ? Promise.reject(new Error("injected outbox write failure"))
+          : memoryBacking.mutate(key, mutation),
+    };
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `retry-volatile-direct-entry-${String(Date.now())}`,
+      failingBacking,
+    );
+    const recorder = vi.fn<CoworkPasteProvenanceRecorder>();
+    const pendingChanges: boolean[] = [];
+    const mounted = await mountPasteEditor(recorder, {
+      outbox,
+      activeLens: "neutral",
+      provenanceProvider: provenanceProvider(),
+      onInputProvenancePendingChange: (pending) =>
+        pendingChanges.push(pending),
+    });
+
+    try {
+      act(() => mounted.editor.commands.insertContentAt(1, "Recovered typing"));
+      mounted.setActiveLens("provenance");
+      const retry = await screen.findByRole("button", {
+        name: "Retry provenance storage",
+      });
+
+      failWrites = false;
+      await userEvent.click(retry);
+
+      await waitFor(() => expect(recorder).toHaveBeenCalledOnce());
+      await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+      await waitFor(() =>
+        expect(pendingChanges[pendingChanges.length - 1]).toBe(false),
+      );
+      expect(
+        screen.queryByRole("button", { name: "Retry provenance storage" }),
+      ).toBeNull();
+    } finally {
+      mounted.unmount();
+    }
+  }, 30_000);
+
+  it("drains a recovered typing capture queued behind an in-flight finalizer", async () => {
+    const memoryBacking =
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore();
+    let failWrites = false;
+    const backing: CoworkPasteProvenanceOutboxBackingStore = {
+      durable: false,
+      read: (key) => memoryBacking.read(key),
+      mutate: (key, mutation) =>
+        failWrites
+          ? Promise.reject(new Error("injected outbox write failure"))
+          : memoryBacking.mutate(key, mutation),
+    };
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `racing-volatile-direct-entry-${String(Date.now())}`,
+      backing,
+    );
+    let blockPush = false;
+    let releasePush!: () => void;
+    const pushGate = new Promise<void>((resolve) => {
+      releasePush = resolve;
+    });
+    let signalBlockedPush!: () => void;
+    const blockedPush = new Promise<void>((resolve) => {
+      signalBlockedPush = resolve;
+    });
+    const recorder = vi.fn<CoworkPasteProvenanceRecorder>();
+    const mounted = await mountPasteEditor(recorder, {
+      outbox,
+      activeLens: "neutral",
+      provenanceProvider: provenanceProvider(),
+      beforePush: async () => {
+        if (!blockPush) return;
+        signalBlockedPush();
+        await pushGate;
+      },
+    });
+
+    try {
+      act(() => mounted.editor.commands.insertContentAt(1, "First burst "));
+      await waitFor(async () =>
+        expect(await outbox.list()).toEqual([
+          expect.objectContaining({
+            sourceKind: "direct_entry",
+            status: "capturing",
+          }),
+        ]),
+      );
+
+      blockPush = true;
+      mounted.setActiveLens("provenance");
+      await blockedPush;
+
+      failWrites = true;
+      act(() => mounted.editor.commands.insertContentAt(13, "Second burst "));
+      const retry = await screen.findByRole("button", {
+        name: "Retry provenance storage",
+      });
+
+      failWrites = false;
+      await userEvent.click(retry);
+      await waitFor(async () =>
+        expect(
+          (await outbox.list()).filter(
+            (entry) => entry.status === "capturing",
+          ),
+        ).toHaveLength(2),
+      );
+      releasePush();
+
+      await waitFor(() => expect(recorder).toHaveBeenCalledTimes(2), {
+        timeout: 10_000,
+      });
+      await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+      expect(
+        screen.queryByRole("button", { name: "Retry provenance storage" }),
+      ).toBeNull();
+    } finally {
+      releasePush();
+      mounted.unmount();
+    }
+  }, 30_000);
+
+  it("retries independent ready provenance while an open capture stays stuck", async () => {
+    const memoryBacking =
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore();
+    let failWrites = false;
+    const backing: CoworkPasteProvenanceOutboxBackingStore = {
+      durable: false,
+      read: (key) => memoryBacking.read(key),
+      mutate: (key, mutation) =>
+        failWrites
+          ? Promise.reject(new Error("injected outbox write failure"))
+          : memoryBacking.mutate(key, mutation),
+    };
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `independent-ready-${String(Date.now())}`,
+      backing,
+    );
+    await outbox.upsertCapture({
+      anchor: { exact: "Missing direct entry", prefix: "", suffix: "" },
+      idempotencyKey: "stuck-open-capture",
+      substantial: false,
+      sourceKind: "direct_entry",
+      basisKind: "automatic_direct_entry_attribution",
+      determination: unknownCoworkProvenanceDetermination(),
+      capturedActor: ACTOR,
+      capturedAt: new Date().toISOString(),
+      passageExcerpt: "Missing direct entry",
+      status: "capturing",
+    });
+    failWrites = true;
+    const recorder = vi.fn<CoworkPasteProvenanceRecorder>();
+    const mounted = await mountPasteEditor(recorder, {
+      outbox,
+      activeLens: "neutral",
+      provenanceProvider: provenanceProvider(),
+    });
+
+    try {
+      act(() => mounted.editor.commands.insertContentAt(1, "Volatile typing "));
+      const retry = await screen.findByRole("button", {
+        name: "Retry provenance storage",
+      });
+      failWrites = false;
+      await outbox.append({
+        anchor: { exact: "Before", prefix: "typing ", suffix: " after" },
+        idempotencyKey: "unrelated-ready-capture",
+        substantial: false,
+        sourceKind: "paste",
+        basisKind: "automatic_short_text_attribution",
+        determination: unknownCoworkProvenanceDetermination(),
+        capturedActor: ACTOR,
+        capturedAt: new Date().toISOString(),
+        passageExcerpt: "Before",
+        status: "ready",
+      });
+
+      await userEvent.click(retry);
+
+      await waitFor(() =>
+        expect(
+          recorder.mock.calls.some(
+            ([request]) =>
+              request.idempotencyKey === "unrelated-ready-capture",
+          ),
+        ).toBe(true),
+      );
+      expect(
+        await screen.findByRole("button", {
+          name: "Retry provenance storage",
+        }),
+      ).toBeVisible();
+      await expect(outbox.list()).resolves.toEqual([
+        expect.objectContaining({
+          idempotencyKey: "stuck-open-capture",
+          status: "capturing",
+        }),
+      ]);
+    } finally {
+      mounted.unmount();
+    }
+  }, 30_000);
+
+  it("does not strand the host pending signal when a staged burst is deleted immediately", async () => {
+    const pendingChanges: boolean[] = [];
+    const recorder = vi.fn<CoworkPasteProvenanceRecorder>();
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `deleted-staged-direct-entry-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    const mounted = await mountPasteEditor(recorder, {
+      outbox,
+      activeLens: "neutral",
+      provenanceProvider: provenanceProvider(),
+      onInputProvenancePendingChange: (pending) =>
+        pendingChanges.push(pending),
+    });
+
+    try {
+      act(() => {
+        mounted.editor.commands.insertContentAt(1, "X");
+        mounted.editor.commands.deleteRange({ from: 1, to: 2 });
+      });
+
+      await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+      await act(async () => Promise.resolve());
+      expect(pendingChanges[pendingChanges.length - 1]).toBe(false);
+      expect(recorder).not.toHaveBeenCalled();
+    } finally {
+      mounted.unmount();
+    }
+  });
 
   it("keeps the frozen capture pending until the refreshed projection matches the complete receipt", async () => {
     const data = emptyProvenanceData();
@@ -481,6 +809,94 @@ describe("CoworkBridgeEditor paste provenance", () => {
           ),
         ).toBeNull(),
       );
+    } finally {
+      mounted.unmount();
+    }
+  }, 30_000);
+
+  it("reconciles a frozen direct-entry receipt when a later provenance snapshot publishes it", async () => {
+    const data = emptyProvenanceData();
+    const requests: CoworkPasteProvenanceRequest[] = [];
+    const snapshotListeners = new Set<() => void>();
+    const pendingChanges: boolean[] = [];
+    let receipt: CoworkPasteProvenanceReceipt | undefined;
+    let receiptProjected = false;
+    const provider: ProvenanceProvider = {
+      load: vi.fn().mockImplementation(async () => ({
+        state: "ready" as const,
+        data: {
+          ...data,
+          history:
+            receipt === undefined || !receiptProjected
+              ? []
+              : [attestationForReceipt(receipt)],
+        },
+      })),
+      refresh: vi.fn().mockImplementation(async () => ({
+        state: "ready" as const,
+        data: {
+          ...data,
+          history:
+            receipt === undefined || !receiptProjected
+              ? []
+              : [attestationForReceipt(receipt)],
+        },
+      })),
+      subscribe: (listener) => {
+        snapshotListeners.add(listener);
+        return () => snapshotListeners.delete(listener);
+      },
+      markReviewed: vi.fn().mockResolvedValue(undefined),
+    };
+    const outbox = new DurableCoworkPasteProvenanceOutbox(
+      `published-receipt-${String(Date.now())}`,
+      new InMemoryCoworkPasteProvenanceOutboxBackingStore(),
+    );
+    const mounted = await mountPasteEditor(
+      async (request) => {
+        requests.push(request);
+        receipt ??= testProvenanceReceipt(request);
+        return receipt;
+      },
+      {
+        outbox,
+        activeLens: "neutral",
+        provenanceProvider: provider,
+        onInputProvenancePendingChange: (pending) =>
+          pendingChanges.push(pending),
+      },
+    );
+
+    try {
+      act(() => mounted.editor.commands.insertContentAt(1, "Published receipt"));
+      mounted.setActiveLens("provenance");
+
+      await screen.findByRole("button", { name: "Retry provenance storage" });
+      expect(requests).toHaveLength(1);
+      await expect(outbox.list()).resolves.toEqual([
+        expect.objectContaining({
+          sourceKind: "direct_entry",
+          status: "retryable_failure",
+          frozenRequest: expect.objectContaining({
+            idempotencyKey: requests[0]!.idempotencyKey,
+          }),
+        }),
+      ]);
+
+      receiptProjected = true;
+      act(() => {
+        for (const listener of snapshotListeners) listener();
+      });
+
+      await waitFor(() => expect(requests).toHaveLength(2));
+      expect(requests[1]).toEqual(requests[0]);
+      await waitFor(() => expect(outbox.list()).resolves.toEqual([]));
+      await waitFor(() =>
+        expect(pendingChanges[pendingChanges.length - 1]).toBe(false),
+      );
+      expect(
+        screen.queryByRole("button", { name: "Retry provenance storage" }),
+      ).toBeNull();
     } finally {
       mounted.unmount();
     }

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.pasteProvenance.test.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.pasteProvenance.test.tsx
@@ -43,6 +43,7 @@ import { CoworkHttpError } from "../providers/errors";
 import {
   CoworkBridgeEditor,
   coworkPasteProvenanceOutboxKey,
+  type CoworkProvenanceIdentityState,
 } from "./CoworkBridgeEditor";
 
 type CoworkPasteProvenanceRecorder = (
@@ -129,6 +130,9 @@ const mountPasteEditor = async (
     readonly activeLens?: CoworkEditorLens;
     readonly provenanceProvider?: ProvenanceProvider;
     readonly onInputProvenancePendingChange?: (pending: boolean) => void;
+    readonly onProvenanceIdentityStateChange?: (
+      state: CoworkProvenanceIdentityState,
+    ) => void;
     readonly document?: Y.Doc;
     readonly server?: InMemoryCoworkYdocTransport;
   } = {},
@@ -193,6 +197,9 @@ const mountPasteEditor = async (
       provenanceSelectionActionsActive
       onProvenanceSelectionAction={() => undefined}
       onInputProvenancePendingChange={options.onInputProvenancePendingChange}
+      onProvenanceIdentityStateChange={
+        options.onProvenanceIdentityStateChange
+      }
       provenanceActor={renderedActor}
       pasteProvenanceOutbox={options.outbox}
       onRecordPasteProvenance={async (request) => {
@@ -2052,6 +2059,59 @@ describe("CoworkBridgeEditor paste provenance", () => {
     reopened.unmount();
   }, 30_000);
 
+  it("keeps non-mutating selection inspection available when provenance identity is unavailable", async () => {
+    const identityStates: CoworkProvenanceIdentityState[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        expect(String(input)).toBe("/api/local-identity/session/csrf");
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            authenticated: false,
+            human_authority_available: false,
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+
+    let mounted: MountedPasteEditor | undefined;
+    try {
+      mounted = await mountPasteEditor(async () => undefined, {
+        resolveActorFromServer: true,
+        activeLens: "provenance",
+        provenanceProvider: provenanceProvider(),
+        onProvenanceIdentityStateChange: (state) =>
+          identityStates.push(state),
+      });
+
+      act(() => {
+        mounted!.editor.commands.setTextSelection({ from: 1, to: 7 });
+      });
+
+      expect(
+        await screen.findByRole("button", { name: "Inspect provenance" }),
+      ).toBeVisible();
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Provenance identity is unavailable.",
+      );
+      expect(
+        screen.getByRole("button", { name: "Retry provenance identity" }),
+      ).toBeVisible();
+      expect(
+        screen.queryByRole("button", { name: "Record provenance" }),
+      ).toBeNull();
+      expect(
+        screen.queryByRole("button", { name: "Give feedback" }),
+      ).toBeNull();
+      expect(identityStates[identityStates.length - 1]).toBe("error");
+    } finally {
+      mounted?.unmount();
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("reassociates an ownerless legacy actor-change row after reload", async () => {
     const requests: CoworkPasteProvenanceRequest[] = [];
     const outbox = new DurableCoworkPasteProvenanceOutbox(
@@ -2960,6 +3020,7 @@ describe("CoworkBridgeEditor paste provenance", () => {
 
   it("clears an expired actor and re-resolves it after trusted session recovery", async () => {
     const recorder = vi.fn<CoworkPasteProvenanceRecorder>().mockResolvedValue();
+    const identityStates: CoworkProvenanceIdentityState[] = [];
     const recoveredActor = {
       kind: "human",
       ref: "recovered-dashboard-user",
@@ -3012,8 +3073,13 @@ describe("CoworkBridgeEditor paste provenance", () => {
         resolveActorFromServer: true,
         activeLens: "provenance",
         provenanceProvider: provenanceProvider(),
+        onProvenanceIdentityStateChange: (state) =>
+          identityStates.push(state),
       });
       await waitFor(() => expect(actorAttempts).toBe(1));
+      await waitFor(() =>
+        expect(identityStates[identityStates.length - 1]).toBe("ready"),
+      );
       act(() => {
         mounted!.editor.commands.setTextSelection({ from: 1, to: 7 });
       });
@@ -3029,6 +3095,9 @@ describe("CoworkBridgeEditor paste provenance", () => {
           screen.queryByRole("button", { name: "Record provenance" }),
         ).toBeNull(),
       );
+      await waitFor(() =>
+        expect(identityStates[identityStates.length - 1]).toBe("error"),
+      );
 
       await act(async () => {
         await refreshLocalIdentity();
@@ -3037,6 +3106,8 @@ describe("CoworkBridgeEditor paste provenance", () => {
       expect(
         await screen.findByRole("button", { name: "Record provenance" }),
       ).toBeVisible();
+      expect(identityStates).toContain("loading");
+      expect(identityStates[identityStates.length - 1]).toBe("ready");
       expect(sessionAttempts).toBeGreaterThanOrEqual(4);
     } finally {
       mounted?.unmount();

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.tsx
@@ -360,6 +360,8 @@ function MountedBridgeEditor({
   const [volatilePasteCaptures, setVolatilePasteCaptures] = useState<
     readonly CoworkPasteProvenanceCapture[]
   >([]);
+  const [stagedDirectEntryDecorations, setStagedDirectEntryDecorations] =
+    useState<readonly CoworkPendingProvenanceDecoration[]>([]);
   const pendingDirectEntryDecorations = useMemo(() => {
     const pending = new Map<string, CoworkPendingProvenanceDecoration>();
     for (const capture of [...pasteEntries, ...volatilePasteCaptures]) {
@@ -369,13 +371,21 @@ function MountedBridgeEditor({
         quoteAnchor: capture.anchor,
       });
     }
+    // beforeTransaction observes the edit before the async outbox mutation can
+    // publish a durable/volatile capture. Keep that synchronous staging gap in
+    // React state so both the editor decoration and host pending signal settle
+    // from one source of truth.
+    for (const decoration of stagedDirectEntryDecorations) {
+      pending.set(decoration.captureId, decoration);
+    }
     return [...pending.values()];
-  }, [pasteEntries, volatilePasteCaptures]);
+  }, [pasteEntries, stagedDirectEntryDecorations, volatilePasteCaptures]);
   const pendingDirectEntryDecorationsRef = useRef(
     pendingDirectEntryDecorations,
   );
   pendingDirectEntryDecorationsRef.current = pendingDirectEntryDecorations;
   const inputProvenancePending =
+    stagedDirectEntryDecorations.length > 0 ||
     pasteEntries.some(
       (entry) =>
         entry.sourceKind === "direct_entry" ||
@@ -403,6 +413,24 @@ function MountedBridgeEditor({
   onReadyRef.current = onReady;
   onTeardownRef.current = onTeardown;
   pasteRecorderRef.current = onRecordPasteProvenance;
+
+  useEffect(() => {
+    const retainedKeys = new Set(
+      [...pasteEntries, ...volatilePasteCaptures]
+        .filter((capture) => capture.sourceKind === "direct_entry")
+        .map((capture) => capture.idempotencyKey),
+    );
+    for (const burst of directEntryClosingBurstsRef.current.values()) {
+      retainedKeys.add(burst.idempotencyKey);
+    }
+    if (directEntryBurstRef.current !== null) {
+      retainedKeys.add(directEntryBurstRef.current.idempotencyKey);
+    }
+    setStagedDirectEntryDecorations((current) => {
+      const next = current.filter((item) => retainedKeys.has(item.captureId));
+      return next.length === current.length ? current : next;
+    });
+  }, [pasteEntries, volatilePasteCaptures]);
 
   useEffect(() => {
     onInputProvenancePendingChange?.(inputProvenancePending);
@@ -1379,6 +1407,7 @@ function MountedBridgeEditor({
         // state, so changing this transaction's metadata is too late. A
         // microtask dispatch lands before the browser can paint the edited
         // frame and avoids a re-entrant EditorView transaction.
+        setStagedDirectEntryDecorations(staged);
         queueMicrotask(() => {
           if (
             pasteEditorRef.current === context.editor &&
@@ -1387,14 +1416,10 @@ function MountedBridgeEditor({
             setCoworkPendingProvenance(context.editor, staged);
           }
         });
-        if (staged.length > 0) {
-          onInputProvenancePendingChange?.(true);
-        }
       }
     },
     [
       directCaptureForBurst,
-      onInputProvenancePendingChange,
       stageDirectEntryProvenanceBeforeTransaction,
       stagePasteProvenanceBeforeTransaction,
     ],
@@ -1689,6 +1714,66 @@ function MountedBridgeEditor({
     resolvedPasteProvenanceOutbox,
   ]);
 
+  useEffect(() => {
+    if (
+      provenanceProvider === undefined ||
+      resolvedPasteProvenanceOutbox === undefined
+    ) {
+      return;
+    }
+    let active = true;
+    let retryingPublishedSnapshot = false;
+    const retryFrozenDirectEntries = (): void => {
+      // A recorder attempt forces its own provider refresh. Ignore that
+      // publication while the immutable request is still in flight, otherwise
+      // a missing projection could recursively replay itself forever.
+      if (
+        !active ||
+        retryingPublishedSnapshot ||
+        pasteAttemptsRef.current.size > 0
+      ) {
+        return;
+      }
+      retryingPublishedSnapshot = true;
+      void resolvedPasteProvenanceOutbox
+        .list()
+        .then(async (entries) => {
+          if (!active) return;
+          for (const entry of entries) {
+            if (
+              entry.sourceKind !== "direct_entry" ||
+              entry.status !== "retryable_failure" ||
+              entry.frozenRequest === undefined
+            ) {
+              continue;
+            }
+            // attemptPasteProvenance replays frozenRequest byte-for-byte. A
+            // server that already committed it returns the same receipt; the
+            // now-published authoritative history then permits outbox removal.
+            await attemptPasteProvenance(entry.id);
+            if (!active) return;
+          }
+        })
+        .catch(() => {
+          if (active) setOutboxError(outboxPasteProvenanceError());
+        })
+        .finally(() => {
+          retryingPublishedSnapshot = false;
+        });
+    };
+    const unsubscribe = provenanceProvider.subscribe(
+      retryFrozenDirectEntries,
+    );
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, [
+    attemptPasteProvenance,
+    provenanceProvider,
+    resolvedPasteProvenanceOutbox,
+  ]);
+
   // Catalog refreshes can revoke editing without changing the keyed document session.
   // Update the actual ProseMirror view during layout so no writable frame is painted.
   useLayoutEffect(() => {
@@ -1760,12 +1845,92 @@ function MountedBridgeEditor({
       }
     }
     setVolatilePasteCaptures(failed);
-    const entries = await refreshPasteEntries();
+    let entries = await refreshPasteEntries();
     if (failed.length > 0 || entries === null) {
       setOutboxError(outboxPasteProvenanceError());
       return;
     }
-    setOutboxError(null);
+    let restoredOpenBurst = false;
+    const recoveredCapturingKeys = new Set<string>();
+    const currentEditor = pasteEditorRef.current;
+    if (currentEditor !== null) {
+      for (const entry of entries) {
+        if (
+          entry.sourceKind !== "direct_entry" ||
+          entry.status !== "capturing"
+        ) {
+          continue;
+        }
+        recoveredCapturingKeys.add(entry.idempotencyKey);
+        const resolution = resolveCoworkPasteAnchor(
+          currentEditor.state.doc,
+          entry.anchor,
+        );
+        if (resolution.kind !== "unique") continue;
+        const alreadyTracked =
+          directEntryClosingBurstsRef.current.has(entry.idempotencyKey) ||
+          directEntryBurstRef.current?.idempotencyKey === entry.idempotencyKey;
+        if (!alreadyTracked) {
+          directEntryClosingBurstsRef.current.set(entry.idempotencyKey, {
+            idempotencyKey: entry.idempotencyKey,
+            from: resolution.from,
+            to: resolution.to,
+            capturedAt: entry.capturedAt,
+            determination: entry.determination,
+            ...(entry.capturedActor === undefined
+              ? {}
+              : { capturedActor: entry.capturedActor }),
+          });
+        }
+        restoredOpenBurst = true;
+      }
+    }
+    if (restoredOpenBurst) {
+      // A volatile direct-entry capture failed before it reached the durable
+      // outbox. Rehydrating it as `capturing` is only half of Retry: the
+      // original blur may already have closed the in-memory burst, so finish
+      // the recovered row explicitly instead of waiting for another gesture.
+      await finalizeDirectEntryBurstRef.current();
+      entries = await refreshPasteEntries();
+      if (entries === null) {
+        setOutboxError(outboxPasteProvenanceError());
+        return;
+      }
+      if (
+        entries.some(
+          (entry) =>
+            entry.status === "capturing" &&
+            recoveredCapturingKeys.has(entry.idempotencyKey),
+        )
+      ) {
+        // Retry can blur the editor while another finalizer is already in
+        // flight. That older pass may have snapshotted its rows before this
+        // recovery was rehydrated, so drain the newly queued burst once the
+        // first promise releases its single-flight lock.
+        await finalizeDirectEntryBurstRef.current();
+        entries = await refreshPasteEntries();
+        if (entries === null) {
+          setOutboxError(outboxPasteProvenanceError());
+          return;
+        }
+      }
+    }
+    const hasStuckRecoveredCapture =
+      entries.some(
+        (entry) =>
+          entry.sourceKind === "direct_entry" &&
+          entry.status === "capturing" &&
+          (recoveredCapturingKeys.size === 0 ||
+            recoveredCapturingKeys.has(entry.idempotencyKey)),
+      );
+    if (hasStuckRecoveredCapture) {
+      // A non-unique anchor, unavailable actor, or failed finalizer must remain
+      // visibly retryable. Never clear the only recovery affordance while a
+      // durable row is still open.
+      setOutboxError(outboxPasteProvenanceError());
+    } else {
+      setOutboxError(null);
+    }
     for (const entry of entries) {
       if (
         entry.sourceKind === "direct_entry" &&
@@ -1785,6 +1950,12 @@ function MountedBridgeEditor({
       if (entry.status === "ready" || entry.status === "retryable_failure") {
         await attemptPasteProvenance(entry.id);
       }
+    }
+    if (hasStuckRecoveredCapture) {
+      // Successful delivery of an independent row clears transient errors in
+      // attemptPasteProvenance. Restore this durable recovery signal until the
+      // still-open row itself can be finalized.
+      setOutboxError(outboxPasteProvenanceError());
     }
   }, [
     attemptPasteProvenance,
@@ -1847,25 +2018,50 @@ function MountedBridgeEditor({
       }
 
       if (entry === undefined) {
-        if (
-          entries.some(
-            (candidate) =>
+        const currentEditor = pasteEditorRef.current;
+        const selected =
+          currentEditor === null
+            ? { kind: "absent" as const }
+            : resolveCoworkPasteAnchor(currentEditor.state.doc, anchor);
+        const overlapsPendingCapture =
+          selected.kind === "unique" &&
+          currentEditor !== null &&
+          [
+            ...entries.flatMap((candidate) =>
               candidate.sourceKind === "direct_entry" ||
               (candidate.sourceKind === "legacy" &&
-                candidate.status !== "awaiting_determination"),
-          )
-        ) {
+                candidate.status !== "awaiting_determination")
+                ? [candidate.anchor]
+                : [],
+            ),
+            ...volatilePasteCaptures.flatMap((candidate) =>
+              candidate.sourceKind === "direct_entry" ||
+              (candidate.sourceKind === "legacy" &&
+                candidate.status !== "awaiting_determination")
+                ? [candidate.anchor]
+                : [],
+            ),
+            ...stagedDirectEntryDecorations.map(
+              (candidate) => candidate.quoteAnchor,
+            ),
+          ].some((pendingAnchor) => {
+            const pending = resolveCoworkPasteAnchor(
+              currentEditor.state.doc,
+              pendingAnchor,
+            );
+            return (
+              pending.kind === "unique" &&
+              pending.from < selected.to &&
+              pending.to > selected.from
+            );
+          });
+        if (overlapsPendingCapture) {
           throw new Error(
-            "Recording recent typing. Try again when provenance finishes refreshing.",
+            "Provenance delivery is already pending for this selection. You can keep working while Co-work confirms it.",
           );
         }
         const refreshed = await provenanceProvider?.refresh();
-        const currentEditor = pasteEditorRef.current;
         if (refreshed?.state === "ready" && currentEditor !== null) {
-          const selected = resolveCoworkPasteAnchor(
-            currentEditor.state.doc,
-            anchor,
-          );
           const overlapsRecordedTarget =
             selected.kind === "unique" &&
             (refreshed.data.documentDefault?.target.currentness === "current" ||
@@ -1949,6 +2145,8 @@ function MountedBridgeEditor({
       refreshPasteEntries,
       resolvedPasteProvenanceOutbox,
       resolvedProvenanceActor,
+      stagedDirectEntryDecorations,
+      volatilePasteCaptures,
     ],
   );
 
@@ -2035,7 +2233,6 @@ function MountedBridgeEditor({
           provider={provenanceProvider}
           currentUserIdentity={resolvedProvenanceActor}
           readOnly={readOnly}
-          inputProvenancePending={inputProvenancePending}
           onRecord={recordSelectedProvenance}
           onAction={onProvenanceSelectionAction}
         />

--- a/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.tsx
+++ b/dashboard-react/src/apps/cowork/bridge/CoworkBridgeEditor.tsx
@@ -115,6 +115,12 @@ export interface CoworkEditorReadyContext {
   readonly dom: HTMLElement;
 }
 
+export type CoworkProvenanceIdentityState =
+  | "disabled"
+  | "loading"
+  | "ready"
+  | "error";
+
 export interface CoworkBridgeEditorProps {
   /** The canonical collaborative document. Open proposals never mutate it. */
   readonly document: Y.Doc;
@@ -155,6 +161,10 @@ export interface CoworkBridgeEditorProps {
   ) => void;
   /** Pending input attribution remains true through authoritative refresh. */
   readonly onInputProvenancePendingChange?: (pending: boolean) => void;
+  /** Keeps provenance mutation controls aligned with the editor's actor lookup. */
+  readonly onProvenanceIdentityStateChange?: (
+    state: CoworkProvenanceIdentityState,
+  ) => void;
   /**
    * Persists authorship and human-review provenance for the exact span inserted
    * by a paste. Omitted in non-registered/demo editors that have no durable
@@ -208,6 +218,7 @@ export interface CoworkBridgeEditorProps {
 interface MountedProps extends CoworkBridgeEditorProps {
   readonly persistence: CoworkYdocPersistence;
   readonly resolvedProvenanceActor?: CoworkProvenanceActorIdentity;
+  readonly allowActorlessProvenanceInspection: boolean;
   readonly resolvedPasteProvenanceOutbox?: CoworkPasteProvenanceOutbox;
   readonly onProvenanceActorChanged?: () => void;
   readonly seedWhenEmpty: boolean;
@@ -279,6 +290,7 @@ function MountedBridgeEditor({
   onInputProvenancePendingChange,
   onRecordPasteProvenance,
   resolvedProvenanceActor,
+  allowActorlessProvenanceInspection,
   resolvedPasteProvenanceOutbox,
   onProvenanceActorChanged,
   readOnly = false,
@@ -2150,6 +2162,14 @@ function MountedBridgeEditor({
     ],
   );
 
+  const provenanceSelectionAffordanceActive =
+    activeLens === "provenance" &&
+    (provenanceSelectionActionsActive ?? true) &&
+    provenanceProvider !== undefined &&
+    (resolvedProvenanceActor !== undefined ||
+      allowActorlessProvenanceInspection) &&
+    onProvenanceSelectionAction !== undefined;
+
   return (
     <>
       <EditorContent editor={editor} className="wb-cowork-editor__content" />
@@ -2210,7 +2230,7 @@ function MountedBridgeEditor({
         </InlineAlert>
       ) : null}
       {editor !== null &&
-      activeLens !== "provenance" &&
+      !provenanceSelectionAffordanceActive &&
       !readOnly &&
       onFeedbackCaptured !== undefined &&
       documentId !== undefined ? (
@@ -2222,11 +2242,7 @@ function MountedBridgeEditor({
           transport={feedbackTransport}
         />
       ) : null}
-      {editor !== null &&
-      activeLens === "provenance" &&
-      provenanceProvider !== undefined &&
-      resolvedProvenanceActor !== undefined &&
-      onProvenanceSelectionAction !== undefined ? (
+      {editor !== null && provenanceSelectionAffordanceActive ? (
         <CoworkProvenanceSelectionAffordance
           editor={editor}
           active={provenanceSelectionActionsActive ?? true}
@@ -2353,15 +2369,14 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
   const [resolvedProvenanceActor, setResolvedProvenanceActor] = useState<
     CoworkProvenanceActorIdentity | undefined
   >(props.provenanceActor);
-  const [provenanceActorState, setProvenanceActorState] = useState<
-    "disabled" | "loading" | "ready" | "error"
-  >(
-    !provenanceEnabled
-      ? "disabled"
-      : props.provenanceActor === undefined
-        ? "loading"
-        : "ready",
-  );
+  const [provenanceActorState, setProvenanceActorState] =
+    useState<CoworkProvenanceIdentityState>(
+      !provenanceEnabled
+        ? "disabled"
+        : props.provenanceActor === undefined
+          ? "loading"
+          : "ready",
+    );
   const [provenanceActorAttempt, setProvenanceActorAttempt] = useState(0);
   const requestProvenanceActorRefresh = useCallback(() => {
     setResolvedProvenanceActor(undefined);
@@ -3099,6 +3114,10 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
     provenanceEnabled,
   ]);
 
+  useEffect(() => {
+    props.onProvenanceIdentityStateChange?.(provenanceActorState);
+  }, [props.onProvenanceIdentityStateChange, provenanceActorState]);
+
   useEffect(
     () =>
       subscribeLocalIdentity((identity) => {
@@ -3133,6 +3152,21 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
 
   return (
     <section className="wb-cowork-editor" aria-label="Editor">
+      {provenanceEnabled &&
+      provenanceActorState === "error" &&
+      props.activeLens === "provenance" ? (
+        <InlineAlert tone="warning" role="alert">
+          <strong>Provenance identity is unavailable.</strong>
+          <span>
+            Open Work Buddy from its launcher to reconnect, then try again.
+            Viewing and inspection remain available; recording and review need
+            a reconnected human identity.
+          </span>
+          <Button size="small" onClick={requestProvenanceActorRefresh}>
+            Retry provenance identity
+          </Button>
+        </InlineAlert>
+      ) : null}
       {hydrationError !== undefined ? (
         <InlineAlert
           tone="danger"
@@ -3167,6 +3201,9 @@ export function CoworkBridgeEditor(props: CoworkBridgeEditorProps) {
           }}
           persistence={persistence}
           resolvedProvenanceActor={resolvedProvenanceActor}
+          allowActorlessProvenanceInspection={
+            effectiveReadOnly || provenanceActorState === "error"
+          }
           resolvedPasteProvenanceOutbox={resolvedPasteProvenanceOutbox}
           onProvenanceActorChanged={requestProvenanceActorRefresh}
           seedWhenEmpty={hydration.wasEmpty}

--- a/dashboard-react/src/apps/cowork/bridge/HttpCoworkDocClient.test.ts
+++ b/dashboard-react/src/apps/cowork/bridge/HttpCoworkDocClient.test.ts
@@ -86,6 +86,97 @@ describe("HttpCoworkDocClient Verify setup", () => {
     });
   });
 
+  it("posts one exact provenance review batch", async () => {
+    const head = "a".repeat(64);
+    const fetchImpl = authenticatedHumanAuthorityFetch(async () =>
+      new Response(
+        JSON.stringify({
+          ok: true,
+          attestations: [
+            {
+              attestation_id: "new-a",
+              supersedes_id: "old-a",
+              scope: { structured_head_sha256: head },
+              human_review: { status: "reviewed" },
+            },
+            {
+              attestation_id: "new-b",
+              supersedes_id: "old-b",
+              scope: { structured_head_sha256: head },
+              human_review: { status: "reviewed" },
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const client = new HttpCoworkDocClient({
+      documentId: "doc-1",
+      storeId: "store-1",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    await client.markProvenanceSelectionReviewed(
+      ["old-a", "old-b"],
+      head,
+      "provenance-review-batch-0001",
+      { ref: "reviewer-1", identityStatus: "local_actor_ref" },
+    );
+
+    const [url, init] = applicationRequest(fetchImpl) ?? [];
+    expect(url).toBe(
+      "/api/truth/doc/doc-1/authorship-attestations/human-review?store_id=store-1",
+    );
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({
+      attestation_ids: ["old-a", "old-b"],
+      expected_structured_head_sha256: head,
+      idempotency_key: "provenance-review-batch-0001",
+      expected_actor_ref: "reviewer-1",
+      expected_actor_identity_status: "local_actor_ref",
+    });
+  });
+
+  it("rejects a provenance review batch receipt bound to different targets", async () => {
+    const head = "a".repeat(64);
+    const fetchImpl = authenticatedHumanAuthorityFetch(async () =>
+      new Response(
+        JSON.stringify({
+          ok: true,
+          attestations: [
+            {
+              attestation_id: "new-a",
+              supersedes_id: "old-b",
+              scope: { structured_head_sha256: head },
+              human_review: { status: "reviewed" },
+            },
+            {
+              attestation_id: "new-b",
+              supersedes_id: "old-a",
+              scope: { structured_head_sha256: head },
+              human_review: { status: "reviewed" },
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const client = new HttpCoworkDocClient({
+      documentId: "doc-1",
+      storeId: "store-1",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    await expect(
+      client.markProvenanceSelectionReviewed(
+        ["old-a", "old-b"],
+        head,
+        "provenance-review-batch-0002",
+        { ref: "reviewer-1", identityStatus: "local_actor_ref" },
+      ),
+    ).rejects.toThrow("invalid receipt");
+  });
+
   it("routes Discuss with the exact Co-think item hash into Chat", async () => {
     const fetchImpl = authenticatedHumanAuthorityFetch(async () =>
       new Response(

--- a/dashboard-react/src/apps/cowork/bridge/HttpCoworkDocClient.ts
+++ b/dashboard-react/src/apps/cowork/bridge/HttpCoworkDocClient.ts
@@ -24,6 +24,7 @@ import {
   CoworkHttpError,
   normalizeCoworkError,
 } from "../providers/errors";
+import type { ProvenanceReviewerBinding } from "../provenance/view/contracts";
 
 type JsonObject = Record<string, unknown>;
 
@@ -74,6 +75,13 @@ export interface CoworkDocClient {
     attestationId: string,
     expectedStructuredHeadSha256: string,
     idempotencyKey: string,
+    expectedReviewer?: ProvenanceReviewerBinding,
+  ): Promise<void>;
+  markProvenanceSelectionReviewed?(
+    attestationIds: readonly string[],
+    expectedStructuredHeadSha256: string,
+    idempotencyKey: string,
+    expectedReviewer?: ProvenanceReviewerBinding,
   ): Promise<void>;
 }
 
@@ -126,11 +134,18 @@ export class HttpCoworkDocClient implements CoworkDocClient {
     attestationId: string,
     expectedStructuredHeadSha256: string,
     idempotencyKey: string,
+    expectedReviewer?: ProvenanceReviewerBinding,
   ): Promise<void> {
     const body = {
       attestation_id: attestationId,
       expected_structured_head_sha256: expectedStructuredHeadSha256,
       idempotency_key: idempotencyKey,
+      ...(expectedReviewer === undefined
+        ? {}
+        : {
+            expected_actor_ref: expectedReviewer.ref,
+            expected_actor_identity_status: expectedReviewer.identityStatus,
+          }),
     };
     const authorityHeaders = await this.#authority("provenance.review", body);
     const response = await this.#fetch(
@@ -161,6 +176,64 @@ export class HttpCoworkDocClient implements CoworkDocClient {
       stringValue(receipt.supersedes_id) !== attestationId ||
       stringValue(scope.structured_head_sha256) !== expectedStructuredHeadSha256 ||
       stringValue(review.status) !== "reviewed"
+    ) {
+      throw new Error("The provenance review returned an invalid receipt.");
+    }
+  }
+
+  async markProvenanceSelectionReviewed(
+    attestationIds: readonly string[],
+    expectedStructuredHeadSha256: string,
+    idempotencyKey: string,
+    expectedReviewer?: ProvenanceReviewerBinding,
+  ): Promise<void> {
+    const body = {
+      attestation_ids: attestationIds,
+      expected_structured_head_sha256: expectedStructuredHeadSha256,
+      idempotency_key: idempotencyKey,
+      ...(expectedReviewer === undefined
+        ? {}
+        : {
+            expected_actor_ref: expectedReviewer.ref,
+            expected_actor_identity_status: expectedReviewer.identityStatus,
+          }),
+    };
+    const authorityHeaders = await this.#authority("provenance.review", body);
+    const response = await this.#fetch(
+      `/api/truth/doc/${encodeURIComponent(this.#documentId)}/authorship-attestations/human-review?store_id=${encodeURIComponent(this.#storeId)}`,
+      {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json", ...authorityHeaders },
+        body: JSON.stringify(body),
+      },
+    );
+    const payload = objectValue(await response.json().catch(() => ({})));
+    if (!response.ok) {
+      throw new CoworkHttpError(
+        normalizeCoworkError(
+          payload,
+          response.status,
+          "Provenance review could not be recorded.",
+        ),
+      );
+    }
+    const receipts = arrayValue(payload.attestations);
+    if (
+      payload.ok !== true ||
+      receipts.length !== attestationIds.length ||
+      receipts.some((value, index) => {
+        const receipt = objectValue(value);
+        const scope = objectValue(receipt.scope);
+        const review = objectValue(receipt.human_review);
+        return (
+          stringValue(receipt.attestation_id).length === 0 ||
+          stringValue(receipt.supersedes_id) !== attestationIds[index] ||
+          stringValue(scope.structured_head_sha256) !==
+            expectedStructuredHeadSha256 ||
+          stringValue(review.status) !== "reviewed"
+        );
+      })
     ) {
       throw new Error("The provenance review returned an invalid receipt.");
     }

--- a/dashboard-react/src/apps/cowork/bridge/index.ts
+++ b/dashboard-react/src/apps/cowork/bridge/index.ts
@@ -17,6 +17,7 @@ export {
   CoworkBridgeEditor,
   type CoworkBridgeEditorProps,
   type CoworkEditorReadyContext,
+  type CoworkProvenanceIdentityState,
 } from "./CoworkBridgeEditor";
 export {
   LiveReviewRailProvider,

--- a/dashboard-react/src/apps/cowork/provenance/CoworkProvenanceSelectionAffordance.test.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/CoworkProvenanceSelectionAffordance.test.tsx
@@ -117,6 +117,8 @@ const mount = (
   options: {
     readonly onAction?: CoworkProvenanceSelectionAffordanceProps["onAction"];
     readonly active?: boolean;
+    readonly actorless?: boolean;
+    readonly readOnly?: boolean;
   } = {},
 ) => {
   editor = makeSuggestionEditor({ content: CONTENT });
@@ -132,7 +134,8 @@ const mount = (
       editor={editor}
       active={options.active ?? true}
       provider={source}
-      currentUserIdentity={ACTOR}
+      currentUserIdentity={options.actorless ? undefined : ACTOR}
+      readOnly={options.readOnly}
       onRecord={onRecord}
       onAction={onAction}
     />,
@@ -213,6 +216,25 @@ describe("CoworkProvenanceSelectionAffordance", () => {
         targetIds: ["document_span:span-1"],
       }),
     );
+  });
+
+  it("keeps non-mutating provenance inspection available without an actor", async () => {
+    const onAction =
+      vi.fn<CoworkProvenanceSelectionAffordanceProps["onAction"]>();
+    mount(data([target()]), { actorless: true, readOnly: true, onAction });
+    select("precise");
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "View provenance" }),
+    );
+
+    expect(onAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: "view",
+        targetIds: ["document_span:span-1"],
+      }),
+    );
+    expect(onAction.mock.calls[0]?.[0]).not.toHaveProperty("reviewer");
   });
 
   it("does not reuse a review action identity after the affordance remounts", async () => {

--- a/dashboard-react/src/apps/cowork/provenance/CoworkProvenanceSelectionAffordance.test.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/CoworkProvenanceSelectionAffordance.test.tsx
@@ -127,7 +127,7 @@ const mount = (
   const onAction =
     options.onAction ??
     vi.fn<CoworkProvenanceSelectionAffordanceProps["onAction"]>();
-  render(
+  const rendered = render(
     <CoworkProvenanceSelectionAffordance
       editor={editor}
       active={options.active ?? true}
@@ -137,7 +137,7 @@ const mount = (
       onAction={onAction}
     />,
   );
-  return { source, onRecord, onAction };
+  return { source, onRecord, onAction, unmount: rendered.unmount };
 };
 
 describe("CoworkProvenanceSelectionAffordance", () => {
@@ -182,13 +182,17 @@ describe("CoworkProvenanceSelectionAffordance", () => {
     );
     select("precise");
     await userEvent.click(
-      await screen.findByRole("button", { name: "Review provenance" }),
+      await screen.findByRole("button", { name: "Mark as reviewed" }),
     );
 
     const action = onAction.mock.calls[0]![0] as ProvenanceSelectionAction;
     expect(action).toMatchObject({
       intent: "review",
       targetIds: ["document_span:span-1"],
+      reviewer: {
+        ref: ACTOR.ref,
+        identityStatus: ACTOR.identity_status,
+      },
     });
     expect(source.markReviewed).not.toHaveBeenCalled();
     expect(screen.queryByRole("dialog")).toBeNull();
@@ -206,6 +210,177 @@ describe("CoworkProvenanceSelectionAffordance", () => {
     expect(onAction).toHaveBeenCalledWith(
       expect.objectContaining({
         intent: "view",
+        targetIds: ["document_span:span-1"],
+      }),
+    );
+  });
+
+  it("does not reuse a review action identity after the affordance remounts", async () => {
+    const firstAction =
+      vi.fn<CoworkProvenanceSelectionAffordanceProps["onAction"]>();
+    const first = mount(data([target()]), { onAction: firstAction });
+    select("precise");
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Mark as reviewed" }),
+    );
+    const firstRequestId = firstAction.mock.calls[0]![0].requestId;
+    first.unmount();
+    editor?.destroy();
+    editor = undefined;
+
+    const secondAction =
+      vi.fn<CoworkProvenanceSelectionAffordanceProps["onAction"]>();
+    mount(data([target()]), { onAction: secondAction });
+    select("precise");
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Mark as reviewed" }),
+    );
+
+    expect(secondAction.mock.calls[0]![0].requestId).toBeGreaterThan(
+      firstRequestId,
+    );
+  });
+
+  it("offers review when another person reviewed the target but the current user did not", async () => {
+    const otherReviewer = {
+      kind: "human" as const,
+      ref: "another-reviewer",
+      label: null,
+      identityStatus: "local_actor_ref" as const,
+    };
+    const reviewed = record({
+      humanReview: { status: "reviewed", reviewers: [otherReviewer] },
+    });
+    const onAction =
+      vi.fn<CoworkProvenanceSelectionAffordanceProps["onAction"]>();
+    mount(
+      data([
+        target({
+          effectiveAttestations: [reviewed],
+          effectiveAttestation: reviewed,
+          history: [reviewed],
+          reviewEligibility: "already_reviewed",
+        }),
+      ]),
+      { onAction },
+    );
+    select("precise");
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Mark as reviewed" }),
+    );
+    expect(onAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: "review",
+        targetIds: ["document_span:span-1"],
+      }),
+    );
+  });
+
+  it("uses View provenance when the current user already reviewed the target", async () => {
+    const currentReviewer = {
+      kind: "human" as const,
+      ref: ACTOR.ref,
+      label: null,
+      identityStatus: ACTOR.identity_status,
+    };
+    const reviewed = record({
+      humanReview: { status: "reviewed", reviewers: [currentReviewer] },
+    });
+    mount(
+      data([
+        target({
+          effectiveAttestations: [reviewed],
+          effectiveAttestation: reviewed,
+          history: [reviewed],
+          reviewEligibility: "already_reviewed",
+        }),
+      ]),
+    );
+    select("precise");
+
+    expect(
+      await screen.findByRole("button", { name: "View provenance" }),
+    ).toBeVisible();
+  });
+
+  it("routes only fully selected targets that still need this user's review", async () => {
+    const currentReviewer = {
+      kind: "human" as const,
+      ref: ACTOR.ref,
+      label: null,
+      identityStatus: ACTOR.identity_status,
+    };
+    const alreadyReviewed = record({
+      attestationId: "attestation-2",
+      scope: {
+        kind: "document_span",
+        documentVersionId: null,
+        documentSpanId: "span-2",
+        structuredHeadSha256: HEAD,
+      },
+      humanReview: { status: "reviewed", reviewers: [currentReviewer] },
+    });
+    const clearTarget = target({
+      projectionId: "document_span:span-2",
+      target: {
+        ...target().target,
+        documentSpanId: "span-2",
+      },
+      span: { exact: "clear", prefix: "", suffix: "" },
+      effectiveAttestations: [alreadyReviewed],
+      effectiveAttestation: alreadyReviewed,
+      reviewEligibility: "already_reviewed",
+      history: [alreadyReviewed],
+    });
+    const onAction =
+      vi.fn<CoworkProvenanceSelectionAffordanceProps["onAction"]>();
+    mount(data([target(), clearTarget]), { onAction });
+    select("precise and clear");
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Mark as reviewed" }),
+    );
+    expect(onAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: "review",
+        targetIds: ["document_span:span-1"],
+      }),
+    );
+  });
+
+  it("offers review for contained targets while leaving partial targets untouched", async () => {
+    const partialRecord = record({
+      attestationId: "attestation-2",
+      scope: {
+        kind: "document_span",
+        documentVersionId: null,
+        documentSpanId: "span-2",
+        structuredHeadSha256: HEAD,
+      },
+    });
+    const partialTarget = target({
+      projectionId: "document_span:span-2",
+      target: {
+        ...target().target,
+        documentSpanId: "span-2",
+      },
+      span: { exact: "clear enough", prefix: "", suffix: "" },
+      effectiveAttestations: [partialRecord],
+      effectiveAttestation: partialRecord,
+      history: [partialRecord],
+    });
+    const onAction =
+      vi.fn<CoworkProvenanceSelectionAffordanceProps["onAction"]>();
+    mount(data([target(), partialTarget]), { onAction });
+    select("precise and clear");
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Mark as reviewed" }),
+    );
+    expect(onAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: "review",
         targetIds: ["document_span:span-1"],
       }),
     );
@@ -282,6 +457,71 @@ describe("CoworkProvenanceSelectionAffordance", () => {
     expect(
       await screen.findByRole("button", { name: "Record provenance" }),
     ).toBeVisible();
+  });
+
+  it("offers this user review for a whole-document record reviewed only by someone else", async () => {
+    const wholeDocumentRecord = record({
+      scope: {
+        kind: "document_version",
+        documentVersionId: "version-1",
+        documentSpanId: null,
+        structuredHeadSha256: HEAD,
+      },
+      humanReview: {
+        status: "reviewed",
+        reviewers: [
+          {
+            kind: "human",
+            ref: "other-reviewer",
+            label: "Other reviewer",
+            identityStatus: "local_actor_ref",
+          },
+        ],
+      },
+    });
+    const wholeDocumentTarget: ProvenanceTarget = {
+      projectionId: "document_version:version-1",
+      target: {
+        kind: "document_version",
+        documentVersionId: "version-1",
+        documentSpanId: null,
+        structuredHeadSha256: HEAD,
+        currentness: "current",
+      },
+      span: null,
+      effectiveAttestations: [wholeDocumentRecord],
+      effectiveAttestation: wholeDocumentRecord,
+      resolution: "resolved",
+      reviewEligibility: "already_reviewed",
+      issue: null,
+      history: [wholeDocumentRecord],
+    };
+    const { onAction } = mount({
+      ...data(),
+      documentDefault: wholeDocumentTarget,
+      history: [wholeDocumentRecord],
+    });
+
+    select("precise");
+    expect(
+      await screen.findByRole("button", { name: "View provenance" }),
+    ).toBeVisible();
+
+    select("Make this sentence precise and clear enough.");
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Mark as reviewed" }),
+    );
+    expect(onAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: "review",
+        targetIds: ["document_version:version-1"],
+        coversWholeDocument: true,
+        reviewer: {
+          ref: ACTOR.ref,
+          identityStatus: ACTOR.identity_status,
+        },
+      }),
+    );
   });
 
   it("routes stale and multiply covered selections to Inspect provenance", async () => {

--- a/dashboard-react/src/apps/cowork/provenance/CoworkProvenanceSelectionAffordance.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/CoworkProvenanceSelectionAffordance.tsx
@@ -36,6 +36,13 @@ interface SelectionClassification {
   readonly targetIds: readonly string[];
 }
 
+let provenanceSelectionRequestSequence = 0;
+
+const nextProvenanceSelectionRequestId = (): number => {
+  provenanceSelectionRequestSequence += 1;
+  return provenanceSelectionRequestSequence;
+};
+
 export interface CoworkProvenanceSelectionAffordanceProps {
   readonly editor: Editor;
   /** Only the active Provenance lens may replace the general feedback action. */
@@ -43,8 +50,6 @@ export interface CoworkProvenanceSelectionAffordanceProps {
   readonly provider: ProvenanceProvider;
   readonly currentUserIdentity: CoworkProvenanceActorIdentity;
   readonly readOnly?: boolean;
-  /** Authoritative editor/outbox state; survives mounting after the edit. */
-  readonly inputProvenancePending?: boolean;
   /**
    * Persists a user-confirmed attestation for a frozen uncovered selection.
    * The caller owns persistence settlement, target/head checks, and refresh.
@@ -63,7 +68,7 @@ export interface CoworkProvenanceSelectionAffordanceProps {
 
 const actionLabel = (intent: ProvenanceSelectionAction["intent"]): string => {
   if (intent === "record") return "Record provenance";
-  if (intent === "review") return "Review provenance";
+  if (intent === "review") return "Mark as reviewed";
   if (intent === "view") return "View provenance";
   return "Inspect provenance";
 };
@@ -73,7 +78,7 @@ const actionTitle = (intent: ProvenanceSelectionAction["intent"]): string => {
     return "Record who wrote the selected text and whether it was reviewed; its earlier source remains untracked.";
   }
   if (intent === "review") {
-    return "Open Provenance to confirm and record human review for this passage.";
+    return "Open Provenance to record your review for the eligible selected passages.";
   }
   if (intent === "view") {
     return "Open the provenance details for this passage.";
@@ -112,6 +117,27 @@ const targetIsHealthy = (
   (target.target.kind === "document_version" || rangeState === "unique") &&
   effectiveRecord(target) !== null;
 
+const selectionCoversDocumentText = (
+  doc: ProseMirrorNode,
+  from: number,
+  to: number,
+): boolean => {
+  let firstTextPosition: number | null = null;
+  let lastTextPosition: number | null = null;
+  doc.descendants((node, position) => {
+    if (!node.isText) return true;
+    firstTextPosition ??= position;
+    lastTextPosition = position + node.nodeSize;
+    return false;
+  });
+  return (
+    firstTextPosition !== null &&
+    lastTextPosition !== null &&
+    from <= firstTextPosition &&
+    to >= lastTextPosition
+  );
+};
+
 /**
  * Classify a selection against the same authoritative projection the panel
  * consumes. Explicit span targets take precedence over a document fallback.
@@ -122,6 +148,7 @@ export const classifyCoworkProvenanceSelection = ({
   from,
   to,
   readOnly,
+  currentUserIdentity,
   locallyDirty = false,
 }: {
   readonly data: ProvenanceData;
@@ -129,6 +156,7 @@ export const classifyCoworkProvenanceSelection = ({
   readonly from: number;
   readonly to: number;
   readonly readOnly: boolean;
+  readonly currentUserIdentity: CoworkProvenanceActorIdentity;
   readonly locallyDirty?: boolean;
 }): SelectionClassification => {
   const explicit = data.spans.flatMap((target) => {
@@ -147,8 +175,10 @@ export const classifyCoworkProvenanceSelection = ({
         state: "unique" as const,
         completelyCoversSelection:
           resolution.from <= from && resolution.to >= to,
-        selectionExactlyMatchesTarget:
-          resolution.from === from && resolution.to === to,
+        selectionCompletelyCoversTarget:
+          from <= resolution.from && to >= resolution.to,
+        from: resolution.from,
+        to: resolution.to,
       },
     ];
   });
@@ -163,7 +193,13 @@ export const classifyCoworkProvenanceSelection = ({
               target: data.documentDefault,
               state: "document" as const,
               completelyCoversSelection: true,
-              selectionExactlyMatchesTarget: false,
+              selectionCompletelyCoversTarget: selectionCoversDocumentText(
+                doc,
+                from,
+                to,
+              ),
+              from: null,
+              to: null,
             },
           ];
   const targetIds = [
@@ -176,26 +212,66 @@ export const classifyCoworkProvenanceSelection = ({
       targetIds: [],
     };
   }
+  const overlappingTargets = matches.some(
+    (candidate, index) =>
+      candidate.from !== null &&
+      candidate.to !== null &&
+      matches.slice(index + 1).some(
+        (peer) =>
+          peer.from !== null &&
+          peer.to !== null &&
+          candidate.from! < peer.to &&
+          candidate.to! > peer.from,
+      ),
+  );
   if (
     locallyDirty ||
-    matches.length !== 1 ||
-    !matches[0]!.completelyCoversSelection ||
-    !targetIsHealthy(matches[0]!.target, matches[0]!.state)
+    overlappingTargets ||
+    matches.some(
+      (match) => !targetIsHealthy(match.target, match.state),
+    )
   ) {
     return { intent: "inspect", targetIds };
   }
 
-  const target = matches[0]!.target;
-  const record = effectiveRecord(target)!;
-  const canOfferReview =
+  const needsCurrentUserReview = (target: ProvenanceTarget): boolean => {
+    const record = effectiveRecord(target);
+    if (
+      record === null ||
+      !["eligible", "already_reviewed"].includes(target.reviewEligibility) ||
+      (record.authorship.kind !== "ai" && record.authorship.kind !== "mixed")
+    ) {
+      return false;
+    }
+    return !record.humanReview.reviewers.some(
+      (reviewer) =>
+        reviewer.ref === currentUserIdentity.ref &&
+        reviewer.identityStatus === currentUserIdentity.identity_status,
+    );
+  };
+  const reviewNeeded = matches.filter(({ target }) =>
+    needsCurrentUserReview(target),
+  );
+  const reviewTargets = reviewNeeded.filter(
+    ({ selectionCompletelyCoversTarget }) => selectionCompletelyCoversTarget,
+  );
+  if (
     !readOnly &&
-    target.reviewEligibility === "eligible" &&
-    matches[0]!.selectionExactlyMatchesTarget &&
-    (record.authorship.kind === "ai" || record.authorship.kind === "mixed") &&
-    (record.humanReview.status === "not_reviewed" ||
-      record.humanReview.status === "unknown");
+    reviewTargets.length > 0
+  ) {
+    return {
+      intent: "review",
+      targetIds: reviewTargets.map(({ target }) => target.projectionId),
+    };
+  }
+  if (
+    matches.length !== 1 ||
+    !matches[0]!.completelyCoversSelection
+  ) {
+    return { intent: "inspect", targetIds };
+  }
   return {
-    intent: canOfferReview ? "review" : "view",
+    intent: "view",
     targetIds,
   };
 };
@@ -206,14 +282,12 @@ export function CoworkProvenanceSelectionAffordance({
   provider,
   currentUserIdentity,
   readOnly = false,
-  inputProvenancePending = false,
   onRecord,
   onAction,
 }: CoworkProvenanceSelectionAffordanceProps) {
   const [selection, setSelection] = useState<EditorSelection | null>(null);
   const [load, setLoad] = useState<ProvenanceLoad | null>(null);
   const requestSequence = useRef(0);
-  const actionSequence = useRef(0);
   const [locallyDirty, setLocallyDirty] = useState(false);
   const [recording, setRecording] = useState<{
     readonly action: ProvenanceSelectionAction;
@@ -301,12 +375,13 @@ export function CoworkProvenanceSelectionAffordance({
       from: selection.from,
       to: selection.to,
       readOnly,
-      locallyDirty: locallyDirty || inputProvenancePending,
+      currentUserIdentity,
+      locallyDirty,
     });
   }, [
     anchor,
+    currentUserIdentity,
     editor,
-    inputProvenancePending,
     load,
     locallyDirty,
     readOnly,
@@ -339,21 +414,33 @@ export function CoworkProvenanceSelectionAffordance({
             type="button"
             className="wb-cowork-provenance-selection__trigger"
             title={
-              inputProvenancePending
-                ? "Co-work is recording provenance for recent typing."
-                : actionTitle(classification.intent)
+              actionTitle(classification.intent)
             }
-            disabled={inputProvenancePending}
             onMouseDown={(event) => event.preventDefault()}
             onClick={() => {
-              actionSequence.current += 1;
               const action: ProvenanceSelectionAction = {
-                requestId: actionSequence.current,
+                // The panel survives lens changes while this affordance does
+                // not. A module-lifetime sequence prevents a remount from
+                // reusing a completed action's identity.
+                requestId: nextProvenanceSelectionRequestId(),
                 intent: classification.intent,
                 anchor,
                 from: selection.from,
                 to: selection.to,
                 targetIds: classification.targetIds,
+                coversWholeDocument: selectionCoversDocumentText(
+                  editor.state.doc,
+                  selection.from,
+                  selection.to,
+                ),
+                ...(classification.intent === "review"
+                  ? {
+                      reviewer: {
+                        ref: currentUserIdentity.ref,
+                        identityStatus: currentUserIdentity.identity_status,
+                      },
+                    }
+                  : {}),
               };
               if (action.intent === "record") {
                 setRecordError(null);
@@ -367,7 +454,7 @@ export function CoworkProvenanceSelectionAffordance({
               onAction({ ...action, intent: action.intent });
             }}
           >
-            {inputProvenancePending ? "Recording recent typing…" : label}
+            {label}
           </button>
         </div>
       )}

--- a/dashboard-react/src/apps/cowork/provenance/CoworkProvenanceSelectionAffordance.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/CoworkProvenanceSelectionAffordance.tsx
@@ -48,7 +48,7 @@ export interface CoworkProvenanceSelectionAffordanceProps {
   /** Only the active Provenance lens may replace the general feedback action. */
   readonly active: boolean;
   readonly provider: ProvenanceProvider;
-  readonly currentUserIdentity: CoworkProvenanceActorIdentity;
+  readonly currentUserIdentity?: CoworkProvenanceActorIdentity;
   readonly readOnly?: boolean;
   /**
    * Persists a user-confirmed attestation for a frozen uncovered selection.
@@ -156,7 +156,7 @@ export const classifyCoworkProvenanceSelection = ({
   readonly from: number;
   readonly to: number;
   readonly readOnly: boolean;
-  readonly currentUserIdentity: CoworkProvenanceActorIdentity;
+  readonly currentUserIdentity?: CoworkProvenanceActorIdentity;
   readonly locallyDirty?: boolean;
 }): SelectionClassification => {
   const explicit = data.spans.flatMap((target) => {
@@ -208,7 +208,10 @@ export const classifyCoworkProvenanceSelection = ({
 
   if (matches.length === 0) {
     return {
-      intent: readOnly || locallyDirty ? "inspect" : "record",
+      intent:
+        readOnly || locallyDirty || currentUserIdentity === undefined
+          ? "inspect"
+          : "record",
       targetIds: [],
     };
   }
@@ -235,6 +238,7 @@ export const classifyCoworkProvenanceSelection = ({
   }
 
   const needsCurrentUserReview = (target: ProvenanceTarget): boolean => {
+    if (currentUserIdentity === undefined) return false;
     const record = effectiveRecord(target);
     if (
       record === null ||
@@ -433,7 +437,8 @@ export function CoworkProvenanceSelectionAffordance({
                   selection.from,
                   selection.to,
                 ),
-                ...(classification.intent === "review"
+                ...(classification.intent === "review" &&
+                currentUserIdentity !== undefined
                   ? {
                       reviewer: {
                         ref: currentUserIdentity.ref,
@@ -443,6 +448,7 @@ export function CoworkProvenanceSelectionAffordance({
                   : {}),
               };
               if (action.intent === "record") {
+                if (currentUserIdentity === undefined) return;
                 setRecordError(null);
                 setRecording({
                   action,
@@ -458,7 +464,7 @@ export function CoworkProvenanceSelectionAffordance({
           </button>
         </div>
       )}
-      {recording === null ? null : (
+      {recording === null || currentUserIdentity === undefined ? null : (
         <CoworkProvenanceDeterminationDialog
           value={recording.value}
           currentUserIdentity={currentUserIdentity}

--- a/dashboard-react/src/apps/cowork/provenance/view/LiveProvenanceProvider.test.ts
+++ b/dashboard-react/src/apps/cowork/provenance/view/LiveProvenanceProvider.test.ts
@@ -4,6 +4,18 @@ import type { CoworkDocClient } from "../../bridge/HttpCoworkDocClient";
 import type { R2DocPayload } from "../../bridge/types";
 import { LiveProvenanceProvider } from "./LiveProvenanceProvider";
 
+const REVIEWER = {
+  ref: "user",
+  identityStatus: "local_actor_ref",
+} as const;
+
+const WIRE_REVIEWER = {
+  kind: "human",
+  ref: REVIEWER.ref,
+  display_name: null,
+  identity_status: REVIEWER.identityStatus,
+} as const;
+
 const payload = (history: readonly unknown[] = []): R2DocPayload => ({
   document_id: "doc", store_id: "store", path: "doc.md", title: "Doc", profile: "document",
   hashes: { ydoc_snapshot_sha256: null, last_materialized_sha256: null, current_file_sha256: null },
@@ -21,17 +33,19 @@ describe("LiveProvenanceProvider", () => {
       attestation_id: "new", at: "2026-08-12T12:00:00Z",
       asserted_by: { kind: "human", ref: "user", meta: null },
       scope: { kind: "document_span", document_version_id: null, document_span_id: "span", structured_head_sha256: "a".repeat(64) },
-      authorship: { kind: "ai", contributors: [] }, human_review: { status: "reviewed", reviewers: [{ kind: "human", ref: "user" }] },
+      authorship: { kind: "ai", contributors: [] }, human_review: { status: "reviewed", reviewers: [WIRE_REVIEWER] },
       source: { kind: "paste" }, basis: { kind: "user_attestation", ref: "old" }, supersedes_id: "old", canonical_sha256: "b".repeat(64),
     };
     const mutation = vi.fn().mockResolvedValue(undefined);
     const provider = new LiveProvenanceProvider(
       { loadPayload: vi.fn().mockResolvedValue(payload()), refreshPayload: vi.fn().mockResolvedValue(payload([successor])), subscribe: () => () => undefined },
-      { fetchDoc: vi.fn(), markProvenanceReviewed: mutation } as unknown as CoworkDocClient,
+      { fetchDoc: vi.fn(), markProvenanceSelectionReviewed: mutation } as unknown as CoworkDocClient,
     );
-    await provider.markReviewed("old", "a".repeat(64));
+    await provider.markReviewed(["old"], "a".repeat(64), REVIEWER);
     expect(mutation).toHaveBeenCalledTimes(1);
+    expect(mutation.mock.calls[0]?.[0]).toEqual(["old"]);
     expect(mutation.mock.calls[0]?.[2]).toMatch(/^provenance-review-/u);
+    expect(mutation.mock.calls[0]?.[3]).toEqual(REVIEWER);
   });
 
   it("reuses the same idempotency key when a successful write is not yet visible", async () => {
@@ -49,8 +63,64 @@ describe("LiveProvenanceProvider", () => {
       } as unknown as CoworkDocClient,
     );
 
-    await provider.markReviewed("old", "a".repeat(64));
-    await provider.markReviewed("old", "a".repeat(64));
+    await provider.markReviewed(["old"], "a".repeat(64), REVIEWER);
+    await provider.markReviewed(["old"], "a".repeat(64), REVIEWER);
+
+    expect(mutation).toHaveBeenCalledTimes(2);
+    expect(mutation.mock.calls[1]?.[2]).toBe(mutation.mock.calls[0]?.[2]);
+    expect(refreshPayload).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses one batch key until every selected successor is visible", async () => {
+    const successor = (prior: string, id: string) => ({
+      attestation_id: id,
+      at: "2026-08-12T12:00:00Z",
+      asserted_by: { kind: "human", ref: "user", meta: null },
+      scope: {
+        kind: "document_span",
+        document_version_id: null,
+        document_span_id: `span-${prior}`,
+        structured_head_sha256: "a".repeat(64),
+      },
+      authorship: { kind: "ai", contributors: [] },
+      human_review: {
+        status: "reviewed",
+        reviewers: [WIRE_REVIEWER],
+      },
+      source: { kind: "paste" },
+      basis: { kind: "user_attestation", ref: prior },
+      supersedes_id: prior,
+      canonical_sha256: "b".repeat(64),
+    });
+    const first = successor("old-a", "new-a");
+    const second = successor("old-b", "new-b");
+    const mutation = vi.fn().mockResolvedValue(undefined);
+    const refreshPayload = vi
+      .fn()
+      .mockResolvedValueOnce(payload([first]))
+      .mockResolvedValueOnce(payload([first, second]));
+    const provider = new LiveProvenanceProvider(
+      {
+        loadPayload: vi.fn().mockResolvedValue(payload()),
+        refreshPayload,
+        subscribe: () => () => undefined,
+      },
+      {
+        fetchDoc: vi.fn(),
+        markProvenanceSelectionReviewed: mutation,
+      } as unknown as CoworkDocClient,
+    );
+
+    await provider.markReviewed(
+      ["old-a", "old-b"],
+      "a".repeat(64),
+      REVIEWER,
+    );
+    await provider.markReviewed(
+      ["old-a", "old-b"],
+      "a".repeat(64),
+      REVIEWER,
+    );
 
     expect(mutation).toHaveBeenCalledTimes(2);
     expect(mutation.mock.calls[1]?.[2]).toBe(mutation.mock.calls[0]?.[2]);

--- a/dashboard-react/src/apps/cowork/provenance/view/LiveProvenanceProvider.ts
+++ b/dashboard-react/src/apps/cowork/provenance/view/LiveProvenanceProvider.ts
@@ -1,7 +1,11 @@
 import type { CoworkDocClient } from "../../bridge/HttpCoworkDocClient";
 import type { R2DocPayload } from "../../bridge/types";
 import { mapProvenanceView } from "./provenanceMapping";
-import type { ProvenanceLoad, ProvenanceProvider } from "./contracts";
+import type {
+  ProvenanceLoad,
+  ProvenanceProvider,
+  ProvenanceReviewerBinding,
+} from "./contracts";
 
 export interface ProvenanceSnapshotSource {
   loadPayload(): Promise<R2DocPayload>;
@@ -53,29 +57,56 @@ export class LiveProvenanceProvider implements ProvenanceProvider {
   }
 
   async markReviewed(
-    attestationId: string,
+    attestationIds: readonly string[],
     expectedStructuredHeadSha256: string,
+    expectedReviewer?: ProvenanceReviewerBinding,
   ): Promise<void> {
-    const mutation = this.#client.markProvenanceReviewed;
-    if (mutation === undefined) throw new Error("Provenance review is unavailable.");
-    const fingerprint = `${attestationId}\u0000${expectedStructuredHeadSha256}`;
+    if (attestationIds.length === 0) return;
+    const batchMutation =
+      expectedReviewer === undefined
+        ? undefined
+        : this.#client.markProvenanceSelectionReviewed;
+    const singleMutation = this.#client.markProvenanceReviewed;
+    if (batchMutation === undefined && (attestationIds.length !== 1 || singleMutation === undefined)) {
+      throw new Error("Provenance review is unavailable.");
+    }
+    const fingerprint = `${JSON.stringify(attestationIds)}\u0000${expectedStructuredHeadSha256}\u0000${JSON.stringify(expectedReviewer ?? null)}`;
     const idempotencyKey =
       this.#pendingKeys.get(fingerprint) ??
       `provenance-review-${globalThis.crypto.randomUUID()}`;
     this.#pendingKeys.set(fingerprint, idempotencyKey);
-    await mutation.call(
-      this.#client,
-      attestationId,
-      expectedStructuredHeadSha256,
-      idempotencyKey,
-    );
+    if (batchMutation !== undefined) {
+      await batchMutation.call(
+        this.#client,
+        attestationIds,
+        expectedStructuredHeadSha256,
+        idempotencyKey,
+        expectedReviewer,
+      );
+    } else {
+      await singleMutation!.call(
+        this.#client,
+        attestationIds[0]!,
+        expectedStructuredHeadSha256,
+        idempotencyKey,
+        expectedReviewer,
+      );
+    }
     const fresh = this.#map(await this.#source.refreshPayload());
     if (
       fresh.state === "ready" &&
-      fresh.data.history.some(
-        (record) =>
-          record.supersedesId === attestationId &&
-          record.humanReview.status === "reviewed",
+      attestationIds.every((attestationId) =>
+        fresh.data.history.some(
+          (record) =>
+            record.supersedesId === attestationId &&
+            record.humanReview.status === "reviewed" &&
+            (expectedReviewer === undefined ||
+              record.humanReview.reviewers.some(
+                (reviewer) =>
+                  reviewer.ref === expectedReviewer.ref &&
+                  reviewer.identityStatus === expectedReviewer.identityStatus,
+              )),
+        ),
       )
     ) {
       this.#pendingKeys.delete(fingerprint);

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.test.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -10,6 +10,11 @@ import type {
   ProvenanceSelectionAction,
 } from "./contracts";
 import { ProvenancePanel } from "./ProvenancePanel";
+
+const REVIEWER = {
+  ref: "user-1",
+  identityStatus: "local_actor_ref",
+} as const;
 
 const attestation = {
   attestationId: "attestation-1",
@@ -187,7 +192,533 @@ describe("ProvenancePanel", () => {
       screen.getByRole("button", { name: "Mark reviewed" }),
     );
     await waitFor(() => expect(source.markReviewed).toHaveBeenCalledOnce());
+    expect(source.markReviewed).toHaveBeenCalledWith(
+      ["attestation-1"],
+      "a".repeat(64),
+    );
     expect(locked).toBe(false);
+  });
+
+  it("atomically marks every eligible provenance target routed from a selection", async () => {
+    const secondAttestation = {
+      ...attestation,
+      attestationId: "attestation-2",
+      scope: {
+        ...attestation.scope,
+        documentSpanId: "span-2",
+      },
+    };
+    const secondTarget = {
+      ...data.spans[0]!,
+      projectionId: "document_span:span-2",
+      target: {
+        ...data.spans[0]!.target,
+        documentSpanId: "span-2",
+      },
+      span: { exact: "Second AI passage", prefix: "", suffix: "" },
+      effectiveAttestations: [secondAttestation],
+      effectiveAttestation: secondAttestation,
+      history: [secondAttestation],
+    };
+    const selectionData: ProvenanceData = {
+      ...data,
+      spans: [data.spans[0]!, secondTarget],
+      history: [attestation, secondAttestation],
+      summary: {
+        ...data.summary,
+        totalTargets: 2,
+        currentSpanCount: 2,
+        aiUnreviewedCount: 2,
+      },
+    };
+    const source = provider();
+    vi.mocked(source.load).mockResolvedValue({
+      state: "ready",
+      data: selectionData,
+    });
+    vi.mocked(source.refresh).mockResolvedValue({
+      state: "ready",
+      data: selectionData,
+    });
+    const barrier: ProvenanceMutationBarrier = {
+      runWithSynchronizedDocument: (operation) =>
+        operation({ structuredHeadSha256: "a".repeat(64) }),
+    };
+    const selectionAction: ProvenanceSelectionAction = {
+      requestId: 1,
+      intent: "review",
+      reviewer: REVIEWER,
+      anchor: { exact: "selected passages", prefix: "", suffix: "" },
+      from: 1,
+      to: 30,
+      targetIds: ["document_span:span-1", "document_span:span-2"],
+    };
+    const rendered = render(
+      <ProvenancePanel
+        provider={source}
+        active
+        editor={editor}
+        mutationBarrier={barrier}
+        selectionAction={selectionAction}
+      />,
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Mark as reviewed" }),
+    );
+    await waitFor(() =>
+      expect(source.markReviewed).toHaveBeenCalledWith(
+        ["attestation-1", "attestation-2"],
+        "a".repeat(64),
+        REVIEWER,
+      ),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Mark as reviewed" }),
+    ).toBeNull();
+    rendered.rerender(
+      <ProvenancePanel
+        provider={source}
+        active
+        editor={editor}
+        mutationBarrier={barrier}
+        selectionAction={{
+          ...selectionAction,
+          anchor: { exact: "Second AI passage", prefix: "", suffix: "" },
+          from: 16,
+          to: 30,
+          targetIds: ["document_span:span-2"],
+        }}
+      />,
+    );
+    expect(
+      await screen.findByRole("button", { name: "Mark as reviewed" }),
+    ).toBeEnabled();
+  });
+
+  it("records this user's review when another user already reviewed the target", async () => {
+    const reviewedByOther = {
+      ...attestation,
+      humanReview: {
+        status: "reviewed" as const,
+        reviewers: [
+          {
+            kind: "human" as const,
+            ref: "other-reviewer",
+            label: null,
+            identityStatus: "local_actor_ref" as const,
+          },
+        ],
+      },
+    };
+    const reviewedTarget = {
+      ...data.spans[0]!,
+      effectiveAttestations: [reviewedByOther],
+      effectiveAttestation: reviewedByOther,
+      reviewEligibility: "already_reviewed" as const,
+      history: [reviewedByOther],
+    };
+    const reviewedData: ProvenanceData = {
+      ...data,
+      spans: [reviewedTarget],
+      history: [reviewedByOther],
+    };
+    const source = provider();
+    vi.mocked(source.load).mockResolvedValue({
+      state: "ready",
+      data: reviewedData,
+    });
+    vi.mocked(source.refresh).mockResolvedValue({
+      state: "ready",
+      data: reviewedData,
+    });
+    render(
+      <ProvenancePanel
+        provider={source}
+        active
+        editor={editor}
+        mutationBarrier={{
+          runWithSynchronizedDocument: (operation) =>
+            operation({ structuredHeadSha256: "a".repeat(64) }),
+        }}
+        selectionAction={{
+          requestId: 1,
+          intent: "review",
+          reviewer: REVIEWER,
+          anchor: { exact: "AI passage", prefix: "", suffix: "" },
+          from: 20,
+          to: 30,
+          targetIds: ["document_span:span-1"],
+        }}
+      />,
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Mark as reviewed" }),
+    );
+    await waitFor(() =>
+      expect(source.markReviewed).toHaveBeenCalledWith(
+        ["attestation-1"],
+        "a".repeat(64),
+        REVIEWER,
+      ),
+    );
+  });
+
+  it("records this user's review for a fully selected document default", async () => {
+    const documentRecord = {
+      ...attestation,
+      scope: {
+        ...attestation.scope,
+        kind: "document_version" as const,
+        documentVersionId: "version-1",
+        documentSpanId: null,
+      },
+      humanReview: {
+        status: "reviewed" as const,
+        reviewers: [
+          {
+            kind: "human" as const,
+            ref: "other-reviewer",
+            label: "Other reviewer",
+            identityStatus: "local_actor_ref" as const,
+          },
+        ],
+      },
+    };
+    const documentTarget = {
+      ...data.spans[0]!,
+      projectionId: "document_version:version-1",
+      target: {
+        kind: "document_version" as const,
+        documentVersionId: "version-1",
+        documentSpanId: null,
+        structuredHeadSha256: "a".repeat(64),
+        currentness: "current" as const,
+      },
+      span: null,
+      effectiveAttestations: [documentRecord],
+      effectiveAttestation: documentRecord,
+      reviewEligibility: "already_reviewed" as const,
+      history: [documentRecord],
+    };
+    const documentData: ProvenanceData = {
+      ...data,
+      documentDefault: documentTarget,
+      spans: [],
+      history: [documentRecord],
+    };
+    const source = provider();
+    vi.mocked(source.load).mockResolvedValue({
+      state: "ready",
+      data: documentData,
+    });
+    vi.mocked(source.refresh).mockResolvedValue({
+      state: "ready",
+      data: documentData,
+    });
+    render(
+      <ProvenancePanel
+        provider={source}
+        active
+        editor={editor}
+        mutationBarrier={{
+          runWithSynchronizedDocument: (operation) =>
+            operation({ structuredHeadSha256: "a".repeat(64) }),
+        }}
+        selectionAction={{
+          requestId: 1,
+          intent: "review",
+          reviewer: REVIEWER,
+          anchor: { exact: "Whole document", prefix: "", suffix: "" },
+          from: 0,
+          to: 100,
+          targetIds: ["document_version:version-1"],
+          coversWholeDocument: true,
+        }}
+      />,
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Mark as reviewed" }),
+    );
+    await waitFor(() =>
+      expect(source.markReviewed).toHaveBeenCalledWith(
+        ["attestation-1"],
+        "a".repeat(64),
+        REVIEWER,
+      ),
+    );
+  });
+
+  it("disables a routed action when this user's review appears before confirmation", async () => {
+    const reviewedByCurrentUser = {
+      ...attestation,
+      humanReview: {
+        status: "reviewed" as const,
+        reviewers: [
+          {
+            kind: "human" as const,
+            ref: REVIEWER.ref,
+            label: null,
+            identityStatus: REVIEWER.identityStatus,
+          },
+        ],
+      },
+    };
+    const reviewedTarget = {
+      ...data.spans[0]!,
+      effectiveAttestations: [reviewedByCurrentUser],
+      effectiveAttestation: reviewedByCurrentUser,
+      reviewEligibility: "already_reviewed" as const,
+      history: [reviewedByCurrentUser],
+    };
+    render(
+      <ProvenancePanel
+        provider={{
+          ...provider(),
+          load: vi.fn().mockResolvedValue({
+            state: "ready",
+            data: { ...data, spans: [reviewedTarget] },
+          }),
+        }}
+        active
+        editor={editor}
+        mutationBarrier={{ runWithSynchronizedDocument: vi.fn() }}
+        selectionAction={{
+          requestId: 1,
+          intent: "review",
+          reviewer: REVIEWER,
+          anchor: { exact: "AI passage", prefix: "", suffix: "" },
+          from: 20,
+          to: 30,
+          targetIds: ["document_span:span-1"],
+        }}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Mark as reviewed" }),
+    ).toBeDisabled();
+    expect(screen.getByText(/selected provenance changed/u)).toBeVisible();
+  });
+
+  it("keeps a completed selection action dismissed after its successor refreshes", async () => {
+    let currentData = data;
+    let publish = (): void => undefined;
+    const base = provider();
+    const source: ProvenanceProvider = {
+      ...base,
+      load: vi.fn().mockImplementation(async () => ({
+        state: "ready" as const,
+        data: currentData,
+      })),
+      refresh: vi.fn().mockResolvedValue({ state: "ready", data }),
+      subscribe: (listener) => {
+        publish = listener;
+        return () => undefined;
+      },
+    };
+    const selectionAction: ProvenanceSelectionAction = {
+      requestId: 1,
+      intent: "review",
+      reviewer: REVIEWER,
+      anchor: { exact: "AI passage", prefix: "", suffix: "" },
+      from: 20,
+      to: 30,
+      targetIds: ["document_span:span-1"],
+    };
+    render(
+      <ProvenancePanel
+        provider={source}
+        active
+        editor={editor}
+        mutationBarrier={{
+          runWithSynchronizedDocument: (operation) =>
+            operation({ structuredHeadSha256: "a".repeat(64) }),
+        }}
+        selectionAction={selectionAction}
+      />,
+    );
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Mark as reviewed" }),
+    );
+    await waitFor(() => expect(source.markReviewed).toHaveBeenCalledOnce());
+    expect(
+      screen.queryByRole("button", { name: "Mark as reviewed" }),
+    ).toBeNull();
+
+    const successor = {
+      ...attestation,
+      attestationId: "attestation-reviewed",
+      humanReview: {
+        status: "reviewed" as const,
+        reviewers: [
+          {
+            kind: "human" as const,
+            ref: "user-1",
+            label: null,
+            identityStatus: "local_actor_ref" as const,
+          },
+        ],
+      },
+      supersedesId: attestation.attestationId,
+    };
+    currentData = {
+      ...data,
+      spans: [
+        {
+          ...data.spans[0]!,
+          effectiveAttestations: [successor],
+          effectiveAttestation: successor,
+          reviewEligibility: "already_reviewed",
+          history: [attestation, successor],
+        },
+      ],
+      history: [attestation, successor],
+    };
+    await act(async () => {
+      publish();
+      await Promise.resolve();
+    });
+    await screen.findByText("AI · reviewed");
+    expect(
+      screen.queryByRole("button", { name: "Mark as reviewed" }),
+    ).toBeNull();
+  });
+
+  it("disables a routed selection action after its target becomes conflicted", async () => {
+    const peer = { ...attestation, attestationId: "attestation-peer" };
+    const conflicted = {
+      ...data.spans[0]!,
+      effectiveAttestations: [attestation, peer],
+      effectiveAttestation: null,
+      resolution: "conflicted" as const,
+      reviewEligibility: "conflicted" as const,
+      issue: { code: "peer_conflict", message: "Conflicting records." },
+      history: [attestation, peer],
+    };
+    render(
+      <ProvenancePanel
+        provider={{
+          ...provider(),
+          load: vi.fn().mockResolvedValue({
+            state: "ready",
+            data: { ...data, spans: [conflicted] },
+          }),
+        }}
+        active
+        editor={editor}
+        mutationBarrier={{ runWithSynchronizedDocument: vi.fn() }}
+        selectionAction={{
+          requestId: 1,
+          intent: "review",
+          reviewer: REVIEWER,
+          anchor: { exact: "AI passage", prefix: "", suffix: "" },
+          from: 20,
+          to: 30,
+          targetIds: ["document_span:span-1"],
+        }}
+      />,
+    );
+
+    const action = await screen.findByRole("button", {
+      name: "Mark as reviewed",
+    });
+    expect(action).toBeDisabled();
+    expect(screen.getByText(/selected provenance changed/u)).toBeVisible();
+    expect(screen.getByLabelText("Review selected provenance")).toHaveFocus();
+  });
+
+  it("moves routed focus to feedback when a live refresh disables review", async () => {
+    const peer = { ...attestation, attestationId: "attestation-peer" };
+    const conflicted = {
+      ...data.spans[0]!,
+      effectiveAttestations: [attestation, peer],
+      effectiveAttestation: null,
+      resolution: "conflicted" as const,
+      reviewEligibility: "conflicted" as const,
+      issue: { code: "peer_conflict", message: "Conflicting records." },
+      history: [attestation, peer],
+    };
+    let currentData = data;
+    let publish = (): void => undefined;
+    const source: ProvenanceProvider = {
+      ...provider(),
+      load: vi.fn().mockImplementation(async () => ({
+        state: "ready" as const,
+        data: currentData,
+      })),
+      subscribe: (listener) => {
+        publish = listener;
+        return () => undefined;
+      },
+    };
+    render(
+      <ProvenancePanel
+        provider={source}
+        active
+        editor={editor}
+        mutationBarrier={{ runWithSynchronizedDocument: vi.fn() }}
+        selectionAction={{
+          requestId: 1,
+          intent: "review",
+          reviewer: REVIEWER,
+          anchor: { exact: "AI passage", prefix: "", suffix: "" },
+          from: 20,
+          to: 30,
+          targetIds: ["document_span:span-1"],
+        }}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Mark as reviewed" }),
+    ).toHaveFocus();
+    currentData = { ...data, spans: [conflicted] };
+    act(() => publish());
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Mark as reviewed" }),
+      ).toBeDisabled(),
+    );
+    expect(screen.getByLabelText("Review selected provenance")).toHaveFocus();
+  });
+
+  it("keeps routed review feedback visible when the selected target disappeared", async () => {
+    render(
+      <ProvenancePanel
+        provider={{
+          ...provider(),
+          load: vi.fn().mockResolvedValue({
+            state: "ready",
+            data: { ...data, spans: [], history: [] },
+          }),
+        }}
+        active
+        editor={editor}
+        mutationBarrier={{ runWithSynchronizedDocument: vi.fn() }}
+        selectionAction={{
+          requestId: 1,
+          intent: "review",
+          reviewer: REVIEWER,
+          anchor: { exact: "AI passage", prefix: "", suffix: "" },
+          from: 20,
+          to: 30,
+          targetIds: ["document_span:span-1"],
+        }}
+      />,
+    );
+
+    const feedback = await screen.findByLabelText(
+      "Review selected provenance",
+    );
+    expect(
+      screen.getByRole("button", { name: "Mark as reviewed" }),
+    ).toBeDisabled();
+    expect(screen.getByText(/selected provenance changed/u)).toBeVisible();
+    await waitFor(() => expect(feedback).toHaveFocus());
   });
 
   it("blocks the write when a fresh pull introduces an incompatible overlap", async () => {
@@ -265,7 +796,7 @@ describe("ProvenancePanel", () => {
     ).toBeNull();
   });
 
-  it("shows recent typing as recording instead of definitively unrecorded", async () => {
+  it("shows recent typing as pending without blocking other provenance actions", async () => {
     render(
       <ProvenancePanel
         provider={provider()}
@@ -276,7 +807,7 @@ describe("ProvenancePanel", () => {
     );
 
     expect(
-      await screen.findByText(/Recording provenance for recent typing…/u),
+      await screen.findByText(/other provenance actions remain available/u),
     ).toBeVisible();
     expect(screen.getByText("Updating…")).toBeVisible();
     expect(
@@ -372,9 +903,10 @@ describe("ProvenancePanel", () => {
     const selectionAction: ProvenanceSelectionAction = {
       requestId: 1,
       intent: "review",
+      reviewer: REVIEWER,
       anchor: { exact: "AI passage", prefix: "", suffix: "" },
-      from: 5,
-      to: 15,
+      from: 20,
+      to: 30,
       targetIds: ["document_span:span-1"],
     };
     render(
@@ -389,7 +921,9 @@ describe("ProvenancePanel", () => {
 
     expect(await screen.findByText("Actions")).toBeVisible();
     await waitFor(() =>
-      expect(screen.getByRole("button", { name: /AI passage/u })).toHaveFocus(),
+      expect(
+        screen.getByRole("button", { name: "Mark as reviewed" }),
+      ).toHaveFocus(),
     );
     expect(screen.getByRole("button", { name: "Mark reviewed" })).toBeEnabled();
   });

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.test.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.test.tsx
@@ -928,6 +928,62 @@ describe("ProvenancePanel", () => {
     expect(screen.getByRole("button", { name: "Mark reviewed" })).toBeEnabled();
   });
 
+  it("keeps review actions visible but disabled while provenance identity reconnects", async () => {
+    const source = provider();
+    const barrier = { runWithSynchronizedDocument: vi.fn() };
+    const selectionAction: ProvenanceSelectionAction = {
+      requestId: 1,
+      intent: "review",
+      reviewer: REVIEWER,
+      anchor: { exact: "AI passage", prefix: "", suffix: "" },
+      from: 20,
+      to: 30,
+      targetIds: ["document_span:span-1"],
+    };
+    const blockedReason =
+      "Open Work Buddy from its launcher to reconnect provenance identity before recording review.";
+    const rendered = render(
+      <ProvenancePanel
+        provider={source}
+        active
+        editor={editor}
+        mutationBarrier={barrier}
+        selectionAction={selectionAction}
+      />,
+    );
+
+    const selectedAction = await screen.findByRole("button", {
+      name: "Mark as reviewed",
+    });
+    expect(await screen.findByText("Actions")).toBeVisible();
+    await waitFor(() => expect(selectedAction).toHaveFocus());
+    rendered.rerender(
+      <ProvenancePanel
+        provider={source}
+        active
+        editor={editor}
+        mutationBarrier={barrier}
+        mutationBlockedReason={blockedReason}
+        selectionAction={selectionAction}
+      />,
+    );
+
+    const targetAction = screen.getByRole("button", {
+      name: "Mark reviewed",
+    });
+    expect(selectedAction).toBeDisabled();
+    expect(targetAction).toBeDisabled();
+    expect(selectedAction).toHaveAccessibleDescription(blockedReason);
+    expect(targetAction).toHaveAccessibleDescription(blockedReason);
+    expect(screen.getByRole("status")).toHaveTextContent(blockedReason);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("article", { name: "Review selected provenance" }),
+      ).toHaveFocus(),
+    );
+    expect(source.markReviewed).not.toHaveBeenCalled();
+  });
+
   it("keeps Mark reviewed discoverable but disabled with a specific reason", async () => {
     const stale = {
       ...data.spans[0]!,

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.tsx
@@ -37,6 +37,8 @@ export interface ProvenancePanelProps {
   readonly selectionAction?: ProvenanceSelectionAction | null;
   /** Browser-local direct entry is awaiting an authoritative ledger receipt. */
   readonly inputProvenancePending?: boolean;
+  /** Visible reason human review mutations are temporarily unavailable. */
+  readonly mutationBlockedReason?: string;
 }
 
 const sourceLabel = (attestation: ProvenanceAttestation): string => {
@@ -411,6 +413,7 @@ function ProvenanceContents({
   readOnly,
   selectionAction,
   inputProvenancePending = false,
+  mutationBlockedReason,
 }: {
   readonly load: ProvenanceLoad;
   readonly provider: ProvenanceProvider;
@@ -419,6 +422,7 @@ function ProvenanceContents({
   readonly mutationBarrier?: ProvenanceMutationBarrier;
   readonly selectionAction?: ProvenanceSelectionAction | null;
   readonly inputProvenancePending?: boolean;
+  readonly mutationBlockedReason?: string;
 }) {
   const view = load.state === "ready" ? load.data : undefined;
   const [filter, setFilter] = useState<ProvenanceFilter>("all");
@@ -470,7 +474,14 @@ function ProvenanceContents({
     if (row === null) return;
     row.focus({ preventScroll: true });
     row.scrollIntoView?.({ block: "nearest" });
-  }, [load, selectedId, selectionAction]);
+  }, [
+    load,
+    mutationBarrier,
+    mutationBlockedReason,
+    readOnly,
+    selectedId,
+    selectionAction,
+  ]);
   if (view === undefined) {
     return (
       <div className="wb-cowork-provenance-panel__unavailable" role="status">
@@ -604,6 +615,10 @@ function ProvenanceContents({
     allowPreviouslyReviewed = false,
   ): Promise<void> => {
     if (mutationLock.current) return;
+    if (mutationBlockedReason !== undefined) {
+      setError(mutationBlockedReason);
+      return;
+    }
     const records = requestedTargets.map(effective);
     if (requestedTargets.length === 0 || view.currentStructuredHeadSha256 === null) {
       return;
@@ -750,8 +765,34 @@ function ProvenanceContents({
     !locallyDirty &&
     view.currentStructuredHeadSha256 !== null &&
     readOnly !== true &&
+    mutationBlockedReason === undefined &&
     mutationBarrier !== undefined &&
     pendingIds.size === 0;
+  const selectionReviewDisabledReason = selectionReviewEnabled
+    ? null
+    : pendingIds.size > 0
+      ? "Human review is being recorded."
+      : !selectionReviewTargetsAreCurrent
+        ? "The selected provenance changed. Reselect the passage to review its current record."
+        : locallyDirty
+          ? "Synchronize local edits and refresh provenance before recording review."
+          : view.currentStructuredHeadSha256 === null
+            ? "No current structured document head is available, so review cannot be recorded."
+            : readOnly === true
+              ? "This document is read-only, so review cannot be recorded."
+              : mutationBlockedReason !== undefined
+                ? mutationBlockedReason
+                : mutationBarrier === undefined
+                  ? "The editor is not ready to record review safely."
+                  : "Review cannot be recorded for this selection.";
+  const selectionReviewReasonId = "wb-cowork-selection-review-disabled";
+  const mutationBlockedReasonId = "wb-cowork-provenance-mutation-blocked";
+  const selectionReviewDescriptionId = selectionReviewEnabled
+    ? undefined
+    : mutationBlockedReason !== undefined &&
+        selectionReviewDisabledReason === mutationBlockedReason
+      ? mutationBlockedReasonId
+      : selectionReviewReasonId;
   return (
     <>
       <dl
@@ -815,6 +856,15 @@ function ProvenanceContents({
           for synchronization.
         </p>
       ) : null}
+      {mutationBlockedReason === undefined ? null : (
+        <p
+          id={mutationBlockedReasonId}
+          className="wb-cowork-provenance-panel__reason"
+          role="status"
+        >
+          {mutationBlockedReason}
+        </p>
+      )}
       <p className="wb-cowork-provenance-panel__success" aria-live="polite">
         {success ?? ""}
       </p>
@@ -839,24 +889,20 @@ function ProvenanceContents({
             ref={routedSelectionReviewRef}
             type="button"
             disabled={!selectionReviewEnabled}
-            aria-describedby={
-              selectionReviewTargetsAreCurrent
-                ? undefined
-                : "wb-cowork-selection-review-stale"
-            }
+            aria-describedby={selectionReviewDescriptionId}
             onClick={() =>
               void markReviewed(selectionReviewTargets, true)
             }
           >
             {pendingIds.size > 0 ? "Recording…" : "Mark as reviewed"}
           </button>
-          {selectionReviewTargetsAreCurrent ? null : (
+          {selectionReviewDisabledReason === null ||
+          selectionReviewDescriptionId === mutationBlockedReasonId ? null : (
             <p
-              id="wb-cowork-selection-review-stale"
+              id={selectionReviewReasonId}
               className="wb-cowork-provenance-panel__reason"
             >
-              The selected provenance changed. Reselect the passage to review
-              its current record.
+              {selectionReviewDisabledReason}
             </p>
           )}
         </article>
@@ -1025,6 +1071,7 @@ function ProvenanceContents({
                               targetCanReview &&
                               view.currentStructuredHeadSha256 !== null &&
                               readOnly !== true &&
+                              mutationBlockedReason === undefined &&
                               mutationBarrier !== undefined &&
                               pendingIds.size === 0;
                             const reason =
@@ -1041,20 +1088,28 @@ function ProvenanceContents({
                                         ? "No current structured document head is available, so review cannot be recorded."
                                         : readOnly === true && targetCanReview
                                           ? "This document is read-only, so review cannot be recorded."
+                                          : mutationBlockedReason !== undefined &&
+                                              targetCanReview
+                                            ? mutationBlockedReason
                                           : mutationBarrier === undefined &&
                                               targetCanReview
                                             ? "The editor is not ready to record review safely."
                                             : reviewBlockedReason(target);
                             const reasonId = `wb-cowork-provenance-review-reason-${id}`;
+                            const descriptionId = reviewEnabled
+                              ? undefined
+                              : mutationBlockedReason !== undefined &&
+                                  targetCanReview &&
+                                  reason === mutationBlockedReason
+                                ? mutationBlockedReasonId
+                                : reasonId;
                             return (
                               <div className="wb-cowork-provenance-panel__actions">
                                 <h4>Actions</h4>
                                 <button
                                   type="button"
                                   disabled={!reviewEnabled}
-                                  aria-describedby={
-                                    reviewEnabled ? undefined : reasonId
-                                  }
+                                  aria-describedby={descriptionId}
                                   onClick={() => void markReviewed([target])}
                                 >
                                   {pendingIds.has(record.attestationId)
@@ -1067,14 +1122,14 @@ function ProvenanceContents({
                                     not change its authorship or assert that it
                                     is true.
                                   </p>
-                                ) : (
+                                ) : descriptionId === reasonId ? (
                                   <p
                                     id={reasonId}
                                     className="wb-cowork-provenance-panel__reason"
                                   >
                                     {reason}
                                   </p>
-                                )}
+                                ) : null}
                               </div>
                             );
                           })()
@@ -1206,6 +1261,7 @@ export function ProvenancePanel(props: ProvenancePanelProps) {
           mutationBarrier={props.mutationBarrier}
           selectionAction={props.selectionAction}
           inputProvenancePending={props.inputProvenancePending}
+          mutationBlockedReason={props.mutationBlockedReason}
         />
       </>
     );
@@ -1217,6 +1273,7 @@ export function ProvenancePanel(props: ProvenancePanelProps) {
     props.mutationBarrier,
     props.provider,
     props.readOnly,
+    props.mutationBlockedReason,
     props.selectionAction,
   ]);
   return (

--- a/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.tsx
+++ b/dashboard-react/src/apps/cowork/provenance/view/ProvenancePanel.tsx
@@ -423,11 +423,17 @@ function ProvenanceContents({
   const view = load.state === "ready" ? load.data : undefined;
   const [filter, setFilter] = useState<ProvenanceFilter>("all");
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [pendingIds, setPendingIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   const mutationLock = useRef(false);
   const routedRowRef = useRef<HTMLButtonElement | null>(null);
+  const routedSelectionReviewRef = useRef<HTMLButtonElement | null>(null);
+  const routedSelectionReviewCardRef = useRef<HTMLElement | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const [completedSelectionFingerprint, setCompletedSelectionFingerprint] =
+    useState<string | null>(null);
   useEffect(() => {
     if (
       selectionAction === null ||
@@ -441,6 +447,17 @@ function ProvenanceContents({
     setSelectedId(selectionAction.targetIds[0]!);
   }, [selectionAction]);
   useLayoutEffect(() => {
+    if (selectionAction?.intent === "review") {
+      const action = routedSelectionReviewRef.current;
+      const focusTarget =
+        action !== null && !action.disabled
+          ? action
+          : routedSelectionReviewCardRef.current;
+      if (focusTarget === null) return;
+      focusTarget.focus({ preventScroll: true });
+      focusTarget.scrollIntoView?.({ block: "nearest" });
+      return;
+    }
     const target = selectionAction?.targetIds[0];
     if (
       target === undefined ||
@@ -453,7 +470,7 @@ function ProvenanceContents({
     if (row === null) return;
     row.focus({ preventScroll: true });
     row.scrollIntoView?.({ block: "nearest" });
-  }, [selectedId, selectionAction]);
+  }, [load, selectedId, selectionAction]);
   if (view === undefined) {
     return (
       <div className="wb-cowork-provenance-panel__unavailable" role="status">
@@ -519,12 +536,92 @@ function ProvenanceContents({
     hasText &&
     targets.length === 0 &&
     view.history.length === 0;
-  const markReviewed = async (target: ProvenanceTarget): Promise<void> => {
+  const selectionReviewFingerprint =
+    selectionAction?.intent === "review"
+      ? JSON.stringify({
+          requestId: selectionAction.requestId,
+          anchor: selectionAction.anchor,
+          from: selectionAction.from,
+          to: selectionAction.to,
+          targetIds: selectionAction.targetIds,
+          coversWholeDocument: selectionAction.coversWholeDocument ?? false,
+          reviewer: selectionAction.reviewer,
+        })
+      : null;
+  const selectionReviewItems =
+    selectionAction?.intent === "review" &&
+    selectionReviewFingerprint !== completedSelectionFingerprint
+      ? selectionAction.targetIds.map((id) =>
+          targets.find(
+            (candidate) => candidate.target.projectionId === id,
+          ),
+        )
+      : [];
+  const selectionReviewTargets = selectionReviewItems.some(
+    (item) => item === undefined,
+  )
+    ? []
+    : selectionReviewItems.flatMap((item) =>
+        item === undefined ? [] : [item.target],
+      );
+  const selectionReviewTargetsAreCurrent =
+    selectionReviewTargets.length > 0 &&
+    selectionReviewItems.every((item) => {
+      if (item === undefined) return false;
+      const record = effective(item.target);
+      const reviewer = selectionAction?.reviewer;
+      const targetIsContained =
+        item.target.span === null
+          ? selectionAction?.coversWholeDocument === true
+          : selectionAction?.intent === "review" &&
+            item.anchorResolution.documentOrder !== null &&
+            item.anchorResolution.documentEnd !== null &&
+            selectionAction.from <= item.anchorResolution.documentOrder &&
+            selectionAction.to >= item.anchorResolution.documentEnd;
+      return (
+        item.peerConflictIds.length === 0 &&
+        item.target.resolution === "resolved" &&
+        item.target.target.currentness === "current" &&
+        ["eligible", "already_reviewed"].includes(
+          item.target.reviewEligibility,
+        ) &&
+        reviewer !== undefined &&
+        record !== null &&
+        !record.humanReview.reviewers.some(
+          (candidate) =>
+            candidate.ref === reviewer.ref &&
+            candidate.identityStatus === reviewer.identityStatus,
+        ) &&
+        (record.authorship.kind === "ai" ||
+          record.authorship.kind === "mixed") &&
+        (item.anchorResolution.state === "unique" ||
+          item.anchorResolution.state === "document") &&
+        targetIsContained
+      );
+    });
+  const markReviewed = async (
+    requestedTargets: readonly ProvenanceTarget[],
+    allowPreviouslyReviewed = false,
+  ): Promise<void> => {
     if (mutationLock.current) return;
-    const record = effective(target);
-    if (record === null || view.currentStructuredHeadSha256 === null) return;
+    const records = requestedTargets.map(effective);
+    if (requestedTargets.length === 0 || view.currentStructuredHeadSha256 === null) {
+      return;
+    }
+    if (records.some((record) => record === null)) {
+      setError(
+        "The selected provenance changed. Reselect the passage before recording review.",
+      );
+      return;
+    }
     mutationLock.current = true;
-    setPendingId(record.attestationId);
+    setPendingIds(
+      new Set(
+        records.flatMap((record) =>
+          record === null ? [] : [record.attestationId],
+        ),
+      ),
+    );
     setError(null);
     setSuccess(null);
     try {
@@ -537,47 +634,106 @@ function ProvenanceContents({
           if (refreshed.state !== "ready") {
             throw new Error(refreshed.reason);
           }
-          const refreshedTarget = [
+          const refreshedTargets = [
             ...(refreshed.data.documentDefault === null
               ? []
               : [refreshed.data.documentDefault]),
             ...refreshed.data.spans,
-          ].find((candidate) => candidate.projectionId === target.projectionId);
-          const refreshedRecord =
-            refreshedTarget === undefined ? null : effective(refreshedTarget);
-          const refreshedItem = resolvePanelTargets(
+          ];
+          const refreshedItems = resolvePanelTargets(
             refreshed.data,
             editor,
-          ).find(
-            (candidate) =>
-              candidate.target.projectionId === target.projectionId,
           );
           if (
             refreshed.data.currentStructuredHeadSha256 === null ||
             synchronized.structuredHeadSha256 !==
-              refreshed.data.currentStructuredHeadSha256 ||
-            refreshedTarget === undefined ||
-            refreshedTarget.reviewEligibility !== "eligible" ||
-            refreshedRecord?.attestationId !== record.attestationId ||
-            refreshedItem === undefined ||
-            refreshedItem.peerConflictIds.length > 0
+              refreshed.data.currentStructuredHeadSha256
           ) {
             throw new Error(
               "The document changed. Provenance was refreshed; inspect the passage and try again.",
             );
           }
-          if (
-            refreshedTarget.span !== null &&
-            editor?.resolveTarget(refreshedTarget.span).state !== "unique"
-          ) {
-            throw new Error("The passage no longer resolves to one location.");
+          const refreshedRecords = requestedTargets.map((target, index) => {
+            const refreshedTarget = refreshedTargets.find(
+              (candidate) =>
+                candidate.projectionId === target.projectionId,
+            );
+            const refreshedRecord =
+              refreshedTarget === undefined ? null : effective(refreshedTarget);
+            const refreshedItem = refreshedItems.find(
+              (candidate) =>
+                candidate.target.projectionId === target.projectionId,
+            );
+            const expectedRecord = records[index];
+            const eligible =
+              refreshedTarget?.reviewEligibility === "eligible" ||
+              (allowPreviouslyReviewed &&
+                refreshedTarget?.reviewEligibility === "already_reviewed");
+            const reviewerStillNeeded =
+              !allowPreviouslyReviewed ||
+              (selectionAction?.reviewer !== undefined &&
+                !refreshedRecord?.humanReview.reviewers.some(
+                  (candidate) =>
+                    candidate.ref === selectionAction.reviewer?.ref &&
+                    candidate.identityStatus ===
+                      selectionAction.reviewer?.identityStatus,
+                ));
+            if (
+              refreshedTarget === undefined ||
+              !eligible ||
+              !reviewerStillNeeded ||
+              refreshedRecord?.attestationId !==
+                expectedRecord?.attestationId ||
+              refreshedItem === undefined ||
+              refreshedItem.peerConflictIds.length > 0
+            ) {
+              throw new Error(
+                "The document changed. Provenance was refreshed; inspect the passage and try again.",
+              );
+            }
+            if (
+              refreshedTarget.span !== null &&
+              editor?.resolveTarget(refreshedTarget.span).state !== "unique"
+            ) {
+              throw new Error(
+                "A selected passage no longer resolves to one location.",
+              );
+            }
+            return refreshedRecord;
+          });
+          if (refreshedRecords.some((record) => record === null)) {
+            throw new Error(
+              "The selected provenance is no longer available for review.",
+            );
           }
-          await provider.markReviewed(
-            refreshedRecord.attestationId,
-            refreshed.data.currentStructuredHeadSha256,
+          const refreshedAttestationIds = refreshedRecords.flatMap((record) =>
+            record === null ? [] : [record.attestationId],
           );
+          if (
+            allowPreviouslyReviewed &&
+            selectionAction?.reviewer !== undefined
+          ) {
+            await provider.markReviewed(
+              refreshedAttestationIds,
+              refreshed.data.currentStructuredHeadSha256,
+              selectionAction.reviewer,
+            );
+          } else {
+            await provider.markReviewed(
+              refreshedAttestationIds,
+              refreshed.data.currentStructuredHeadSha256,
+            );
+          }
+          if (
+            allowPreviouslyReviewed &&
+            selectionReviewFingerprint !== null
+          ) {
+            setCompletedSelectionFingerprint(selectionReviewFingerprint);
+          }
           setSuccess(
-            `Human review was recorded for “${refreshedTarget.span === null ? "the whole document" : passageExcerpt(refreshedTarget.span.exact)}”.`,
+            requestedTargets.length === 1
+              ? `Your review was recorded for “${requestedTargets[0]!.span === null ? "the whole document" : passageExcerpt(requestedTargets[0]!.span.exact)}”.`
+              : `Your review was recorded for ${String(requestedTargets.length)} selected passages.`,
           );
         },
       );
@@ -585,9 +741,17 @@ function ProvenanceContents({
       setError(mutationErrorMessage(cause));
     } finally {
       mutationLock.current = false;
-      setPendingId(null);
+      setPendingIds(new Set());
     }
   };
+  const selectionReviewEnabled =
+    selectionReviewTargets.length > 0 &&
+    selectionReviewTargetsAreCurrent &&
+    !locallyDirty &&
+    view.currentStructuredHeadSha256 !== null &&
+    readOnly !== true &&
+    mutationBarrier !== undefined &&
+    pendingIds.size === 0;
   return (
     <>
       <dl
@@ -640,9 +804,9 @@ function ProvenanceContents({
       )}
       {inputProvenancePending ? (
         <p className="wb-cowork-provenance-panel__reason" role="status">
-          Recording provenance for recent typing… The editor has captured the
-          text; authorship and review will appear after the server confirms the
-          record.
+          Recent typing provenance is awaiting confirmation. The editor has
+          captured the text, and other provenance actions remain available while
+          authorship and review catch up.
         </p>
       ) : locallyDirty ? (
         <p className="wb-cowork-provenance-panel__reason" role="status">
@@ -654,6 +818,49 @@ function ProvenanceContents({
       <p className="wb-cowork-provenance-panel__success" aria-live="polite">
         {success ?? ""}
       </p>
+      {selectionReviewItems.length === 0 ? null : (
+        <article
+          ref={routedSelectionReviewCardRef}
+          className="wb-cowork-provenance-panel__selection-review"
+          tabIndex={-1}
+          aria-label="Review selected provenance"
+        >
+          <h3>
+            {selectionAction?.targetIds.length === 1
+              ? "Review selected passage"
+              : `Review ${String(selectionAction?.targetIds.length ?? 0)} selected passages`}
+          </h3>
+          <p>
+            Records your review for the eligible AI or mixed-authored
+            provenance fully contained in the selection. It does not change
+            authorship or assert that the text is true.
+          </p>
+          <button
+            ref={routedSelectionReviewRef}
+            type="button"
+            disabled={!selectionReviewEnabled}
+            aria-describedby={
+              selectionReviewTargetsAreCurrent
+                ? undefined
+                : "wb-cowork-selection-review-stale"
+            }
+            onClick={() =>
+              void markReviewed(selectionReviewTargets, true)
+            }
+          >
+            {pendingIds.size > 0 ? "Recording…" : "Mark as reviewed"}
+          </button>
+          {selectionReviewTargetsAreCurrent ? null : (
+            <p
+              id="wb-cowork-selection-review-stale"
+              className="wb-cowork-provenance-panel__reason"
+            >
+              The selected provenance changed. Reselect the passage to review
+              its current record.
+            </p>
+          )}
+        </article>
+      )}
       {noRecordedProvenance && filter === "all" ? (
         <article className="wb-cowork-provenance-panel__unrecorded">
           <h3>No provenance has been recorded for this document</h3>
@@ -819,11 +1026,11 @@ function ProvenanceContents({
                               view.currentStructuredHeadSha256 !== null &&
                               readOnly !== true &&
                               mutationBarrier !== undefined &&
-                              pendingId === null;
+                              pendingIds.size === 0;
                             const reason =
-                              pendingId === record.attestationId
+                              pendingIds.has(record.attestationId)
                                 ? "Human review is being recorded."
-                                : pendingId !== null
+                                : pendingIds.size > 0
                                   ? "Finish recording the current review before starting another."
                                   : peerConflictIds.length > 0
                                     ? "Overlapping provenance records disagree, so review cannot be recorded."
@@ -848,9 +1055,9 @@ function ProvenanceContents({
                                   aria-describedby={
                                     reviewEnabled ? undefined : reasonId
                                   }
-                                  onClick={() => void markReviewed(target)}
+                                  onClick={() => void markReviewed([target])}
                                 >
-                                  {pendingId === record.attestationId
+                                  {pendingIds.has(record.attestationId)
                                     ? "Recording…"
                                     : "Mark reviewed"}
                                 </button>

--- a/dashboard-react/src/apps/cowork/provenance/view/contracts.ts
+++ b/dashboard-react/src/apps/cowork/provenance/view/contracts.ts
@@ -9,6 +9,14 @@ export type ProvenanceIdentityStatus =
   | "account_ref"
   | "claimed_name";
 
+export interface ProvenanceReviewerBinding {
+  readonly ref: string;
+  readonly identityStatus: Exclude<
+    ProvenanceIdentityStatus,
+    "claimed_name"
+  >;
+}
+
 export interface ProvenanceActor {
   readonly kind: string;
   readonly ref: string | null;
@@ -103,7 +111,11 @@ export interface ProvenanceProvider {
   /** Force one fresh authoritative document pull (used by mutation preflight). */
   refresh(): Promise<ProvenanceLoad>;
   subscribe(listener: () => void): () => void;
-  markReviewed(attestationId: string, expectedStructuredHeadSha256: string): Promise<void>;
+  markReviewed(
+    attestationIds: readonly string[],
+    expectedStructuredHeadSha256: string,
+    expectedReviewer?: ProvenanceReviewerBinding,
+  ): Promise<void>;
 }
 
 export interface ProvenanceMutationBarrier {
@@ -129,4 +141,8 @@ export interface ProvenanceSelectionAction {
   readonly from: number;
   readonly to: number;
   readonly targetIds: readonly string[];
+  /** True only when the frozen selection spans all document text. */
+  readonly coversWholeDocument?: boolean;
+  /** Frozen actor binding for actor-aware review revalidation in stable detail. */
+  readonly reviewer?: ProvenanceReviewerBinding;
 }

--- a/dashboard-react/src/apps/cowork/rail/CoworkRail.tsx
+++ b/dashboard-react/src/apps/cowork/rail/CoworkRail.tsx
@@ -102,6 +102,7 @@ export interface CoworkRailProps {
     readonly mutationBarrier?: ProvenanceMutationBarrier;
     readonly selectionAction?: ProvenanceSelectionAction | null;
     readonly inputProvenancePending?: boolean;
+    readonly mutationBlockedReason?: string;
   };
   readonly chat: CoworkRailChat;
   /** Fired only for a present user click on the wide Chat tab. */
@@ -465,6 +466,7 @@ export function CoworkRail(props: CoworkRailProps) {
             mutationBarrier={props.provenance.mutationBarrier}
             selectionAction={props.provenance.selectionAction}
             inputProvenancePending={props.provenance.inputProvenancePending}
+            mutationBlockedReason={props.provenance.mutationBlockedReason}
             readOnly={props.readOnly}
           />
         )}

--- a/dashboard-react/src/apps/cowork/rail/styles.css
+++ b/dashboard-react/src/apps/cowork/rail/styles.css
@@ -327,12 +327,27 @@
 }
 
 .wb-cowork-provenance-panel__list > li,
+.wb-cowork-provenance-panel__selection-review,
 .wb-cowork-provenance-panel__unrecorded,
 .wb-cowork-provenance-panel__unavailable {
   border: 1px solid var(--wb-color-border-subtle);
   border-inline-start: 3px solid var(--wb-color-accent);
   border-radius: var(--wb-radius-control);
   background: var(--wb-color-surface-raised);
+}
+
+.wb-cowork-provenance-panel__selection-review {
+  display: grid;
+  gap: var(--wb-space-2);
+  padding: var(--wb-space-3);
+}
+
+.wb-cowork-provenance-panel__selection-review > * {
+  margin: 0;
+}
+
+.wb-cowork-provenance-panel__selection-review button {
+  justify-self: start;
 }
 
 .wb-cowork-provenance-panel__list > li[data-state="issue"] {
@@ -407,6 +422,7 @@
 
 @media (forced-colors: active) {
   .wb-cowork-provenance-panel__list > li,
+  .wb-cowork-provenance-panel__selection-review,
   .wb-cowork-provenance-panel__unrecorded {
     border-inline-start-color: CanvasText;
   }

--- a/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.tsx
+++ b/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.tsx
@@ -46,7 +46,11 @@ import type {
   CoworkMaterializationState,
   CoworkMaterializeReceipt,
 } from "../materialization/contracts";
-import { CoworkBridgeEditor, useCoworkBridge } from "../bridge";
+import {
+  CoworkBridgeEditor,
+  useCoworkBridge,
+  type CoworkProvenanceIdentityState,
+} from "../bridge";
 import {
   CoworkChatAnnotations,
   CoworkChatTargetingProvider,
@@ -669,6 +673,33 @@ export function CoworkLiveWorkspace({
   const [provenanceSelectionAction, setProvenanceSelectionAction] =
     useState<ProvenanceSelectionAction | null>(null);
   const [inputProvenancePending, setInputProvenancePending] = useState(false);
+  const provenanceIdentityKey = `${workspaceIdentity}\u0000${readOnly ? "read-only" : "writable"}`;
+  const [provenanceIdentity, setProvenanceIdentity] = useState<{
+    readonly key: string;
+    readonly state: CoworkProvenanceIdentityState;
+  }>(() => ({
+    key: provenanceIdentityKey,
+    state: readOnly ? "disabled" : "loading",
+  }));
+  const provenanceIdentityState =
+    provenanceIdentity.key === provenanceIdentityKey
+      ? provenanceIdentity.state
+      : readOnly
+        ? "disabled"
+        : "loading";
+  const handleProvenanceIdentityStateChange = useCallback(
+    (state: CoworkProvenanceIdentityState) => {
+      setProvenanceIdentity({ key: provenanceIdentityKey, state });
+    },
+    [provenanceIdentityKey],
+  );
+  const provenanceMutationBlockedReason = readOnly
+    ? undefined
+    : provenanceIdentityState === "ready"
+      ? undefined
+      : provenanceIdentityState === "loading"
+        ? "Provenance identity is reconnecting. Review actions will be available when it is ready."
+        : "Open Work Buddy from its launcher to reconnect provenance identity before recording review.";
   const truthStore = useMemo(
     () => createPersistedTruthStore(window.localStorage, storeId, documentId),
     [documentId, storeId],
@@ -1372,6 +1403,9 @@ export function CoworkLiveWorkspace({
           )}
           onProvenanceSelectionAction={handleProvenanceSelectionAction}
           onInputProvenancePendingChange={setInputProvenancePending}
+          onProvenanceIdentityStateChange={
+            handleProvenanceIdentityStateChange
+          }
         />
       }
       rail={
@@ -1397,6 +1431,7 @@ export function CoworkLiveWorkspace({
               mutationBarrier: bridge.provenanceMutationBarrier,
               selectionAction: provenanceSelectionAction,
               inputProvenancePending,
+              mutationBlockedReason: provenanceMutationBlockedReason,
             }}
             chat={chat}
             reviewAnchors={reviewAnchors}

--- a/knowledge/store/cowork/content-provenance.md
+++ b/knowledge/store/cowork/content-provenance.md
@@ -9,10 +9,10 @@ summary: >-
   exact spans, with direct entry shown as pending delivery before its receipt
   and actorless captures retained for explicit attribution after recovery.
   Accepted agent proposals transactionally attribute only replacement text to
-  the producing run. A human review action appends a user-attested superseding
-  record while preserving source and authorship. Attestations report what a
-  person says about content; they do not verify authorship, correctness, or
-  claims.
+  the producing run. Human review is recorded per enrolled user and can append
+  one atomic batch of superseding records for eligible selected targets while
+  preserving source and authorship. Attestations report what a person says
+  about content; they do not verify authorship, correctness, or claims.
 tags:
 - cowork
 - provenance
@@ -25,6 +25,14 @@ aliases:
 - authorship attestation
 - human review attestation
 - document provenance attestation
+dev_notes: >-
+  The browser pending projection is derived from synchronous staged captures,
+  mounted-page volatile captures, and durable outbox rows; authoritative
+  receipt coverage wins before local cleanup. Selection request identities must
+  remain unique across Provenance-affordance remounts because the stable panel
+  persists across lens changes. Review-batch slot keys bind the ordered
+  predecessor IDs plus expected structured head and require an exact slot set;
+  both the panel and server revalidate the frozen reviewer binding.
 parents:
 - cowork
 ---
@@ -118,12 +126,22 @@ inspectable without receiving a guessed range.
 
 The generic **Give feedback** selection bubble belongs to the other lenses and
 is suppressed in Provenance. A selected passage instead gets exactly one
-coverage-aware action: **Record provenance** when uncovered, **Review provenance**
-when it exactly matches one eligible AI/mixed span, **View provenance** for one
-healthy record, or **Inspect provenance** for stale, ambiguous, conflicting, or
-multiple coverage. Review provenance only opens the stable target detail; its
-guarded append remains in the panel. Recording pre-existing text uses an
-explicit determination and keeps its source labeled **Untracked / legacy**.
+coverage-aware action: **Record provenance** when uncovered, **Mark as
+reviewed** when the selection fully contains at least one current AI/mixed
+target which the current enrolled user has not reviewed, **View provenance**
+for one healthy record, or **Inspect provenance** for stale, ambiguous, or
+conflicting coverage. A selection can review several fully contained span
+targets together; a partially selected target is never promoted into a claim
+that its whole passage was reviewed. A document-version fallback is eligible
+from the selection action only when all document text is selected. Review by
+another person does not suppress the current user's action.
+
+The floating action routes review to a stable confirmation card rather than
+mutating immediately. If a selected target disappears, conflicts, or becomes
+ineligible before confirmation, that card stays visible, disables the write,
+and receives focus with a reselect-and-inspect explanation. Recording
+pre-existing text uses an explicit determination and keeps its source labeled
+**Untracked / legacy**.
 
 Provenance has a dedicated typed provider and panel projection. It can share the
 authoritative open-document snapshot source with other rails, but it does not
@@ -154,25 +172,30 @@ requiring re-anchor, so newly typed text cannot inherit stale authorship. A
 unique span may stay paintable for inspection; review stays unavailable until
 persistence settles and a matching fresh authoritative projection arrives.
 
-**Mark reviewed** is a constrained append-only action for one effective,
-exact-current-head AI- or mixed-authored document-version or span target. The
-server derives a superseding record
-which preserves the target, source, authorship, and contributors, changes human
-review to reviewed, and records the enrolled acting user as reviewer and
-attester. The new record has a `user_attestation` basis referencing its
-predecessor; the old record keeps its own automatic, proposal, migration, or
-legacy basis in history. The transition therefore remains “AI-authored,
-human-reviewed,” not “human-authored.” Reviewed is not approval, factual
-confirmation, or acceptance.
+**Mark as reviewed** is a constrained, per-user append-only action for one or
+more effective, exact-current-head AI- or mixed-authored document-version or
+span targets. Each derived successor preserves its target, source, authorship,
+and contributors, changes human review to reviewed, retains every distinct
+prior reviewer, and adds the enrolled acting user as reviewer and attester. A
+review already recorded by someone else therefore remains eligible for the
+current user; a duplicate review by that same current user is rejected. Every
+new record has a `user_attestation` basis referencing its predecessor, while
+the old record keeps its own automatic, proposal, migration, or legacy basis in
+history. The transition remains “AI-authored, human-reviewed,” not
+“human-authored.” Reviewed is not approval, factual confirmation, or
+acceptance.
 
 The editor owns the review mutation barrier. It disables editing, retries and
 flushes pending Yjs persistence, verifies canonical state, and compacts to one
 durable structured head. While that lock remains held, the dedicated provider
 forces a fresh document pull and the panel rechecks the same effective leaf,
 head, eligibility, unique exact-span resolution, and incompatible peer overlap.
-Only then does it post the append-only transition and repull authoritative
-state. Any drift fails closed; the editor is re-enabled only if the mounted
-document is still writable.
+Only then does it post one atomic batch and repull authoritative state. The
+signed command is bound to the frozen reviewer, ordered predecessor IDs, and
+exact structured head; an identity change, changed target set, reordered
+replay, partial prior batch, or head drift fails before any target is appended.
+Any drift fails closed; the editor is re-enabled only if the mounted document
+is still writable.
 
 ## Accepted agent proposals
 
@@ -225,14 +248,21 @@ Provenance lens projects the uniquely resolved exact local capture range as
 **Recording provenance…**. This pending decoration is delivery state only. It
 does not provisionally assert authorship, review, contributor, reviewer, or
 attester facts, even when the capture already carries a frozen actor binding.
-The stable panel exposes the same pending state and does not announce that the
-passage has no provenance. As soon as authoritative recorded coverage is
-present, that ledger projection wins for the overlapping range even if local
-outbox cleanup has not completed; removing the pending row later cannot make a
-server receipt disappear. The client retains the frozen outbox row and pending
-treatment until a fresh history entry matches the server receipt's attestation
-ID, document-span ID, and structured head. A missing, stale, misbound, or failed
-refresh therefore remains visibly pending and safely retryable.
+The stable panel exposes the same passage-scoped pending state and does not
+announce that the passage has no provenance. Pending typing never replaces or
+disables the selection menu for unrelated text. Manual recording is blocked
+only when its selected range overlaps an unresolved local capture, preventing a
+duplicate attestation while leaving every other provenance action available.
+
+As soon as authoritative recorded coverage is present, that ledger projection
+wins for the overlapping range even if local outbox cleanup has not completed;
+removing the pending row later cannot make a server receipt disappear. The
+client retains the frozen outbox row and pending treatment until a fresh
+history entry matches the server receipt's attestation ID, document-span ID,
+and structured head. A missing, stale, misbound, or failed refresh therefore
+remains visibly pending and safely retryable. Publication of a later matching
+snapshot automatically replays and reconciles the frozen request, so receipt
+visibility does not depend on another user gesture.
 
 Typing observed without a capture-time actor, or whose actor changes before
 the automatic request can be frozen, is not discarded. Its exact selector
@@ -255,7 +285,10 @@ The synchronous recovery journal retains the newest coalesced burst over an
 older unfrozen `capturing` row. It never overwrites a ready or frozen request.
 Closing the page leaves an unfinished capture recoverable rather than trying to
 resolve it after the editor has disappeared. Once frozen, retry is the same
-immutable logical request.
+immutable logical request. A visible storage retry rehydrates and explicitly
+finalizes an open mounted-page capture, including one queued behind an already
+running finalizer. If an open row still cannot resolve or finalize, the retry
+warning remains visible while independent ready rows continue delivery.
 
 Text that predates this path cannot be safely attributed retroactively. In the
 Provenance lens the user can select that text and choose **Record provenance**;

--- a/knowledge/store/cowork/content-provenance.md
+++ b/knowledge/store/cowork/content-provenance.md
@@ -143,6 +143,16 @@ and receives focus with a reselect-and-inspect explanation. Recording
 pre-existing text uses an explicit determination and keeps its source labeled
 **Untracked / legacy**.
 
+Resolving the current human actor is required for **Record provenance** and
+**Mark as reviewed**, but never for non-mutating **View provenance** or
+**Inspect provenance**. If the dashboard's local identity session is missing or
+expires, the Provenance selection affordance remains available for inspection;
+the editor shows a reconnect action, and the stable panel keeps review controls
+visible but disabled with the same reconnect reason. If identity becomes
+unavailable while a routed review is focused, focus moves to that review's
+status card. The generic **Give feedback** action is not substituted because it
+also records a human-authority mutation.
+
 Provenance has a dedicated typed provider and panel projection. It can share the
 authoritative open-document snapshot source with other rails, but it does not
 enlarge Review's domain payload into a general provenance transport. Hover and

--- a/tests/unit/cowork/test_api_routes.py
+++ b/tests/unit/cowork/test_api_routes.py
@@ -1256,6 +1256,8 @@ def test_ai_provenance_human_review_is_target_bound_and_idempotent(
     )
     body = {
         "attestation_id": original.id,
+        "expected_actor_ref": HUMAN.ref,
+        "expected_actor_identity_status": "local_actor_ref",
         "expected_structured_head_sha256": head,
         "idempotency_key": "review-route-command-0001",
     }
@@ -1284,6 +1286,188 @@ def test_ai_provenance_human_review_is_target_bound_and_idempotent(
     assert view["summary"]["ai_unreviewed_count"] == 0
     assert view["spans"][0]["effective_attestation"] == first
     assert len(view["spans"][0]["history"]) == 2
+
+
+def test_provenance_review_route_batches_selected_targets_atomically(
+    client,
+    seeded,
+):
+    document = seeded["document"]
+    head = ydoc_store.current_structured_head(
+        seeded["store"],
+        document_id=document.id,
+        snapshot_sha256=seeded["snapshot_sha256"],
+    )
+    originals = [
+        provenance.record_span_attestation(
+            seeded["store"],
+            document_id=document.id,
+            exact=exact,
+            prefix=prefix,
+            suffix=suffix,
+            attestation={
+                "schema": "cowork-authorship-attestation/v1",
+                "authorship": {"kind": "ai", "contributors": []},
+                "human_review": {
+                    "status": "not_reviewed",
+                    "reviewers": [],
+                },
+            },
+            actor=HUMAN,
+            idempotency_key=key,
+            expected_structured_head_sha256=head,
+        )[0]
+        for exact, prefix, suffix, key in [
+            (
+                "Original sentence",
+                "",
+                " for co-work tests.",
+                "review-route-batch-origin-0001",
+            ),
+            (
+                "co-work tests",
+                "Original sentence for ",
+                ".",
+                "review-route-batch-origin-0002",
+            ),
+        ]
+    ]
+    url = _url(
+        f"/api/truth/doc/{document.id}/authorship-attestations/human-review",
+        seeded["store_id"],
+    )
+    body = {
+        "attestation_ids": [record.id for record in originals],
+        "expected_actor_ref": HUMAN.ref,
+        "expected_actor_identity_status": "local_actor_ref",
+        "expected_structured_head_sha256": head,
+        "idempotency_key": "review-route-batch-command-0001",
+    }
+
+    reviewed = client.post(url, json=body)
+    replay = client.post(url, json=body)
+
+    assert reviewed.status_code == replay.status_code == 201
+    records = reviewed.get_json()["attestations"]
+    assert replay.get_json()["attestations"] == records
+    assert [record["supersedes_id"] for record in records] == [
+        original.id for original in originals
+    ]
+    assert all(
+        record["human_review"]["reviewers"][0]["ref"] == HUMAN.ref
+        for record in records
+    )
+
+
+@pytest.mark.parametrize(
+    "malformation",
+    [
+        "duplicate_ids",
+        "too_many_ids",
+        "malformed_id",
+        "malformed_head",
+        "malformed_key",
+        "missing_actor_pair",
+    ],
+)
+def test_provenance_review_batch_prevalidates_malformed_requests_as_400(
+    client,
+    seeded,
+    monkeypatch,
+    malformation,
+):
+    document = seeded["document"]
+    body = {
+        "attestation_ids": ["a" * 32],
+        "expected_actor_ref": HUMAN.ref,
+        "expected_actor_identity_status": "local_actor_ref",
+        "expected_structured_head_sha256": "0" * 64,
+        "idempotency_key": "review-route-validation-0001",
+    }
+    if malformation == "duplicate_ids":
+        body["attestation_ids"] = ["a" * 32, "A" * 32]
+    elif malformation == "too_many_ids":
+        body["attestation_ids"] = [f"{index:032x}" for index in range(101)]
+    elif malformation == "malformed_id":
+        body["attestation_ids"] = ["not-an-attestation-id"]
+    elif malformation == "malformed_head":
+        body["expected_structured_head_sha256"] = "not-a-digest"
+    elif malformation == "malformed_key":
+        body["idempotency_key"] = "short"
+    else:
+        body.pop("expected_actor_identity_status")
+
+    monkeypatch.setattr(
+        api,
+        "_require_human_action",
+        lambda **_kwargs: pytest.fail(
+            "malformed batch reached human-authority consumption"
+        ),
+    )
+    response = client.post(
+        _url(
+            f"/api/truth/doc/{document.id}/authorship-attestations/human-review",
+            seeded["store_id"],
+        ),
+        json=body,
+    )
+
+    assert response.status_code == 400
+
+
+def test_provenance_review_batch_rejects_changed_actor_without_append(
+    client,
+    seeded,
+):
+    document = seeded["document"]
+    head = ydoc_store.current_structured_head(
+        seeded["store"],
+        document_id=document.id,
+        snapshot_sha256=seeded["snapshot_sha256"],
+    )
+    original, _span_id = provenance.record_span_attestation(
+        seeded["store"],
+        document_id=document.id,
+        exact=DOC_QUOTE,
+        attestation={
+            "schema": "cowork-authorship-attestation/v1",
+            "authorship": {"kind": "ai", "contributors": []},
+            "human_review": {"status": "not_reviewed", "reviewers": []},
+        },
+        actor=HUMAN,
+        idempotency_key="review-route-actor-change-origin-0001",
+        expected_structured_head_sha256=head,
+    )
+    history_before = provenance.list_attestations(
+        seeded["store"],
+        document.id,
+    )
+
+    response = client.post(
+        _url(
+            f"/api/truth/doc/{document.id}/authorship-attestations/human-review",
+            seeded["store_id"],
+        ),
+        json={
+            "attestation_ids": [original.id],
+            "expected_actor_ref": "another-reviewer",
+            "expected_actor_identity_status": "local_actor_ref",
+            "expected_structured_head_sha256": head,
+            "idempotency_key": "review-route-actor-change-command-0001",
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.get_json()["error"] == {
+        "code": "provenance_actor_changed",
+        "message": "The acting identity changed before review was recorded.",
+        "details": {},
+        "retryable": False,
+    }
+    assert (
+        provenance.list_attestations(seeded["store"], document.id)
+        == history_before
+    )
 
 
 @pytest.mark.parametrize("damage", ["missing", "malformed_selector"])

--- a/tests/unit/cowork/test_provenance_attestations.py
+++ b/tests/unit/cowork/test_provenance_attestations.py
@@ -12,7 +12,7 @@ from work_buddy.cowork import bootstrap, provenance
 from work_buddy.truth import documents, export as truth_export, ydoc_store
 from work_buddy.truth.contracts import Actor, InvariantViolation
 from work_buddy.truth.export import FORMAT_VERSION, export_store, import_store
-from work_buddy.truth.identity import sha256_bytes
+from work_buddy.truth.identity import canonical_json, sha256_bytes, sha256_text
 from work_buddy.truth.queries import integrity_findings
 
 from .conftest import HUMAN
@@ -619,6 +619,433 @@ def test_human_review_supersedes_effective_ai_without_rewriting_source(
         "kind": "user_attestation",
         "ref": original.id,
     }
+
+
+def test_human_review_accumulates_distinct_reviewers_without_duplicates(
+    store_ctx,
+):
+    store = store_ctx["store"]
+    document, version, _intent, _source = _import_ready(store_ctx)
+    original, _span_id = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="durable provenance",
+        prefix="A ",
+        suffix=" target.",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="multi-reviewer-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    first = provenance.record_human_review(
+        store,
+        document_id=document.id,
+        attestation_id=original.id,
+        actor=HUMAN,
+        idempotency_key="multi-reviewer-first-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    second_actor = Actor(
+        "human",
+        "local:second-reviewer",
+        {"identity_status": "local_actor_ref"},
+    )
+    second = provenance.record_human_review(
+        store,
+        document_id=document.id,
+        attestation_id=first.id,
+        actor=second_actor,
+        idempotency_key="multi-reviewer-second-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+
+    assert json.loads(second.human_reviewers_json) == [
+        provenance.actor_binding(HUMAN),
+        provenance.actor_binding(second_actor),
+    ]
+    assert second.supersedes_id == first.id
+    with pytest.raises(provenance.ProvenanceReviewError) as duplicate:
+        provenance.record_human_review(
+            store,
+            document_id=document.id,
+            attestation_id=second.id,
+            actor=second_actor,
+            idempotency_key="multi-reviewer-duplicate-0001",
+            expected_structured_head_sha256=version.structured_head_sha256,
+        )
+    assert duplicate.value.code == "provenance_review_already_recorded"
+
+
+def test_human_review_batch_is_atomic_across_multiple_targets(store_ctx):
+    store = store_ctx["store"]
+    document, version, _intent, _source = _import_ready(store_ctx)
+    first, _ = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="Imported",
+        prefix="# ",
+        suffix="\n\nA",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="batch-review-first-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    second, _ = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="durable provenance",
+        prefix="A ",
+        suffix=" target.",
+        attestation=_attestation(authorship="mixed", review="unknown"),
+        actor=HUMAN,
+        idempotency_key="batch-review-second-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+
+    reviewed = provenance.record_human_reviews(
+        store,
+        document_id=document.id,
+        attestation_ids=[first.id, second.id],
+        actor=HUMAN,
+        idempotency_key="batch-review-command-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    replay = provenance.record_human_reviews(
+        store,
+        document_id=document.id,
+        attestation_ids=[first.id, second.id],
+        actor=HUMAN,
+        idempotency_key="batch-review-command-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+
+    assert replay == reviewed
+    assert [row.supersedes_id for row in reviewed] == [first.id, second.id]
+    assert all(row.review_status == "reviewed" for row in reviewed)
+
+    third, _ = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="target",
+        prefix="provenance ",
+        suffix=".",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="batch-review-third-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    ineligible, _ = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="A",
+        prefix="\n\n",
+        suffix=" durable",
+        attestation=_attestation(authorship="human", review="not_applicable"),
+        actor=HUMAN,
+        idempotency_key="batch-review-ineligible-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    history_before = store.list_document_provenance_attestations(document.id)
+    with pytest.raises(provenance.ProvenanceReviewError) as failed:
+        provenance.record_human_reviews(
+            store,
+            document_id=document.id,
+            attestation_ids=[third.id, ineligible.id],
+            actor=HUMAN,
+            idempotency_key="batch-review-atomic-failure-0001",
+            expected_structured_head_sha256=version.structured_head_sha256,
+        )
+    assert failed.value.code == "provenance_review_ineligible"
+    assert store.list_document_provenance_attestations(document.id) == history_before
+
+
+def test_human_review_batch_accumulates_distinct_reviewers_and_rejects_repeat(
+    store_ctx,
+):
+    store = store_ctx["store"]
+    document, version, _intent, _source = _import_ready(store_ctx)
+    original, _ = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="durable provenance",
+        prefix="A ",
+        suffix=" target.",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="batch-multi-reviewer-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    first = provenance.record_human_reviews(
+        store,
+        document_id=document.id,
+        attestation_ids=[original.id],
+        actor=HUMAN,
+        idempotency_key="batch-multi-reviewer-first-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )[0]
+    second_actor = Actor(
+        "human",
+        "local:second-batch-reviewer",
+        {"identity_status": "local_actor_ref"},
+    )
+    second = provenance.record_human_reviews(
+        store,
+        document_id=document.id,
+        attestation_ids=[first.id],
+        actor=second_actor,
+        idempotency_key="batch-multi-reviewer-second-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )[0]
+
+    assert json.loads(second.human_reviewers_json) == [
+        provenance.actor_binding(HUMAN),
+        provenance.actor_binding(second_actor),
+    ]
+    with pytest.raises(provenance.ProvenanceReviewError) as duplicate:
+        provenance.record_human_reviews(
+            store,
+            document_id=document.id,
+            attestation_ids=[second.id],
+            actor=second_actor,
+            idempotency_key="batch-multi-reviewer-duplicate-0001",
+            expected_structured_head_sha256=version.structured_head_sha256,
+        )
+    assert duplicate.value.code == "provenance_review_already_recorded"
+
+
+def test_human_review_batch_rolls_back_mid_append_then_retries_idempotently(
+    store_ctx,
+    monkeypatch,
+):
+    store = store_ctx["store"]
+    document, version, _intent, _source = _import_ready(store_ctx)
+    first, _ = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="Imported",
+        prefix="# ",
+        suffix="\n\nA",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="batch-rollback-first-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    second, _ = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="durable provenance",
+        prefix="A ",
+        suffix=" target.",
+        attestation=_attestation(authorship="mixed", review="unknown"),
+        actor=HUMAN,
+        idempotency_key="batch-rollback-second-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    history_before = store.list_document_provenance_attestations(document.id)
+    original_record = provenance._record_attestation_locked
+    calls = 0
+
+    def fail_second_append(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("injected second append failure")
+        return original_record(*args, **kwargs)
+
+    monkeypatch.setattr(provenance, "_record_attestation_locked", fail_second_append)
+    with pytest.raises(RuntimeError, match="injected second append failure"):
+        provenance.record_human_reviews(
+            store,
+            document_id=document.id,
+            attestation_ids=[first.id, second.id],
+            actor=HUMAN,
+            idempotency_key="batch-rollback-command-0001",
+            expected_structured_head_sha256=version.structured_head_sha256,
+        )
+    assert store.list_document_provenance_attestations(document.id) == history_before
+
+    monkeypatch.setattr(provenance, "_record_attestation_locked", original_record)
+    reviewed = provenance.record_human_reviews(
+        store,
+        document_id=document.id,
+        attestation_ids=[first.id, second.id],
+        actor=HUMAN,
+        idempotency_key="batch-rollback-command-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    replay = provenance.record_human_reviews(
+        store,
+        document_id=document.id,
+        attestation_ids=[first.id, second.id],
+        actor=HUMAN,
+        idempotency_key="batch-rollback-command-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    assert replay == reviewed
+    assert [row.supersedes_id for row in reviewed] == [first.id, second.id]
+
+
+def test_human_review_batch_binds_key_to_exact_ordered_target_set(store_ctx):
+    store = store_ctx["store"]
+    document, version, _intent, _source = _import_ready(store_ctx)
+    first, _ = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="Imported",
+        prefix="# ",
+        suffix="\n\nA",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="batch-binding-first-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    second, _ = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="durable provenance",
+        prefix="A ",
+        suffix=" target.",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="batch-binding-second-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    provenance.record_human_reviews(
+        store,
+        document_id=document.id,
+        attestation_ids=[first.id, second.id],
+        actor=HUMAN,
+        idempotency_key="batch-binding-command-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    history_before = store.list_document_provenance_attestations(document.id)
+
+    for changed_targets in ([second.id, first.id], [first.id]):
+        with pytest.raises(provenance.ProvenanceReviewError) as conflict:
+            provenance.record_human_reviews(
+                store,
+                document_id=document.id,
+                attestation_ids=changed_targets,
+                actor=HUMAN,
+                idempotency_key="batch-binding-command-0001",
+                expected_structured_head_sha256=(
+                    version.structured_head_sha256
+                ),
+            )
+
+        assert conflict.value.code == "provenance_idempotency_conflict"
+        assert (
+            store.list_document_provenance_attestations(document.id)
+            == history_before
+        )
+
+
+def test_human_review_batch_binds_key_to_expected_structured_head(store_ctx):
+    store = store_ctx["store"]
+    document, version, _intent, _source = _import_ready(store_ctx)
+    original, _ = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="durable provenance",
+        prefix="A ",
+        suffix=" target.",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="batch-head-binding-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    provenance.record_human_reviews(
+        store,
+        document_id=document.id,
+        attestation_ids=[original.id],
+        actor=HUMAN,
+        idempotency_key="batch-head-binding-command-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    history_before = store.list_document_provenance_attestations(document.id)
+
+    with pytest.raises(provenance.ProvenanceReviewError) as conflict:
+        provenance.record_human_reviews(
+            store,
+            document_id=document.id,
+            attestation_ids=[original.id],
+            actor=HUMAN,
+            idempotency_key="batch-head-binding-command-0001",
+            expected_structured_head_sha256="0" * 64,
+        )
+
+    assert conflict.value.code == "provenance_idempotency_conflict"
+    assert store.list_document_provenance_attestations(document.id) == history_before
+
+
+@pytest.mark.parametrize("contamination", ["partial_slot", "unexpected_slot"])
+def test_human_review_batch_rejects_contaminated_slot_namespace(
+    store_ctx,
+    contamination,
+):
+    store = store_ctx["store"]
+    document, version, _intent, _source = _import_ready(store_ctx)
+    first, _ = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="Imported",
+        prefix="# ",
+        suffix="\n\nA",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="batch-contamination-first-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    second, _ = provenance.record_span_attestation(
+        store,
+        document_id=document.id,
+        exact="durable provenance",
+        prefix="A ",
+        suffix=" target.",
+        attestation=_attestation(authorship="ai", review="not_reviewed"),
+        actor=HUMAN,
+        idempotency_key="batch-contamination-second-origin-0001",
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    batch_key = "batch-contamination-command-0001"
+    batch_prefix = f"review-batch:{sha256_text(batch_key)}:"
+    request_digest = sha256_text(
+        canonical_json(
+            {
+                "attestation_ids": [first.id, second.id],
+                "expected_structured_head_sha256": (
+                    version.structured_head_sha256
+                ),
+            }
+        )
+    )[:32]
+    contaminating_key = (
+        f"{batch_prefix}{request_digest}:000"
+        if contamination == "partial_slot"
+        else f"{batch_prefix}unexpected"
+    )
+    provenance.record_human_review(
+        store,
+        document_id=document.id,
+        attestation_id=first.id,
+        actor=HUMAN,
+        idempotency_key=contaminating_key,
+        expected_structured_head_sha256=version.structured_head_sha256,
+    )
+    history_before = store.list_document_provenance_attestations(document.id)
+
+    with pytest.raises(provenance.ProvenanceReviewError) as conflict:
+        provenance.record_human_reviews(
+            store,
+            document_id=document.id,
+            attestation_ids=[first.id, second.id],
+            actor=HUMAN,
+            idempotency_key=batch_key,
+            expected_structured_head_sha256=version.structured_head_sha256,
+        )
+
+    assert conflict.value.code == "provenance_idempotency_conflict"
+    assert store.list_document_provenance_attestations(document.id) == history_before
 
 
 def test_human_review_of_proposal_acceptance_round_trips(

--- a/work_buddy/cowork/api.py
+++ b/work_buddy/cowork/api.py
@@ -72,7 +72,12 @@ from work_buddy.truth.events import emit_truth_event
 from work_buddy.truth.expressions import ensure_document_span
 from work_buddy.truth.identity import parse_truth_uri, sha256_text
 from work_buddy.truth.registry import TruthStoreRegistry
-from work_buddy.truth.store import DocumentRecord, TruthStore
+from work_buddy.truth.store import (
+    DocumentRecord,
+    TruthStore,
+    _valid_digest,
+    _valid_record_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -2060,6 +2065,190 @@ def api_doc_authorship_attestation(document_id: str):
 
 
 @cowork_blueprint.post(
+    "/api/truth/doc/<document_id>/authorship-attestations/human-review"
+)
+def api_doc_provenance_human_review_batch(document_id: str):
+    """Atomically append per-user review successors for selected targets."""
+
+    blocked = _reject_read_only()
+    if blocked:
+        return blocked
+    store, error = _resolve_store(request.args.get("store_id"))
+    if error:
+        return error
+    gate = _document_surface_or_403(store)
+    if gate:
+        return gate
+    document, doc_error = _resolve_document(store, document_id)
+    if doc_error:
+        return doc_error
+    if not document_surface_allowed(store, document):
+        return _fail(
+            "This document is not available in Co-work for this folder.",
+            403,
+        )
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return _fail("request body must be a JSON object", 400)
+    if set(body) != {
+        "attestation_ids",
+        "expected_actor_identity_status",
+        "expected_actor_ref",
+        "expected_structured_head_sha256",
+        "idempotency_key",
+    }:
+        return _fail(
+            "human review requires exactly attestation_ids, "
+            "expected_actor_ref, expected_actor_identity_status, "
+            "expected_structured_head_sha256, and idempotency_key",
+            400,
+        )
+    attestation_ids = body.get("attestation_ids")
+    expected_actor_ref = body.get("expected_actor_ref")
+    expected_actor_identity_status = body.get(
+        "expected_actor_identity_status"
+    )
+    expected_head = body.get("expected_structured_head_sha256")
+    idempotency_key = body.get("idempotency_key")
+    if (
+        not isinstance(attestation_ids, list)
+        or not attestation_ids
+        or any(not isinstance(value, str) or not value for value in attestation_ids)
+    ):
+        return _fail("attestation_ids must be a non-empty string array", 400)
+    if len(attestation_ids) > 100:
+        return _fail("attestation_ids may contain at most 100 targets", 400)
+    if (
+        not isinstance(expected_actor_ref, str)
+        or not expected_actor_ref
+        or expected_actor_identity_status
+        not in provenance.CURRENT_USER_IDENTITY_STATUSES
+    ):
+        return _fail(
+            "expected_actor_ref and expected_actor_identity_status are required",
+            400,
+        )
+    try:
+        normalized_attestation_ids = [
+            _valid_record_id(value, "attestation_id")
+            for value in attestation_ids
+        ]
+        expected_head = _valid_digest(
+            expected_head,
+            "expected_structured_head_sha256",
+        )
+        idempotency_key = provenance._idempotency_key(idempotency_key)
+    except InvariantViolation as exc:
+        return _fail(str(exc), 400)
+    if len(set(normalized_attestation_ids)) != len(
+        normalized_attestation_ids
+    ):
+        return _fail("attestation_ids must not contain duplicates", 400)
+
+    try:
+        _authority_context, actor = _require_human_action(
+            operation="provenance.review",
+            store_id=store.store_id,
+            document_id=document.id,
+            body=body,
+        )
+    except LocalIdentityError as exc:
+        return _local_identity_error(exc)
+    try:
+        acting_binding = provenance.actor_binding(actor)
+        if (
+            acting_binding["ref"] != expected_actor_ref
+            or acting_binding["identity_status"]
+            != expected_actor_identity_status
+        ):
+            raise provenance.ProvenanceActorBindingError(
+                "The acting identity changed before review was recorded."
+            )
+        from work_buddy.consent import user_initiated
+
+        with user_initiated("dashboard.cowork.provenance_review_selection"):
+            records = provenance.record_human_reviews(
+                store,
+                document_id=document.id,
+                attestation_ids=normalized_attestation_ids,
+                actor=actor,
+                idempotency_key=idempotency_key,
+                expected_structured_head_sha256=expected_head,
+            )
+    except provenance.ProvenanceActorBindingError as exc:
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": {
+                        "code": exc.code,
+                        "message": str(exc),
+                        "details": {},
+                        "retryable": False,
+                    },
+                }
+            ),
+            exc.status,
+        )
+    except provenance.ProvenanceReviewError as exc:
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": {
+                        "code": exc.code,
+                        "message": str(exc),
+                        "details": exc.details,
+                        "retryable": exc.retryable,
+                    },
+                }
+            ),
+            exc.status,
+        )
+    except (provenance.ProvenanceConflictError, InvariantViolation) as exc:
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": {
+                        "code": "provenance_review_state_conflict",
+                        "message": str(exc),
+                        "details": {},
+                        "retryable": False,
+                    },
+                }
+            ),
+            409,
+        )
+
+    for record in records:
+        _emit(
+            "truth.doc_provenance_reviewed",
+            store.store_id,
+            {
+                "document_id": document.id,
+                "attestation_id": record.id,
+                "supersedes_id": record.supersedes_id,
+                "target_structured_head_sha256": (
+                    record.target_structured_head_sha256
+                ),
+            },
+            event_id=f"truth-doc-provenance-review-{record.id}",
+        )
+    return (
+        jsonify(
+            {
+                "ok": True,
+                "attestations": [
+                    provenance.portable_attestation(record) for record in records
+                ],
+            }
+        ),
+        201,
+    )
+
+
+@cowork_blueprint.post(
     "/api/truth/doc/<document_id>/authorship-attestations/"
     "<attestation_id>/human-review"
 )
@@ -2089,24 +2278,47 @@ def api_doc_provenance_human_review(
     body = request.get_json(silent=True)
     if not isinstance(body, dict):
         return _fail("request body must be a JSON object", 400)
-    if set(body) != {
+    base_fields = {
         "attestation_id",
         "expected_structured_head_sha256",
         "idempotency_key",
+    }
+    actor_fields = {
+        "expected_actor_identity_status",
+        "expected_actor_ref",
+    }
+    if frozenset(body) not in {
+        frozenset(base_fields),
+        frozenset(base_fields | actor_fields),
     }:
         return _fail(
             "human review requires exactly attestation_id, "
-            "expected_structured_head_sha256, and idempotency_key",
+            "expected_structured_head_sha256, and idempotency_key, with an "
+            "optional expected_actor_ref and expected_actor_identity_status pair",
             400,
         )
     if body.get("attestation_id") != attestation_id:
         return _fail("attestation_id must match the route target", 400)
     expected_head = body.get("expected_structured_head_sha256")
     idempotency_key = body.get("idempotency_key")
+    expected_actor_ref = body.get("expected_actor_ref")
+    expected_actor_identity_status = body.get(
+        "expected_actor_identity_status"
+    )
     if not isinstance(expected_head, str) or not expected_head:
         return _fail("expected_structured_head_sha256 is required", 400)
     if not isinstance(idempotency_key, str) or not idempotency_key:
         return _fail("idempotency_key is required", 400)
+    if actor_fields.issubset(body) and (
+        not isinstance(expected_actor_ref, str)
+        or not expected_actor_ref
+        or expected_actor_identity_status
+        not in provenance.CURRENT_USER_IDENTITY_STATUSES
+    ):
+        return _fail(
+            "expected_actor_ref and expected_actor_identity_status are required",
+            400,
+        )
 
     try:
         _authority_context, actor = _require_human_action(
@@ -2118,6 +2330,16 @@ def api_doc_provenance_human_review(
     except LocalIdentityError as exc:
         return _local_identity_error(exc)
     try:
+        if actor_fields.issubset(body):
+            acting_binding = provenance.actor_binding(actor)
+            if (
+                acting_binding["ref"] != expected_actor_ref
+                or acting_binding["identity_status"]
+                != expected_actor_identity_status
+            ):
+                raise provenance.ProvenanceActorBindingError(
+                    "The acting identity changed before review was recorded."
+                )
         from work_buddy.consent import user_initiated
 
         with user_initiated("dashboard.cowork.provenance_review"):
@@ -2129,6 +2351,21 @@ def api_doc_provenance_human_review(
                 idempotency_key=idempotency_key,
                 expected_structured_head_sha256=expected_head,
             )
+    except provenance.ProvenanceActorBindingError as exc:
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": {
+                        "code": exc.code,
+                        "message": str(exc),
+                        "details": {},
+                        "retryable": False,
+                    },
+                }
+            ),
+            exc.status,
+        )
     except provenance.ProvenanceReviewError as exc:
         return (
             jsonify(

--- a/work_buddy/cowork/provenance.py
+++ b/work_buddy/cowork/provenance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import re
 import sqlite3
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from work_buddy.cowork.lifecycle_lock import document_lifecycle_lock
@@ -1576,6 +1576,18 @@ def record_human_review(
                     prior=prior,
                 )
 
+                prior_reviewers = (
+                    json.loads(prior.human_reviewers_json)
+                    if prior.review_status == "reviewed"
+                    else []
+                )
+                if reviewer in prior_reviewers:
+                    raise ProvenanceReviewError(
+                        "Review by this user is already recorded for this text.",
+                        code="provenance_review_already_recorded",
+                        status=409,
+                    )
+                reviewers = [*prior_reviewers, reviewer]
                 normalized = {
                     "authorship": {
                         "kind": prior.authorship_kind,
@@ -1585,7 +1597,7 @@ def record_human_review(
                     },
                     "human_review": {
                         "status": "reviewed",
-                        "reviewers": [reviewer],
+                        "reviewers": reviewers,
                     },
                 }
                 source = json.loads(prior.source_json)
@@ -1606,7 +1618,7 @@ def record_human_review(
                     authorship_kind=prior.authorship_kind,
                     human_contributors=normalized["authorship"]["contributors"],
                     review_status="reviewed",
-                    human_reviewers=[reviewer],
+                    human_reviewers=reviewers,
                     source_kind=prior.source_kind,
                     source=source,
                     basis_kind="user_attestation",
@@ -1664,15 +1676,14 @@ def record_human_review(
                     )
                 if (
                     prior.authorship_kind not in {"ai", "mixed"}
-                    or prior.review_status not in {"not_reviewed", "unknown"}
+                    or prior.review_status
+                    not in {"not_reviewed", "unknown", "reviewed"}
                 ):
                     raise ProvenanceReviewError(
-                        "Only unreviewed AI or mixed-authored content can be "
-                        "marked reviewed.",
+                        "Only AI or mixed-authored content can be marked reviewed.",
                         code="provenance_review_ineligible",
                         status=400,
                     )
-
                 all_rows = store._document_provenance_attestations_locked(
                     conn,
                     document_ref,
@@ -1729,6 +1740,320 @@ def record_human_review(
                 )
 
 
+def record_human_reviews(
+    store: TruthStore,
+    *,
+    document_id: str,
+    attestation_ids: Sequence[str],
+    actor: Actor,
+    idempotency_key: str,
+    expected_structured_head_sha256: str,
+    at: str | None = None,
+) -> list[DocumentProvenanceAttestationRecord]:
+    """Atomically append per-user review successors for effective targets."""
+
+    if actor.kind != "human" or not actor.ref:
+        raise InvariantViolation("provenance review requires a human actor")
+    document_ref = _valid_record_id(document_id, "document_id")
+    prior_ids = [
+        _valid_record_id(value, "attestation_id") for value in attestation_ids
+    ]
+    if not prior_ids:
+        raise InvariantViolation("attestation_ids must contain at least one target")
+    if len(prior_ids) > 100:
+        raise InvariantViolation("attestation_ids may contain at most 100 targets")
+    if len(set(prior_ids)) != len(prior_ids):
+        raise InvariantViolation("attestation_ids must not contain duplicates")
+    batch_key = _idempotency_key(idempotency_key)
+    batch_prefix = f"review-batch:{sha256_text(batch_key)}:"
+    expected_head = _valid_digest(
+        expected_structured_head_sha256,
+        "expected_structured_head_sha256",
+    )
+    # Keep the batch-key namespace stable so every prior use is discoverable,
+    # while binding its exact slots to the complete logical request.  The
+    # truncated request digest leaves the generated keys inside the public
+    # 128-character idempotency-key limit.
+    request_digest = sha256_text(
+        canonical_json(
+            {
+                "attestation_ids": prior_ids,
+                "expected_structured_head_sha256": expected_head,
+            }
+        )
+    )[:32]
+    expected_slot_keys = [
+        f"{batch_prefix}{request_digest}:{index:03d}"
+        for index in range(len(prior_ids))
+    ]
+    reviewer = actor_binding(actor)
+
+    with document_lifecycle_lock(store.store_id, document_ref):
+        with ydoc_store.document_lock(store, document_ref):
+            with store.write_transaction() as conn:
+                document = store._get_document_locked(conn, document_ref)
+                if document is None:
+                    raise ProvenanceReviewError(
+                        f"document does not exist: {document_ref}",
+                        code="provenance_review_target_mismatch",
+                        status=404,
+                    )
+                all_rows = store._document_provenance_attestations_locked(
+                    conn,
+                    document_ref,
+                )
+                existing_batch_rows = conn.execute(
+                    "SELECT id, idempotency_key "
+                    "FROM document_provenance_attestations "
+                    "WHERE document_id = ? AND attested_by_kind = ? "
+                    "AND ifnull(attested_by_ref, '') = ? "
+                    "AND idempotency_key GLOB ?",
+                    (
+                        document_ref,
+                        actor.kind,
+                        actor.ref or "",
+                        f"{batch_prefix}*",
+                    ),
+                ).fetchall()
+                existing_slot_keys = {
+                    row["idempotency_key"] for row in existing_batch_rows
+                }
+                if existing_batch_rows and existing_slot_keys != set(
+                    expected_slot_keys
+                ):
+                    raise ProvenanceReviewError(
+                        "The idempotency key was already used for a different "
+                        "provenance review batch.",
+                        code="provenance_idempotency_conflict",
+                        details={
+                            "existing_attestation_ids": [
+                                row["id"] for row in existing_batch_rows
+                            ]
+                        },
+                    )
+                prepared: list[dict[str, Any]] = []
+                for index, prior_id in enumerate(prior_ids):
+                    prior = store._get_document_provenance_attestation_locked(
+                        conn,
+                        prior_id,
+                    )
+                    if prior is None:
+                        raise ProvenanceReviewError(
+                            "That provenance attestation no longer exists.",
+                            code="provenance_attestation_not_found",
+                            status=404,
+                        )
+                    if prior.document_id != document_ref:
+                        raise ProvenanceReviewError(
+                            "The attestation does not belong to this document.",
+                            code="provenance_review_target_mismatch",
+                        )
+                    _validate_review_target_locked(
+                        store,
+                        conn,
+                        document_id=document_ref,
+                        prior=prior,
+                    )
+                    prior_reviewers = (
+                        json.loads(prior.human_reviewers_json)
+                        if prior.review_status == "reviewed"
+                        else []
+                    )
+                    if reviewer in prior_reviewers:
+                        raise ProvenanceReviewError(
+                            "Review by this user is already recorded for this text.",
+                            code="provenance_review_already_recorded",
+                            status=409,
+                        )
+                    reviewers = [*prior_reviewers, reviewer]
+                    normalized = {
+                        "authorship": {
+                            "kind": prior.authorship_kind,
+                            "contributors": json.loads(
+                                prior.human_contributors_json
+                            ),
+                        },
+                        "human_review": {
+                            "status": "reviewed",
+                            "reviewers": reviewers,
+                        },
+                    }
+                    source = json.loads(prior.source_json)
+                    # The durable slot binds this batch key to the exact target
+                    # ordering and expected structured head. Reusing a key
+                    # with any changed logical request collides before append.
+                    target_key = expected_slot_keys[index]
+                    identifier = _attestation_id(
+                        store_id=store.store_id,
+                        document_id=document_ref,
+                        actor_ref=actor.ref,
+                        idempotency_key=target_key,
+                    )
+                    expected_canonical = attestation_canonical_sha256(
+                        document_id=document_ref,
+                        target_kind=prior.target_kind,
+                        document_version_id=prior.document_version_id,
+                        document_span_id=prior.document_span_id,
+                        target_structured_head_sha256=(
+                            prior.target_structured_head_sha256
+                        ),
+                        authorship_kind=prior.authorship_kind,
+                        human_contributors=normalized["authorship"][
+                            "contributors"
+                        ],
+                        review_status="reviewed",
+                        human_reviewers=reviewers,
+                        source_kind=prior.source_kind,
+                        source=source,
+                        basis_kind="user_attestation",
+                        basis_ref=prior.id,
+                        supersedes_id=prior.id,
+                        attested_by_kind=actor.kind,
+                        attested_by_ref=actor.ref,
+                        attested_by_meta=(
+                            dict(actor.meta) if actor.meta else None
+                        ),
+                    )
+                    existing = store._get_document_provenance_attestation_locked(
+                        conn,
+                        identifier,
+                    )
+                    if existing is not None:
+                        if existing.canonical_sha256 != expected_canonical:
+                            raise ProvenanceReviewError(
+                                "The idempotency key was already used for a different "
+                                "provenance review batch.",
+                                code="provenance_idempotency_conflict",
+                                details={
+                                    "existing_attestation_ids": [existing.id]
+                                },
+                            )
+                        prepared.append({"existing": existing})
+                        continue
+                    prepared.append(
+                        {
+                            "prior": prior,
+                            "prior_reviewers": prior_reviewers,
+                            "normalized": normalized,
+                            "source": source,
+                            "target_key": target_key,
+                        }
+                    )
+
+                pending = [item for item in prepared if "existing" not in item]
+                if pending:
+                    if (
+                        documents._lifecycle_locked(store, conn, document.id)
+                        != "active"
+                    ):
+                        raise ProvenanceReviewError(
+                            "provenance cannot be reviewed on a retired document",
+                            code="provenance_review_state_conflict",
+                        )
+                    if not document_surface_allowed(store, document):
+                        raise ProvenanceReviewError(
+                            "This document is not available in Co-work for this folder",
+                            code="provenance_review_forbidden",
+                            status=403,
+                        )
+                    if document.ydoc_snapshot_sha256 is None:
+                        raise ProvenanceReviewError(
+                            "document has no frozen structured baseline",
+                            code="provenance_review_state_conflict",
+                        )
+                    current_head = ydoc_store.current_structured_head(
+                        store,
+                        document_id=document.id,
+                        snapshot_sha256=document.ydoc_snapshot_sha256,
+                    )
+                    if current_head != expected_head:
+                        raise ProvenanceReviewError(
+                            "The provenance target changed before review was recorded.",
+                            code="provenance_target_changed",
+                            retryable=True,
+                        )
+
+                for item in pending:
+                    prior = item["prior"]
+                    if prior.target_structured_head_sha256 != expected_head:
+                        raise ProvenanceReviewError(
+                            "The provenance target changed before review was recorded.",
+                            code="provenance_target_changed",
+                            retryable=True,
+                        )
+                    if prior.authorship_kind not in {"ai", "mixed"} or (
+                        prior.review_status
+                        not in {"not_reviewed", "unknown", "reviewed"}
+                    ):
+                        raise ProvenanceReviewError(
+                            "Only AI or mixed-authored content can be marked reviewed.",
+                            code="provenance_review_ineligible",
+                            status=400,
+                        )
+                    same_target = [
+                        row
+                        for row in all_rows
+                        if row.target_kind == prior.target_kind
+                        and row.document_version_id == prior.document_version_id
+                        and row.document_span_id == prior.document_span_id
+                    ]
+                    if any(
+                        row.target_structured_head_sha256
+                        != prior.target_structured_head_sha256
+                        for row in same_target
+                    ):
+                        raise ProvenanceReviewError(
+                            "The target has incompatible frozen provenance records.",
+                            code="provenance_review_conflict",
+                        )
+                    superseded = {
+                        row.supersedes_id
+                        for row in same_target
+                        if row.supersedes_id is not None
+                    }
+                    leaves = [
+                        row.id for row in same_target if row.id not in superseded
+                    ]
+                    if leaves != [prior.id]:
+                        raise ProvenanceReviewError(
+                            "The attestation is no longer the sole effective record "
+                            "for this target.",
+                            code="provenance_review_conflict",
+                            details={"effective_attestation_ids": leaves},
+                        )
+
+                records: list[DocumentProvenanceAttestationRecord] = []
+                for item in prepared:
+                    existing = item.get("existing")
+                    if existing is not None:
+                        records.append(existing)
+                        continue
+                    prior = item["prior"]
+                    records.append(
+                        _record_attestation_locked(
+                            store,
+                            conn,
+                            document_id=document_ref,
+                            attestation={},
+                            normalized_attestation=item["normalized"],
+                            source=item["source"],
+                            actor=actor,
+                            idempotency_key=item["target_key"],
+                            target_kind=prior.target_kind,
+                            document_version_id=prior.document_version_id,
+                            document_span_id=prior.document_span_id,
+                            target_structured_head_sha256=(
+                                prior.target_structured_head_sha256
+                            ),
+                            basis_kind="user_attestation",
+                            basis_ref=prior.id,
+                            supersedes_id=prior.id,
+                            at=at,
+                        )
+                    )
+                return records
+
+
 __all__ = [
     "ATTESTATION_SCHEMA",
     "AUTOMATIC_SHORT_TEXT_MAX_CHARS",
@@ -1747,6 +2072,7 @@ __all__ = [
     "project_attestations",
     "record_document_attestation",
     "record_human_review",
+    "record_human_reviews",
     "record_proposal_acceptance_attestations_locked",
     "record_span_attestation",
 ]


### PR DESCRIPTION
## Summary
- keep the provenance selection menu usable while recent typing attribution settles, blocking only actions that overlap pending text
- add actor-aware Mark as reviewed for every fully contained eligible span, backed by an atomic idempotent batch API
- make late receipts, volatile retry recovery, stale selections, and focus feedback deterministic

## Test plan
- [x] uv run pytest tests/unit/cowork/test_api_routes.py tests/unit/cowork/test_provenance_attestations.py -q --tb=short (115 passed)
- [x] focused Co-work Vitest suite (96 passed)
- [x] npm run typecheck
- [x] knowledge-store validation