### PR TITLE
fix(cowork): bound folder setup by measured work, not file count

### DIFF
--- a/dashboard-react/COMPONENTS.md
+++ b/dashboard-react/COMPONENTS.md
@@ -12,6 +12,14 @@ Reusable components and component families in the React dashboard, one entry per
 | Running Notes | `src/widget-library/notes/` | `wb.notes.running` widget type, `wb.widget-role.running-notes@1` |
 | Shared widget primitives | `src/widget-library/shared/` | Cross-publisher presentation helpers consumed by the library widgets |
 
+## Shared UI primitives: busy states
+
+Foundation-consuming presentation components in `src/ui/`, imported through the barrel. They are the compatibility boundary between built-in and contributed UI, so views compose them rather than restyling host markup, and their styles live in `src/theme/components.css` under `@layer wb.components`. Knowledge unit: `services/dashboard/react/appearance`. The rows below cover the busy-state primitives; the rest of `src/ui/` is not yet inventoried here.
+
+| Component | Location | Contract |
+|---|---|---|
+| ActivityStatus | `src/ui/ActivityStatus.tsx` | Busy state with an optional running quantity. `role="status"` scopes the announcement to `label`; `detail` is a secondary line for work whose total is unknown, rendered as a sibling outside that region and `aria-hidden`, so a rising count stays a sighted-user signal rather than re-announcing through the implicit polite live region. Indeterminate by construction, so no `role="progressbar"`. Callers mark the surrounding region `aria-busy` |
+
 ## Chat primitives (library components, not registered widget types)
 
 Reusable conversational surface for any view that mounts a house conversation. Knowledge unit: `services/dashboard/react/chat-primitives`.

--- a/dashboard-react/src/apps/cowork/contracts.ts
+++ b/dashboard-react/src/apps/cowork/contracts.ts
@@ -161,7 +161,8 @@ export type CoworkFolderAction =
   | "retry"
   | "inspect"
   | "open_owner"
-  | "choose_another";
+  | "choose_another"
+  | "choose_narrower_folder";
 
 export type CoworkFolderSelection =
   | { readonly kind: "none" }
@@ -205,6 +206,7 @@ export type CoworkFolderSelection =
       readonly candidate: CoworkFolderCandidate | null;
       readonly reasonCode: CoworkFolderUnavailableCode;
       readonly retryable: boolean;
+      readonly availableActions: readonly CoworkFolderAction[];
     };
 
 export type CoworkCatalogStatus =

--- a/dashboard-react/src/apps/cowork/documents/CoworkLauncher.test.tsx
+++ b/dashboard-react/src/apps/cowork/documents/CoworkLauncher.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CoworkFolderSelection, CoworkViewModel } from "../contracts";
+import { CoworkLauncher } from "./CoworkLauncher";
+
+const candidate = {
+  folderName: "work-buddy",
+  folderPath: "C:/Projects/work-buddy",
+};
+
+const baseModel: CoworkViewModel = {
+  folders: [],
+  folderChooser: {
+    available: true,
+    kind: "host",
+    importAvailable: true,
+    locationAvailable: true,
+  },
+  folderSelection: { kind: "none" },
+  activeFolderStoreId: null,
+  catalog: { status: "ready", documents: [], refreshedAt: null, error: null },
+  scratches: [],
+  routeTarget: { kind: "launcher", storeId: null },
+  activeSession: { kind: "none" },
+  openingTarget: null,
+  navigationError: null,
+  readOnly: false,
+  document: null,
+};
+
+const renderLauncher = (
+  folderSelection: CoworkFolderSelection,
+  overrides: Partial<CoworkViewModel> = {},
+) => {
+  const handlers = {
+    onRetryInspection: vi.fn(),
+    onCancelInspection: vi.fn(),
+    onChooseFolder: vi.fn(),
+    onInitialize: vi.fn(),
+    onOpenFolder: vi.fn(),
+    onOpenDocument: vi.fn(),
+    onOpenLocalDocument: vi.fn(),
+  };
+  render(
+    <CoworkLauncher
+      model={{ ...baseModel, ...overrides, folderSelection }}
+      {...handlers}
+    />,
+  );
+  return handlers;
+};
+
+describe("CoworkLauncher descendant scan", () => {
+  it("reports how many items the scan has checked", () => {
+    renderLauncher({
+      kind: "inspecting_descendants",
+      candidate,
+      progress: { visited: 12_450, complete: false },
+    });
+
+    expect(
+      screen.getByText(`${(12_450).toLocaleString()} items checked`),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Opening work-buddy…")).toBeInTheDocument();
+  });
+
+  it("cancels the scan from the busy state", async () => {
+    const user = userEvent.setup();
+    const { onCancelInspection } = renderLauncher({
+      kind: "inspecting_descendants",
+      candidate,
+      progress: { visited: 12_450, complete: false },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onCancelInspection).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the count until the scan has checked something", () => {
+    renderLauncher({
+      kind: "inspecting_descendants",
+      candidate,
+      progress: { visited: 0, complete: false },
+    });
+
+    expect(screen.getByText("Opening work-buddy…")).toBeInTheDocument();
+    expect(screen.queryByText(/items checked/)).toBeNull();
+  });
+});
+
+describe("CoworkLauncher folder refusal", () => {
+  it("offers a way out of an oversized folder with no session and no active folder", async () => {
+    const user = userEvent.setup();
+    const { onChooseFolder } = renderLauncher({
+      kind: "unavailable",
+      candidate,
+      reasonCode: "folder_too_large_for_safe_setup",
+      retryable: false,
+      availableActions: ["choose_narrower_folder"],
+    });
+
+    expect(
+      screen.getByText("That folder holds too many items for Co-work to check safely."),
+    ).toBeInTheDocument();
+    const chooser = screen.getByRole("button", { name: "Choose a smaller folder" });
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+
+    await user.click(chooser);
+
+    expect(onChooseFolder).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds the chooser back where the host cannot pick a folder", () => {
+    renderLauncher(
+      {
+        kind: "unavailable",
+        candidate,
+        reasonCode: "folder_too_large_for_safe_setup",
+        retryable: false,
+        availableActions: ["choose_narrower_folder"],
+      },
+      {
+        folderChooser: {
+          available: false,
+          kind: "none",
+          importAvailable: false,
+          locationAvailable: false,
+        },
+      },
+    );
+
+    expect(screen.queryByRole("button", { name: /Choose/ })).toBeNull();
+  });
+
+  it("keeps Try again for a refusal the user can retry", async () => {
+    const user = userEvent.setup();
+    const { onRetryInspection } = renderLauncher({
+      kind: "unavailable",
+      candidate,
+      reasonCode: "descendant_scan_incomplete",
+      retryable: true,
+      availableActions: ["retry"],
+    });
+
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(onRetryInspection).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: /Choose/ })).toBeNull();
+  });
+});

--- a/dashboard-react/src/apps/cowork/documents/CoworkLauncher.tsx
+++ b/dashboard-react/src/apps/cowork/documents/CoworkLauncher.tsx
@@ -5,9 +5,10 @@ import {
   ModalOverlay,
 } from "react-aria-components";
 
-import { Button, InlineAlert, Spinner } from "../../../ui";
+import { ActivityStatus, Button, InlineAlert } from "../../../ui";
 import type {
   CoworkDocumentSummary,
+  CoworkFolderAction,
   CoworkFolderSummary,
   CoworkScratchSummary,
   CoworkViewModel,
@@ -26,6 +27,7 @@ interface CoworkLauncherProps {
   } | null;
   readonly onRetryInspection: () => void;
   readonly onCancelInspection: () => void;
+  readonly onChooseFolder: () => void;
   readonly onInitialize: () => void;
   readonly onOpenFolder: (storeId: string) => void;
   readonly onOpenDocument: (document: CoworkDocumentSummary) => void;
@@ -37,8 +39,18 @@ const unavailableCopy: Record<string, string> = {
   folder_unreadable: "Work Buddy can’t read that folder.",
   folder_disallowed: "Work Buddy can’t open that location.",
   descendant_scan_incomplete: "Co-work couldn’t finish opening that folder.",
-  folder_too_large_for_safe_setup: "Choose a smaller folder to use with Co-work.",
+  folder_too_large_for_safe_setup:
+    "That folder holds too many items for Co-work to check safely.",
 };
+
+/** A refusal the user can leave by picking a different folder. */
+const offersFolderChoice = (actions: readonly CoworkFolderAction[]): boolean =>
+  actions.includes("choose_narrower_folder") || actions.includes("choose_another");
+
+const folderChoiceLabel = (actions: readonly CoworkFolderAction[]): string =>
+  actions.includes("choose_narrower_folder")
+    ? "Choose a smaller folder"
+    : "Choose another folder";
 
 const folderConflictCopy: Record<string, string> = {
   folder_layout_incomplete: "This folder has an incomplete Co-work setup.",
@@ -189,6 +201,7 @@ export function CoworkLauncher({
   pendingFolderAction = null,
   onRetryInspection,
   onCancelInspection,
+  onChooseFolder,
   onInitialize,
   onOpenFolder,
   onOpenDocument,
@@ -205,14 +218,21 @@ export function CoworkLauncher({
   const navigationBusy = openingFolder || folderActionBusy;
 
   if (selection.kind === "inspecting_descendants") {
+    // The scan reports what it has checked, never a total, so the count appears only
+    // once the walk has something to report.
+    const visited = selection.progress.visited;
     return (
       <section
         className="wb-cowork-launcher wb-cowork-launcher--centered"
         aria-label="Opening folder"
         aria-busy="true"
       >
-        <Spinner />
-        <p>Opening {selection.candidate.folderName}…</p>
+        <ActivityStatus
+          label={`Opening ${selection.candidate.folderName}…`}
+          detail={
+            visited > 0 ? `${visited.toLocaleString()} items checked` : undefined
+          }
+        />
         <Button onClick={onCancelInspection}>Cancel</Button>
       </section>
     );
@@ -405,6 +425,18 @@ export function CoworkLauncher({
               {folderActionBusy ? "Opening…" : "Try again"}
             </Button>
           ) : null}
+          {model.folderChooser.available &&
+          offersFolderChoice(selection.availableActions) ? (
+            <Button
+              variant="primary"
+              onClick={onChooseFolder}
+              disabled={folderActionBusy}
+            >
+              {folderActionBusy
+                ? "Opening…"
+                : folderChoiceLabel(selection.availableActions)}
+            </Button>
+          ) : null}
         </div>
       </section>
     );
@@ -429,9 +461,7 @@ export function CoworkLauncher({
           </InlineAlert>
         ) : null}
         {model.catalog.status === "loading" ? (
-          <p role="status" className="wb-cowork-launcher__loading">
-            <Spinner /> Loading documents…
-          </p>
+          <ActivityStatus label="Loading documents…" />
         ) : null}
         {model.catalog.error !== null ? (
           <InlineAlert tone="danger">

--- a/dashboard-react/src/apps/cowork/providers/HttpCoworkProvider.test.ts
+++ b/dashboard-react/src/apps/cowork/providers/HttpCoworkProvider.test.ts
@@ -6,7 +6,7 @@ import {
   asWidgetTypeId,
   type DashboardIntent,
 } from "../../../dashboard/contributions/contracts";
-import { COWORK_INTENTS } from "../contracts";
+import { COWORK_INTENTS, type CoworkFolderSelection } from "../contracts";
 import { bootstrapCoworkYdoc } from "../documents/bootstrapCoworkYdoc";
 import { frameSegments } from "../persistence/framing";
 import {
@@ -1303,6 +1303,7 @@ describe("HttpCoworkProvider", () => {
   it("continues a bounded folder check automatically before asking to set up the Folder", async () => {
     const location = new MemoryLocation();
     let inspections = 0;
+    let selectionDuringScan: CoworkFolderSelection | null = null;
     const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.startsWith("/api/truth/cowork/folders?")) {
@@ -1323,6 +1324,7 @@ describe("HttpCoworkProvider", () => {
           });
         }
         expect(body).toEqual({ continuation_token: "continue-1" });
+        selectionDuringScan = (await provider.loadView()).model.folderSelection;
         return json({
           status: "uninitialized",
           folder_name: "work-buddy",
@@ -1350,9 +1352,66 @@ describe("HttpCoworkProvider", () => {
     ).toMatchObject({ status: "accepted" });
 
     expect(inspections).toBe(2);
+    expect(selectionDuringScan).toEqual({
+      kind: "inspecting_descendants",
+      candidate: {
+        folderName: "work-buddy",
+        folderPath: "C:/Projects/work-buddy",
+      },
+      progress: { visited: 250, complete: false },
+    });
     expect((await provider.loadView()).model.folderSelection).toMatchObject({
       kind: "setup_confirmation",
       candidate: { folderName: "work-buddy" },
+    });
+  });
+
+  it("surfaces the narrower folder action when a folder is too large to check", async () => {
+    const location = new MemoryLocation();
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.startsWith("/api/truth/cowork/folders?")) {
+        return json({ read_only: false, folders: [], diagnostics: [] });
+      }
+      if (url.endsWith("/folders/inspect")) {
+        expect(JSON.parse(String(init?.body))).toEqual({
+          folder_path: "C:/Projects/work-buddy",
+        });
+        return json({
+          status: "unavailable",
+          folder_name: "work-buddy",
+          folder_path: "C:/Projects/work-buddy",
+          reason_code: "folder_too_large_for_safe_setup",
+          actions: ["choose_narrower_folder"],
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    const provider = new HttpCoworkProvider({
+      location,
+      storage: localStorage,
+      client: new CoworkHttpClient(fetchImpl as typeof fetch),
+    });
+    await provider.loadView();
+
+    await expect(
+      provider.dispatch(
+        intent(COWORK_INTENTS.folderSelect, {
+          action: "inspect",
+          folderPath: "C:/Projects/work-buddy",
+        }),
+      ),
+    ).resolves.toMatchObject({ status: "accepted" });
+
+    expect((await provider.loadView()).model.folderSelection).toEqual({
+      kind: "unavailable",
+      candidate: {
+        folderName: "work-buddy",
+        folderPath: "C:/Projects/work-buddy",
+      },
+      reasonCode: "folder_too_large_for_safe_setup",
+      retryable: false,
+      availableActions: ["choose_narrower_folder"],
     });
   });
 

--- a/dashboard-react/src/apps/cowork/providers/HttpCoworkProvider.ts
+++ b/dashboard-react/src/apps/cowork/providers/HttpCoworkProvider.ts
@@ -18,6 +18,7 @@ import {
   type CoworkCatalogState,
   type CoworkDocumentOpenIntentPayload,
   type CoworkDocumentSummary,
+  type CoworkFolderAction,
   type CoworkFolderCandidate,
   type CoworkFolderSelectIntentPayload,
   type CoworkFolderSelection,
@@ -89,6 +90,26 @@ const payloadRecord = (intent: DashboardIntent): Record<string, unknown> =>
   typeof intent.payload === "object" && intent.payload !== null
     ? (intent.payload as Record<string, unknown>)
     : {};
+
+/**
+ * The action union is the single source of truth for what the server may offer.
+ * A widened union fails to compile here until this lookup names the addition,
+ * so an action the server already emits cannot be dropped in transit.
+ */
+const FOLDER_ACTIONS: Record<CoworkFolderAction, true> = {
+  retry: true,
+  inspect: true,
+  open_owner: true,
+  choose_another: true,
+  choose_narrower_folder: true,
+};
+
+const folderActions = (
+  actions: readonly string[],
+): readonly CoworkFolderAction[] =>
+  actions.filter((action): action is CoworkFolderAction =>
+    Object.prototype.hasOwnProperty.call(FOLDER_ACTIONS, action),
+  );
 
 const folderActionError = (error: unknown): CoworkApiError => {
   const apiError = asCoworkApiError(error);
@@ -802,6 +823,7 @@ export class HttpCoworkProvider implements ViewProvider {
           candidate: null,
           reasonCode: "folder_not_found",
           retryable: true,
+          availableActions: ["retry"],
         },
         ...(hasPreviousFolder
           ? {}
@@ -1636,13 +1658,7 @@ export class HttpCoworkProvider implements ViewProvider {
           | "folder_layout_incomplete"
           | "folder_store_collision"
           | "identity_conflict",
-        availableActions: inspection.actions.filter(
-          (action): action is "retry" | "inspect" | "open_owner" | "choose_another" =>
-            action === "retry" ||
-            action === "inspect" ||
-            action === "open_owner" ||
-            action === "choose_another",
-        ),
+        availableActions: folderActions(inspection.actions),
       };
     }
     return {
@@ -1655,6 +1671,7 @@ export class HttpCoworkProvider implements ViewProvider {
         | "descendant_scan_incomplete"
         | "folder_too_large_for_safe_setup",
       retryable: inspection.actions.includes("retry"),
+      availableActions: folderActions(inspection.actions),
     };
   }
 

--- a/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.test.tsx
+++ b/dashboard-react/src/apps/cowork/surface/CoworkWorkspaceSurface.test.tsx
@@ -1003,6 +1003,7 @@ describe("CoworkWorkspaceWidget default (empty) mode", () => {
           },
           reasonCode: "descendant_scan_incomplete",
           retryable: true,
+          availableActions: ["retry"],
         },
         catalog: {
           status: "error",

--- a/dashboard-react/src/apps/cowork/surface/styles.css
+++ b/dashboard-react/src/apps/cowork/surface/styles.css
@@ -247,14 +247,6 @@
   gap: var(--wb-space-2);
 }
 
-.wb-cowork-launcher__loading {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--wb-space-2);
-  color: var(--wb-color-text-muted);
-}
-
 .wb-cowork-launcher__section {
   inline-size: 100%;
   margin-block-start: var(--wb-space-6);

--- a/dashboard-react/src/apps/cowork/widget/CoworkWorkspaceWidget.tsx
+++ b/dashboard-react/src/apps/cowork/widget/CoworkWorkspaceWidget.tsx
@@ -691,6 +691,11 @@ export default function CoworkWorkspaceWidget({
         }
       }}
       onCancelInspection={() => runFolderAction("cancel")}
+      onChooseFolder={() => {
+        setLocalNotice(null);
+        setPendingTruthPassageNavigation(null);
+        runFolderAction("choose");
+      }}
       onInitialize={() => runFolderAction("initialize")}
       onOpenFolder={(storeId) => {
         setLocalNotice(null);

--- a/dashboard-react/src/theme/components.css
+++ b/dashboard-react/src/theme/components.css
@@ -666,6 +666,25 @@
     gap: var(--wb-space-4);
   }
 
+  .wb-activity-status {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: var(--wb-space-4);
+  }
+
+  .wb-activity-status__indicator {
+    display: inline-flex;
+    flex: 0 0 auto;
+  }
+
+  /* The label and its detail read as one message, so they sit tighter than
+     the stack's default rhythm. This follows .wb-stack to win on order. */
+  .wb-activity-status__copy {
+    gap: var(--wb-space-2);
+    text-align: start;
+  }
+
   .wb-widget-frame {
     position: relative;
     display: flex;

--- a/dashboard-react/src/ui/ActivityStatus.test.tsx
+++ b/dashboard-react/src/ui/ActivityStatus.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { expectNoAccessibilityViolations } from "../test/setup";
+import { ActivityStatus } from "./ActivityStatus";
+
+describe("ActivityStatus", () => {
+  it("exposes the label through one status region", () => {
+    render(<ActivityStatus label="Checking the folder" />);
+
+    expect(screen.getAllByRole("status")).toHaveLength(1);
+    expect(screen.getByRole("status")).toHaveTextContent("Checking the folder");
+  });
+
+  it("keeps a ticking detail out of the announced region", () => {
+    render(
+      <ActivityStatus label="Checking the folder" detail="1,204 items checked" />,
+    );
+
+    const region = screen.getByRole("status");
+    const detail = screen.getByText("1,204 items checked");
+
+    // `role="status"` carries an implicit polite, atomic live region. A detail that
+    // rises through a long operation would re-announce the whole message on every
+    // tick, so it renders outside that region and out of the accessibility tree.
+    expect(region).not.toContainElement(detail);
+    expect(detail).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("renders no second line when the caller gives no detail", () => {
+    render(<ActivityStatus label="Checking the folder" />);
+
+    const region = screen.getByRole("status");
+
+    expect(region.parentElement).toHaveTextContent("Checking the folder");
+    expect(region.parentElement?.childElementCount).toBe(1);
+  });
+
+  it("carries no progressbar semantics", () => {
+    const { container } = render(
+      <ActivityStatus label="Checking the folder" detail="1,204 items checked" />,
+    );
+
+    expect(container.querySelector("[aria-valuenow]")).toBeNull();
+    expect(screen.queryByRole("progressbar")).toBeNull();
+    expect(screen.queryByRole("meter")).toBeNull();
+  });
+
+  it("passes an accessibility audit with and without a detail", async () => {
+    const { container, rerender } = render(
+      <ActivityStatus label="Checking the folder" />,
+    );
+    await expectNoAccessibilityViolations(container);
+
+    rerender(
+      <ActivityStatus label="Checking the folder" detail="1,204 items checked" />,
+    );
+    await expectNoAccessibilityViolations(container);
+  });
+});

--- a/dashboard-react/src/ui/ActivityStatus.tsx
+++ b/dashboard-react/src/ui/ActivityStatus.tsx
@@ -1,0 +1,41 @@
+import { Spinner } from "./Spinner";
+import { Stack, Text } from "./Typography";
+
+export interface ActivityStatusProps {
+  /** The message describing the work in progress. */
+  readonly label: string;
+  /** A secondary line carrying a running quantity, for work with no known total. */
+  readonly detail?: string;
+}
+
+/**
+ * Busy state that can carry a running quantity.
+ *
+ * Indeterminate by construction: the caller reports how much work it has done, not how
+ * much is left, so this is a status message rather than `role="progressbar"`.
+ *
+ * `role="status"` sits on the label alone, and that role is a polite, atomic live region:
+ * anything inside it re-announces in full whenever it changes. The label is stable, so it
+ * announces once. The detail ticks upward through a long operation, so it renders as a
+ * sibling outside the region and carries `aria-hidden`, which keeps it a sighted-user
+ * reassurance signal instead of a stream of announcements. The spinner mark is decorative
+ * and hidden for the same reason. Busy state for the surrounding region is the caller's
+ * `aria-busy`.
+ */
+export function ActivityStatus({ label, detail }: ActivityStatusProps) {
+  return (
+    <div className="wb-activity-status">
+      <span className="wb-activity-status__indicator" aria-hidden="true">
+        <Spinner label="" />
+      </span>
+      <Stack className="wb-activity-status__copy">
+        <Text role="status">{label}</Text>
+        {detail ? (
+          <Text size="small" tone="muted" aria-hidden="true">
+            {detail}
+          </Text>
+        ) : null}
+      </Stack>
+    </div>
+  );
+}

--- a/dashboard-react/src/ui/index.ts
+++ b/dashboard-react/src/ui/index.ts
@@ -3,6 +3,7 @@ export {
   type ActionMenuItemDefinition,
   type ActionMenuSectionDefinition,
 } from "./ActionMenu";
+export { ActivityStatus, type ActivityStatusProps } from "./ActivityStatus";
 export {
   Button,
   type ButtonProps,

--- a/knowledge/store/cowork/folder.md
+++ b/knowledge/store/cowork/folder.md
@@ -1,0 +1,40 @@
+---
+name: Co-work Folder
+kind: concept
+description: 'The folder a person selects as their Co-work working boundary: what it owns on disk, what it contains, and the lifecycle entry point for setting one up.'
+summary: A Co-work Folder is an ordinary host folder that Co-work has been set up in. It owns .wbuddy/manifest.yaml and the canonical .wbuddy/cowork store, and it is the containment boundary for every document, conversation, and claim beneath it.
+tags:
+- cowork
+- folders
+- boundary
+- lifecycle
+- overview
+aliases:
+- co-work folder
+- folder boundary
+- working folder
+- folder lifecycle
+parents:
+- cowork
+dev_notes: |
+  Keep this unit short and conceptual. It is the browse node for the folder
+  lifecycle, so per-stage mechanics, refusal vocabularies, budgets, and lock
+  ordering belong in the child units rather than here.
+
+  Path identity is the canonical host path, not the folder's basename: the
+  basename labels the chip and never determines identity, and symlink and
+  junction aliases are canonicalized before any comparison so an alias cannot
+  register the same store twice.
+---
+
+# Co-work Folder
+
+A Co-work Folder is the working boundary a person selects. It is an ordinary folder on the host that Co-work has been set up in, and it is the containment boundary for everything Co-work knows about the work inside it.
+
+A folder owns two things on disk. `.wbuddy/manifest.yaml` declares which Work Buddy components the folder carries. `.wbuddy/cowork/` holds the canonical store: the profile that names the folder's identity, the SQLite database behind its documents and claims, and the deterministic export that travels with the folder. Everything else beside the store is machine-local and stays uncommitted.
+
+One folder may own many documents. Every document is addressed by a path relative to the folder root, which is why a folder can enclose no other Co-work folder: two folders that both enclose a file would each claim it under a different relative path and neither could see the other's record of it.
+
+The folder is also the scope a person moves between. Opening a folder selects the documents, conversations, and claims beneath it; closing it puts them away as a set.
+
+Children of this unit cover the folder's lifecycle. Start with `cowork/folder/setup` for how a folder is inspected, proven safe, and set up.

--- a/knowledge/store/cowork/folder/setup.md
+++ b/knowledge/store/cowork/folder/setup.md
@@ -1,0 +1,197 @@
+---
+name: Co-work Folder Setup Boundary
+kind: system
+description: The read-only proof that a selected folder is the only Co-work folder on its line of descent, and the explicit all-or-nothing setup that writes only after that proof holds.
+summary: Choosing a folder inspects it without mutation, classifying its own Work Buddy data, its ancestors, and a budgeted walk of its descendants. Setup is a separate call that re-walks the whole tree under the folder operation locks and writes only into a folder that still classifies as uninitialized. Every refusal carries a typed code naming both the folder's state and the action that answers it.
+entry_points:
+- work_buddy.cowork.project_store
+- work_buddy.cowork.folder_api
+tags:
+- cowork
+- folders
+- setup
+- inspection
+- boundaries
+- refusals
+aliases:
+- folder setup
+- folder inspection
+- nested folder boundary
+- descendant scan
+- setup refusal
+- folder boundary proof
+parents:
+- cowork/folder
+dev_notes: |
+  The descendant walk is budgeted in work units, not files, because a file count
+  prices two very different trees the same. Opening a directory costs two
+  metadata lookups plus a listing, while reading one entry out of an open
+  listing is served from the enumeration already in hand. Measured against a
+  large repository the first is roughly forty times the second, so the walk
+  charges a directory `_SCAN_DIRECTORY_WEIGHT` (40) and an entry 1. Both budgets
+  are derived from that weight: `DEFAULT_SCAN_WORK_PER_PAGE` (20,000) affords
+  five hundred directory opens per page, and `DEFAULT_SCAN_WORK_LIMIT` (750,000)
+  affords eighteen thousand seven hundred and fifty before the folder is refused
+  as too large. The weight describes the hardware rather than a caller's
+  preference, and the predicate reads only the shape of the tree, so the same
+  tree refuses on every machine.
+
+  A directory is charged only once its metadata lookup and its listing have both
+  succeeded. A directory that vanished between being queued and being read costs
+  nothing rather than being billed for work the walk never did, and a path that
+  does not exist cannot hold a store, so dropping it leaves the proof intact. A
+  directory re-read after an mtime race is charged for each read, so the total
+  is exact only for a quiescent tree.
+
+  The two budgets are independent knobs and neither is derived from the other at
+  construction. The page budget bounds one request; the cumulative limit bounds
+  the whole scan and is carried across pages in the scan cursor. A walk that
+  restarted its total at every page would spend unbounded work while no single
+  page reached the threshold, and an arbitrarily large folder would classify as
+  a setup candidate. A page budget larger than the threshold simply means one
+  page reaches it, and flooring the threshold to the page budget would discard a
+  deliberately small one, so neither is clamped to the other.
+
+  The paged walk is an advisory preview. It drives the launcher and mints an
+  inspection token, and it trusts the pages it already walked instead of
+  revalidating them on each continuation. The proof that gates a write is
+  `initialize`, which re-walks the whole tree in one unpaged pass under the
+  folder operation locks and refuses anything that does not classify as
+  `uninitialized`. A preview that drifted between pages therefore cannot
+  authorize an unsafe setup: the locked re-walk sees the store that appeared and
+  stops the write. Ownership and exact classification gate the walk, so a
+  continuation token exists only where no ancestor owns the folder and the
+  folder itself classified as `uninitialized`; a continuation carries no
+  authority those two would have to re-establish.
+
+  `inspection_fingerprint` is a digest over existence, mtime, and size for the
+  folder root, `.wbuddy/manifest.yaml`, `.wbuddy/cowork/store.yaml`, and
+  `.wbuddy/cowork/store.db`. It expresses one thing: a caller's earlier
+  observation of the folder, held so setup can refuse a folder that moved since
+  a human was shown it. Passing `None` means the caller has no such gap to
+  honour, and the refusal then carries the classification's own code and prose,
+  naming what the folder is rather than implying a race that did not happen. A
+  caller that does pass one collapses every non-`uninitialized` classification
+  into `folder_changed`, which is correct for a human-facing surface and wrong
+  for a programmatic one. `None` is safe because neither caller rests its safety
+  on the fingerprint: the walk inside the locks classifies from the filesystem
+  and refuses anything that is not `uninitialized`, and the managed-layout
+  assertion re-runs around every write beneath the folder.
+
+  Membership in `_RETRYABLE_SETUP_REFUSALS` decides both the `retryable` flag
+  and the HTTP status for a refusal that `_setup_refusal` composes, so those two
+  cannot drift apart. Keep the set restricted to codes a `FolderInspection` can
+  actually carry as a `reason_code`; a code that exists only as a raised
+  exception makes the lookup unconditionally false and leaves the retryable
+  branch dead. `folder_unreachable` is the sole member and maps to a retryable
+  503. Two other retryable refusals do not pass through that membership test at
+  all: `descendant_scan_incomplete`, raised directly by the walk, and
+  `folder_changed`, raised on fingerprint mismatch, both carry `retryable=True`
+  with the default 409. A transient scan failure and a transient read failure
+  therefore answer with different statuses.
+
+  The boundary sentinel is decided from a listing the walk already holds. A
+  directory listing that never names `.wbuddy` cannot be a store root, so
+  `_is_store_root` is spent only on the few directories whose own listing named
+  it. That probe `lstat`s the component child before reading through it, so a
+  redirected component is refused rather than followed and cannot expose a store
+  living outside the scanned tree. Every directory the walk opens is one a
+  listing admitted: an entry is queued only after `is_symlink` and the
+  reparse-point attribute clear it and its device matches the root's, and
+  `inspect` validates the root before the walk starts.
+
+  The proof covers walked descendants. `_SKIP_DIRS` holds `.git`, `.wbuddy`,
+  `node_modules`, `.venv`, and `vendor`, and the walk does not descend them, so
+  a store beneath one of those names is not a boundary the proof reports, and
+  neither is one behind a symlink, reparse point, or device boundary. `.wbuddy`
+  is the one skipped name the scan still learns from: seeing it sets the flag
+  that decides whether the enclosing directory is worth probing.
+
+  Known bound: a page is terminated only between directories. Work is spent per
+  directory and per entry, but the page budget is tested per directory, so one
+  page spends at most the budget plus one directory's worth of work and a single
+  very large listing runs to its end inside one request. The cumulative limit is
+  tested after the directory charge and after every entry charge, so an enormous
+  listing still stops at the threshold rather than running unbounded. Tightening
+  the page boundary needs a cursor inside a directory listing, and `os.scandir`
+  exposes no stable resume point, so the alternative is buffering whole listings
+  to disk, which costs more than the overshoot.
+
+  A directory whose mtime changed while it was being listed is re-queued and the
+  children it yielded are dropped, so the re-read is the only thing that
+  enqueues them. `_SCAN_DIRECTORY_RETRY_LIMIT` (3) caps that: a directory under
+  continuous churn raises `descendant_scan_incomplete` rather than spinning. An
+  entry that exists but cannot be read raises the same code, because skipping it
+  could hide a store and make the proof unsound. An entry that vanished between
+  the listing and the lookup is skipped, since a path that no longer exists
+  cannot hold a store.
+
+  Scan cursors live under the machine data root keyed by an opaque token, never
+  beneath the selected folder. A cursor records its root and is deleted and
+  refused if replayed against a different one, since a cursor holds one folder's
+  pending list. Cursors are swept at the token TTL, and every sweep failure is
+  swallowed: an undeleted cursor is a small leak, never a reason to refuse a
+  scan. A terminal page deletes its cursor.
+
+  Inspection stays byte-for-byte read-only on the selected folder. Store
+  identity reads open SQLite with `mode=ro&immutable=1` so a browse cannot
+  create or update WAL/SHM sidecars; a mutating open is deferred to the explicit
+  open action.
+
+  At the HTTP surface the fingerprint is a server precondition carried only by
+  an opaque short-lived token and is stripped from the JSON response, so no host
+  path or fingerprint enters a URL. A continuation token wraps the folder path
+  together with the internal scan token, and an inspection token wraps the
+  folder path, the classified status, and the fingerprint; `open` and
+  `initialize` each reject a token whose recorded status does not authorize
+  them. An expired token returns `selection_expired` as a retryable 409, which
+  the surface answers by inspecting again.
+---
+
+# Co-work folder setup
+
+Setting a folder up for Co-work writes `.wbuddy/manifest.yaml` and the canonical store at `.wbuddy/cowork/`. Before either exists, Co-work proves that the selected folder is the only Co-work folder on its own line of descent: no ancestor already holds a store, and no walked descendant already holds a `.wbuddy/cowork/store.yaml` of its own.
+
+Overlapping stores are unresolvable rather than untidy. Two stores that both enclose a file each claim that file under a different folder-relative path, each keep their own content hash for it, and each read the other's writes as outside drift. The overlap has no correct resolution once it exists, so the boundary is established before any write rather than repaired afterwards.
+
+## Inspection reads, setup writes
+
+Choosing a folder inspects it. Inspection writes nothing beneath the selected folder. It reads that folder's Work Buddy data, walks its ancestors looking for an owning Co-work folder, and walks its descendants looking for a store boundary. It resolves to one of a small set of states:
+
+- **initialized**: the folder is already a Co-work folder. The only action offered is opening it.
+- **inside_existing_folder**: an ancestor is already a Co-work folder. The result names that folder and its store identity, and offers opening the owner or choosing another folder.
+- **contains_nested_folder**: the descendant walk crossed at least one store boundary. The result names every boundary crossed, each with its folder name, host path, and store identity where that boundary itself reads as an initialized folder. The only action offered is choosing another folder.
+- **unavailable**: the descendant walk reached its cumulative work threshold before it could answer, carrying the reason `folder_too_large_for_safe_setup`. The action offered is choosing a narrower folder inside the selected one.
+- **collision**: the folder holds Work Buddy data that does not form a complete Co-work folder. A reason code separates an incomplete or redirected managed layout, store records that contradict each other, and data that could not be read at all. The actions offered are repairing that data or choosing another folder.
+- **uninitialized**: an ordinary folder that can be set up.
+- **inspection_pending**: the descendant walk has more tree to cover. The result carries a continuation token, a count of entries visited, and a short suggested wait. A caller asks again with that token until the walk resolves.
+
+Setup is a separate, explicit call. It consumes the authorization a terminal inspection minted, re-walks the whole tree in one unpaged pass while holding the folder operation locks, and proceeds only if the folder still classifies as uninitialized.
+
+Setup is all or nothing. A failure part way through removes the store directory it created, restores the exact manifest bytes it published, removes the `.wbuddy` directory when setup was what created it, and unregisters the store. A refused or failed setup leaves the folder as it was.
+
+## Refusals name the state and the action
+
+A caller that asks for setup on a folder that cannot take it receives a typed code, prose that names both the folder's state and the action that answers it, and an HTTP status consistent with that code:
+
+- **`folder_already_initialized`**: the folder is already a Co-work folder, and the answer is to open it instead of setting it up again.
+- **`inside_existing_folder`**: the folder sits inside a Co-work folder, and the answer is to select a folder outside that one.
+- **`contains_nested_folder`**: the folder encloses a Co-work folder, and the answer is to select a folder that does not enclose it.
+- **`folder_too_large_for_safe_setup`**: the folder holds too many items to check safely, and the answer is to select a narrower folder inside it.
+- **`folder_layout_incomplete`**: the folder holds Work Buddy data that does not form a complete Co-work folder, and the answer is to repair that data or select a different folder.
+- **`identity_conflict`**: the folder's store records were read and disagree about which store the folder holds. That is a different repair from an incomplete layout, and it is reported as its own code rather than folded into one.
+- **`folder_unreachable`**: the folder's Work Buddy data could not be read.
+- **`descendant_scan_incomplete`**: the descendant walk could not finish, because a descendant could not be read or kept changing while it was listed.
+- **`folder_changed`**: the folder moved out from under the observation a person was shown.
+
+The message is the whole contract for an agent caller, which reads the exception text and nothing else, so each refusal states the folder's state and the action together.
+
+## Retryable and settled refusals
+
+Three refusals are worth asking again unchanged. `folder_unreachable` says that reading the folder's Work Buddy data failed, so the classification settled nothing about what that data holds and the same folder can classify differently on the next attempt. `descendant_scan_incomplete` says the same thing about one descendant. `folder_changed` says the folder moved between observation and setup, and a fresh inspection can resolve it.
+
+Every other refusal describes a fact the walk established. An already initialized folder, an enclosing or enclosed Co-work folder, a folder past the work threshold, an incomplete layout, and contradictory store records are all settled: repeating the call cannot change any of them, and only the user acting on the folder can. Those refusals carry a non-retryable status and prose that avoids transient wording, so an automatic retry layer does not queue a folder whose answer is fixed.
+
+## An unreadable folder is unread, not broken
+
+Failing to read the folder's Work Buddy data is a different answer from reading it and finding it damaged. `folder_unreachable` reports that Co-work cannot tell what state the folder is in and asks the caller to try again in a moment. It deliberately does not use the repair wording that a genuine collision uses, because an agent told the data is broken repairs a folder that was never shown to be broken. A healthy store held open by a backup or a scanner classifies this way, and the very next attempt is expected to succeed.

--- a/knowledge/store/truth/truth_store_create.md
+++ b/knowledge/store/truth/truth_store_create.md
@@ -9,7 +9,7 @@ schema_version: wb-capability/v1
 parameters:
   root:
     type: str
-    description: Folder that will own .wbuddy/manifest.yaml and the canonical .wbuddy/cowork sidecar. Initialization refuses unsafe, nested, ambiguous, or pre-existing state without partial mutation.
+    description: Folder that will own .wbuddy/manifest.yaml and the canonical .wbuddy/cowork sidecar. Setup proves under the folder operation locks that the folder holds no Co-work store, sits inside none, and encloses none, then writes all of it or none of it. A folder that fails that proof is refused with the typed code naming its state.
     required: true
   profile:
     type: dict
@@ -38,3 +38,13 @@ aliases:
 parents:
 - truth
 ---
+
+Store creation delegates the folder work to Co-work's setup path, so the capability inherits one boundary proof rather than repeating it. The folder is walked exactly once, inside the folder operation locks, and that single walk is what authorizes the write: it classifies the folder from the filesystem and proceeds only if the folder holds no Co-work store, sits inside no Co-work folder, and encloses none. There is no partial outcome. A failure part way through removes the store directory, restores the exact manifest bytes, unregisters the store, and leaves the folder as it was.
+
+This caller shows the folder to nobody between deciding and writing, so it holds no prior observation to pin and passes no inspection fingerprint. That choice is what makes its refusals useful. Instead of a generic report that the folder changed, a refusal carries the reason code for the state the walk actually found: `folder_already_initialized`, `inside_existing_folder`, `contains_nested_folder`, `folder_too_large_for_safe_setup`, `folder_layout_incomplete`, or `identity_conflict`. Each message names both the folder's state and the action that answers it, which is the whole contract for an agent caller that reads the exception text and nothing else.
+
+A folder whose Work Buddy data could not be read comes back as `folder_unreachable`, a retryable failure saying the data is temporarily unavailable and to try again in a moment. It is deliberately not the repair wording a genuine collision uses, because nothing was established about what that data holds and a healthy store held open by a backup or a scanner classifies this way. A descendant that could not be read, or that kept changing while it was listed, comes back as `descendant_scan_incomplete` and is retryable for the same reason. Every other refusal is settled: repeating the call cannot change it.
+
+Store identity is resolved before the folder is touched. A `store_id` argument and a `profile.store_id` that disagree are rejected, either one alone is accepted, and an identity supplied by neither is minted. An identity already present in the registry is refused before any folder work begins. On success the validated store is registered, the registered row is returned, and a `truth.store_created` event is emitted carrying the sidecar path and profile name. A created store that did not reach the registry is an invariant violation, not a partial success.
+
+See `cowork/folder/setup` for the boundary proof, the full refusal vocabulary, and which refusals are worth retrying.

--- a/tests/unit/cowork/test_folder_routes.py
+++ b/tests/unit/cowork/test_folder_routes.py
@@ -30,6 +30,7 @@ from work_buddy.cowork.file_importers import (
     MARKDOWN_FILE_IMPORTER,
     MARKDOWN_MAX_SOURCE_BYTES,
 )
+from work_buddy.cowork import project_store
 from work_buddy.cowork.native_folder_chooser import NativeFolderChooserError
 from work_buddy.cowork.project_store import FolderLifecycleError, ProjectStoreManager
 from work_buddy.truth.identity import sha256_bytes
@@ -114,12 +115,13 @@ def _client(
     location_chooser=None,
     importer_registry=None,
     read_only=lambda: False,
-    scan_budget: int = 2_000,
+    scan_work_per_page: int | None = None,
+    scan_work_limit: int | None = None,
 ):
     manager = ProjectStoreManager(
         data_root=tmp_path / "machine",
-        scan_budget=scan_budget,
-        scan_hard_limit=100,
+        scan_work_per_page=scan_work_per_page,
+        scan_work_limit=scan_work_limit,
     )
     registry = TruthStoreRegistry(tmp_path / "registry.db")
     blueprint = create_folder_blueprint(
@@ -1053,7 +1055,7 @@ def test_scan_continuation_token_hides_machine_scan_cursor(tmp_path: Path) -> No
     folder.mkdir()
     for index in range(4):
         (folder / f"child-{index}").mkdir()
-    client, manager, _ = _client(tmp_path, scan_budget=1)
+    client, manager, _ = _client(tmp_path, scan_work_per_page=1)
 
     response = client.post(
         "/api/truth/cowork/folders/inspect", json={"folder_path": str(folder)}
@@ -1071,6 +1073,61 @@ def test_scan_continuation_token_hides_machine_scan_cursor(tmp_path: Path) -> No
             break
     assert response["status"] == "uninitialized"
     assert "inspection_token" in response
+
+
+def test_a_folder_past_the_work_limit_refuses_without_minting_a_token(
+    tmp_path: Path,
+) -> None:
+    folder = tmp_path / "sprawling"
+    folder.mkdir()
+    for index in range(4):
+        (folder / f"entry-{index}.txt").write_text(str(index), encoding="ascii")
+    client, _, _ = _client(tmp_path, scan_work_limit=1)
+
+    response = client.post(
+        "/api/truth/cowork/folders/inspect",
+        json={"folder_path": str(folder)},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "unavailable"
+    assert payload["reason_code"] == "folder_too_large_for_safe_setup"
+    assert payload["actions"] == ["choose_narrower_folder"]
+    # The refusal carries an action and no authority: a scan that stopped
+    # early proved nothing about the tree, so it cannot mint a token that
+    # setup would spend.
+    assert "inspection_token" not in payload
+
+
+def test_folder_growth_after_the_token_is_minted_still_refuses_setup(
+    tmp_path: Path,
+) -> None:
+    folder = tmp_path / "growing"
+    folder.mkdir()
+    client, _, _ = _client(
+        tmp_path,
+        scan_work_limit=project_store._SCAN_DIRECTORY_WEIGHT,
+    )
+
+    inspected = client.post(
+        "/api/truth/cowork/folders/inspect",
+        json={"folder_path": str(folder)},
+    ).get_json()
+    assert inspected["status"] == "uninitialized"
+
+    (folder / "child").mkdir()
+    refused = client.post(
+        "/api/truth/cowork/folders/initialize",
+        json={
+            "inspection_token": inspected["inspection_token"],
+            "idempotency_key": "grew-past-the-work-limit",
+        },
+    )
+
+    assert refused.status_code == 409
+    assert refused.get_json()["error"]["code"] == "folder_changed"
+    assert not (folder / ".wbuddy").exists()
 
 
 def test_nested_folder_boundary_details_survive_the_http_contract(

--- a/tests/unit/cowork/test_project_store.py
+++ b/tests/unit/cowork/test_project_store.py
@@ -2,16 +2,21 @@
 
 from __future__ import annotations
 
+import errno
 import os
 import shutil
 import subprocess
+import time
 from pathlib import Path
+from typing import Callable
 
 import pytest
 import yaml
 
+from work_buddy.cowork import project_store
 from work_buddy.cowork.project_store import (
     COMPONENT_GITIGNORE_LINES,
+    DEFAULT_TOKEN_TTL_SECONDS,
     FolderLifecycleError,
     ProjectStoreManager,
     patch_cowork_manifest,
@@ -87,6 +92,117 @@ def _remove_directory_redirect(link: Path) -> None:
         os.rmdir(link)
     else:
         link.unlink()
+
+
+class _PhantomDirectoryEntry:
+    """An entry naming a subdirectory the filesystem does not have.
+
+    Its metadata is borrowed from a real directory, so the scan accepts it and
+    queues it, and the lookup only fails once the scan tries to read it.
+    """
+
+    def __init__(self, name: str, borrowed: os.stat_result) -> None:
+        self.name = name
+        self._borrowed = borrowed
+
+    def stat(self, **_kwargs: object) -> os.stat_result:
+        return self._borrowed
+
+    def is_dir(self, **_kwargs: object) -> bool:
+        return True
+
+    def is_symlink(self) -> bool:
+        return False
+
+
+class _RaisingEntry:
+    """A directory entry whose every metadata lookup raises one chosen error."""
+
+    def __init__(self, name: str, error: OSError) -> None:
+        self.name = name
+        self._error = error
+
+    def stat(self, **_kwargs: object) -> os.stat_result:
+        raise self._error
+
+    def is_dir(self, **_kwargs: object) -> bool:
+        raise self._error
+
+    def is_symlink(self) -> bool:
+        raise self._error
+
+
+class _FileEntryWithoutMetadata:
+    """A file entry that answers the directory question and nothing else.
+
+    Reading a file's metadata raises, so a scan that consults it fails loudly
+    rather than paying for facts a file can never make relevant.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def is_dir(self, **_kwargs: object) -> bool:
+        return False
+
+    def stat(self, **_kwargs: object) -> os.stat_result:
+        raise AssertionError(f"{self.name} metadata was read")
+
+    def is_symlink(self) -> bool:
+        raise AssertionError(f"{self.name} redirection was read")
+
+
+def _instrument_scandir(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    directory: Path | None = None,
+    rewrite: Callable[[list[object]], list[object]] | None = None,
+) -> list[Path]:
+    """Record every directory the scan lists, optionally rewriting one listing.
+
+    ``rewrite`` sees the entries yielded for ``directory`` and returns what the
+    caller should observe, which is how a vanished or unreadable entry is
+    staged without depending on the platform's caching of ``scandir`` metadata.
+    Every other listing is handed straight to the real ``os.scandir``.
+    """
+
+    real = os.scandir
+    listed: list[Path] = []
+    target = directory.resolve() if directory is not None else None
+
+    class _Listing:
+        def __init__(self, path: object) -> None:
+            self._inner = real(path)
+
+        def __enter__(self) -> list[object]:
+            assert rewrite is not None
+            return rewrite(list(self._inner.__enter__()))
+
+        def __exit__(self, *exc_info: object) -> None:
+            self._inner.__exit__(*exc_info)
+
+    def scandir(path: object = ".", *args: object, **kwargs: object) -> object:
+        if args or kwargs:
+            return real(path, *args, **kwargs)
+        here = Path(os.fspath(path))
+        listed.append(here)
+        if target is not None and rewrite is not None and here.resolve() == target:
+            return _Listing(path)
+        return real(path)
+
+    monkeypatch.setattr(project_store.os, "scandir", scandir)
+    return listed
+
+
+def _count_listings(listed: list[Path], directory: Path) -> int:
+    resolved = directory.resolve()
+    return sum(1 for path in listed if path.resolve() == resolved)
+
+
+def _surviving_cursors(manager: ProjectStoreManager) -> list[Path]:
+    """Scan cursors still on disk, tolerating a directory never written to."""
+
+    return sorted(manager.scan_dir.glob("*.json"))
 
 
 def test_manifest_patch_preserves_unowned_bytes_and_comments(tmp_path: Path) -> None:
@@ -390,7 +506,9 @@ def test_setup_preserves_unrelated_manifest_component(tmp_path: Path) -> None:
     assert yaml.safe_load(published)["components"]["cowork"] == {"path": "cowork"}
 
 
-def test_descendant_scan_is_resumable_and_hard_limit_is_terminal(tmp_path: Path) -> None:
+def test_a_paged_descendant_scan_resumes_onto_a_nested_boundary(
+    tmp_path: Path,
+) -> None:
     parent = tmp_path / "parent"
     parent.mkdir()
     for index in range(5):
@@ -399,8 +517,7 @@ def test_descendant_scan_is_resumable_and_hard_limit_is_terminal(tmp_path: Path)
     nested_root.mkdir()
     manager = ProjectStoreManager(
         data_root=tmp_path / "machine",
-        scan_budget=1,
-        scan_hard_limit=100,
+        scan_work_per_page=1,
     )
     registry = TruthStoreRegistry(tmp_path / "registry.db")
     nested_inspection = manager.inspect(nested_root)
@@ -426,18 +543,598 @@ def test_descendant_scan_is_resumable_and_hard_limit_is_terminal(tmp_path: Path)
     assert result.boundaries == (expected_boundary,)
     assert result.to_dict()["boundaries"] == [expected_boundary]
 
+
+def test_a_folder_past_the_work_limit_refuses_terminally(tmp_path: Path) -> None:
     too_large = tmp_path / "too-large"
     too_large.mkdir()
     for index in range(4):
         (too_large / f"entry-{index}.txt").write_text(str(index), encoding="ascii")
-    capped = ProjectStoreManager(
-        data_root=tmp_path / "other-machine",
-        scan_budget=1,
-        scan_hard_limit=2,
-    ).inspect(too_large)
+    manager = ProjectStoreManager(
+        data_root=tmp_path / "machine",
+        scan_work_per_page=1,
+        # Room to open the folder and list two of its entries.
+        scan_work_limit=project_store._SCAN_DIRECTORY_WEIGHT + 2,
+    )
+
+    capped = manager.inspect(too_large)
+
     assert capped.status == "unavailable"
     assert capped.reason_code == "folder_too_large_for_safe_setup"
     assert capped.continuation_token is None
+    assert _surviving_cursors(manager) == []
+
+
+@pytest.mark.parametrize("width", [1, 3])
+def test_a_directory_and_an_entry_are_charged_the_measured_ratio(
+    tmp_path: Path,
+    width: int,
+) -> None:
+    weight = project_store._SCAN_DIRECTORY_WEIGHT
+    shapes = {
+        # Opening the folder, listing its entries, then opening each empty
+        # child.
+        "directories": weight * (width + 1) + width,
+        # Opening the folder and listing its entries.
+        "files": weight + width,
+    }
+    directories = tmp_path / "directories"
+    directories.mkdir()
+    for index in range(width):
+        (directories / f"child-{index}").mkdir()
+    files = tmp_path / "files"
+    files.mkdir()
+    for index in range(width):
+        (files / f"entry-{index}.txt").write_text(str(index), encoding="ascii")
+
+    for name, expected_work in shapes.items():
+        folder = tmp_path / name
+        afforded = ProjectStoreManager(
+            data_root=tmp_path / f"{name}-afforded",
+            scan_work_limit=expected_work,
+        ).inspect(folder)
+        assert afforded.status == "uninitialized", name
+
+        starved = ProjectStoreManager(
+            data_root=tmp_path / f"{name}-starved",
+            scan_work_limit=expected_work - 1,
+        ).inspect(folder)
+        assert starved.status == "unavailable", name
+        assert starved.reason_code == "folder_too_large_for_safe_setup", name
+
+
+def test_a_tree_of_empty_directories_is_bounded_by_the_page_budget(
+    tmp_path: Path,
+) -> None:
+    folder = tmp_path / "hollow"
+    folder.mkdir()
+    for index in range(6):
+        (folder / f"child-{index}").mkdir()
+    manager = ProjectStoreManager(
+        data_root=tmp_path / "machine",
+        scan_work_per_page=project_store._SCAN_DIRECTORY_WEIGHT,
+    )
+
+    result = manager.inspect(folder)
+    pages = 1
+    while result.status == "inspection_pending":
+        result = manager.inspect(folder, continuation_token=result.continuation_token)
+        pages += 1
+
+    assert result.status == "uninitialized"
+    # Directories carry weight, so a tree that lists almost no entries still
+    # pages instead of running its whole walk inside one request.
+    assert pages == 7
+
+
+def test_the_work_limit_is_not_floored_to_the_page_budget(tmp_path: Path) -> None:
+    folder = tmp_path / "wide"
+    folder.mkdir()
+    for index in range(4):
+        (folder / f"entry-{index}.txt").write_text(str(index), encoding="ascii")
+    manager = ProjectStoreManager(
+        data_root=tmp_path / "machine",
+        scan_work_per_page=10_000,
+        scan_work_limit=1,
+    )
+
+    assert manager.scan_work_limit == 1
+
+    result = manager.inspect(folder)
+
+    assert result.status == "unavailable"
+    assert result.reason_code == "folder_too_large_for_safe_setup"
+
+
+def test_the_work_limit_stops_an_unpaged_scan(tmp_path: Path) -> None:
+    folder = tmp_path / "deep"
+    folder.mkdir()
+    for index in range(4):
+        (folder / f"child-{index}").mkdir()
+    manager = ProjectStoreManager(
+        data_root=tmp_path / "machine",
+        scan_work_limit=project_store._SCAN_DIRECTORY_WEIGHT * 2,
+    )
+
+    result = manager.inspect(folder, complete_scan=True)
+
+    assert result.status == "unavailable"
+    assert result.reason_code == "folder_too_large_for_safe_setup"
+    assert result.continuation_token is None
+    assert _surviving_cursors(manager) == []
+
+
+def test_the_work_limit_counts_work_spent_on_earlier_pages(tmp_path: Path) -> None:
+    """The threshold is reached by the whole scan, not by one page of it.
+
+    The launcher polls a paged scan, so the resumed walk is the only path a
+    person takes. Each continuation restores the running total from the
+    cursor; a walk that started every page from zero would spend an unbounded
+    amount of work in total while no single page ever reached the threshold,
+    and an arbitrarily large folder would classify as a setup candidate.
+    """
+
+    folder = tmp_path / "paged-wide"
+    folder.mkdir()
+    for index in range(4):
+        (folder / f"child-{index}").mkdir()
+    weight = project_store._SCAN_DIRECTORY_WEIGHT
+    manager = ProjectStoreManager(
+        data_root=tmp_path / "machine",
+        # One directory per page, so each page opens exactly one directory.
+        scan_work_per_page=1,
+        # Room to open the folder, list its four entries, and open two of the
+        # four children. The third child crosses the threshold, and it is the
+        # fourth page that opens it.
+        scan_work_limit=weight * 3 + 4,
+    )
+
+    result = manager.inspect(folder)
+    pages = 1
+    while result.status == "inspection_pending":
+        result = manager.inspect(folder, continuation_token=result.continuation_token)
+        pages += 1
+
+    assert result.status == "unavailable"
+    assert result.reason_code == "folder_too_large_for_safe_setup"
+    assert pages == 4
+    assert result.continuation_token is None
+    assert _surviving_cursors(manager) == []
+
+
+def test_the_scan_weight_and_both_budgets_are_pinned() -> None:
+    """The numbers the whole budget rests on are named, not incidental.
+
+    The directory weight is a measured ratio between opening a directory and
+    reading one entry out of an already open listing, so it describes the
+    hardware rather than a caller's preference. Both budgets are counted in
+    those units and derived from the weight, which is what makes a page of
+    directories and a page of files take comparable wall time.
+    """
+
+    assert project_store._SCAN_DIRECTORY_WEIGHT == 40
+    assert project_store.DEFAULT_SCAN_WORK_PER_PAGE == 20_000
+    assert project_store.DEFAULT_SCAN_WORK_LIMIT == 750_000
+    # A page affords five hundred directory opens.
+    assert (
+        project_store.DEFAULT_SCAN_WORK_PER_PAGE
+        == project_store._SCAN_DIRECTORY_WEIGHT * 500
+    )
+    # The refusal threshold affords eighteen thousand seven hundred and fifty.
+    assert (
+        project_store.DEFAULT_SCAN_WORK_LIMIT
+        == project_store._SCAN_DIRECTORY_WEIGHT * 18_750
+    )
+
+
+def test_scan_progress_counts_entries_rather_than_work(tmp_path: Path) -> None:
+    folder = tmp_path / "wide"
+    folder.mkdir()
+    for index in range(3):
+        (folder / f"child-{index}").mkdir()
+    manager = ProjectStoreManager(
+        data_root=tmp_path / "machine",
+        scan_work_per_page=1,
+    )
+
+    first = manager.inspect(folder)
+
+    assert first.status == "inspection_pending"
+    # One directory was opened and three entries were listed, which costs far
+    # more than three work units. Progress reports the items a person can
+    # recognize in the folder they picked.
+    assert first.progress == {"visited": 3, "visited_entries": 3}
+
+
+def test_directory_changed_while_listed_is_rescanned_without_double_queueing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    folder = tmp_path / "racy"
+    (folder / "child").mkdir(parents=True)
+    (folder / "child" / "leaf.txt").write_text("throwaway\n", encoding="utf-8")
+    disturbances: list[int] = []
+
+    def disturb(entries: list[object]) -> list[object]:
+        if not disturbances:
+            disturbances.append(1)
+            stamp = folder.stat().st_mtime + 60
+            os.utime(folder, (stamp, stamp))
+        return entries
+
+    listed = _instrument_scandir(monkeypatch, directory=folder, rewrite=disturb)
+    manager = ProjectStoreManager(data_root=tmp_path / "machine")
+
+    result = manager.inspect(folder)
+
+    assert result.status == "uninitialized"
+    assert disturbances == [1]
+    # The changed directory is read twice, and the child it yielded is queued
+    # by the successful read alone.
+    assert _count_listings(listed, folder) == 2
+    assert _count_listings(listed, folder / "child") == 1
+
+
+def test_relentlessly_changing_directory_exhausts_its_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    folder = tmp_path / "churning"
+    folder.mkdir()
+    for index in range(3):
+        (folder / f"entry-{index}.txt").write_text("throwaway\n", encoding="utf-8")
+
+    def disturb(entries: list[object]) -> list[object]:
+        stamp = folder.stat().st_mtime + 60
+        os.utime(folder, (stamp, stamp))
+        return entries
+
+    _instrument_scandir(monkeypatch, directory=folder, rewrite=disturb)
+    manager = ProjectStoreManager(data_root=tmp_path / "machine", scan_work_per_page=1)
+    allowance = project_store._SCAN_DIRECTORY_RETRY_LIMIT
+    token: str | None = None
+    pages = 0
+
+    with pytest.raises(FolderLifecycleError) as failure:
+        for _ in range(allowance + 3):
+            pending = manager.inspect(folder, continuation_token=token)
+            assert pending.status == "inspection_pending"
+            pages += 1
+            token = pending.continuation_token
+
+    assert failure.value.code == "descendant_scan_incomplete"
+    assert failure.value.retryable is True
+    # Each retry lands on its own page, so the count is carried by the cursor.
+    assert pages == allowance
+    assert _surviving_cursors(manager) == []
+
+
+def test_entry_that_vanishes_mid_listing_does_not_abort_the_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    folder = tmp_path / "vanishing"
+    folder.mkdir()
+    (folder / "gone.txt").write_text("throwaway\n", encoding="utf-8")
+    (folder / "sibling").mkdir()
+
+    def vanish(entries: list[object]) -> list[object]:
+        return [
+            _RaisingEntry(entry.name, FileNotFoundError(errno.ENOENT, "gone"))
+            if entry.name == "gone.txt"
+            else entry
+            for entry in entries
+        ]
+
+    listed = _instrument_scandir(monkeypatch, directory=folder, rewrite=vanish)
+    manager = ProjectStoreManager(data_root=tmp_path / "machine")
+
+    result = manager.inspect(folder)
+
+    assert result.status == "uninitialized"
+    assert _count_listings(listed, folder / "sibling") == 1
+
+
+def test_directory_that_vanishes_before_it_is_read_does_not_abort_the_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    folder = tmp_path / "shrinking"
+    survivor = folder / "survivor"
+    survivor.mkdir(parents=True)
+    borrowed = survivor.stat()
+
+    def add_phantom(entries: list[object]) -> list[object]:
+        # A listing names a subdirectory that is gone by the time the scan pops
+        # it off the queue. Deleting a real directory cannot stage this: a
+        # platform may keep serving a delete-pending handle, so the race would
+        # not reliably reach the queued-then-missing path.
+        return [*entries, _PhantomDirectoryEntry("ghost", borrowed)]
+
+    listed = _instrument_scandir(monkeypatch, directory=folder, rewrite=add_phantom)
+    manager = ProjectStoreManager(data_root=tmp_path / "machine")
+
+    result = manager.inspect(folder)
+
+    assert result.status == "uninitialized"
+    assert _count_listings(listed, folder / "ghost") == 0
+    assert _count_listings(listed, survivor) == 1
+
+
+def test_unreadable_entry_stops_the_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    folder = tmp_path / "guarded"
+    folder.mkdir()
+    (folder / "sealed").mkdir()
+
+    def seal(entries: list[object]) -> list[object]:
+        return [
+            _RaisingEntry(entry.name, PermissionError(errno.EACCES, "denied"))
+            if entry.name == "sealed"
+            else entry
+            for entry in entries
+        ]
+
+    _instrument_scandir(monkeypatch, directory=folder, rewrite=seal)
+    manager = ProjectStoreManager(data_root=tmp_path / "machine")
+
+    with pytest.raises(FolderLifecycleError) as failure:
+        manager.inspect(folder)
+
+    assert failure.value.code == "descendant_scan_incomplete"
+    assert _surviving_cursors(manager) == []
+
+
+def test_every_boundary_in_one_page_is_reported_together(tmp_path: Path) -> None:
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    manager = ProjectStoreManager(data_root=tmp_path / "machine")
+    registry = TruthStoreRegistry(tmp_path / "registry.db")
+    stores = {}
+    for name in ("alpha", "beta"):
+        boundary = parent / name
+        boundary.mkdir()
+        inspected = manager.inspect(boundary)
+        stores[name] = manager.initialize(
+            boundary,
+            registry=registry,
+            inspection_fingerprint=inspected.fingerprint or "",
+            idempotency_key=f"sibling-{name}",
+        )
+
+    result = manager.inspect(parent)
+
+    assert result.status == "contains_nested_folder"
+    assert result.progress == {"nested_count": 2}
+    assert [boundary["folder_name"] for boundary in result.boundaries] == [
+        "alpha",
+        "beta",
+    ]
+    assert [boundary["store_id"] for boundary in result.boundaries] == [
+        stores["alpha"].store_id,
+        stores["beta"].store_id,
+    ]
+    assert len(result.to_dict()["boundaries"]) == 2
+
+
+def test_a_boundary_interior_is_left_unwalked(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent = tmp_path / "parent"
+    boundary = parent / "boundary"
+    interior = boundary / "interior"
+    (interior / "deeper").mkdir(parents=True)
+    sibling = parent / "sibling"
+    sibling.mkdir()
+    manager = ProjectStoreManager(data_root=tmp_path / "machine")
+    registry = TruthStoreRegistry(tmp_path / "registry.db")
+    inspected = manager.inspect(boundary)
+    manager.initialize(
+        boundary,
+        registry=registry,
+        inspection_fingerprint=inspected.fingerprint or "",
+        idempotency_key="boundary-interior",
+    )
+    listed = _instrument_scandir(monkeypatch)
+
+    result = manager.inspect(parent)
+
+    assert result.status == "contains_nested_folder"
+    assert _count_listings(listed, interior) == 0
+    assert _count_listings(listed, interior / "deeper") == 0
+    assert _count_listings(listed, sibling) == 1
+
+
+def test_a_boundary_listing_is_read_and_its_children_are_dropped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent = tmp_path / "parent"
+    boundary = parent / "boundary"
+    boundary.mkdir(parents=True)
+    manager = ProjectStoreManager(data_root=tmp_path / "machine")
+    registry = TruthStoreRegistry(tmp_path / "registry.db")
+    inspected = manager.inspect(boundary)
+    manager.initialize(
+        boundary,
+        registry=registry,
+        inspection_fingerprint=inspected.fingerprint or "",
+        idempotency_key="boundary-children",
+    )
+    children = [boundary / f"child-{index}" for index in range(3)]
+    for child in children:
+        child.mkdir()
+    listed = _instrument_scandir(monkeypatch)
+
+    result = manager.inspect(parent)
+
+    assert result.status == "contains_nested_folder"
+    assert [entry["folder_name"] for entry in result.boundaries] == ["boundary"]
+    # The boundary's own listing is what identifies it, and the children that
+    # listing yields belong to its store, so none of them is queued.
+    assert _count_listings(listed, boundary) == 1
+    assert [_count_listings(listed, child) for child in children] == [0, 0, 0]
+
+
+def test_a_component_child_without_a_store_is_not_a_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent = tmp_path / "parent"
+    bare = parent / "bare"
+    (bare / ".wbuddy").mkdir(parents=True)
+    (bare / "interior").mkdir()
+    partial = parent / "partial"
+    (partial / ".wbuddy" / "cowork").mkdir(parents=True)
+    (partial / "interior").mkdir()
+    listed = _instrument_scandir(monkeypatch)
+    manager = ProjectStoreManager(data_root=tmp_path / "machine")
+
+    result = manager.inspect(parent)
+
+    assert result.status == "uninitialized"
+    assert result.boundaries == ()
+    assert _count_listings(listed, bare / "interior") == 1
+    assert _count_listings(listed, partial / "interior") == 1
+
+
+def test_a_directory_naming_no_component_child_is_never_probed_for_a_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent = tmp_path / "parent"
+    (parent / "plain" / "deeper").mkdir(parents=True)
+    (parent / "notes.md").write_text("throwaway\n", encoding="utf-8")
+    holder = parent / "holder"
+    (holder / ".wbuddy").mkdir(parents=True)
+    probed: list[str] = []
+    real_probe = project_store._is_store_root
+
+    def record(scan_root: Path, directory: str) -> bool:
+        probed.append(Path(directory).name)
+        return real_probe(scan_root, directory)
+
+    monkeypatch.setattr(project_store, "_is_store_root", record)
+    manager = ProjectStoreManager(data_root=tmp_path / "machine")
+
+    result = manager.inspect(parent)
+
+    assert result.status == "uninitialized"
+    # A listing that never names the component child answers the boundary
+    # question by itself, so only the one directory that names it is probed.
+    assert probed == ["holder"]
+
+
+def test_a_redirected_component_child_is_refused_without_traversal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent = tmp_path / "parent"
+    descendant = parent / "descendant"
+    descendant.mkdir(parents=True)
+    target = tmp_path / "external"
+    interior = target / "cowork"
+    interior.mkdir(parents=True)
+    (interior / "store.yaml").write_text("store_id: outside\n", encoding="utf-8")
+    link = descendant / ".wbuddy"
+    _make_directory_redirect(link, target)
+    listed = _instrument_scandir(monkeypatch)
+    manager = ProjectStoreManager(data_root=tmp_path / "machine")
+    try:
+        with pytest.raises(FolderLifecycleError) as failure:
+            manager.inspect(parent)
+    finally:
+        _remove_directory_redirect(link)
+
+    assert failure.value.code == "folder_layout_incomplete"
+    assert _count_listings(listed, target) == 0
+    assert _count_listings(listed, interior) == 0
+
+
+def test_a_file_entry_is_classified_without_reading_its_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    folder = tmp_path / "documents"
+    folder.mkdir()
+    (folder / "notes.md").write_text("throwaway\n", encoding="utf-8")
+    (folder / "sibling").mkdir()
+
+    def hide_metadata(entries: list[object]) -> list[object]:
+        return [
+            _FileEntryWithoutMetadata(entry.name)
+            if entry.name == "notes.md"
+            else entry
+            for entry in entries
+        ]
+
+    listed = _instrument_scandir(monkeypatch, directory=folder, rewrite=hide_metadata)
+    manager = ProjectStoreManager(data_root=tmp_path / "machine")
+
+    result = manager.inspect(folder)
+
+    assert result.status == "uninitialized"
+    assert _count_listings(listed, folder / "sibling") == 1
+
+
+def test_a_continuation_page_reuses_the_settled_ownership_answer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    folder = tmp_path / "wide"
+    folder.mkdir()
+    for index in range(4):
+        (folder / f"child-{index}").mkdir()
+    manager = ProjectStoreManager(data_root=tmp_path / "machine", scan_work_per_page=1)
+
+    first = manager.inspect(folder)
+    assert first.status == "inspection_pending"
+
+    owner_calls: list[Path] = []
+    real_owner = ProjectStoreManager._nearest_owner
+
+    def record(self: ProjectStoreManager, root: Path) -> object:
+        owner_calls.append(root)
+        return real_owner(self, root)
+
+    monkeypatch.setattr(ProjectStoreManager, "_nearest_owner", record)
+    result = manager.inspect(folder, continuation_token=first.continuation_token)
+    while result.status == "inspection_pending":
+        result = manager.inspect(folder, continuation_token=result.continuation_token)
+
+    assert result.status == "uninitialized"
+    # The page that minted the token proved no ancestor owns the folder, so a
+    # continuation asks the ancestors nothing.
+    assert owner_calls == []
+
+
+def test_scan_cursors_outlive_their_token_no_longer_than_its_lifetime(
+    tmp_path: Path,
+) -> None:
+    folder = tmp_path / "wide"
+    folder.mkdir()
+    for index in range(4):
+        (folder / f"child-{index}").mkdir()
+    machine = tmp_path / "machine"
+    scan_dir = ProjectStoreManager(data_root=machine).scan_dir
+    scan_dir.mkdir(parents=True, exist_ok=True)
+    abandoned = scan_dir / f"{'a' * 32}.json"
+    live = scan_dir / f"{'b' * 32}.json"
+    for cursor in (abandoned, live):
+        cursor.write_text("{}", encoding="utf-8")
+    expired = time.time() - DEFAULT_TOKEN_TTL_SECONDS - 60
+    os.utime(abandoned, (expired, expired))
+
+    manager = ProjectStoreManager(data_root=machine, scan_work_per_page=1)
+    assert abandoned.exists(), "constructing a manager stays free of filesystem work"
+
+    result = manager.inspect(folder)
+
+    assert result.status == "inspection_pending"
+    assert not abandoned.exists()
+    assert live.exists()
 
 
 def test_manifest_compare_and_swap_rejects_changed_bytes(tmp_path: Path) -> None:
@@ -455,3 +1152,324 @@ def test_manifest_compare_and_swap_rejects_changed_bytes(tmp_path: Path) -> None
     with pytest.raises(FolderLifecycleError, match="changed") as failure:
         patch_cowork_manifest(tmp_path, expected_sha256=snapshot.sha256)
     assert failure.value.code == "folder_changed"
+
+
+def test_setup_without_a_prior_observation_names_an_oversized_folder(
+    tmp_path: Path,
+) -> None:
+    """A caller that showed the folder to nobody is refused on what it is.
+
+    The walk inside the folder operation locks classifies the folder as too
+    large to prove anything about, and the refusal carries that
+    classification's own code and an action the caller can take, instead of
+    reporting a change nobody made.
+    """
+
+    folder = tmp_path / "wide-folder"
+    folder.mkdir()
+    for index in range(4):
+        (folder / f"item-{index}").write_text("x", encoding="utf-8")
+    registry = TruthStoreRegistry(tmp_path / "registry.db")
+    manager = ProjectStoreManager(
+        data_root=tmp_path / "machine",
+        # Opening the folder fits the threshold; the entries it lists do not.
+        scan_work_limit=project_store._SCAN_DIRECTORY_WEIGHT,
+    )
+
+    with pytest.raises(FolderLifecycleError) as failure:
+        manager.initialize(
+            folder,
+            registry=registry,
+            inspection_fingerprint=None,
+            idempotency_key="oversized-unobserved",
+        )
+
+    assert failure.value.code == "folder_too_large_for_safe_setup"
+    assert failure.value.retryable is False
+    message = str(failure.value)
+    assert "too many items" in message
+    assert "narrower folder" in message
+    assert not (folder / ".wbuddy").exists()
+    assert registry.list_stores(refresh=False) == ()
+
+
+def test_setup_after_an_observation_reports_the_folder_changing(
+    tmp_path: Path,
+) -> None:
+    """A caller holding a fingerprint is refused in the fingerprint's terms.
+
+    The fingerprint says a human was shown this folder, so the refusal speaks
+    to that observation rather than to the classification. The branch is
+    chosen by the presence of the observation, not by the folder's status,
+    which is why the same oversized folder answers both ways.
+    """
+
+    folder = tmp_path / "observed-wide-folder"
+    folder.mkdir()
+    for index in range(4):
+        (folder / f"item-{index}").write_text("x", encoding="utf-8")
+    registry = TruthStoreRegistry(tmp_path / "registry.db")
+    manager = ProjectStoreManager(
+        data_root=tmp_path / "machine",
+        scan_work_limit=project_store._SCAN_DIRECTORY_WEIGHT,
+    )
+    inspected = manager.inspect(folder, complete_scan=True)
+    assert inspected.status == "unavailable"
+    assert inspected.fingerprint is not None
+
+    with pytest.raises(FolderLifecycleError) as failure:
+        manager.initialize(
+            folder,
+            registry=registry,
+            inspection_fingerprint=inspected.fingerprint,
+            idempotency_key="oversized-observed",
+        )
+
+    assert failure.value.code == "folder_changed"
+    assert "no longer available for setup" in str(failure.value)
+    assert not (folder / ".wbuddy").exists()
+    assert registry.list_stores(refresh=False) == ()
+
+
+def test_setup_without_a_prior_observation_still_refuses_an_initialized_folder(
+    tmp_path: Path,
+) -> None:
+    """Dropping the fingerprint drops no protection.
+
+    Safety rests on the walk under the folder operation locks, which
+    classifies the folder from the filesystem and refuses anything that is not
+    an empty candidate. A caller passing no fingerprint is refused by that
+    walk and leaves the folder byte-identical.
+    """
+
+    folder = tmp_path / "already-set-up"
+    folder.mkdir()
+    registry = TruthStoreRegistry(tmp_path / "registry.db")
+    manager = ProjectStoreManager(data_root=tmp_path / "machine")
+    inspected = manager.inspect(folder)
+    seeded = manager.initialize(
+        folder,
+        registry=registry,
+        inspection_fingerprint=inspected.fingerprint or "",
+        idempotency_key="seed-initialized",
+    )
+    before = _tree_bytes(folder)
+
+    with pytest.raises(FolderLifecycleError) as failure:
+        manager.initialize(
+            folder,
+            registry=registry,
+            inspection_fingerprint=None,
+            idempotency_key="initialized-unobserved",
+        )
+
+    assert failure.value.code == "folder_already_initialized"
+    assert failure.value.retryable is False
+    assert "already set up" in str(failure.value)
+    assert _tree_bytes(folder) == before
+    assert [row.store_id for row in registry.list_stores(refresh=False)] == [
+        seeded.store_id
+    ]
+
+
+def test_settled_setup_refusals_stay_out_of_the_transient_retry_vocabulary() -> None:
+    """A refusal about a settled fact must not read as worth retrying.
+
+    ``FolderLifecycleError`` is a ``RuntimeError``, and error classification
+    falls back to reading a ``RuntimeError``'s message for transient wording.
+    A refusal whose prose matched would be queued for retry against a folder
+    whose answer cannot change without the user acting on it.
+    """
+
+    from work_buddy.errors import classify_error
+
+    folder = Path("/scan-target")
+    classifications = (
+        project_store.FolderInspection("initialized", folder, folder.name),
+        project_store.FolderInspection("inside_existing_folder", folder, folder.name),
+        project_store.FolderInspection(
+            "contains_nested_folder",
+            folder,
+            folder.name,
+            reason_code="contains_nested_folder",
+        ),
+        project_store.FolderInspection(
+            "unavailable",
+            folder,
+            folder.name,
+            reason_code="folder_too_large_for_safe_setup",
+        ),
+        project_store.FolderInspection(
+            "collision",
+            folder,
+            folder.name,
+            reason_code="folder_layout_incomplete",
+        ),
+        project_store.FolderInspection(
+            "collision",
+            folder,
+            folder.name,
+            reason_code="identity_conflict",
+        ),
+    )
+
+    for classification in classifications:
+        assert (
+            classification.reason_code
+            not in project_store._RETRYABLE_SETUP_REFUSALS
+        )
+        refusal = project_store._setup_refusal(classification, observed=False)
+        assert refusal.retryable is False, str(refusal)
+        assert refusal.status == 409, str(refusal)
+        assert classify_error(refusal) != "transient", str(refusal)
+
+
+def test_an_unread_folder_is_refused_as_unread_rather_than_as_broken() -> None:
+    """Failing to read the folder is a different answer from reading it.
+
+    ``folder_unreachable`` says the Work Buddy data could not be read, so
+    nothing is known about whether that data is complete. Answering it with the
+    collision prose would tell an agent to repair a store that was only held
+    open for a moment, and an agent reads the exception text and nothing else.
+    """
+
+    from work_buddy.errors import classify_error
+
+    folder = Path("/scan-target")
+    unreachable = project_store.FolderInspection(
+        "collision",
+        folder,
+        folder.name,
+        reason_code="folder_unreachable",
+    )
+
+    refusal = project_store._setup_refusal(unreachable, observed=False)
+
+    assert refusal.code == "folder_unreachable"
+    assert refusal.retryable is True
+    assert refusal.status == 503
+    message = str(refusal)
+    assert "temporarily unavailable" in message
+    assert "again in a moment" in message
+    assert "Repair" not in message
+    # The retry queue reads a ``RuntimeError``'s message, and this one names a
+    # failure that clears on its own.
+    assert classify_error(refusal) == "transient"
+
+
+def test_contradictory_store_records_are_not_called_incomplete() -> None:
+    """An identity conflict is its own repair, not an incomplete layout.
+
+    The records were read; they disagree. Folding that into the incomplete
+    layout prose would send a caller looking for missing data instead of
+    contradictory data.
+    """
+
+    folder = Path("/scan-target")
+    conflict = project_store.FolderInspection(
+        "collision",
+        folder,
+        folder.name,
+        reason_code="identity_conflict",
+    )
+
+    refusal = project_store._setup_refusal(conflict, observed=False)
+
+    assert refusal.code == "identity_conflict"
+    assert refusal.retryable is False
+    assert refusal.status == 409
+    message = str(refusal)
+    assert "disagree about which store" in message
+    assert "does not form a" not in message
+
+
+def test_setup_refuses_an_unreadable_manifest_as_a_transient_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The whole path from a failed read to the caller's refusal stays transient.
+
+    A healthy folder whose manifest is momentarily locked by another process
+    classifies as ``folder_unreachable``, and setup is the caller that turns a
+    classification into an exception. The refusal it hands back has to keep
+    the retryable 503 the classification carried, because the very next
+    attempt is expected to succeed.
+    """
+
+    folder = tmp_path / "locked-manifest"
+    (folder / ".wbuddy").mkdir(parents=True)
+    manifest = folder / ".wbuddy" / "manifest.yaml"
+    manifest.write_text(
+        "format: wbuddy-folder/v1\ncomponents:\n  cowork: {path: cowork}\n",
+        encoding="utf-8",
+    )
+    registry = TruthStoreRegistry(tmp_path / "registry.db")
+    manager = ProjectStoreManager(data_root=tmp_path / "machine")
+    real_read_bytes = Path.read_bytes
+
+    def refuse_the_manifest(self: Path) -> bytes:
+        if self.name == "manifest.yaml":
+            raise OSError(errno.EACCES, "manifest held open by another process")
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", refuse_the_manifest)
+
+    with pytest.raises(FolderLifecycleError) as failure:
+        manager.initialize(
+            folder,
+            registry=registry,
+            inspection_fingerprint=None,
+            idempotency_key="unreadable-manifest",
+        )
+
+    assert failure.value.code == "folder_unreachable"
+    assert failure.value.retryable is True
+    assert failure.value.status == 503
+    assert "temporarily unavailable" in str(failure.value)
+    assert not (folder / ".wbuddy" / "cowork").exists()
+    assert registry.list_stores(refresh=False) == ()
+
+
+def test_every_retryable_setup_refusal_is_a_code_setup_can_reach() -> None:
+    """The retryable set has to name codes that reach ``_setup_refusal``.
+
+    Setup composes its refusal from a ``FolderInspection``, so a code reaches
+    the lookup only if a classification carries it as a ``reason_code``. A code
+    that exists only as a raised exception makes the lookup unconditionally
+    false and leaves the retryable branch dead, so the set is pinned against
+    the reason codes a classification can actually carry.
+    """
+
+    classifiable_reason_codes = frozenset(
+        {
+            # Redirected or malformed Work Buddy data under the folder.
+            "folder_layout_incomplete",
+            # The data could not be read at all.
+            "folder_unreachable",
+            # The data was read and contradicts itself.
+            "identity_conflict",
+            # The descendant walk stopped at the work threshold.
+            "folder_too_large_for_safe_setup",
+            # The walk found a store root beneath the folder.
+            "contains_nested_folder",
+        }
+    )
+    retryable = project_store._RETRYABLE_SETUP_REFUSALS
+
+    assert retryable
+    assert retryable <= classifiable_reason_codes
+
+    folder = Path("/scan-target")
+    for code in retryable:
+        refusal = project_store._setup_refusal(
+            project_store.FolderInspection(
+                "collision",
+                folder,
+                folder.name,
+                reason_code=code,
+            ),
+            observed=False,
+        )
+        assert refusal.code == code
+        assert refusal.retryable is True
+        assert refusal.status == 503

--- a/tests/unit/truth/test_ops.py
+++ b/tests/unit/truth/test_ops.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import importlib
 import json
 from pathlib import Path
@@ -9,6 +10,11 @@ import pytest
 from work_buddy.consent import (
     ConsentRequired,
     per_invocation_authorization,
+)
+from work_buddy.cowork import project_store
+from work_buddy.cowork.project_store import (
+    FolderLifecycleError,
+    ProjectStoreManager,
 )
 from work_buddy.mcp_server.op_registry import load_builtin_ops
 from work_buddy.truth.contracts import InvariantViolation
@@ -218,15 +224,158 @@ def test_generic_store_create_rejects_partial_cowork_directory(
     sentinel = partial_canonical / "interrupted-setup"
     sentinel.write_text("preserve", encoding="utf-8")
 
-    with pytest.raises(RuntimeError, match="no longer available"):
+    # The folder is a collision, and the refusal says so: it holds Work Buddy
+    # data that does not form a complete Co-work folder.
+    with pytest.raises(FolderLifecycleError) as failure:
         truth_ops.truth_store_create.__wrapped__(
             str(root),
             _profile("3" * 32),
         )
 
+    assert failure.value.code == "folder_layout_incomplete"
+    assert "does not form a complete Co-work folder" in str(failure.value)
     assert sentinel.read_text(encoding="utf-8") == "preserve"
     assert not (partial_canonical / "store.db").exists()
     assert not (partial_canonical / "store.yaml").exists()
+
+
+def test_store_create_walks_the_folder_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setup pays for one descendant walk, not two.
+
+    The walk that authorizes the write runs inside the folder operation locks
+    and re-classifies the folder from the filesystem. A second walk ahead of
+    it would prove nothing the locked one does not re-prove, and on a large
+    folder it is the dominant cost of the operation.
+    """
+
+    registry = TruthStoreRegistry(tmp_path / "truth-registry.db")
+    monkeypatch.setattr(truth_ops, "_registry", lambda: registry)
+    monkeypatch.setattr(
+        truth_ops,
+        "emit_truth_event",
+        lambda *args, **kwargs: TruthEventEmission("event-create", True),
+    )
+    root = tmp_path / "walked-once"
+    (root / "nested" / "deeper").mkdir(parents=True)
+    (root / "nested" / "note.txt").write_text("content", encoding="utf-8")
+    walks: list[Path] = []
+    real_scan = ProjectStoreManager._scan_descendants
+
+    def record(self: ProjectStoreManager, scanned: Path, **kwargs: object):
+        walks.append(scanned)
+        return real_scan(self, scanned, **kwargs)
+
+    monkeypatch.setattr(ProjectStoreManager, "_scan_descendants", record)
+
+    created = truth_ops.truth_store_create.__wrapped__(
+        str(root),
+        _profile("4" * 32),
+    )
+
+    assert created["store"]["store_id"] == "4" * 32
+    assert [item.resolve() for item in walks] == [root.resolve()]
+
+
+def test_store_create_refuses_an_oversized_folder_with_an_actionable_reason(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An oversized folder is named as oversized, not as a race.
+
+    Setup here holds no earlier observation of the folder, so the refusal
+    carries the classification's own code and prose. The agent reads the
+    exception text and nothing else, so that text names both the folder's
+    state and the action that answers it.
+    """
+
+    registry = TruthStoreRegistry(tmp_path / "truth-registry.db")
+    monkeypatch.setattr(truth_ops, "_registry", lambda: registry)
+    monkeypatch.setattr(
+        truth_ops,
+        "emit_truth_event",
+        lambda *args, **kwargs: TruthEventEmission("event-create", True),
+    )
+    # The manager is built inside the operation with no scan arguments, and it
+    # resolves the module defaults in its body, so lowering the threshold here
+    # reaches it. A refusal proves the threshold moved: at the shipped value
+    # this folder sets up cleanly.
+    monkeypatch.setattr(
+        project_store,
+        "DEFAULT_SCAN_WORK_LIMIT",
+        project_store._SCAN_DIRECTORY_WEIGHT,
+    )
+    root = tmp_path / "too-wide"
+    root.mkdir()
+    for index in range(4):
+        (root / f"item-{index}").write_text("x", encoding="utf-8")
+
+    with pytest.raises(FolderLifecycleError) as failure:
+        truth_ops.truth_store_create.__wrapped__(
+            str(root),
+            _profile("5" * 32),
+        )
+
+    assert failure.value.code == "folder_too_large_for_safe_setup"
+    message = str(failure.value)
+    assert "too many items" in message
+    assert "narrower folder" in message
+    assert not (root / ".wbuddy").exists()
+    assert registry.list_stores(refresh=False) == ()
+
+
+def test_store_create_hands_back_an_unread_folder_as_worth_retrying(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A folder Co-work could not read is refused as unread, not as damaged.
+
+    The agent surface renders the exception type and its text and nothing
+    else, so a healthy folder whose manifest another process held open for a
+    moment has to come back saying exactly that. Reporting it as incomplete
+    Work Buddy data would send an autonomous caller to repair a store the very
+    next call would have read without trouble.
+    """
+
+    registry = TruthStoreRegistry(tmp_path / "truth-registry.db")
+    monkeypatch.setattr(truth_ops, "_registry", lambda: registry)
+    monkeypatch.setattr(
+        truth_ops,
+        "emit_truth_event",
+        lambda *args, **kwargs: TruthEventEmission("event-create", True),
+    )
+    root = tmp_path / "held-open"
+    (root / ".wbuddy").mkdir(parents=True)
+    (root / ".wbuddy" / "manifest.yaml").write_text(
+        "format: wbuddy-folder/v1\ncomponents:\n  cowork: {path: cowork}\n",
+        encoding="utf-8",
+    )
+    real_read_bytes = Path.read_bytes
+
+    def refuse_the_manifest(self: Path) -> bytes:
+        if self.name == "manifest.yaml":
+            raise OSError(errno.EACCES, "held open by another process")
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", refuse_the_manifest)
+
+    with pytest.raises(FolderLifecycleError) as failure:
+        truth_ops.truth_store_create.__wrapped__(
+            str(root),
+            _profile("6" * 32),
+        )
+
+    assert failure.value.code == "folder_unreachable"
+    assert failure.value.retryable is True
+    assert failure.value.status == 503
+    message = str(failure.value)
+    assert "temporarily unavailable" in message
+    assert "again in a moment" in message
+    assert "Repair" not in message
+    assert not (root / ".wbuddy" / "cowork").exists()
+    assert registry.list_stores(refresh=False) == ()
 
 
 def test_agent_capture_validates_locator_and_forces_producer_identity(

--- a/work_buddy/cowork/project_store.py
+++ b/work_buddy/cowork/project_store.py
@@ -64,12 +64,26 @@ COMPONENT_GITIGNORE_LINES = (
     "!/store.yaml",
     "!/export/",
 )
-DEFAULT_SCAN_BUDGET = 2_000
-DEFAULT_SCAN_HARD_LIMIT = 50_000
+DEFAULT_SCAN_WORK_PER_PAGE = 20_000
+DEFAULT_SCAN_WORK_LIMIT = 750_000
 DEFAULT_TOKEN_TTL_SECONDS = 15 * 60
+# A directory that mutates while it is being listed is re-queued instead of
+# failing the whole scan. This caps that: a directory under continuous churn
+# stops the scan honestly rather than spinning against it.
+_SCAN_DIRECTORY_RETRY_LIMIT = 3
+# Opening a directory costs two metadata lookups plus a listing; reading one
+# entry out of an open listing is served from the same enumeration. Measured
+# against a large repository the first is roughly forty times the second, so
+# the scan charges a directory forty units and an entry one. The weight prices
+# opening a directory, not every syscall the walk makes.
+_SCAN_DIRECTORY_WEIGHT = 40
 _TOKEN = re.compile(r"^[0-9a-f]{32}$")
+# The child every Work Buddy component writes beneath. A directory listing
+# that never names it cannot be a store root, which is what lets the scan
+# decide a boundary from the listing it already has.
+_COMPONENT_DIR_NAME = ".wbuddy"
 _SKIP_DIRS = frozenset(
-    {".git", ".wbuddy", "node_modules", ".venv", "vendor"}
+    {".git", _COMPONENT_DIR_NAME, "node_modules", ".venv", "vendor"}
 )
 _REPARSE_POINT = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
 
@@ -331,6 +345,23 @@ def _assert_managed_layout_safe(root: Path) -> None:
         root / ".wbuddy" / "cowork",
         root_device=root_info.st_dev,
     )
+
+
+def _is_store_root(scan_root: Path, directory: str) -> bool:
+    """Report whether ``directory`` holds a Co-work store of its own.
+
+    Only a directory whose own listing named the component child reaches this
+    probe, so the metadata lookups are spent on the few directories that can
+    possibly answer yes. The component child is read with ``lstat`` first: a
+    redirected component is refused rather than followed, so the probe cannot
+    read a store that lives outside the scanned tree.
+    """
+
+    component = os.path.join(directory, _COMPONENT_DIR_NAME)
+    info = _lstat_managed(scan_root, Path(component))
+    if info is None or not stat.S_ISDIR(info.st_mode):
+        return False
+    return os.path.isfile(os.path.join(component, "cowork", "store.yaml"))
 
 
 def _managed_sidecar_root(sidecar: str | Path) -> tuple[Path, Path]:
@@ -679,6 +710,103 @@ def _fingerprint(root: Path) -> str:
     ).hexdigest()
 
 
+# The one setup refusal a caller can answer by asking again: reading the
+# folder's Work Buddy data failed, so the classification settled nothing about
+# what that data holds and the same folder can classify differently on the next
+# attempt. Every other refusal describes a fact the walk did establish, which
+# repeating the call cannot change. Membership decides both the ``retryable``
+# flag and the HTTP status, so the two cannot drift apart.
+_RETRYABLE_SETUP_REFUSALS = frozenset({"folder_unreachable"})
+
+
+def _setup_refusal(
+    current: FolderInspection,
+    *,
+    observed: bool,
+) -> FolderLifecycleError:
+    """Compose the refusal that stops setup on a folder that cannot take it.
+
+    A caller that inspected the folder and then asked for setup holds a
+    fingerprint over that observation, so its refusal reports the folder
+    moving out from under what a human was shown. A caller with no prior
+    observation has no such gap to honour, and its refusal carries the
+    classification's own code and prose, naming what the folder is instead of
+    implying a race that did not happen.
+
+    The message is the whole contract for an agent caller, which reads the
+    exception text and nothing else, so each one names both the folder's state
+    and the action that answers it. A refusal that follows from failing to read
+    the folder, rather than from what a read found, says exactly that and keeps
+    the unreachable classification's retryable 503: an agent told the data is
+    unread waits and asks again, where an agent told the data is broken repairs
+    a folder that was never shown to be broken.
+    """
+
+    if observed:
+        return FolderLifecycleError(
+            "folder_changed",
+            "The folder is no longer available for setup.",
+            retryable=True,
+        )
+    status = current.status
+    code = current.reason_code or status
+    if status == "initialized":
+        code = "folder_already_initialized"
+        message = (
+            "This folder is already set up for Co-work. Open it instead of "
+            "setting it up again."
+        )
+    elif status == "inside_existing_folder":
+        code = "inside_existing_folder"
+        message = (
+            "This folder sits inside a folder that is already set up for "
+            "Co-work. Set up a folder outside that one instead."
+        )
+    elif code == "contains_nested_folder":
+        message = (
+            "This folder encloses a folder that is already set up for "
+            "Co-work. Set up a folder that does not enclose it instead."
+        )
+    elif code == "folder_too_large_for_safe_setup":
+        message = (
+            "This folder holds too many items for Co-work to check safely. "
+            "Set up a narrower folder inside it instead."
+        )
+    elif code == "folder_unreachable":
+        # Reading the folder's Work Buddy data failed, so nothing is known
+        # about what that data holds. Naming the folder unread rather than
+        # incomplete is what keeps a caller from repairing a healthy store
+        # that a backup or a scanner happened to be holding open.
+        message = (
+            "This folder's Work Buddy data is temporarily unavailable, so "
+            "Co-work cannot tell what state the folder is in. Try setting it "
+            "up again in a moment."
+        )
+    elif code == "identity_conflict":
+        # The data was read and the records contradict each other, which is a
+        # settled fact about the folder and a different repair from an
+        # incomplete layout.
+        message = (
+            "This folder's Co-work records disagree about which store the "
+            "folder holds. Repair that data, or set up a different folder."
+        )
+    elif status == "collision":
+        message = (
+            "This folder already holds Work Buddy data that does not form a "
+            "complete Co-work folder. Repair that data, or set up a "
+            "different folder."
+        )
+    else:
+        message = "Co-work cannot set this folder up in the state it is in."
+    retryable = code in _RETRYABLE_SETUP_REFUSALS
+    return FolderLifecycleError(
+        code,
+        message,
+        status=503 if retryable else 409,
+        retryable=retryable,
+    )
+
+
 def _folder_from_registry_path(path: Path) -> Path:
     if path.name == "cowork" and path.parent.name == ".wbuddy":
         return path.parent.parent
@@ -724,16 +852,36 @@ class ProjectStoreManager:
         self,
         *,
         data_root: str | Path | None = None,
-        scan_budget: int = DEFAULT_SCAN_BUDGET,
-        scan_hard_limit: int = DEFAULT_SCAN_HARD_LIMIT,
+        scan_work_per_page: int | None = None,
+        scan_work_limit: int | None = None,
     ) -> None:
         if data_root is None:
             from work_buddy.paths import data_dir
 
             data_root = data_dir()
         self.data_root = Path(data_root).expanduser().resolve()
-        self.scan_budget = max(1, int(scan_budget))
-        self.scan_hard_limit = max(self.scan_budget, int(scan_hard_limit))
+        # Both budgets are resolved here rather than in the signature, so a
+        # caller that reassigns the module default reaches every manager it
+        # builds afterwards. The two knobs are independently valid: a page
+        # budget larger than the refusal threshold simply means one page
+        # reaches it, and flooring the threshold to the page budget would
+        # discard a deliberately small one.
+        self.scan_work_per_page = max(
+            1,
+            int(
+                DEFAULT_SCAN_WORK_PER_PAGE
+                if scan_work_per_page is None
+                else scan_work_per_page
+            ),
+        )
+        self.scan_work_limit = max(
+            1,
+            int(
+                DEFAULT_SCAN_WORK_LIMIT
+                if scan_work_limit is None
+                else scan_work_limit
+            ),
+        )
         self.scan_dir = self.data_root / "runtime" / "cowork-folder-scans"
         self.receipt_dir = self.data_root / "runtime" / "cowork-folder-receipts"
 
@@ -749,6 +897,27 @@ class ProjectStoreManager:
             absent_only=not path.exists(),
         )
 
+    def _sweep_scan_state(self) -> None:
+        """Drop scan cursors no continuation token can still reach.
+
+        A caller can abandon a paged scan at any point, leaving its pending
+        list on disk. The cursor is reachable only through a signed token that
+        expires after ``DEFAULT_TOKEN_TTL_SECONDS``, so a file older than that
+        window is unreachable work. Every failure here is swallowed: an
+        undeleted cursor is a small leak, never a reason to refuse a scan.
+        """
+
+        cutoff = time.time() - DEFAULT_TOKEN_TTL_SECONDS
+        try:
+            for entry in self.scan_dir.iterdir():
+                try:
+                    if entry.is_file() and entry.stat().st_mtime < cutoff:
+                        entry.unlink(missing_ok=True)
+                except OSError:
+                    continue
+        except OSError:
+            return
+
     def _scan_descendants(
         self,
         root: Path,
@@ -756,6 +925,34 @@ class ProjectStoreManager:
         continuation_token: str | None = None,
         complete: bool = False,
     ) -> ScanResult:
+        """Look for a Co-work store beneath ``root``, a budgeted page at a time.
+
+        The paged walk is an advisory preview: it drives the launcher and mints
+        an inspection token, and it trusts the pages it already walked instead
+        of revalidating them on every continuation. The proof that gates a
+        write is ``initialize``, which re-walks the whole tree in one unpaged
+        pass while holding the folder operation locks and refuses anything that
+        no longer classifies as ``uninitialized``. A preview that drifted
+        between pages therefore cannot authorize an unsafe setup: the locked
+        re-walk sees the store that appeared and stops the write.
+
+        Every directory the walk reads is one a listing admitted: an entry is
+        queued only after ``is_symlink`` and the reparse-point attribute clear
+        it and its device matches the root's, and the root itself is validated
+        by ``inspect`` before the walk starts. The walk therefore holds a
+        redirect-free path to each directory it opens, and spends metadata
+        lookups only where a listing names a component child.
+
+        Both the page budget and the refusal threshold are counted in work
+        units, where opening a directory costs ``_SCAN_DIRECTORY_WEIGHT`` and
+        listing one entry costs 1, so a page of directories and a page of
+        files take comparable wall time and neither shape escapes the
+        threshold. The predicate reads only the shape of the tree, so the same
+        tree refuses on every machine. A directory re-read after an mtime race
+        is charged for each read, so the total is exact only for a quiescent
+        tree.
+        """
+
         root_info = root.stat()
         if continuation_token:
             state_path = self._scan_path(continuation_token)
@@ -767,106 +964,155 @@ class ProjectStoreManager:
                     "The folder scan can no longer be resumed; inspect it again.",
                     retryable=True,
                 ) from exc
-            if state.get("root") != str(root) or state.get("root_mtime_ns") != root_info.st_mtime_ns:
+            if state.get("root") != str(root):
+                # A cursor holds the pending list of one folder. Replaying it
+                # against another would report that folder's descendants.
                 state_path.unlink(missing_ok=True)
                 raise FolderLifecycleError(
                     "descendant_scan_incomplete",
-                    "The folder changed while descendants were inspected.",
+                    "The folder scan belongs to another folder; inspect it again.",
                     retryable=True,
                 )
             token = continuation_token
             pending = list(state.get("pending") or [])
             visited = int(state.get("visited") or 0)
-            fingerprints = {
+            work = int(state.get("work") or 0)
+            retries = {
                 str(key): int(value)
-                for key, value in (state.get("directory_fingerprints") or {}).items()
+                for key, value in (state.get("directory_retries") or {}).items()
             }
-            for relative, expected_mtime in fingerprints.items():
-                directory = root if relative == "." else root / relative
-                try:
-                    current_mtime = directory.stat().st_mtime_ns
-                except OSError as exc:
-                    state_path.unlink(missing_ok=True)
-                    raise FolderLifecycleError(
-                        "descendant_scan_incomplete",
-                        "A visited folder descendant changed during inspection.",
-                        retryable=True,
-                    ) from exc
-                if current_mtime != expected_mtime:
-                    state_path.unlink(missing_ok=True)
-                    raise FolderLifecycleError(
-                        "descendant_scan_incomplete",
-                        "A visited folder descendant changed during inspection.",
-                        retryable=True,
-                    )
         else:
             token = uuid.uuid4().hex
             state_path = self._scan_path(token)
+            self._sweep_scan_state()
             pending = ["."]
             visited = 0
-            fingerprints: dict[str, int] = {}
+            work = 0
+            retries: dict[str, int] = {}
 
-        budget_used = 0
+        page_work = 0
         nested: list[str] = []
         root_device = root_info.st_dev
+        # The walk addresses directories as plain strings joined onto the
+        # resolved root. ``Path`` belongs at the API boundary. Inside the loop
+        # every path is built once and handed straight to an ``os`` call, and
+        # relative paths are held POSIX-style, which is the form the cursor
+        # stores and the caller reads.
+        root_path = str(root)
         try:
-            while pending and (complete or budget_used < self.scan_budget):
+            # Work is spent per directory and per entry but tested per
+            # directory, so one page spends at most the budget plus one
+            # directory's worth of work. Tightening that needs a cursor inside
+            # a directory listing, and ``os.scandir`` exposes no stable resume
+            # point, so the alternative is buffering whole listings to disk:
+            # dearer than the overshoot.
+            while pending and (complete or page_work < self.scan_work_per_page):
                 relative = pending.pop()
-                directory = root if relative == "." else root / relative
-                if relative != ".":
-                    _assert_managed_layout_safe(directory)
-                    if (
-                        directory / ".wbuddy" / "cowork" / "store.yaml"
-                    ).is_file():
-                        nested.append(relative.replace(os.sep, "/"))
+                directory = (
+                    root_path if relative == "." else os.path.join(root_path, relative)
+                )
+                try:
+                    before_mtime = os.stat(directory).st_mtime_ns
+                    listing = os.scandir(directory)
+                except (FileNotFoundError, NotADirectoryError):
+                    # The directory went away between being queued and being
+                    # read, the same race an entry can lose. A path that no
+                    # longer exists cannot hold a store, so dropping it leaves
+                    # the proof intact.
+                    retries.pop(relative, None)
+                    continue
+                children: list[str] = []
+                names_component = False
+                with listing as entries:
+                    # Charged only once the metadata lookup and the listing
+                    # have both succeeded, so a directory that went away
+                    # between being queued and being read costs nothing
+                    # rather than being billed for work the walk never did.
+                    page_work += _SCAN_DIRECTORY_WEIGHT
+                    work += _SCAN_DIRECTORY_WEIGHT
+                    if work > self.scan_work_limit:
                         state_path.unlink(missing_ok=True)
-                        return ScanResult(
-                            "nested",
-                            visited_entries=visited,
-                            nested_folders=tuple(sorted(nested)),
-                        )
-                before_mtime = directory.stat().st_mtime_ns
-                with os.scandir(directory) as entries:
+                        return ScanResult("too_large", visited_entries=visited)
                     for entry in entries:
                         visited += 1
-                        budget_used += 1
-                        if visited > self.scan_hard_limit:
+                        page_work += 1
+                        work += 1
+                        if work > self.scan_work_limit:
                             state_path.unlink(missing_ok=True)
                             return ScanResult("too_large", visited_entries=visited)
-                        if entry.name in _SKIP_DIRS:
+                        name = entry.name
+                        if name in _SKIP_DIRS:
+                            # A component child is the one skipped name the
+                            # scan still learns something from: it decides
+                            # whether this directory is worth probing at all.
+                            if name == _COMPONENT_DIR_NAME:
+                                names_component = True
                             continue
                         try:
+                            if not entry.is_dir(follow_symlinks=False):
+                                # A file holds no store and is never opened, so
+                                # its redirection and device facts are never
+                                # consulted and never worth reading.
+                                continue
+                            redirected = entry.is_symlink()
                             info = entry.stat(follow_symlinks=False)
+                        except (FileNotFoundError, NotADirectoryError):
+                            # The entry went away between the listing and the
+                            # lookup. A path that no longer exists cannot hold
+                            # a store, so skipping it leaves the proof intact.
+                            continue
                         except OSError as exc:
+                            # An entry that exists but cannot be read could
+                            # hide a store, so skipping it would make the
+                            # proof unsound.
                             raise FolderLifecycleError(
                                 "descendant_scan_incomplete",
                                 "A folder descendant could not be inspected.",
                                 retryable=True,
                             ) from exc
                         attributes = getattr(info, "st_file_attributes", 0)
-                        reparse = getattr(__import__("stat"), "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
                         crosses_device = bool(
                             root_device and info.st_dev and info.st_dev != root_device
                         )
-                        if entry.is_symlink() or attributes & reparse or crosses_device:
+                        if redirected or attributes & _REPARSE_POINT or crosses_device:
                             continue
-                        if entry.is_dir(follow_symlinks=False):
-                            child = entry.name if relative == "." else str(Path(relative) / entry.name)
-                            pending.append(child)
-                after_mtime = directory.stat().st_mtime_ns
-                if after_mtime != before_mtime:
-                    state_path.unlink(missing_ok=True)
-                    raise FolderLifecycleError(
-                        "descendant_scan_incomplete",
-                        "A folder descendant changed while it was inspected.",
-                        retryable=True,
-                    )
-                fingerprints[relative] = after_mtime
-                if nested:
-                    state_path.unlink(missing_ok=True)
-                    return ScanResult(
-                        "nested", visited_entries=visited, nested_folders=tuple(sorted(nested))
-                    )
+                        children.append(
+                            name if relative == "." else f"{relative}/{name}"
+                        )
+                try:
+                    settled = os.stat(directory).st_mtime_ns == before_mtime
+                except (FileNotFoundError, NotADirectoryError):
+                    # Deleted while it was being listed. Whatever it held is
+                    # gone with it, so the children it yielded are dropped too.
+                    retries.pop(relative, None)
+                    continue
+                if not settled:
+                    # The listing raced a writer and may have missed an entry.
+                    # Re-queue the directory and drop the children it yielded,
+                    # so the re-read is the only thing that enqueues them.
+                    attempts = retries.get(relative, 0) + 1
+                    if attempts > _SCAN_DIRECTORY_RETRY_LIMIT:
+                        raise FolderLifecycleError(
+                            "descendant_scan_incomplete",
+                            "A folder descendant kept changing while it was inspected.",
+                            retryable=True,
+                        )
+                    retries[relative] = attempts
+                    pending.append(relative)
+                    continue
+                retries.pop(relative, None)
+                if (
+                    names_component
+                    and relative != "."
+                    and _is_store_root(root, directory)
+                ):
+                    # A store root is a hard boundary: record it and leave its
+                    # interior unwalked. The caller needs the boundary, and
+                    # everything below it belongs to that store, so the
+                    # children this listing yielded are dropped.
+                    nested.append(relative)
+                    continue
+                pending.extend(children)
         except FolderLifecycleError:
             state_path.unlink(missing_ok=True)
             raise
@@ -878,15 +1124,25 @@ class ProjectStoreManager:
                 retryable=True,
             ) from exc
 
+        if nested:
+            # One page can cross several boundaries, and the caller renders
+            # them as a list. Report all of them together and stop: the folder
+            # is already disqualified, so further pages buy nothing.
+            state_path.unlink(missing_ok=True)
+            return ScanResult(
+                "nested",
+                visited_entries=visited,
+                nested_folders=tuple(sorted(nested)),
+            )
         if pending:
             self._save_json(
                 state_path,
                 {
                     "root": str(root),
-                    "root_mtime_ns": root_info.st_mtime_ns,
                     "pending": pending,
                     "visited": visited,
-                    "directory_fingerprints": fingerprints,
+                    "work": work,
+                    "directory_retries": retries,
                     "updated_at": time.time(),
                 },
             )
@@ -987,16 +1243,26 @@ class ProjectStoreManager:
                 reason_code=exc.code,
                 actions=("repair", "choose_another"),
             )
-        owner = self._nearest_owner(root)
-        if owner is not None:
-            return FolderInspection(
-                "inside_existing_folder", root, root.name,
-                owner_path=owner.folder_path, owner_store_id=owner.store_id,
-                actions=("open_owner", "choose_another"), fingerprint=_fingerprint(root),
-            )
-        exact = self._classify_exact(root)
-        if exact.status != "uninitialized":
-            return exact
+        if continuation_token is None:
+            # Ownership and exact classification gate the walk, so a
+            # continuation token exists only where both already answered:
+            # no ancestor owns the folder and the folder itself classifies as
+            # ``uninitialized``. Every terminal page classifies again, and the
+            # answer that gates a write comes from ``initialize``, which
+            # re-walks the tree unpaged under the folder operation locks. A
+            # continuation therefore carries no authority these two would have
+            # to re-establish.
+            owner = self._nearest_owner(root)
+            if owner is not None:
+                return FolderInspection(
+                    "inside_existing_folder", root, root.name,
+                    owner_path=owner.folder_path, owner_store_id=owner.store_id,
+                    actions=("open_owner", "choose_another"),
+                    fingerprint=_fingerprint(root),
+                )
+            exact = self._classify_exact(root)
+            if exact.status != "uninitialized":
+                return exact
         scan = self._scan_descendants(
             root,
             continuation_token=continuation_token,
@@ -1184,10 +1450,25 @@ class ProjectStoreManager:
         folder: str | Path,
         *,
         registry: TruthStoreRegistry,
-        inspection_fingerprint: str,
+        inspection_fingerprint: str | None,
         idempotency_key: str,
         profile: Mapping[str, Any] | None = None,
     ) -> TruthStore:
+        """Set one folder up for Co-work under the folder operation locks.
+
+        ``inspection_fingerprint`` carries a caller's earlier observation of
+        the folder, and setup refuses a folder that moved since a human was
+        shown it. A caller that reaches setup with no such gap to honour passes
+        ``None`` and is refused on what the locked walk finds, which names the
+        folder's actual state rather than reporting a change nobody made.
+
+        Neither caller rests its safety on the fingerprint. The walk here runs
+        inside the folder operation locks, classifies the folder from the
+        filesystem, and refuses anything that is not ``uninitialized``; the
+        managed-layout assertion then re-runs around every write beneath the
+        folder.
+        """
+
         root = _canonical_folder(folder)
         replay = self._receipt(idempotency_key, "initialize", root, registry)
         if replay is not None:
@@ -1197,14 +1478,13 @@ class ProjectStoreManager:
             if replay is not None:
                 return replay
             current = self.inspect(root, complete_scan=True)
-            if current.fingerprint != inspection_fingerprint:
+            observed = inspection_fingerprint is not None
+            if observed and current.fingerprint != inspection_fingerprint:
                 raise FolderLifecycleError(
                     "folder_changed", "The folder changed after it was inspected.", retryable=True
                 )
             if current.status != "uninitialized":
-                raise FolderLifecycleError(
-                    "folder_changed", "The folder is no longer available for setup.", retryable=True
-                )
+                raise _setup_refusal(current, observed=observed)
             _assert_managed_layout_safe(root)
             manifest = read_manifest(root)
             wbuddy = root / ".wbuddy"
@@ -1257,8 +1537,8 @@ class ProjectStoreManager:
 __all__ = [
     "CANONICAL_LAYOUT",
     "COMPONENT_GITIGNORE_LINES",
-    "DEFAULT_SCAN_BUDGET",
-    "DEFAULT_SCAN_HARD_LIMIT",
+    "DEFAULT_SCAN_WORK_LIMIT",
+    "DEFAULT_SCAN_WORK_PER_PAGE",
     "FolderInspection",
     "FolderLifecycleError",
     "MANIFEST_FORMAT",

--- a/work_buddy/mcp_server/ops/truth_ops.py
+++ b/work_buddy/mcp_server/ops/truth_ops.py
@@ -372,13 +372,16 @@ def truth_store_create(
         registry_parent.parent if registry_parent.name == "db" else registry_parent
     )
     manager = ProjectStoreManager(data_root=manager_data_root)
-    inspection = manager.inspect(root, complete_scan=True)
-    if inspection.fingerprint is None:
-        raise InvariantViolation("Folder inspection did not produce a setup fingerprint")
+    # Setup walks the folder once. The walk that authorizes the write is the
+    # one inside the folder operation locks, which classifies the folder from
+    # the filesystem and refuses anything that is not an empty candidate. This
+    # caller shows the folder to nobody between deciding and writing, so it
+    # holds no observation for a fingerprint to pin, and a refusal here names
+    # the folder's state instead of a change nobody made.
     store = manager.initialize(
         root,
         registry=registry,
-        inspection_fingerprint=inspection.fingerprint,
+        inspection_fingerprint=None,
         idempotency_key=f"truth-store-create:{requested}",
         profile=values,
     )


### PR DESCRIPTION
## Summary

Setting up a Co-work folder first proves no descendant already holds a store, because two overlapping stores each claim the same file under a different relative path and each read the other's writes as drift. That proof refused any folder past 50,000 filesystem entries, which made a 110,772-entry repo impossible to open.

- **The bound now tracks the work the walk does.** Opening a directory costs two metadata lookups plus a listing; reading an entry out of an open listing comes from the enumeration already in hand. Measured, the first is roughly 40x the second, so counting entries priced a tree of directories and a tree of files identically. Both the per-page budget and the cumulative limit are now counted in work units at that ratio.
- **The per-page budget was unbounded on directories.** It charged nothing for popping one, so a page walking empty directories could run for tens of seconds while the cumulative cap never fired. Both knobs are weighted now, and the cumulative total is carried across pages in the scan cursor.
- **Paging was unreliable above ~50k entries.** It re-stat'd every already-visited directory on each continuation and discarded the whole scan when any of their mtimes moved. Resume now trusts the pages it walked; a directory that changes while being listed is re-queued under a retry cap; an entry or directory that vanishes mid-walk is skipped rather than aborting; a page reports every boundary it crossed instead of only the first; abandoned cursors are swept.
- **`truth_store_create` walked the tree twice**, the first time purely to obtain a fingerprint that is four stat calls. It now walks once, and its refusals carry the reason code for the state actually found instead of a generic `folder_changed`. A folder whose data could not be read comes back retryable rather than as an instruction to repair data never shown to be broken.
- **The refusal screen could render zero buttons**, since the provider dropped the server's suggested action and a first-run user has nothing to go "back" to. It now offers the chooser.
- **Scan progress was plumbed to the client and discarded.** A new shared `ActivityStatus` primitive renders it, with the count outside the `role="status"` region so a rising number does not re-announce on every page.

Measured against a 110,772-entry folder: refused before, opens now; 43 pages to 13; median 19.5s to 3.0s; reliability 2/10 to 10/10.

## Test plan

- [ ] `uv run pytest tests/unit/cowork/ tests/unit/truth/test_ops.py` (842 passed, 2 pre-existing skips)
- [ ] `cd dashboard-react && npm run typecheck && npm test` (1,972 passed, 15 skipped)
- [ ] Open Co-work with no folder active, pick a large folder, confirm a rising item count and working Cancel, then setup offered rather than refused
- [ ] Pick a deliberately oversized folder (a home directory) and confirm the refusal renders an actionable chooser rather than a dead end

## Notes for review

- `DEFAULT_SCAN_WORK_LIMIT` is 750,000 units and `_SCAN_DIRECTORY_WEIGHT` is 40; all three constants are pinned by a test so they cannot regress silently.
- Adds `cowork/folder` and `cowork/folder/setup` knowledge units. This subsystem previously had no unit at all.
- Known and deliberately unaddressed: `folder_unreachable` returns a retryable 503 while `descendant_scan_incomplete` and `folder_changed` are also retryable but return 409, because they bypass `_setup_refusal`. The latter two are pre-existing; documented in the new unit's `dev_notes` rather than widened into this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)