### PR TITLE
fix(ir): serialize index builds on a DB-wide lock

### DIFF
--- a/knowledge/store/architecture/embedding-service.md
+++ b/knowledge/store/architecture/embedding-service.md
@@ -107,6 +107,24 @@ dev_notes: |-
 
   A reachable embedding service that fails an ``/ir/index`` request surfaces the **real** error, not a generic "service unavailable". ``client._request`` catches ``HTTPError`` (a subclass of ``URLError``, so it must be caught first) separately from connection failures, logs the status + body, and — with ``return_http_error=True`` (passed only by ``ir_index``) — returns ``{"error", "status"}`` rather than collapsing a 500 to ``None``. The ``ir_index`` dispatch then distinguishes: ``None`` → service unreachable (remediation points at the sidecar via ``utils/service_hints.py::sidecar_restart_command``, since the embedding service is a sidecar-supervised child, not a standalone scheduled task); an error envelope → surface the real ``/ir/index`` error; otherwise the status/build result. Every *other* client caller still gets ``None`` on any failure — the flag defaults off, so their graceful-degradation contract is unchanged.
 
+  ## IR builds serialize on a DB-wide lock, and skip rather than queue
+
+  ``/ir/search`` and ``/ir/index`` run in the SAME process, and building is CPU-bound (BM25 tokenisation plus SentenceTransformer encoding). Werkzeug is threaded, so a concurrent search is accepted but its thread is starved for the duration of the build. Unserialized builds compound: every IR source (conversation, summary, task_note, docs, chrome) writes to ONE SQLite DB on its own cron, so overlapping builds contend for a single writer and a single GIL, each inflating the others' duration. Once a build outlasts its own cron interval the next tick stacks on top of it, a positive feedback loop whose end state is searches exceeding the 30s client timeout in ``client.ir_search`` and surfacing as the misleading "embedding service unavailable".
+
+  The exclusion boundary:
+
+  - ``ir_index_endpoint`` holds ``utils.index_lock.index_lock(ir.store._db_path())`` across BOTH ``build_index`` and ``build_vectors``, so a build's rows and its vectors land as one unit. Mirrors ``vault_index.indexer.run_index``.
+  - Acquisition uses ``_IR_BUILD_LOCK_TIMEOUT_S`` (short); a ``TimeoutError`` returns a skipped result. **Skip, never queue.** A waiting caller would hold an HTTP request open for the length of another source's build, and the scheduled tick picks the work up next cycle anyway.
+  - ``action="status"`` returns before the lock is taken, so status stays readable during a build (the same guarantee ``context/vault_index`` documents).
+  - ``context_ops._ir_index_dispatch`` probes ``index_lock.is_locked`` read-only and short-circuits before the HTTP round trip. The endpoint enforces the exclusion regardless; the probe only avoids the request.
+  - ``indexing/adapters/ir.py::bulk_build`` holds the same lock across its whole multi-source sweep so it cannot interleave with the scheduled per-source builds.
+
+  The lock self-heartbeats from a daemon thread, so a long build never ages past the stale window. Never SIGKILL a build; a killed holder can leave a ``*.lock`` that is honored until it ages out.
+
+  **What the lock does not fix.** Serialization stops builds compounding; it does not make search fast while a single build runs. Build and search share one interpreter, and the legacy IR search path materialises every candidate row into Python (``load_documents`` pulls and JSON-parses the corpus, then scoring runs in a Python loop), so a query costing ~2s of interpreter time stretches to minutes against an active build. This is contention for Python execution inside one process, not a saturated machine: ``/health`` still answers in under 0.1s and the service occupies roughly one core. The durable fixes are moving builds out of the process, or serving the lexical path natively from FTS5 the way ``architecture/consolidated-index`` does.
+
+  ``IndexProtocol.lock_key`` (``indexing/protocol.py``) is declared by every adapter but consumed by nothing. It is not an exclusion mechanism, and reading it as one would be a mistake.
+
   ## Adding a new model
 
   Add an entry to `config.yaml` under `embedding.models` (or `_DEFAULT_MODELS` in `service.py` for the fallback). Required fields: HF name, dims, `eager` (bool). Eager-load only models on the critical path for interactive work; lazy-load large models (e.g. the 526 MB `leaf-ir` passage encoder) that are used only during indexing.
@@ -165,7 +183,11 @@ A long-running sidecar service providing dense vector embeddings for work-buddy'
 - `POST /embed` — embed a batch of texts, return vectors
 - `POST /similarity` — cosine similarity between a query and candidate texts
 - `POST /search` — BM25 + embedding hybrid search over candidates
-- `POST /ir/search`, `POST /ir/index` — indexed IR search over registered sources
+- `POST /ir/search`, `POST /ir/index` — indexed IR search over registered sources. Every IR
+  source shares one SQLite DB, so builds serialize on a DB-wide advisory lock; a build that
+  arrives while another build is running returns `{"skipped": true, "reason":
+  "build_in_progress"}` instead of queueing. `action="status"` is never gated and stays
+  readable during a build
 - `POST /vault/search`, `POST /vault/index` — vault semantic index search / build, run
   in-process so the resident vector matrix stays warm and the bulk encode shares the broker
   (see `architecture/vault-index`)

--- a/knowledge/store/context/ir_index.md
+++ b/knowledge/store/context/ir_index.md
@@ -1,7 +1,7 @@
 ---
 name: Ir Index
 kind: capability
-description: Build or check the IR search index. Run 'build' to (re)encode dense vectors for indexed documents; 'status' returns per-source counts including dense_eligible_docs (how many docs CAN be encoded) and pending_eligible (real backlog — NOT doc_count vs vector_count, which is misleading because sources like conversation intentionally leave dense_text empty for tool-only spans).
+description: Build or check the IR search index. Run 'build' to (re)encode dense vectors for indexed documents; builds across every IR source share one SQLite DB and serialize on a DB-wide advisory lock, so a build that arrives while another is running returns {skipped true, reason 'build_in_progress'} rather than queueing behind it. 'status' is never gated and returns per-source counts including dense_eligible_docs (how many docs CAN be encoded) and pending_eligible (real backlog — NOT doc_count vs vector_count, which is misleading because sources like conversation intentionally leave dense_text empty for tool-only spans).
 capability_name: ir_index
 category: context
 op: op.wb.ir_index

--- a/tests/unit/test_ir_build_serialization.py
+++ b/tests/unit/test_ir_build_serialization.py
@@ -1,0 +1,247 @@
+"""IR index builds serialize on one DB-wide advisory lock.
+
+Every IR source (conversation, summary, task_note, docs, chrome) shares one
+SQLite DB and one embedding-service process, and building is CPU-bound in the
+same interpreter that serves ``/ir/search``. Unserialized builds therefore
+contend for one writer and one GIL, inflating each other's duration until a
+search exceeds its client timeout and reports the service as unavailable.
+
+Pins the exclusion contract:
+
+- a build that arrives while another holds the lock is **skipped, not queued**
+  (queuing would hold a request open for the length of someone else's build);
+- ``action="status"`` is never gated, so status stays readable during a build;
+- the op-level probe short-circuits before the HTTP round trip;
+- the bulk-build sweep holds the lock across every source.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from work_buddy.utils.index_lock import index_lock, is_locked
+
+
+@pytest.fixture
+def tmp_ir_db(tmp_path, monkeypatch):
+    """Point ``ir.store._db_path`` at a temp file so the lock lands in tmp_path."""
+    db = tmp_path / "work_buddy_ir.db"
+    monkeypatch.setattr("work_buddy.ir.store._db_path", lambda cfg=None: db)
+    return db
+
+
+@pytest.fixture
+def client():
+    from work_buddy.embedding.service import app
+
+    app.config.update(TESTING=True)
+    return app.test_client()
+
+
+def _post(client, **body):
+    return client.post("/ir/index", json=body)
+
+
+def test_build_skips_while_another_build_holds_the_lock(client, tmp_ir_db, monkeypatch):
+    """A second build reports itself skipped instead of waiting out the first."""
+    called = []
+    monkeypatch.setattr(
+        "work_buddy.ir.store.build_index",
+        lambda **kw: called.append(kw) or {"source": kw.get("source")},
+    )
+
+    with index_lock(tmp_ir_db):
+        resp = _post(client, action="build", source="summary")
+
+    assert resp.status_code == 200
+    assert resp.get_json()["result"] == {
+        "source": "summary",
+        "skipped": True,
+        "reason": "build_in_progress",
+    }
+    # The whole point: no build work ran behind the held lock.
+    assert called == []
+
+
+def test_build_runs_and_releases_the_lock(client, tmp_ir_db, monkeypatch):
+    """An uncontended build acquires, builds, and leaves the lock free."""
+    monkeypatch.setattr(
+        "work_buddy.ir.store.build_index",
+        lambda **kw: {"source": kw.get("source"), "docs_inserted": 3},
+    )
+
+    resp = _post(client, action="build", source="summary", include_dense=False)
+
+    assert resp.status_code == 200
+    result = resp.get_json()["result"]
+    assert result["docs_inserted"] == 3
+    assert "skipped" not in result
+    assert not is_locked(tmp_ir_db), "lock must be released after the build"
+
+
+def test_lock_is_held_for_the_duration_of_the_build(client, tmp_ir_db, monkeypatch):
+    """The lock covers the build body, not just its entry and exit."""
+    observed: list[bool] = []
+
+    def _slow_build(**kw):
+        observed.append(is_locked(tmp_ir_db))
+        return {"source": kw.get("source")}
+
+    monkeypatch.setattr("work_buddy.ir.store.build_index", _slow_build)
+
+    _post(client, action="build", source="summary", include_dense=False)
+
+    assert observed == [True]
+
+
+def test_dense_encode_runs_inside_the_lock(client, tmp_ir_db, monkeypatch):
+    """Index and vectors are written as one unit, so encoding is covered too."""
+    observed: list[bool] = []
+    monkeypatch.setattr("work_buddy.ir.store.build_index", lambda **kw: {})
+    monkeypatch.setattr(
+        "work_buddy.ir.dense.build_vectors",
+        lambda **kw: observed.append(is_locked(tmp_ir_db)) or {"encoded": 0},
+    )
+
+    _post(client, action="build", source="summary", include_dense=True)
+
+    assert observed == [True]
+
+
+def test_status_is_never_gated_by_the_lock(client, tmp_ir_db, monkeypatch):
+    """Status must stay readable while a build holds the lock."""
+    monkeypatch.setattr(
+        "work_buddy.ir.store.index_status",
+        lambda source=None: {"status": "ok", "source": source},
+    )
+
+    with index_lock(tmp_ir_db):
+        resp = _post(client, action="status", source="summary")
+
+    assert resp.status_code == 200
+    assert resp.get_json()["result"] == {"status": "ok", "source": "summary"}
+
+
+def test_concurrent_builds_do_not_overlap(client, tmp_ir_db, monkeypatch):
+    """Two builds racing the endpoint never run their bodies at the same time."""
+    # Shrink the wait so the loser gives up quickly rather than queueing.
+    monkeypatch.setattr(
+        "work_buddy.embedding.service._IR_BUILD_LOCK_TIMEOUT_S", 0.05
+    )
+
+    inside = 0
+    peak = 0
+    guard = threading.Lock()
+    entered = threading.Event()
+
+    def _build(**kw):
+        nonlocal inside, peak
+        with guard:
+            inside += 1
+            peak = max(peak, inside)
+        entered.set()
+        # Hold well past the acquire timeout so the second request must skip.
+        threading.Event().wait(0.5)
+        with guard:
+            inside -= 1
+        return {"source": kw.get("source")}
+
+    monkeypatch.setattr("work_buddy.ir.store.build_index", _build)
+
+    results: list = []
+
+    def _fire():
+        results.append(_post(client, action="build", source="summary",
+                             include_dense=False).get_json()["result"])
+
+    first = threading.Thread(target=_fire)
+    first.start()
+    entered.wait(timeout=5)
+    second = threading.Thread(target=_fire)
+    second.start()
+    first.join(timeout=15)
+    second.join(timeout=15)
+
+    assert peak == 1, "build bodies overlapped despite the lock"
+    assert sum(1 for r in results if r.get("skipped")) == 1
+    assert not is_locked(tmp_ir_db)
+
+
+@pytest.fixture
+def no_real_http(monkeypatch):
+    """Intercept the embedding client's transport.
+
+    ``context_ops`` binds ``ir_index`` into a closure at import, so the client
+    function itself cannot be swapped. ``_request`` is resolved as a module global
+    on every call, which makes it the reliable seam.
+    """
+    calls: list = []
+
+    def _fake(method, path, data=None, **kw):
+        calls.append((method, path, data))
+        return {"result": {"status": "ok"}}
+
+    monkeypatch.setattr("work_buddy.embedding.client._request", _fake)
+    return calls
+
+
+def test_op_dispatch_skips_before_the_http_round_trip(tmp_ir_db, no_real_http):
+    """The op probes the lock read-only and never calls the service when held."""
+    import json
+
+    from work_buddy.mcp_server.op_registry import get_op, load_builtin_ops
+
+    # Idempotent, and re-registers if an earlier test cleared the registry, so
+    # this test does not depend on selection order.
+    load_builtin_ops()
+    dispatch = get_op("op.wb.ir_index")
+    assert dispatch is not None
+
+    with index_lock(tmp_ir_db):
+        out = json.loads(dispatch(action="build", source="conversation"))
+
+    assert out == {
+        "source": "conversation",
+        "skipped": True,
+        "reason": "build_in_progress",
+    }
+    assert no_real_http == [], "op must not reach the service while a build is running"
+
+
+def test_op_dispatch_status_is_not_gated(tmp_ir_db, no_real_http):
+    """A status call still reaches the service while a build runs."""
+    import json
+
+    from work_buddy.mcp_server.op_registry import get_op, load_builtin_ops
+
+    # Idempotent, and re-registers if an earlier test cleared the registry, so
+    # this test does not depend on selection order.
+    load_builtin_ops()
+    dispatch = get_op("op.wb.ir_index")
+    assert dispatch is not None
+
+    with index_lock(tmp_ir_db):
+        out = json.loads(dispatch(action="status", source="conversation"))
+
+    assert out == {"status": "ok"}
+    assert [p for _, p, _ in no_real_http] == ["/ir/index"]
+
+
+def test_bulk_build_holds_the_lock_across_every_source(tmp_ir_db, monkeypatch):
+    """The bulk sweep cannot interleave with the scheduled per-source builds."""
+    observed: list[bool] = []
+    monkeypatch.setattr(
+        "work_buddy.ir.store.build_index",
+        lambda **kw: observed.append(is_locked(tmp_ir_db)) or {},
+    )
+    monkeypatch.setattr("work_buddy.ir.dense.build_vectors", lambda **kw: {})
+
+    from work_buddy.indexing.adapters.ir import IRIndexAdapter
+
+    result = IRIndexAdapter().bulk_build()
+
+    assert result.ok, result.error
+    assert observed and all(observed), "lock must be held for every source"
+    assert not is_locked(tmp_ir_db)

--- a/work_buddy/embedding/service.py
+++ b/work_buddy/embedding/service.py
@@ -20,6 +20,7 @@ Model registry:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import re
 import sys
@@ -32,6 +33,8 @@ from typing import Any
 import numpy as np
 from flask import Flask, Response, jsonify, request
 from rank_bm25 import BM25Okapi
+
+from work_buddy.utils.index_lock import index_lock
 
 # ---------------------------------------------------------------------------
 # Model registry
@@ -862,6 +865,12 @@ def ir_search_endpoint():
         return jsonify({"error": f"{type(exc).__name__}: {exc}"}), 500
 
 
+# How long a build waits for the DB-wide IR lock before reporting itself skipped.
+# Short but nonzero: long enough to absorb the handoff from a build that is already
+# finishing, short enough that a caller never waits out someone else's full build.
+_IR_BUILD_LOCK_TIMEOUT_S = 1.0
+
+
 @app.route("/ir/index", methods=["POST"])
 def ir_index_endpoint():
     """Build or check the IR search index.
@@ -873,17 +882,41 @@ def ir_index_endpoint():
         "force": false                  // default false
     }
     Response: {"result": {...}}
+
+    Builds across every IR source serialize on one DB-wide advisory lock. A build
+    that arrives while another holds it is not queued; it returns
+    ``{"skipped": true, "reason": "build_in_progress"}`` so a scheduled caller
+    fails fast and retries on its next tick.
     """
     data = request.get_json(silent=True) or {}
     action = data.get("action", "build")
     source = data.get("source", "conversation")
 
-    from work_buddy.ir.store import build_index, index_status
+    from work_buddy.ir.store import _db_path, build_index, index_status
 
     try:
         if action == "status":
-            result = index_status(source=source)
-        else:
+            return jsonify({"result": index_status(source=source)})
+
+        # Every IR source shares one SQLite DB, and building is CPU-bound in this
+        # same process that serves /ir/search. Concurrent builds therefore contend
+        # for one writer and one interpreter, which inflates each build's duration
+        # and starves search until it exceeds the client timeout. Serialize every
+        # build on a DB-wide advisory lock, and skip rather than queue: a caller
+        # that waited would hold a request open for the length of another source's
+        # build, and the next scheduled tick will pick the work up anyway.
+        with contextlib.ExitStack() as stack:
+            try:
+                stack.enter_context(
+                    index_lock(_db_path(), timeout=_IR_BUILD_LOCK_TIMEOUT_S)
+                )
+            except TimeoutError:
+                return jsonify({"result": {
+                    "source": source,
+                    "skipped": True,
+                    "reason": "build_in_progress",
+                }})
+
             result = build_index(
                 source=source,
                 days=data.get("days", 30),
@@ -894,6 +927,8 @@ def ir_index_endpoint():
             # self-call) because _IN_SERVICE is set in main(). Failures
             # here degrade the index to BM25-only rather than failing the
             # whole build — callers can check result["dense"] for status.
+            # Encoding stays inside the lock so a build's index and vectors
+            # are written as one unit.
             if data.get("include_dense", True):
                 try:
                     from work_buddy.ir.dense import build_vectors

--- a/work_buddy/indexing/adapters/ir.py
+++ b/work_buddy/indexing/adapters/ir.py
@@ -71,18 +71,24 @@ class IRIndexAdapter:
         on_progress: Callable[[BuildProgress], None] | None = None,
     ) -> BuildResult:
         from work_buddy.ir.dense import build_vectors
-        from work_buddy.ir.store import build_index
+        from work_buddy.ir.store import _db_path, build_index
+        from work_buddy.utils.index_lock import index_lock
 
         days = 36500 if full_history else 30
         stats: dict = {}
         try:
-            for src in _IR_SOURCES:
-                if on_progress:
-                    on_progress(BuildProgress(phase="scanning"))
-                stats[src] = {
-                    "index": build_index(source=src, days=days),
-                    "dense": build_vectors(source=src),
-                }
+            # Every IR source shares one SQLite DB and one embedding-service
+            # process. Hold the DB-wide lock across the whole sweep so this bulk
+            # build cannot interleave with the scheduled per-source builds; the
+            # lock heartbeats itself, so a long full-history run stays honored.
+            with index_lock(_db_path()):
+                for src in _IR_SOURCES:
+                    if on_progress:
+                        on_progress(BuildProgress(phase="scanning"))
+                    stats[src] = {
+                        "index": build_index(source=src, days=days),
+                        "dense": build_vectors(source=src),
+                    }
             return BuildResult(name=self.name, ok=True, stats=stats)
         except Exception as exc:
             return BuildResult(

--- a/work_buddy/mcp_server/ops/context_ops.py
+++ b/work_buddy/mcp_server/ops/context_ops.py
@@ -109,10 +109,27 @@ def _register() -> None:
         days: int = 30,
         force: bool = False,
     ) -> str:
-        """Build or check the IR index via the embedding service."""
+        """Build or check the IR index via the embedding service.
+
+        A ``build`` skips when another IR build already holds the DB-wide advisory
+        lock, detected with a read-only ``is_locked`` probe. The four index crons
+        and any manual run all write to one SQLite DB. The service enforces the
+        same exclusion; probing here just avoids the round trip.
+        """
         import json
 
         from work_buddy.utils.service_hints import sidecar_restart_command
+
+        if action == "build":
+            from work_buddy.ir.store import _db_path
+            from work_buddy.utils import index_lock
+
+            if index_lock.is_locked(_db_path()):
+                return json.dumps({
+                    "source": source,
+                    "skipped": True,
+                    "reason": "build_in_progress",
+                })
 
         result = _ir_index_client(
             action, source=source, days=days, force=force,


### PR DESCRIPTION
## Summary

The four IR index crons (conversation, summary, task_note, docs) all write to one SQLite DB and build inside the embedding service, each on its own 5-minute schedule, with nothing preventing overlap. Once a build outlasted its own interval the next tick stacked on top, and the overlap compounded.

Build duration turned out to be a function of concurrency and almost nothing else. Measured over 4,318 builds in the retained service log:

| concurrent builds | n | median duration |
|---|---|---|
| alone | 3060 | **6.6 s** |
| 1 other | 785 | 24.9 s |
| 2 others | 280 | 169.7 s |
| 4+ others | 103 | **1079.0 s** |

Conversation builds alone: median 6.7 s. The same builds with 2+ concurrent: median 622 s. Corpus growth, work volume (`docs_inserted`) and the LM Studio encode route were each tested against the data and none of them explain the shape.

This reuses the existing heartbeated advisory lock (`utils/index_lock`) rather than adding another, mirroring `vault_index.indexer.run_index`:

- `/ir/index` holds the DB-wide lock across `build_index` **and** `build_vectors`, so a build's rows and vectors land as one unit.
- A build arriving while another holds the lock returns `{skipped, build_in_progress}` rather than queueing. Waiting would hold an HTTP request open for the length of another source's build, and the next tick picks the work up anyway.
- `action="status"` returns before the lock, so status stays readable during a build.
- The `ir_index` op probes `is_locked` read-only to skip the round trip.
- `indexing/adapters/ir.py::bulk_build` holds the same lock across its sweep. `IndexProtocol.lock_key` is declared by every adapter but consumed by nothing, so it was never an exclusion mechanism.

## Scope: what this does not fix

This stops builds compounding. It does **not** fix search latency during a single build, and that was verified live rather than assumed.

With the lock working, a search costing ~2.1 s of Python still took **162-227 s** while one build ran. Throughout, `/health` answered in **0.09 s** and the service used about **one core of sixteen**, so this is neither a wedged process nor a saturated machine. It is contention for Python execution inside one process, made worse by a search path that materialises 6,560 rows into Python per query.

The durable fixes are moving builds out of the process, or serving the lexical path natively from FTS5 as `architecture/consolidated-index` already does. Both are larger changes and land separately.

## Test plan

- [x] 9 new unit tests pin the exclusion contract: skip-not-queue, status ungated, dense encode inside the lock, no overlap under concurrency, op-level probe, bulk sweep
- [x] 80 tests pass across the IR, index-lock and embedding suites
- [x] Live-verified against a restarted service: concurrent build skipped in 1.03 s, lock heartbeat advanced 1200 s past `started_at` across a 40-minute build, status stayed readable, lock released on completion
- [ ] Takes effect on the next embedding-service restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)