### PR TITLE
fix(tasks): harden legacy rollback export

### DIFF
--- a/knowledge/store/tasks/native-task-system.md
+++ b/knowledge/store/tasks/native-task-system.md
@@ -34,6 +34,8 @@ dev_notes: |-
   The task Co-work store ID is persisted in `task_system_state` and resolved through the Truth store registry so relocation preserves identity. Task reads and IR indexing project the current structured head plus uncompacted Yjs updates. Do not read only the last compacted blob.
 
   Document create/attach and delete/restore are recoverable sagas. Restoring a task whose binding was retired preserves the retired document and binding, creates one new projection-free successor with retained content, and atomically attaches it at the current task revision.
+
+  Reverse export intentionally splits legacy representability by liveness. Live rows must have parser-safe single-line descriptions and complete note-link identity because they render into master/archive Markdown. Deleted rows are database-only v11 tombstones: preserve nullable descriptions and dangling but syntactically valid note UUIDs in SQLite, while still validating task IDs and any document links that do exist. Local-file handles read from projected Co-work Markdown must be canonicalized for Markdown-escaped punctuation (for example, `lf\_...`) before catalog matching and replacement; verified assets are then rehydrated only from the sealed frozen root.
 ---
 
 # Native task authority

--- a/tests/unit/tasks/test_rollback_export.py
+++ b/tests/unit/tasks/test_rollback_export.py
@@ -145,7 +145,7 @@ def _seed_native_store(tmp_path: Path, *, distinct_dates: bool = False):
                 "t-cc33",
                 "inbox",
                 "low",
-                "Retain deleted task",
+                None,
                 NOTE_DELETED,
                 None,
                 "2026-11-03",
@@ -422,6 +422,7 @@ def test_prepare_exports_tree_v11_database_and_native_supplement(tmp_path):
         assert rows["t-bb22"]["deadline_date"] == "2026-10-02"
         assert rows["t-cc33"]["deadline_date"] == "2026-11-03"
         assert rows["t-cc33"]["deleted_at"] is not None
+        assert rows["t-cc33"]["description"] is None
         assert connection.execute("SELECT COUNT(*) FROM task_tags").fetchone()[0] == 3
         assert connection.execute("SELECT COUNT(*) FROM task_state_history").fetchone()[0] == 3
         assert [
@@ -448,6 +449,35 @@ def test_prepare_exports_tree_v11_database_and_native_supplement(tmp_path):
         assert old.execute("PRAGMA user_version").fetchone()[0] == 11
     finally:
         old.close()
+
+
+def test_prepare_preserves_deleted_tombstone_without_document_link(tmp_path):
+    operator, _database, store, _documents = _operator(tmp_path)
+    with store.transaction() as connection:
+        connection.execute(
+            "DELETE FROM task_document_links WHERE task_id = 't-cc33'"
+        )
+
+    _prepare(operator)
+
+    legacy_db = operator.staging_root / "task_metadata.v11.db"
+    connection = sqlite3.connect(legacy_db)
+    connection.row_factory = sqlite3.Row
+    try:
+        row = connection.execute(
+            "SELECT description, note_uuid, deleted_at "
+            "FROM task_metadata WHERE task_id = 't-cc33'"
+        ).fetchone()
+        assert dict(row) == {
+            "description": None,
+            "note_uuid": NOTE_DELETED,
+            "deleted_at": "2026-08-25T00:00:00+00:00",
+        }
+    finally:
+        connection.close()
+    assert not (
+        operator.staging_root / "legacy-tree" / "notes" / f"{NOTE_DELETED}.md"
+    ).exists()
 
 
 def test_distinct_due_deadline_blocks_until_explicit_per_task_resolution(tmp_path):
@@ -754,8 +784,8 @@ def test_local_files_require_hash_verified_frozen_root_and_are_rehydrated(tmp_pa
                 NOW,
             ),
         )
-    documents["doc-live"] += "\nLocal file (Spec): wb-local-file:lf_asset\n"
-    documents["doc-live"] += "\nKey location: wb-local-file:lf_key\n"
+    documents["doc-live"] += "\nLocal file (Spec): wb-local-file:lf\\_asset\n"
+    documents["doc-live"] += "\nKey location: wb-local-file:lf\\_key\n"
     without_root = ReverseLegacyTaskExportOperator(
         source_db_path=database,
         staging_root=tmp_path / "rollback-stage",

--- a/work_buddy/tasks/rollback_export.py
+++ b/work_buddy/tasks/rollback_export.py
@@ -78,9 +78,24 @@ _NOTE_UUID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
     re.IGNORECASE,
 )
-_LOCAL_FILE_TOKEN_RE = re.compile(r"wb-local-file:([A-Za-z0-9_.:-]+)")
+_LOCAL_FILE_TOKEN_RE = re.compile(
+    r"wb-local-file:((?:[A-Za-z0-9_.:-]|\\[_.:-])+)",
+)
+_LOCAL_FILE_ESCAPE_RE = re.compile(r"\\([_.:-])")
 _UNREPRESENTABLE_DESCRIPTION_RE = re.compile(r"[\r\n]|\[\[|#\S|[🆔📅✅🔽🔼⏫]")
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _normalize_local_file_tokens(content: str) -> str:
+    """Undo Markdown escapes inside opaque local-file identifiers."""
+
+    return _LOCAL_FILE_TOKEN_RE.sub(
+        lambda match: (
+            "wb-local-file:" + _LOCAL_FILE_ESCAPE_RE.sub(r"\1", match.group(1))
+        ),
+        content,
+    )
+
 
 _LEGACY_TASK_COLUMNS = (
     "task_id",
@@ -2252,18 +2267,26 @@ class ReverseLegacyTaskExportOperator:
         for task_id, task in task_by_id.items():
             if _LEGACY_TASK_ID_RE.fullmatch(task_id) is None:
                 blockers.append({"task_id": task_id, "reason": "legacy_task_id_unrepresentable"})
-            description = str(task.get("description") or "").strip()
-            if not description or _UNREPRESENTABLE_DESCRIPTION_RE.search(description):
-                blockers.append(
-                    {"task_id": task_id, "reason": "legacy_description_unrepresentable"}
-                )
+            is_tombstone = task.get("deleted_at") is not None
+            # Deleted rows are retained as database-only tombstones.  Legacy v11
+            # permits their historical description to be NULL, and they are not
+            # rendered into a Markdown task line for the parser to consume.
+            if not is_tombstone:
+                description = str(task.get("description") or "").strip()
+                if not description or _UNREPRESENTABLE_DESCRIPTION_RE.search(description):
+                    blockers.append(
+                        {"task_id": task_id, "reason": "legacy_description_unrepresentable"}
+                    )
             note_uuid = task.get("note_uuid")
             link = links_by_task.get(task_id)
             if note_uuid:
                 if _NOTE_UUID_RE.fullmatch(str(note_uuid)) is None:
                     blockers.append({"task_id": task_id, "reason": "legacy_note_uuid_invalid"})
                 if link is None:
-                    blockers.append({"task_id": task_id, "reason": "task_document_link_missing"})
+                    if not is_tombstone:
+                        blockers.append(
+                            {"task_id": task_id, "reason": "task_document_link_missing"}
+                        )
                 elif str(link["note_uuid"]).casefold() != str(note_uuid).casefold():
                     blockers.append({"task_id": task_id, "reason": "task_note_link_mismatch"})
             elif link is not None:
@@ -2874,6 +2897,8 @@ class ReverseLegacyTaskExportOperator:
         documents: dict[str, str],
     ) -> list[dict[str, Any]]:
         links = list(snapshot.local_file_links)
+        for note_uuid, content in tuple(documents.items()):
+            documents[note_uuid] = _normalize_local_file_tokens(content)
         all_tokens = {
             token
             for content in documents.values()


### PR DESCRIPTION
## Summary
- preserve database-only deleted tombstones when historical v11 task rows lack descriptions or document links
- normalize Markdown-escaped local-file handles before catalog verification and sealed-asset rehydration
- document the rollback-export invariant for native task cutover

## Validation
- `tests/unit/tasks/test_rollback_export.py`
- `tests/unit/tasks/test_migration_cutover.py`
- `tests/unit/tasks/test_production_cutover.py`
- 52 passed, 0 failed