### PR TITLE
feat(cowork): export a document to Markdown and rendered formats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ Every scope below is browsable with `mcp__work-buddy__wb_run("agent_docs", {"sco
 | `notifications/` | Notify, request, consent, surfaces |
 | `events/` | Durable in-process delivery spine for event-shaped facts — CloudEvents-superset envelope, SQLite log (dedup + offsets + DLQ), one drain thread, consent gate; `event_publish` to emit, plus user-authored **pull sources** (poll → diff → CEL condition → notify) authored via `/wb-event-new` |
 | `truth/` | Scoped evidence, claims, registered documents with tracked-edit proposals, human confirmation, provenance, revision, registry, and integrity sweeps |
-| `cowork/` | Co-work Folder and document lifecycle: setup, catalog, create/register/scratch, source-safe **From file** import, durable editing, explicit Markdown writes, frozen-target content provenance, drift/reimport/retirement, sittings, feedback, conversations, and `cowork_doc_*` proposal capabilities |
+| `cowork/` | Co-work Folder and document lifecycle: setup, catalog, create/register/scratch, source-safe **From file** import, durable editing, explicit Markdown writes, frozen-target content provenance, drift/reimport/retirement, sittings, feedback, conversations, canonical-Markdown reads and rendered export, and `cowork_doc_*` proposal capabilities |
 | `services/` | Messaging, memory (Hindsight), dashboard, sidecar |
 | `settings/` | Registry-driven settings, Apps-based placement, authority, persistence, Journal policy |
 | `features/` | Preferences and feature opt-in |

--- a/dashboard-react/src/apps/cowork/documents/CoworkDocumentBar.tsx
+++ b/dashboard-react/src/apps/cowork/documents/CoworkDocumentBar.tsx
@@ -15,6 +15,7 @@ import {
 import type { CoworkSyncStatus } from "../persistence/CoworkYdocPersistence";
 import type { CoworkMaterializationState } from "../materialization/contracts";
 import { coworkErrorMessage } from "../providers/errors";
+import { CoworkExportButton } from "./CoworkExportButton";
 import { LinkedLocalFilesPanel } from "./LinkedLocalFilesPanel";
 
 interface CoworkDocumentBarProps {
@@ -434,6 +435,14 @@ export function CoworkDocumentBar({
           <Button size="small" onClick={onRetrySync} disabled={onRetrySync === undefined}>
             {scratch !== null ? "Try saving again" : "Sync now"}
           </Button>
+        ) : null}
+        {registeredSession !== null ? (
+          <CoworkExportButton
+            storeId={registeredSession.storeId}
+            documentId={registeredSession.document.documentId}
+            syncStatus={syncStatus}
+            disabled={folderActionBusy}
+          />
         ) : null}
         {document !== null || scratch !== null ? (
           <Button

--- a/dashboard-react/src/apps/cowork/documents/CoworkExportButton.test.tsx
+++ b/dashboard-react/src/apps/cowork/documents/CoworkExportButton.test.tsx
@@ -1,0 +1,227 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { expectNoAccessibilityViolations } from "../../../test/setup";
+import {
+  CoworkExportButton,
+  coworkExportBlockedReason,
+} from "./CoworkExportButton";
+
+const formatsResponse = (formats: unknown[]) =>
+  new Response(JSON.stringify({ ok: true, formats }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+const MARKDOWN_ONLY = [
+  { format: "markdown", label: "Markdown", extension: ".md", media_type: "text/markdown" },
+];
+
+const WITH_PANDOC = [
+  ...MARKDOWN_ONLY,
+  { format: "latex", label: "LaTeX", extension: ".tex", media_type: "application/x-tex" },
+  { format: "pdf", label: "PDF", extension: ".pdf", media_type: "application/pdf" },
+];
+
+beforeEach(() => {
+  Object.defineProperty(URL, "createObjectURL", {
+    value: vi.fn(() => "blob:stub"),
+    configurable: true,
+  });
+  Object.defineProperty(URL, "revokeObjectURL", { value: vi.fn(), configurable: true });
+});
+
+describe("coworkExportBlockedReason", () => {
+  it("permits export from a settled document", () => {
+    expect(coworkExportBlockedReason("clean")).toBeNull();
+  });
+
+  it("asks the author to wait while the outbox drains", () => {
+    expect(coworkExportBlockedReason("saving")).toMatch(/finish saving/iu);
+    expect(coworkExportBlockedReason("retrying")).toMatch(/finish saving/iu);
+  });
+
+  it("refuses while unsynced, so no one receives a stale copy", () => {
+    for (const status of ["offline", "error", "conflict", "saved_on_device"] as const) {
+      expect(coworkExportBlockedReason(status)).not.toBeNull();
+    }
+  });
+});
+
+describe("CoworkExportButton", () => {
+  it("offers only the formats the host can produce", async () => {
+    const fetchImpl = vi.fn(async () => formatsResponse(MARKDOWN_ONLY));
+
+    render(
+      <CoworkExportButton
+        storeId="store"
+        documentId="doc"
+        syncStatus="clean"
+        fetchImpl={fetchImpl as unknown as typeof fetch}
+      />,
+    );
+
+    await waitFor(() => expect(fetchImpl).toHaveBeenCalled());
+    expect(screen.getByRole("button", { name: "Export as Markdown" })).toBeInTheDocument();
+    // No toolchain means no dropdown at all, rather than a menu of dead entries.
+    expect(
+      screen.queryByRole("button", { name: "Choose an export format" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("discovers formats once, not once per render", async () => {
+    // Regression: depending on a wrapper built during render re-ran the effect,
+    // which set state, which rendered again. The loop did not just spin this
+    // control, it stalled the surface around it so documents never opened.
+    const fetchImpl = vi.fn(async () => formatsResponse(WITH_PANDOC));
+
+    const { rerender } = render(
+      <CoworkExportButton
+        storeId="store"
+        documentId="doc"
+        syncStatus="clean"
+        fetchImpl={fetchImpl as unknown as typeof fetch}
+      />,
+    );
+    await screen.findByRole("button", { name: "Choose an export format" });
+
+    for (const status of ["clean", "saving", "clean"] as const) {
+      rerender(
+        <CoworkExportButton
+          storeId="store"
+          documentId="doc"
+          syncStatus={status}
+          fetchImpl={fetchImpl as unknown as typeof fetch}
+        />,
+      );
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes the extra formats when the host has the toolchain", async () => {
+    const fetchImpl = vi.fn(async () => formatsResponse(WITH_PANDOC));
+
+    render(
+      <CoworkExportButton
+        storeId="store"
+        documentId="doc"
+        syncStatus="clean"
+        fetchImpl={fetchImpl as unknown as typeof fetch}
+      />,
+    );
+
+    const trigger = await screen.findByRole("button", { name: "Choose an export format" });
+    await userEvent.click(trigger);
+
+    expect(await screen.findByRole("menuitem", { name: "LaTeX" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "PDF" })).toBeInTheDocument();
+    // Markdown is the primary click, so repeating it in the menu would be noise.
+    expect(screen.queryByRole("menuitem", { name: "Markdown" })).not.toBeInTheDocument();
+  });
+
+  it("requests the chosen format for the given document", async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/render/formats")) return formatsResponse(MARKDOWN_ONLY);
+      return new Response("# Doc\n", {
+        status: 200,
+        headers: { "Content-Disposition": 'attachment; filename="doc-abc.md"' },
+      });
+    });
+
+    render(
+      <CoworkExportButton
+        storeId="store-1"
+        documentId="doc-1"
+        syncStatus="clean"
+        fetchImpl={fetchImpl as unknown as typeof fetch}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Export as Markdown" }));
+
+    await waitFor(() => {
+      const requested = fetchImpl.mock.calls.map((call) => String(call[0]));
+      expect(
+        requested.some(
+          (url) =>
+            url.includes("/api/truth/doc/doc-1/render") &&
+            url.includes("store_id=store-1") &&
+            url.includes("format=markdown"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("surfaces a refusal instead of failing silently", async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes("/render/formats")) return formatsResponse(MARKDOWN_ONLY);
+      return new Response(
+        JSON.stringify({ ok: false, error: { code: "stale_head", message: "The document moved on." } }),
+        { status: 409, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    render(
+      <CoworkExportButton
+        storeId="store"
+        documentId="doc"
+        syncStatus="clean"
+        fetchImpl={fetchImpl as unknown as typeof fetch}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Export as Markdown" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("The document moved on.");
+  });
+
+  it("blocks with a reason the assistive tree can reach", async () => {
+    const fetchImpl = vi.fn(async () => formatsResponse(MARKDOWN_ONLY));
+
+    const { container } = render(
+      <CoworkExportButton
+        storeId="store"
+        documentId="doc"
+        syncStatus="offline"
+        fetchImpl={fetchImpl as unknown as typeof fetch}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Export as Markdown" });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-describedby", "cowork-export-blocked-reason");
+    expect(container.querySelector("#cowork-export-blocked-reason")).toHaveTextContent(
+      /sync this document/iu,
+    );
+  });
+
+  it("has no accessibility violations in either state", async () => {
+    const fetchImpl = vi.fn(async () => formatsResponse(WITH_PANDOC));
+
+    const ready = render(
+      <CoworkExportButton
+        storeId="store"
+        documentId="doc"
+        syncStatus="clean"
+        fetchImpl={fetchImpl as unknown as typeof fetch}
+      />,
+    );
+    await screen.findByRole("button", { name: "Choose an export format" });
+    await expectNoAccessibilityViolations(ready.container);
+    ready.unmount();
+
+    const blocked = render(
+      <CoworkExportButton
+        storeId="store"
+        documentId="doc"
+        syncStatus="conflict"
+        fetchImpl={fetchImpl as unknown as typeof fetch}
+      />,
+    );
+    await expectNoAccessibilityViolations(blocked.container);
+  });
+});

--- a/dashboard-react/src/apps/cowork/documents/CoworkExportButton.tsx
+++ b/dashboard-react/src/apps/cowork/documents/CoworkExportButton.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useState } from "react";
+import { CaretDown } from "@phosphor-icons/react/CaretDown";
+import { DownloadSimple } from "@phosphor-icons/react/DownloadSimple";
+import { Menu, MenuItem, MenuTrigger, Popover, type Key } from "react-aria-components";
+
+import { Button } from "../../../ui";
+import type { CoworkSyncStatus } from "../persistence/CoworkYdocPersistence";
+
+export interface CoworkRenderFormat {
+  readonly format: string;
+  readonly label: string;
+  readonly extension: string;
+  readonly media_type: string;
+}
+
+interface CoworkExportButtonProps {
+  readonly storeId: string;
+  readonly documentId: string;
+  readonly syncStatus?: CoworkSyncStatus;
+  readonly disabled?: boolean;
+  readonly fetchImpl?: typeof fetch;
+}
+
+/**
+ * Why export is gated on a settled document rather than always available.
+ *
+ * Structured edits reach the server through an outbox, so a document can be
+ * complete on screen and not yet complete in the store. An export taken during
+ * that window would be a file the author believes is current and is not, with
+ * nothing in the artifact to reveal the difference. Waiting is cheap; an
+ * unnoticed stale copy sent to someone else is not.
+ */
+export const coworkExportBlockedReason = (
+  syncStatus?: CoworkSyncStatus,
+): string | null => {
+  if (syncStatus === undefined) return null;
+  if (syncStatus === "clean") return null;
+  if (syncStatus === "saving" || syncStatus === "retrying") {
+    return "Wait for Co-work to finish saving before exporting.";
+  }
+  return "Sync this document to Co-work before exporting.";
+};
+
+const MARKDOWN: CoworkRenderFormat = {
+  format: "markdown",
+  label: "Markdown",
+  extension: ".md",
+  media_type: "text/markdown; charset=utf-8",
+};
+
+const filenameFrom = (disposition: string | null, fallback: string): string => {
+  const match = disposition?.match(/filename="([^"]+)"/u);
+  return match?.[1] ?? fallback;
+};
+
+export function CoworkExportButton({
+  storeId,
+  documentId,
+  syncStatus,
+  disabled = false,
+  fetchImpl,
+}: CoworkExportButtonProps) {
+  const [formats, setFormats] = useState<readonly CoworkRenderFormat[]>([MARKDOWN]);
+  const [busy, setBusy] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
+
+  // Depend on the injected implementation itself, never on a wrapper created
+  // during render. A fresh closure each render would re-run this effect, which
+  // sets state, which renders again: an unbounded loop that stalls the whole
+  // Co-work surface rather than just this control.
+  useEffect(() => {
+    const request = fetchImpl ?? fetch;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await request("/api/truth/cowork/render/formats", {
+          headers: { accept: "application/json" },
+        });
+        if (!response.ok) return;
+        const payload = (await response.json()) as { formats?: CoworkRenderFormat[] };
+        // A host without pandoc offers fewer formats. Showing one it cannot
+        // produce would be a menu entry whose only outcome is an error.
+        if (!cancelled && payload.formats && payload.formats.length > 0) {
+          setFormats(payload.formats);
+        }
+      } catch {
+        // Markdown needs no toolchain, so the default list stays correct.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchImpl]);
+
+  const blockedReason = coworkExportBlockedReason(syncStatus);
+  const unavailable = disabled || busy || blockedReason !== null;
+
+  const exportAs = async (format: string): Promise<void> => {
+    const request = fetchImpl ?? fetch;
+    setBusy(true);
+    setFailure(null);
+    try {
+      const query = new URLSearchParams({ store_id: storeId, format });
+      const response = await request(
+        `/api/truth/doc/${encodeURIComponent(documentId)}/render?${query.toString()}`,
+      );
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as
+          | { error?: { message?: string } }
+          | null;
+        setFailure(payload?.error?.message ?? "Co-work could not export this document.");
+        return;
+      }
+      const blob = await response.blob();
+      const href = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = href;
+      anchor.download = filenameFrom(
+        response.headers.get("Content-Disposition"),
+        `document${format === "markdown" ? ".md" : ""}`,
+      );
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(href);
+    } catch {
+      setFailure("Co-work could not export this document.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const alternates = formats.filter((entry) => entry.format !== "markdown");
+
+  return (
+    <span className="wb-cowork__export">
+      <Button
+        size="small"
+        variant="ghost"
+        onClick={() => void exportAs("markdown")}
+        disabled={unavailable}
+        aria-label="Export as Markdown"
+        title={blockedReason ?? "Export as Markdown"}
+        aria-describedby={blockedReason !== null ? "cowork-export-blocked-reason" : undefined}
+      >
+        <DownloadSimple aria-hidden="true" /> {busy ? "Exporting…" : "Export"}
+      </Button>
+      {alternates.length > 0 ? (
+        <MenuTrigger>
+          <Button
+            size="small"
+            variant="ghost"
+            disabled={unavailable}
+            aria-label="Choose an export format"
+            title="Choose an export format"
+          >
+            <CaretDown weight="bold" aria-hidden="true" />
+          </Button>
+          <Popover className="wb-popover" placement="bottom end">
+            <Menu
+              aria-label="Export format"
+              className="wb-action-menu"
+              onAction={(key: Key) => void exportAs(String(key))}
+            >
+              {alternates.map((entry) => (
+                <MenuItem
+                  key={entry.format}
+                  id={entry.format}
+                  className="wb-action-menu__item"
+                  textValue={entry.label}
+                >
+                  {entry.label}
+                </MenuItem>
+              ))}
+            </Menu>
+          </Popover>
+        </MenuTrigger>
+      ) : null}
+      {blockedReason !== null ? (
+        <span id="cowork-export-blocked-reason" className="wb-visually-hidden">
+          {blockedReason}
+        </span>
+      ) : null}
+      {failure !== null ? (
+        <span className="wb-cowork__save-message is-error" role="alert">
+          {failure}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/dashboard-react/tests/live/cowork-live.spec.ts
+++ b/dashboard-react/tests/live/cowork-live.spec.ts
@@ -280,6 +280,13 @@ const waitForEditor = async (page: Page): Promise<ReturnType<Page["getByRole"]>>
   return editor;
 };
 
+/**
+ * Read the store and document identities out of the current Co-work route.
+ *
+ * The route carries a unique eight-character prefix whenever the Folder
+ * catalog admits one, and the full identity otherwise. These values are the
+ * URL's own presentation form, not registry identities.
+ */
 const currentRouteIds = (page: Page): { storeId: string; documentId: string } => {
   const query = new URL(page.url()).searchParams;
   const storeId = query.get("store_id");
@@ -287,6 +294,57 @@ const currentRouteIds = (page: Page): { storeId: string; documentId: string } =>
   if (storeId === null || documentId === null) {
     throw new Error(`expected a registered Co-work route, received ${page.url()}`);
   }
+  return { storeId, documentId };
+};
+
+const widen = (routeId: string, registered: readonly string[], label: string): string => {
+  const matches = registered.filter(
+    (candidate) => candidate === routeId || candidate.startsWith(routeId),
+  );
+  expect(
+    matches,
+    `route ${label} ${routeId} must widen to exactly one registered identity`,
+  ).toHaveLength(1);
+  return matches[0];
+};
+
+const registeredStoreIds = async (page: Page): Promise<string[]> => {
+  const payload = await page.evaluate(async () => {
+    const response = await fetch("/api/truth/cowork/folders", {
+      headers: { accept: "application/json" },
+    });
+    return (await response.json()) as { folders?: { store_id: string }[] };
+  });
+  return (payload.folders ?? []).map((entry) => entry.store_id);
+};
+
+const registeredDocumentIds = async (page: Page, storeId: string): Promise<string[]> => {
+  const payload = await page.evaluate(async (id: string) => {
+    const response = await fetch(`/api/truth/doc/list?store_id=${encodeURIComponent(id)}`, {
+      headers: { accept: "application/json" },
+    });
+    return (await response.json()) as { docs?: { document_id: string }[] };
+  }, storeId);
+  return (payload.docs ?? []).map((entry) => entry.document_id);
+};
+
+/**
+ * Widen the route's presentation identities back to the registry identities.
+ *
+ * Every API surface resolves store and document identities exactly, so any
+ * value threaded from the route into a request, or compared against a value
+ * that came from an API payload, has to be widened first.
+ */
+const resolveRouteIds = async (
+  page: Page,
+): Promise<{ storeId: string; documentId: string }> => {
+  const route = currentRouteIds(page);
+  const storeId = widen(route.storeId, await registeredStoreIds(page), "store_id");
+  const documentId = widen(
+    route.documentId,
+    await registeredDocumentIds(page, storeId),
+    "document_id",
+  );
   return { storeId, documentId };
 };
 
@@ -505,9 +563,10 @@ test.describe.serial("Co-work live lifecycle", () => {
     await expect(
       page.getByRole("button", { name: fixture.ordinary.name, exact: true }).first(),
     ).toBeVisible({ timeout: 30_000 });
-    const storeId = new URL(page.url()).searchParams.get("store_id");
-    expect(storeId).toMatch(/^[0-9a-f]{32}$/);
-    ordinaryStoreId = storeId ?? "";
+    const routeStoreId = new URL(page.url()).searchParams.get("store_id");
+    expect(routeStoreId).toMatch(/^[0-9a-f]{8}(?:[0-9a-f]{24})?$/);
+    ordinaryStoreId = widen(routeStoreId ?? "", await registeredStoreIds(page), "store_id");
+    expect(ordinaryStoreId).toMatch(/^[0-9a-f]{32}$/);
     await expect(
       page.getByRole("button", { name: fixture.ordinary.name, exact: true }).first(),
     ).toBeVisible();
@@ -525,8 +584,16 @@ test.describe.serial("Co-work live lifecycle", () => {
       path.join(fixture.ordinary.path, ".wbuddy", "cowork", ".gitignore"),
       "utf-8",
     );
-    for (const entry of ["/store.db", "/store.db-*", "/runtime/", "/blobs/"]) {
-      expect(componentIgnore).toContain(entry);
+    // The component directory ignores everything and re-includes only the
+    // durable surface, so a new sidecar file fails closed instead of leaking
+    // into history. Assert that shape rather than a list of named exclusions,
+    // which would go stale the moment the store grows another local file.
+    expect(componentIgnore).toContain("/*");
+    for (const reincluded of ["!/.gitignore", "!/store.yaml", "!/export/"]) {
+      expect(componentIgnore).toContain(reincluded);
+    }
+    for (const machineLocal of ["!/store.db", "!/runtime/", "!/blobs/"]) {
+      expect(componentIgnore).not.toContain(machineLocal);
     }
     const publishedManifest = await readFile(
       path.join(fixture.ordinary.path, ".wbuddy", "manifest.yaml"),
@@ -556,8 +623,8 @@ test.describe.serial("Co-work live lifecycle", () => {
     const editor = await waitForEditor(page);
     await expect(editor).toHaveText("");
     await expect(editor).not.toContainText("Context bundle cache");
-    ({ documentId: firstDocumentId } = currentRouteIds(page));
-    expect(currentRouteIds(page).storeId).toBe(ordinaryStoreId);
+    ({ documentId: firstDocumentId } = await resolveRouteIds(page));
+    expect((await resolveRouteIds(page)).storeId).toBe(ordinaryStoreId);
     expect(
       await readFile(path.join(fixture.ordinary.path, "drafts", "first-working-note.md")),
     ).toEqual(Buffer.alloc(0));
@@ -578,7 +645,7 @@ test.describe.serial("Co-work live lifecycle", () => {
 
     await page.reload({ waitUntil: "domcontentloaded" });
     await expect(await waitForEditor(page)).toHaveText("");
-    expect(currentRouteIds(page)).toEqual({
+    expect(await resolveRouteIds(page)).toEqual({
       storeId: ordinaryStoreId,
       documentId: firstDocumentId,
     });
@@ -595,7 +662,7 @@ test.describe.serial("Co-work live lifecycle", () => {
     const editor = await waitForEditor(page);
     await expect(editor).toContainText("Imported note");
     await expect(editor).toContainText("A line preserved exactly.");
-    ({ documentId: importedDocumentId } = currentRouteIds(page));
+    ({ documentId: importedDocumentId } = await resolveRouteIds(page));
     expect(await readFile(fixture.source.path)).toEqual(before);
 
     await page.reload({ waitUntil: "domcontentloaded" });
@@ -1082,10 +1149,10 @@ test.describe.serial("Co-work live lifecycle", () => {
     );
     await page.getByRole("button", { name: "Create document" }).click();
     await expect
-      .poll(() => currentRouteIds(page).documentId, { timeout: 30_000 })
+      .poll(async () => (await resolveRouteIds(page)).documentId, { timeout: 30_000 })
       .not.toBe(firstDocumentId);
     await waitForEditor(page);
-    const second = currentRouteIds(page);
+    const second = await resolveRouteIds(page);
     const secondPath = path.join(fixture.ordinary.path, "second-working-note.md");
 
     // Reload makes the catalog-derived mutation permissions authoritative after bootstrap.
@@ -1130,17 +1197,17 @@ test.describe.serial("Co-work live lifecycle", () => {
     const firstOption = page.getByRole("option", { name: /First Working Note/ });
     await firstOption.click();
     await expect
-      .poll(() => currentRouteIds(page).documentId, { timeout: 30_000 })
+      .poll(async () => (await resolveRouteIds(page)).documentId, { timeout: 30_000 })
       .toBe(firstDocumentId);
     await expect(await waitForEditor(page)).toHaveText("");
-    expect(currentRouteIds(page).documentId).toBe(firstDocumentId);
+    expect((await resolveRouteIds(page)).documentId).toBe(firstDocumentId);
 
     await page.goBack({ waitUntil: "domcontentloaded" });
     await expect(await waitForEditor(page)).toContainText(firstMarker);
-    expect(currentRouteIds(page).documentId).toBe(second.documentId);
+    expect((await resolveRouteIds(page)).documentId).toBe(second.documentId);
     await page.goForward({ waitUntil: "domcontentloaded" });
     await expect(await waitForEditor(page)).toHaveText("");
-    expect(currentRouteIds(page).documentId).toBe(firstDocumentId);
+    expect((await resolveRouteIds(page)).documentId).toBe(firstDocumentId);
 
     await chooseFolder(page, fixture.initialized, fixture.ordinary.name);
     await expect(
@@ -1151,7 +1218,7 @@ test.describe.serial("Co-work live lifecycle", () => {
     );
     await page.goBack({ waitUntil: "domcontentloaded" });
     await expect(await waitForEditor(page)).toHaveText("");
-    expect(currentRouteIds(page).documentId).toBe(firstDocumentId);
+    expect((await resolveRouteIds(page)).documentId).toBe(firstDocumentId);
   });
 
   test("AC-PROV: direct-entry provenance is durable and owns selection actions", async ({
@@ -1230,7 +1297,7 @@ test.describe.serial("Co-work live lifecycle", () => {
     await expect(editor).toHaveAttribute("aria-readonly", "false");
     await expect(editor.locator("p")).toHaveCount(1);
     await expect(editor.locator("p").first()).toHaveText(existingParagraph);
-    const { documentId } = currentRouteIds(page);
+    const { documentId } = await resolveRouteIds(page);
 
     const attestationResponses: number[] = [];
     const attestationRequestFailures: string[] = [];
@@ -1431,7 +1498,8 @@ test.describe.serial("Co-work live lifecycle", () => {
     await page.getByRole("button", { name: "Create document" }).click();
     await expect
       .poll(() => new URL(page.url()).searchParams.get("document_id"), { timeout: 30_000 })
-      .toMatch(/^[0-9a-f]{32}$/);
+      .toMatch(/^[0-9a-f]{8}(?:[0-9a-f]{24})?$/);
+    expect((await resolveRouteIds(page)).documentId).toMatch(/^[0-9a-f]{32}$/);
     await expect(await waitForEditor(page)).toContainText(fixture.scratch.marker);
     expect(await readFile(path.join(fixture.ordinary.path, "recovered-document.md"), "utf-8")).toBe(
       fixture.scratch.marker,

--- a/knowledge/store/cowork.md
+++ b/knowledge/store/cowork.md
@@ -2,7 +2,7 @@
 name: Co-work
 kind: concept
 description: The human-and-agent surface for living documents, with durable editing, source-safe file import, explicit file writes, content provenance, proposal review, and first-class Truth observability and management.
-summary: A user opens an ordinary folder, Co-work inspects it without mutation, and a one-time confirmation discloses the .wbuddy support data before setup. An invariant toolbar owns New, From file, folder selection, document selection, and explicit folder closing. From file uses a format-neutral importer boundary with Markdown support today; it creates a managed Co-work document without rewriting the source artifact. Co-work keeps structured editing state durable through an offline-capable outbox, records frozen-target authorship and human-review attestations for imported, pasted, directly entered, and accepted-proposal text, binds each document to one durable conversation with exact feedback anchors, and routes agent contributions through human-reviewed proposals.
+summary: A user opens an ordinary folder, Co-work inspects it without mutation, and a one-time confirmation discloses the .wbuddy support data before setup. An invariant toolbar owns New, From file, Export, folder selection, document selection, and explicit folder closing. From file uses a format-neutral importer boundary with Markdown support today; it creates a managed Co-work document without rewriting the source artifact. Co-work keeps structured editing state durable through an offline-capable outbox, records frozen-target authorship and human-review attestations for imported, pasted, directly entered, and accepted-proposal text, binds each document to one durable conversation with exact feedback anchors, and routes agent contributions through human-reviewed proposals.
 tags:
 - cowork
 - documents
@@ -137,6 +137,13 @@ import. It is disabled only when read-only mode, folder permissions, or host
 capabilities make that continuation unavailable. These creation actions never
 appear in the launcher body or inside the Open document dialog, and catalog
 loading does not keep them locked after a writable folder has been established.
+
+**Export** joins the bar for a registered folder document. Its primary action
+downloads Markdown, and a menu beside it offers whichever converted formats the
+host can actually produce. It is absent for a browser-local document, which has
+no server copy to render, and blocked while the document is unsynced, because a
+copy taken mid-drain would be older than the editor is showing with nothing in
+the file to reveal it. See `cowork/render`.
 
 The launcher has one **Documents** list whose contents follow the current
 context. With a folder open, it contains only ready registered documents from
@@ -437,7 +444,8 @@ from appearing after retirement.
 ## Human and agent authority
 
 The agent-facing capabilities are `cowork_doc_list`, `cowork_doc_get`,
-`cowork_doc_propose_edit`, `cowork_doc_comment`, and `cowork_doc_expression_mark`.
+`cowork_doc_serialize`, `cowork_doc_propose_edit`, `cowork_doc_comment`, and
+`cowork_doc_expression_mark`.
 An agent reads a document and proposes work on it. Every agent contribution is an
 open proposal, never a decision. Accept, amend, reject, redirect, endorse, and
 defer are human gestures collected on the dashboard, because an agent cannot

--- a/knowledge/store/cowork/cowork_doc_get.md
+++ b/knowledge/store/cowork/cowork_doc_get.md
@@ -32,7 +32,9 @@ parents:
 ---
 
 `cowork_doc_get` is a read-only view of the document's metadata and
-ledger-canonical review layer; content itself rides the binary Y.Doc transport.
+ledger-canonical review layer. Content itself rides the binary Y.Doc transport
+and is not returned here; `cowork_doc_serialize` is the sibling read that
+projects the document's canonical Markdown at its current head.
 It returns open proposals, expressions, feedback, source-writeback policy, and
 separately named structured, projection, recorded-import-source, and
 currently-observed-file hashes. The read does not append a drift event.

--- a/knowledge/store/cowork/cowork_doc_serialize.md
+++ b/knowledge/store/cowork/cowork_doc_serialize.md
@@ -1,0 +1,92 @@
+---
+name: Cowork Doc Serialize
+kind: capability
+description: Return one cowork doc's canonical Markdown at its current head, with the head and projection digests that identify it.
+capability_name: cowork_doc_serialize
+category: cowork
+op: op.wb.cowork_doc_serialize
+schema_version: wb-capability/v1
+parameters:
+  store_id:
+    type: str
+    description: Registered Truth store identity.
+    required: true
+  document_id:
+    type: str
+    description: Target cowork doc id.
+    required: true
+mutates_state: false
+retry_policy: manual
+auto_retry: false
+tags:
+- cowork
+- doc
+- serialize
+- projection
+aliases:
+- read cowork document text
+- cowork document markdown
+- project cowork document
+- get document content
+parents:
+- cowork
+---
+
+`cowork_doc_serialize` is the read that returns document *text*. Its sibling
+`cowork_doc_get` returns metadata and the review layer and deliberately carries
+no content, because content otherwise rides the binary Y.Doc transport and is
+reachable only inside the browser.
+
+## What the text is
+
+The **canonical projection**: exactly what the browser's own Markdown serializer
+produces for the same state. That matters beyond fidelity, because it is the
+coordinate space in which proposal anchors, expression marks, and content hashes
+resolve. A caller comparing offsets, placing a selector, or hashing content is
+only correct against this text.
+
+The projection covers the compacted snapshot **plus every un-compacted update**,
+so it reflects edits that have not yet been folded into a snapshot.
+
+## The canonical form is not publication shaping
+
+Canonical Markdown encodes `&`, `<`, and `>` as entity references and
+backslash-escapes Markdown-significant punctuation outside code spans and code
+blocks. That is part of the form, not damage to be repaired:
+
+- It is valid CommonMark, and every renderer decodes it. A converter emits
+  `Abbas, M., & Khan` from `Abbas, M., &amp; Khan`.
+- The escaping is what keeps a document's literal text literal. Removing it can
+  turn prose into markup, an author's typed `&amp;` into `&`, or an inert
+  bracket into an active citation.
+
+Convert from this text. Do not rewrite it first.
+
+## Reading the response
+
+| Field | Meaning |
+|---|---|
+| `markdown` | The canonical projection. |
+| `structured_head_sha256` | The head this text was produced from. Pin it when the text will be sent somewhere, so the recipient's copy is identifiable later. |
+| `projection_sha256` | Digest of these exact bytes. |
+| `byte_length` | UTF-8 length of `markdown`. |
+| `projection_receipt_match` | Whether the stored projection blob agrees with what the worker just produced. `null` when no receipt-bound projection is available to compare. |
+
+`projection_receipt_match: false` is the observable form of a serializer
+disagreement between the packaged worker and the browser. It is reported rather
+than raised so that a caller can decide whether the difference matters for what
+it is doing.
+
+## Failure modes
+
+- A document with no structured snapshot cannot be projected.
+- An in-flight compaction raises rather than returning text. Compaction rotates
+  the update log separately from the snapshot pointer, so a head derived from an
+  unchecked pair can name state that no longer exists. Retry.
+
+## Scope
+
+Ordinary agent sessions reach this capability by default. It is deliberately
+absent from the hosted document agent's execution set: that agent is
+generation-fenced and grounds its work in frozen action snapshots with
+consumption receipts, which a live-head read would quietly bypass.

--- a/knowledge/store/cowork/render.md
+++ b/knowledge/store/cowork/render.md
@@ -1,0 +1,107 @@
+---
+name: Co-work document rendering
+kind: system
+description: Server-side conversion of a Co-work document's canonical Markdown into a downloadable deliverable, with a host-capability gate and an untrusted-content boundary.
+summary: Export downloads Markdown by default and converts to HTML, LaTeX, DOCX or PDF where the host has pandoc and a TeX engine. Conversion runs server-side so one implementation owns it, the browser receives a download rather than the folder receiving a file, and the reader never interprets raw passthrough because document text is untrusted input.
+entry_points:
+- work_buddy.cowork.render
+- work_buddy.cowork.catalog_api
+- dashboard-react/src/apps/cowork/documents/CoworkExportButton.tsx
+tags:
+- cowork
+- render
+- export
+- pandoc
+- latex
+- security
+aliases:
+- export a cowork document
+- download document as pdf
+- cowork export
+- markdown to latex
+parents:
+- cowork
+dev_notes: |-
+  The reader string and the TeX flags are the security boundary, not stylistic
+  choices. Raw TeX, raw HTML and raw attributes stay disabled, and the engine
+  runs with shell escape off and reads confined to the scratch directory.
+  Anything that widens either needs to argue why document text is trustworthy.
+
+  The canonical projection's backslash escaping must survive to the converter.
+  A step that "tidies" it is reintroducing exactly what the reader flags exclude.
+---
+
+Export turns a document into a file someone else can open. It is the only path
+out of Co-work for a document whose source writeback is `never`, which is every
+document created through **From file**.
+
+## Where the work happens
+
+Conversion is server-side for every format. The browser holds a serializer of
+its own, so a client-side Markdown path is tempting, but it would mean two
+implementations of the same conversion. The packaged worker and the browser
+serializer already disagree on at least one input class, so a second
+implementation is a demonstrated defect source rather than a hypothetical one.
+
+Delivery is a browser download. Nothing is written into the folder, which keeps
+export clear of the source-writeback and human-actor rules that govern
+materialization.
+
+## Formats and the host gate
+
+| Format | Needs |
+|---|---|
+| Markdown | nothing |
+| HTML, LaTeX, Word | pandoc |
+| PDF | pandoc and a TeX engine |
+
+`GET /api/truth/cowork/render/formats` reports what this host can produce. The
+menu is built from that response, so a host without pandoc offers no entry whose
+only possible outcome is an error. Availability is probed by asking each program
+for its version rather than by resolving its name: an installer stub resolves on
+PATH and then blocks on a prompt the first time it is asked to do real work.
+
+PDF uses xelatex or lualatex. pdflatex cannot set the accented names ordinary
+prose carries.
+
+## Document text is untrusted input
+
+Agents write into documents through proposals, so document content is reachable
+by anything that can persuade an agent. Handed to a permissive Markdown reader,
+a code span carrying a raw-format attribute stops being text: `{=latex}` reaches
+the TeX engine as a command, `{=html}` reaches the browser as a tag. A TeX engine
+allowed to read freely will then embed whatever file it is pointed at.
+
+Three properties close that, and each is load-bearing:
+
+- **The reader never interprets raw passthrough.** Raw TeX, raw HTML and raw
+  attributes are disabled, so those constructs stay literal text in the output.
+- **The engine cannot reach the host.** No shell escape, and reads and writes
+  confined to a per-request scratch directory that is removed on every path.
+- **The canonical escaping survives.** The projection escapes
+  Markdown-significant punctuation, and that escaping is what keeps a
+  document's literal punctuation literal. No render step may undo it.
+
+Every subprocess runs under a timeout and non-interactive flags, so a prompting
+or wedged toolchain becomes a typed failure the caller can show rather than a
+request that never returns.
+
+## Freshness
+
+Structured edits reach the server through an outbox, so a document can be
+finished on screen and not yet finished in the store. A caller may pin
+`expected_structured_head_sha256`; a mismatch is a `409` rather than a quiet
+substitution. The response carries the head it rendered from in a header, and
+the filename embeds a short form of it, so a copy someone received months ago is
+still identifiable.
+
+The control is unavailable for a browser-local document, which has no server copy
+to render, and blocked while the document is unsynced.
+
+## What this is not
+
+Rendering converts one document. Composing several in order, applying a venue
+template, and resolving citations are manuscript concerns that sit above this
+seam. Conversion options are assembled on the server, and a caller never supplies
+converter arguments, so that layer can be added without widening the boundary
+this unit defends.

--- a/knowledge/store/cowork/source-backed-documents.md
+++ b/knowledge/store/cowork/source-backed-documents.md
@@ -32,6 +32,8 @@ dev_notes: |-
 
   Task reads and IR must project the current structured head plus uncompacted Yjs updates, not only the compacted blob. Restore preserves retired bindings/documents and creates a new active successor. Opaque local-file handles never expose absolute paths to the browser.
 
+  `document_kernel.projection.project_document` is the shared entry point for that read. It resolves the head through `ydoc_store.current_structured_head` rather than hashing whatever three separate reads happened to observe, because compaction rotates the update log separately from the snapshot pointer and an unchecked pair can name state that no longer exists: the authority raises on an in-flight marker instead, turning a silently stale projection into a retryable failure. It also defaults to the shared kernel client, so a caller does not spawn a Node worker per read.
+
   Never append a normal browser update to a bound document without a `DocumentChangeRecord`. The durable intent/materialized/committed state is the recovery authority. The `change_id` query link opens a compact source-and-change inspection row; do not expose raw source bytes through that read endpoint.
 ---
 

--- a/knowledge/store/dev/testing.md
+++ b/knowledge/store/dev/testing.md
@@ -1,0 +1,23 @@
+---
+name: Testing
+kind: concept
+description: Testing as a development concern in work-buddy, covering how the per-surface test runners relate to each other and what a passing run does and does not prove.
+summary: work-buddy is tested per surface rather than by one command. Each surface owns its runner, its isolation story, and its coverage in continuous integration, and none of them substitutes for another.
+tags:
+- dev
+- developmental
+- testing
+- verification
+aliases:
+- test suites
+- running the tests
+- how work-buddy is tested
+parents:
+- dev
+---
+
+work-buddy is tested per surface, not by one command. The Python package has a pytest suite, run with `uv run pytest` from the repo root. The React dashboard carries its own runners, its own isolation rules, and its own relationship to what continuous integration executes. Other subsystems add checks that live beside the code they cover.
+
+Two things are worth establishing before reaching for any of them. A passing run proves only what that runner covered: the surfaces are independent, and green on one says nothing about the others. And a test that reaches a running work-buddy process reaches the user's real data unless it explicitly selected a fixture or an isolated root, so every surface has to document how it stays off production state.
+
+Automated testing is distinct from live testing, which drives an in-progress change through the real running system with the user in the loop. See `dev/live-testing-directions` for that, and `dev/testing/react-dashboard` for the dashboard's five test surfaces.

--- a/knowledge/store/dev/testing/react-dashboard.md
+++ b/knowledge/store/dev/testing/react-dashboard.md
@@ -1,0 +1,82 @@
+---
+name: React Dashboard Testing
+kind: concept
+description: The five test surfaces of dashboard-react, how each one stays off the user's real data, the authentication boundary an agent must not try to cross, and what a green continuous-integration run actually proves.
+summary: 'dashboard-react has five independent test surfaces: a vitest component suite, a Playwright end-to-end suite, an isolated Co-work live harness, a document-kernel determinism check, and a separate projection-fidelity package. The end-to-end suite proxies to the developer''s real dashboard by default and avoids live data only through explicit fixture query parameters, so anything that writes belongs in the live harness.'
+tags:
+- dev
+- developmental
+- testing
+- dashboard
+- react
+- vitest
+- playwright
+- isolation
+- continuous-integration
+aliases:
+- dashboard-react tests
+- Co-work live harness
+- Playwright dashboard specs
+- dashboard test isolation
+- how to test the React dashboard
+parents:
+- dev/testing
+- services/dashboard/react
+---
+
+`dashboard-react/` carries five test surfaces. They share a package root and nothing else: separate runners, separate configuration files, separate isolation stories, and separate coverage in continuous integration. Running one of them proves nothing about the other four, so a report on dashboard testing has to name which surface was exercised.
+
+## The five surfaces
+
+**Component tests.** `npm test` runs `vitest run` under `dashboard-react/vitest.config.ts`: a jsdom environment, the setup file `src/test/setup.ts`, and roughly 250 co-located `*.test.ts` and `*.test.tsx` files collected from `src/`. The setup file installs a no-op `ResizeObserver` that jsdom lacks, and exports `expectNoAccessibilityViolations(container)`, an axe wrapper that shared widgets are expected to call from both their ready and non-ready state tests instead of inventing local accessibility assertions.
+
+**Browser end-to-end.** `npm run test:e2e` runs Playwright under `dashboard-react/playwright.config.ts`, which matches about twenty specs across `tests/e2e/` and `tests/performance/`. It starts its own front end: the `webServer` entry runs `npm run dev` bound to loopback on port 4173, overridable with `PLAYWRIGHT_PORT`, and reuses an already-listening server on that port outside continuous integration. Two projects are declared, chromium and firefox, and neither filters the spec set, so a full local run executes every spec twice.
+
+**The Co-work live harness.** `npm run test:e2e:cowork-live` runs `tests/live/run-cowork-live.mjs`, a process orchestrator rather than a Playwright entry point. It creates a temporary root holding a `.cowork-live-harness` marker, draws two random loopback ports and redraws them until neither one is 5127, seeds a fixture folder tree, typechecks and builds the production bundle, starts a Flask backend from `tests/live/cowork_live_server.py` against an isolated config root and data root, serves the built app through `vite preview`, and only then invokes Playwright with `playwright.cowork-live.config.ts`. That config pins `workers: 1` and `fullyParallel: false`. Teardown removes the temporary root only after confirming both the expected path prefix and the marker file, and treats a failed cleanup as a failed run. The `--interactive` flag, wrapped as `npm run test:e2e:cowork-live:interactive`, builds the same isolated stack, skips Playwright entirely, prints a live URL into the isolated dashboard, and holds everything open for a bounded window until it expires or receives an interrupt.
+
+**Document-kernel determinism.** `npm run test:document-kernel-build` runs `scripts/verify-document-kernel-determinism.mjs`, which builds the document-kernel worker twice and compares the sha256 of the emitted `worker.mjs`, failing when the two builds disagree.
+
+**Projection fidelity.** `dashboard-react/tests/fidelity/` is a separate npm package, `@work-buddy/cowork-fidelity`, with its own `package.json`, lockfile, and vitest config. No root script reaches it, and the root vitest config collects only under `src/`, so `npm test` never runs it. Run `npm ci && npm test` from inside that directory. Its `.gitattributes` marks `corpus/** -text` because the corpus is a byte-fidelity fixture and a line-ending rewrite would invalidate the recorded digests.
+
+## Isolation is a fixture choice, not a sandbox
+
+This is the section to read before pointing any browser at the dashboard.
+
+The Vite dev server that the end-to-end suite starts proxies `/api` to `WB_DASHBOARD_PROXY_TARGET`, which defaults to loopback port 5127. On a developer machine that is the real Flask dashboard, backed by the user's real notes, tasks, and Co-work Folders. Nothing about running Playwright puts a boundary between the specs and that data.
+
+What keeps the specs off it is an explicit fixture selection in every navigation. Journal specs go through `openJournal` in `tests/e2e/helpers.ts`, which loads `/app/journal?provider=demo`. Co-work specs go through `openCowork` in `tests/e2e/cowork-helpers.ts`, which loads `/app/cowork?cowork_fixture=demo`. Both parameters swap in in-memory providers. A spec, or an agent, that navigates without one of them is driving the user's live dashboard.
+
+The rule that follows is simple: reads and local presentation state can run against the proxied dashboard with a demo parameter, and anything that must write goes through the live harness, which owns its own ports, config root, data root, and folder tree and deletes all of it on teardown. `services/dashboard/react` already states this constraint in its dev notes as a standing rule for browser specifications. The parameters and the harness above are the mechanisms that implement it.
+
+## The authentication boundary
+
+`work_buddy/dashboard/local_identity_api.py` states in its module docstring that there is intentionally no HTTP bootstrap-mint route. A trusted host launch path calls `LocalIdentityAuthority.mint_bootstrap` in process and places the one-time grant in a browser URL fragment. Nothing reachable over the network can ask the real dashboard for a session.
+
+The live harness needs a browser session, so its throwaway server adds one that production does not have: `/api/_cowork-live/identity-bootstrap` in `tests/live/cowork_live_server.py`, gated on the harness nonce and on an exact match between the requested origin and the observed `Origin` header, minting into an authority database that lives under the harness temporary root and disappears with it.
+
+Stated plainly, because it is the mistake worth preventing: do not attempt to mint a session against the real dashboard. The route is absent by design, and its absence is not a gap to route around. When browser-driven work needs an authenticated session, start the interactive harness and use the URL it prints.
+
+## Driving the browser pane
+
+For read-only inspection of dashboard UI, open the demo fixture routes against whatever dev server is already running: `/app/journal?provider=demo` and `/app/cowork?cowork_fixture=demo`. Real components render against in-memory providers, so clicking through them cannot reach the user's data.
+
+For anything that writes, meaning creating a Folder, saving a document, or exercising persistence, recovery, or the review loop, run `npm run test:e2e:cowork-live:interactive` and drive the URL it prints. That is the only browser surface where a write is both meaningful and safe.
+
+The `wb-dashboard` entry in `.claude/launch.json` starts no dashboard. Its command is a Node process that does nothing but stay alive, a keepalive placeholder so the preview attaches to port 5127, where the sidecar-hosted dashboard the user already runs is listening. Starting that entry does not produce a server, and stopping it does not stop one.
+
+## Gotchas
+
+- The live specification is one `test.describe.serial` block of sixteen tests that share module-level store and document identifiers built up by earlier tests. A single failure skips every test after it, so only the first red result carries information. Narrowing to one test with `--grep`, exposed as `COWORK_LIVE_PLAYWRIGHT_GREP`, usually fails outright, because the prerequisites that create its Folder and its documents never ran.
+- Pass `--reporter=verbose` to vitest when you need to read `console` output from a test. The default reporter is not a reliable place to look for it.
+- `dashboard-react/test-results/` is gitignored. Harness logs, the run summary, traces, videos, and screenshots land there and cannot be recovered from version control, so read them in the same session that produced them.
+- `npm run build` writes outside `dashboard-react/`. The document-kernel step emits into `work_buddy/document_kernel/runtime_dist/` with `emptyOutDir` set, so a dashboard build modifies a Python-package directory. That is intended, and that emitted worker is what the determinism check hashes.
+
+## What a green continuous-integration run proves
+
+The `dashboard-test` job in `.github/workflows/tests.yml` installs dependencies, runs `npm test`, installs chromium and firefox, runs an explicit allowlist of eleven Playwright specs, and builds the production assets.
+
+The allowlist covers the Journal specs, shell routing, the layout contract, themes, and the mobile and settings accessibility specs. It omits the five `cowork-*.spec.ts` specs, `visual.spec.ts`, `widget-lab.spec.ts`, `calendar-spike.spec.ts`, and everything under `tests/performance/`. The live harness, the fidelity package, and the document-kernel determinism check appear in no workflow at all. Continuous integration also installs no pandoc, so the Python render tests that require it skip on every run.
+
+So "continuous integration is green" means: the component suite passed, eleven browser specs passed in two browsers against demo providers, and the production bundle compiled. It does not mean Co-work works, that persistence or recovery hold, that the document kernel builds reproducibly, that Markdown projection is byte-faithful, or that any code was exercised against a real backend. Those claims require running the matching surface locally, and a report that makes one should say which surface was run.
+
+See `services/dashboard/react` for the hosting, provider, and network contract these tests exercise, `dev/live-testing-directions` for user-in-the-loop verification across the running multi-process system, and the `cowork/` scope for the document lifecycle the live harness covers.

--- a/tests/unit/cowork/test_render.py
+++ b/tests/unit/cowork/test_render.py
@@ -1,0 +1,101 @@
+"""Rendering contract, with the injection boundary as the headline case.
+
+A document's text is untrusted: agents write into documents through proposals.
+The reader configuration is what stops that text from becoming executable
+markup, so it is asserted directly rather than trusted.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from work_buddy.cowork import render
+
+
+pandoc_required = pytest.mark.skipif(
+    shutil.which("pandoc") is None,
+    # CI installs no pandoc, so this skip is taken on every CI run and the
+    # assertions below only ever execute on a developer host that has it.
+    reason="pandoc is not installed on this host",
+)
+
+
+def test_unknown_format_is_rejected() -> None:
+    with pytest.raises(render.RenderError) as caught:
+        render.render("# Doc\n", "postscript")
+    assert caught.value.code == "unsupported_format"
+    assert caught.value.status == 400
+
+
+def test_markdown_render_is_byte_identical_and_needs_no_tool() -> None:
+    """Markdown is the canonical text itself, not a conversion of it."""
+    canonical = "Walters &amp; Wilder \\[Preprint\\].\n"
+    assert render.render(canonical, "markdown") == canonical.encode("utf-8")
+
+
+def test_oversized_documents_are_refused() -> None:
+    oversized = "x" * (render.MAX_RENDERED_BYTES + 1)
+    with pytest.raises(render.RenderError) as caught:
+        render.render(oversized, "markdown")
+    assert caught.value.code == "document_too_large"
+    assert caught.value.status == 413
+
+
+def test_reader_disables_every_raw_passthrough_extension() -> None:
+    """The reader string is the injection boundary, so pin it explicitly."""
+    for extension in ("raw_tex", "raw_attribute", "raw_html"):
+        assert f"-{extension}" in render.MARKDOWN_READER
+
+
+def test_pdf_uses_an_engine_that_can_set_accented_names() -> None:
+    assert render.TEX_ENGINE in {"xelatex", "lualatex"}
+
+
+@pandoc_required
+def test_raw_latex_attribute_stays_literal_text() -> None:
+    """A code span carrying {=latex} must not reach the engine as a command."""
+    hostile = "Cite `\\input{/etc/passwd}`{=latex} here.\n"
+    produced = render.render(hostile, "latex").decode("utf-8")
+    assert "\\input{/etc/passwd}" not in produced
+    assert "input" in produced  # it survives, as inert text
+
+
+@pandoc_required
+def test_raw_html_attribute_stays_literal_text() -> None:
+    hostile = "Text `<script>alert(1)</script>`{=html} more.\n"
+    produced = render.render(hostile, "html").decode("utf-8")
+    assert "<script>alert(1)</script>" not in produced
+
+
+@pandoc_required
+def test_canonical_escaping_renders_as_the_author_wrote_it() -> None:
+    """Entities and escapes decode at render time, which is why nothing strips them earlier."""
+    canonical = "Abbas, M., &amp; Khan, T. I. (2024) \\[Preprint\\].\n"
+    produced = render.render(canonical, "latex").decode("utf-8")
+    assert "\\&" in produced
+    assert "&amp;" not in produced
+
+
+@pandoc_required
+def test_available_formats_reports_markdown_at_minimum() -> None:
+    names = [entry["format"] for entry in render.available_formats()]
+    assert "markdown" in names
+    assert names.index("markdown") == 0
+
+
+def test_markdown_is_available_without_any_toolchain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(render, "available_tools", lambda: {"pandoc": False, "tex": False})
+    names = [entry["format"] for entry in render.available_formats()]
+    assert names == ["markdown"]
+
+
+def test_missing_toolchain_is_a_typed_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(render, "available_tools", lambda: {"pandoc": False, "tex": False})
+    with pytest.raises(render.RenderError) as caught:
+        render.render("# Doc\n", "pdf")
+    assert caught.value.code == "render_tool_unavailable"
+    assert caught.value.status == 503

--- a/tests/unit/cowork/test_render_route.py
+++ b/tests/unit/cowork/test_render_route.py
@@ -1,0 +1,100 @@
+"""The download route: freshness, identity headers, and format admission."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from work_buddy.cowork import api as cowork_api
+
+from .test_serialize import _bootstrap_real_document
+
+
+@pytest.fixture
+def rendered_ctx(
+    store_ctx: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> dict[str, Any]:
+    monkeypatch.setattr(cowork_api, "_registry", lambda: store_ctx["registry"])
+    document_id = _bootstrap_real_document(
+        store_ctx["store"],
+        source=b"# Route fixture\n\nWalters & Wilder (2023).\n",
+        path="docs/route.md",
+        title="Route fixture",
+    )
+    return {**store_ctx, "document_id": document_id}
+
+
+def _render(client, ctx, **params: str):
+    query = {"store_id": ctx["store_id"], **params}
+    query_string = "&".join(f"{key}={value}" for key, value in query.items())
+    return client.get(f"/api/truth/doc/{ctx['document_id']}/render?{query_string}")
+
+
+def test_markdown_download_carries_its_identity(client, rendered_ctx) -> None:
+    response = _render(client, rendered_ctx, format="markdown")
+
+    assert response.status_code == 200
+    body = response.data.decode("utf-8")
+    assert "# Route fixture" in body
+    # The canonical form reaches the caller unaltered. A renderer decodes it.
+    assert "&amp;" in body
+
+    head = response.headers["X-WB-Structured-Head-Sha256"]
+    assert len(head) == 64
+    disposition = response.headers["Content-Disposition"]
+    assert disposition.startswith("attachment; ")
+    # The filename carries the head, so a recipient's copy stays identifiable.
+    assert head[:12] in disposition
+    assert disposition.endswith('.md"')
+
+
+def test_a_moved_head_is_a_conflict_not_a_substitution(client, rendered_ctx) -> None:
+    """Rendering mid-drain must not hand back text older than the editor shows."""
+    response = _render(
+        client,
+        rendered_ctx,
+        format="markdown",
+        expected_structured_head_sha256="0" * 64,
+    )
+
+    assert response.status_code == 409
+    payload = response.get_json()
+    assert payload["error"]["code"] == "stale_head"
+    assert len(payload["error"]["details"]["structured_head_sha256"]) == 64
+
+
+def test_a_matching_head_is_served(client, rendered_ctx) -> None:
+    observed = _render(client, rendered_ctx, format="markdown")
+    head = observed.headers["X-WB-Structured-Head-Sha256"]
+
+    response = _render(
+        client, rendered_ctx, format="markdown", expected_structured_head_sha256=head
+    )
+
+    assert response.status_code == 200
+
+
+def test_unknown_format_is_refused(client, rendered_ctx) -> None:
+    response = _render(client, rendered_ctx, format="postscript")
+
+    assert response.status_code == 400
+    assert response.get_json()["error"]["code"] == "invalid_request"
+
+
+def test_missing_document_is_not_found(client, rendered_ctx) -> None:
+    response = client.get(
+        f"/api/truth/doc/{'0' * 32}/render?store_id={rendered_ctx['store_id']}"
+    )
+
+    assert response.status_code == 404
+
+
+def test_format_discovery_always_offers_markdown(client) -> None:
+    response = client.get("/api/truth/cowork/render/formats")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["ok"] is True
+    names = [entry["format"] for entry in payload["formats"]]
+    assert names[0] == "markdown"

--- a/tests/unit/cowork/test_serialize.py
+++ b/tests/unit/cowork/test_serialize.py
@@ -1,0 +1,207 @@
+"""Canonical Markdown reads over genuine structured state.
+
+Every other cowork fixture stores opaque placeholder bytes where a Y.Doc
+snapshot belongs, which is fine for tests that never interpret them. A
+serializer test cannot use those: the packaged worker rejects anything that is
+not real Yjs state. These tests bootstrap through the worker so the snapshot
+under test is the same shape production writes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from work_buddy.cowork import bootstrap
+from work_buddy.cowork import ops as cowork_ops
+from work_buddy.document_kernel.protocol import structured_head_sha256
+from work_buddy.document_kernel.runtime_service import shared_document_kernel
+from work_buddy.truth import documents, ydoc_store
+from work_buddy.truth.contracts import InvariantViolation
+from work_buddy.truth.identity import sha256_bytes
+
+from .conftest import HUMAN
+from .test_ops import NOW
+
+
+def _bootstrap_real_document(store: Any, *, source: bytes, path: str, title: str) -> str:
+    """Register a document whose snapshot is genuine worker-produced Yjs state."""
+    kernel = shared_document_kernel()
+    built = kernel.request(
+        {
+            "kind": "bootstrap_markdown",
+            "sourceBase64": source,
+            "sourceSha256": sha256_bytes(source),
+            "newlineStyle": "lf",
+            "utf8Bom": False,
+            "trailingNewlineCount": 1,
+        },
+        request_id=f"test_bootstrap_{sha256_bytes(source)[:16]}",
+    )
+    snapshot = built.snapshot
+    assert snapshot is not None, "worker returned no snapshot"
+
+    intent, _ = bootstrap.prepare_bootstrap(
+        store,
+        metadata={
+            "mode": "create",
+            "path": path,
+            "title": title,
+            "initial_source_sha256": sha256_bytes(source),
+            "idempotency_key": f"serialize-fixture-{sha256_bytes(path.encode())[:16]}",
+        },
+        source=source,
+        actor=HUMAN,
+    )
+    receipt = bootstrap.commit_bootstrap(
+        store,
+        bootstrap_id=intent.id,
+        snapshot=snapshot,
+        source_sha256=intent.source_sha256,
+        snapshot_sha256=sha256_bytes(snapshot),
+        ydoc_schema=bootstrap.YDOC_SCHEMA,
+        actor=HUMAN,
+    )
+    return receipt["document_id"]
+
+
+@pytest.fixture
+def serialize_ctx(
+    store_ctx: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> dict[str, Any]:
+    monkeypatch.setattr(cowork_ops, "_registry", lambda: store_ctx["registry"])
+    return store_ctx
+
+
+def test_serialize_returns_canonical_markdown_and_its_identities(
+    serialize_ctx: dict[str, Any],
+) -> None:
+    store = serialize_ctx["store"]
+    source = b"# Serialize fixture\n\nA plain sentence.\n"
+    document_id = _bootstrap_real_document(
+        store, source=source, path="docs/serialize.md", title="Serialize fixture"
+    )
+
+    result = cowork_ops.cowork_doc_serialize(serialize_ctx["store_id"], document_id)
+
+    assert result["ok"] is True
+    assert result["document_id"] == document_id
+    assert "# Serialize fixture" in result["markdown"]
+    assert "A plain sentence." in result["markdown"]
+    assert result["byte_length"] == len(result["markdown"].encode("utf-8"))
+    assert len(result["structured_head_sha256"]) == 64
+    assert len(result["projection_sha256"]) == 64
+    assert result["projection_sha256"] == sha256_bytes(
+        result["markdown"].encode("utf-8")
+    )
+
+
+def test_serialize_head_matches_the_store_head_authority(
+    serialize_ctx: dict[str, Any],
+) -> None:
+    """The reported head is the authority's, not a hash over unchecked reads."""
+    store = serialize_ctx["store"]
+    source = b"# Head\n\nBody.\n"
+    document_id = _bootstrap_real_document(
+        store, source=source, path="docs/head.md", title="Head"
+    )
+    document = documents.get_document(store, document_id)
+
+    result = cowork_ops.cowork_doc_serialize(serialize_ctx["store_id"], document_id)
+
+    assert result["structured_head_sha256"] == ydoc_store.current_structured_head(
+        store,
+        document_id=document_id,
+        snapshot_sha256=document.ydoc_snapshot_sha256,
+    )
+
+
+def test_serialize_preserves_the_canonical_escaping(
+    serialize_ctx: dict[str, Any],
+) -> None:
+    """Entity encoding and backslash escaping are the canonical form.
+
+    A renderer decodes both. Stripping them here would change the document, so
+    the read must hand back exactly what the serializer produced.
+    """
+    store = serialize_ctx["store"]
+    source = b"Walters & Wilder (2023) [Preprint].\n"
+    document_id = _bootstrap_real_document(
+        store, source=source, path="docs/escaping.md", title="Escaping"
+    )
+
+    markdown = cowork_ops.cowork_doc_serialize(
+        serialize_ctx["store_id"], document_id
+    )["markdown"]
+
+    assert "&amp;" in markdown
+    assert r"\[Preprint\]" in markdown
+
+
+def test_serialize_reflects_uncompacted_updates(
+    serialize_ctx: dict[str, Any],
+) -> None:
+    """Reading only the compacted snapshot would silently drop recent edits."""
+    store = serialize_ctx["store"]
+    source = b"# Tail\n\nFirst paragraph.\n"
+    document_id = _bootstrap_real_document(
+        store, source=source, path="docs/tail.md", title="Tail"
+    )
+    document = documents.get_document(store, document_id)
+    snapshot = ydoc_store.read_snapshot(
+        store, snapshot_sha256=document.ydoc_snapshot_sha256
+    )
+
+    revised = b"# Tail\n\nSecond paragraph.\n"
+    kernel = shared_document_kernel()
+    edited = kernel.request(
+        {
+            "kind": "apply_source_markdown",
+            "snapshotBase64": snapshot,
+            "updatesBase64": [],
+            "expectedBaseStructuredHeadSha256": structured_head_sha256(snapshot, ()),
+            "sourceBase64": revised,
+            "sourceSha256": sha256_bytes(revised),
+            "newlineStyle": "lf",
+            "utf8Bom": False,
+            "trailingNewlineCount": 1,
+        },
+        request_id="test_tail_edit",
+    )
+    update = edited.update
+    assert update is not None, "worker returned no update"
+    ydoc_store.append_update(store, document_id=document_id, update=update)
+
+    markdown = cowork_ops.cowork_doc_serialize(
+        serialize_ctx["store_id"], document_id
+    )["markdown"]
+
+    assert "Second paragraph." in markdown
+
+
+def test_serialize_refuses_a_document_without_structured_state(
+    serialize_ctx: dict[str, Any],
+) -> None:
+    store = serialize_ctx["store"]
+    body = b"# No snapshot\n"
+    record = documents.register_document(
+        store,
+        path="docs/no-snapshot.md",
+        title="No snapshot",
+        document_class="co_authored",
+        content_sha256=sha256_bytes(body),
+        actor=HUMAN,
+        at=NOW,
+    )
+
+    with pytest.raises(InvariantViolation):
+        cowork_ops.cowork_doc_serialize(serialize_ctx["store_id"], record.id)
+
+
+def test_serialize_is_registered_as_an_op() -> None:
+    from work_buddy.mcp_server import op_registry
+
+    cowork_ops.register_ops()
+    assert op_registry.get_op("op.wb.cowork_doc_serialize") is not None

--- a/work_buddy/cowork/catalog_api.py
+++ b/work_buddy/cowork/catalog_api.py
@@ -18,6 +18,8 @@ from work_buddy.cowork.source_observation import (
     SourceObservationError,
     read_document_source,
 )
+from work_buddy.cowork import render
+from work_buddy.document_kernel.projection import project_document
 from work_buddy.truth import documents
 from work_buddy.truth.contracts import InvariantViolation
 from work_buddy.truth.identity import sha256_bytes
@@ -295,6 +297,86 @@ def api_doc_source(document_id: str):
     for name, value in _source_headers(data).items():
         response.headers[name] = value
     return response
+
+
+@catalog_blueprint.get("/api/truth/cowork/render/formats")
+def api_render_formats():
+    """Which deliverables this host can actually produce.
+
+    The caller renders a menu from this rather than from a fixed list, so a host
+    without pandoc never offers a format that would fail when clicked.
+    """
+    return jsonify({"ok": True, "formats": render.available_formats()})
+
+
+@catalog_blueprint.get("/api/truth/doc/<document_id>/render")
+def api_doc_render(document_id: str):
+    """Serve one document's current head as a downloadable deliverable.
+
+    The caller may pin ``expected_structured_head_sha256``. A mismatch is a
+    conflict rather than a silent substitution: the browser holds edits in an
+    outbox, so a render issued mid-drain would otherwise hand back text older
+    than the editor is showing, with nothing to reveal it.
+    """
+    store, failure = _store_from_request()
+    if failure:
+        return failure
+    try:
+        document = documents.get_document(store, document_id)
+    except InvariantViolation:
+        return _error("document_not_found", "Document does not exist.", 404)
+
+    fmt = str(request.args.get("format") or "markdown").strip()
+    if fmt not in render.FORMATS:
+        return _error(
+            "invalid_request",
+            f"format must be one of {', '.join(render.FORMATS)}",
+            400,
+            field="format",
+        )
+
+    try:
+        projection = project_document(store, document_id)
+    except InvariantViolation as exc:
+        return _error("projection_unavailable", str(exc), 409, retryable=True)
+
+    expected = str(request.args.get("expected_structured_head_sha256") or "").strip()
+    if expected and expected != projection.structured_head_sha256:
+        return _error(
+            "stale_head",
+            "The document moved on since the render was requested.",
+            409,
+            retryable=True,
+            details={"structured_head_sha256": projection.structured_head_sha256},
+        )
+
+    try:
+        payload = render.render(projection.markdown, fmt)
+    except render.RenderError as exc:
+        return _error(exc.code, str(exc), exc.status)
+
+    spec = render.FORMATS[fmt]
+    response = Response(payload, mimetype=spec.media_type)
+    for name, value in _source_headers(payload).items():
+        response.headers[name] = value
+    response.headers["X-WB-Structured-Head-Sha256"] = projection.structured_head_sha256
+    response.headers["Content-Disposition"] = (
+        f'attachment; filename="{_render_filename(document, projection, spec)}"'
+    )
+    return response
+
+
+def _render_filename(document, projection, spec) -> str:
+    """A stable, filesystem-safe name that carries the head it was cut from.
+
+    The head fragment is what makes "which copy did I send" answerable later,
+    without the recipient needing anything but the filename.
+    """
+    stem = "".join(
+        character if character.isalnum() or character in "-_" else "-"
+        for character in (document.title or "document")
+    ).strip("-")
+    return f"{stem or 'document'}-{projection.structured_head_sha256[:12]}{spec.extension}"
 
 
 def register_catalog_routes(app):

--- a/work_buddy/cowork/ops.py
+++ b/work_buddy/cowork/ops.py
@@ -44,6 +44,7 @@ from work_buddy.cowork.proposal_applicability import (
     assess_proposal_applicability,
     load_current_projection,
 )
+from work_buddy.document_kernel.projection import project_document
 from work_buddy.mcp_server.op_registry import register_op
 from work_buddy.truth import documents, expressions, proposals, ydoc_store
 from work_buddy.truth.anchors import CompositeSelector, parse_selector
@@ -514,6 +515,50 @@ def cowork_doc_list(store_id: str, profile: str | None = None) -> dict[str, Any]
         "docs": docs_payload,
     }
     return result
+
+
+def cowork_doc_serialize(store_id: str, document_id: str) -> dict[str, Any]:
+    """Return one cowork doc's canonical Markdown at its current head.
+
+    This is the text the browser's own serializer produces, and the space in
+    which proposal anchors and expression marks resolve. It is not shaped for
+    publication: entity encoding and backslash escaping are part of the
+    canonical form, and every renderer that consumes it decodes them. A caller
+    that strips them is changing the document, not cleaning it up.
+
+    ``projection_sha256`` names this exact text. ``projection_receipt_match``
+    reports whether the stored projection blob agrees with what the kernel just
+    produced, so a divergence between the packaged worker and the browser
+    surfaces as data rather than as a silent difference in an exported file.
+    """
+    store = _open_store(store_id)
+    _require_document_surface(store)
+    document = documents.get_document(store, document_id)
+    projection = project_document(store, document_id)
+
+    with store._read_connection() as conn:
+        recorded, _reason = load_current_projection(
+            store,
+            document,
+            structured_head_sha256=projection.structured_head_sha256,
+            conn=conn,
+        )
+    receipt_match = (
+        None
+        if recorded is None
+        else recorded.projection_sha256 == projection.projection_sha256
+    )
+
+    return {
+        "ok": True,
+        "store_id": store.store_id,
+        "document_id": document.id,
+        "markdown": projection.markdown,
+        "structured_head_sha256": projection.structured_head_sha256,
+        "projection_sha256": projection.projection_sha256,
+        "byte_length": projection.byte_length,
+        "projection_receipt_match": receipt_match,
+    }
 
 
 def cowork_doc_get(
@@ -1390,6 +1435,9 @@ def register_ops(*, replace: bool = True) -> None:
     """
     register_op("op.wb.cowork_doc_list", cowork_doc_list, replace=replace)
     register_op("op.wb.cowork_doc_get", cowork_doc_get, replace=replace)
+    register_op(
+        "op.wb.cowork_doc_serialize", cowork_doc_serialize, replace=replace
+    )
     register_op(
         "op.wb.cowork_action_snapshot_get",
         cowork_action_snapshot_get,

--- a/work_buddy/cowork/render.py
+++ b/work_buddy/cowork/render.py
@@ -1,0 +1,267 @@
+"""Convert a Co-work document's canonical Markdown into a deliverable file.
+
+Rendering runs entirely on the server so one implementation owns the conversion
+for every format. Markdown needs no external program; every other format shells
+out to pandoc, and PDF additionally needs a TeX engine.
+
+## Document content is untrusted input
+
+Agents write into documents through proposals, so a document can carry whatever
+an agent was persuaded to write. Handed to pandoc's default reader, a code span
+carrying a raw-format attribute becomes executable markup: ``{=latex}`` reaches
+the TeX engine as a real command, ``{=html}`` reaches the browser as a real tag.
+A TeX engine configured to read freely will then embed any file it is pointed at.
+
+Two properties keep that shut, and both are load-bearing rather than defensive
+decoration:
+
+- The reader never interprets raw passthrough. Raw TeX, raw HTML, and raw
+  attributes are disabled, so those constructs stay literal text.
+- The canonical projection's own backslash escaping is preserved end to end. No
+  step here may "clean up" the escaping it receives, because that escaping is
+  what keeps a document's literal punctuation literal.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from work_buddy.compat import subprocess_creation_flags
+from work_buddy.cowork.materialization import MAX_RENDERED_BYTES
+
+
+RENDER_TIMEOUT_SECONDS = 120
+
+# Raw passthrough is what turns document text into executable markup, so the
+# reader is pinned rather than left to pandoc's default.
+MARKDOWN_READER = "markdown-raw_tex-raw_attribute-raw_html"
+
+# pdflatex cannot set the accented names ordinary prose carries.
+TEX_ENGINE = "xelatex"
+
+
+class RenderError(Exception):
+    """A render failed in a way the caller should surface, not retry blindly."""
+
+    def __init__(self, code: str, message: str, *, status: int = 500) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status = status
+
+
+@dataclass(frozen=True, slots=True)
+class RenderFormat:
+    """One deliverable shape, and what the host must provide to produce it."""
+
+    name: str
+    extension: str
+    media_type: str
+    requires: tuple[str, ...]
+    label: str
+
+
+FORMATS: dict[str, RenderFormat] = {
+    "markdown": RenderFormat(
+        name="markdown",
+        extension=".md",
+        media_type="text/markdown; charset=utf-8",
+        requires=(),
+        label="Markdown",
+    ),
+    "html": RenderFormat(
+        name="html",
+        extension=".html",
+        media_type="text/html; charset=utf-8",
+        requires=("pandoc",),
+        label="HTML",
+    ),
+    "latex": RenderFormat(
+        name="latex",
+        extension=".tex",
+        media_type="application/x-tex; charset=utf-8",
+        requires=("pandoc",),
+        label="LaTeX",
+    ),
+    "docx": RenderFormat(
+        name="docx",
+        extension=".docx",
+        media_type=(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        ),
+        requires=("pandoc",),
+        label="Word",
+    ),
+    "pdf": RenderFormat(
+        name="pdf",
+        extension=".pdf",
+        media_type="application/pdf",
+        requires=("pandoc", "tex"),
+        label="PDF",
+    ),
+}
+
+
+def _probe(command: list[str]) -> bool:
+    """Run a version probe, because a resolvable name is not a working program.
+
+    An installer stub resolves on PATH and then blocks on a prompt the first
+    time it is asked to do real work. Asking for a version up front turns that
+    into a fast, silent unavailability instead of a hung request.
+    """
+    if shutil.which(command[0]) is None:
+        return False
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            timeout=20,
+            creationflags=subprocess_creation_flags(),
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return completed.returncode == 0
+
+
+def available_tools() -> dict[str, bool]:
+    return {
+        "pandoc": _probe(["pandoc", "--version"]),
+        "tex": _probe([TEX_ENGINE, "--version"]),
+    }
+
+
+def available_formats() -> list[dict[str, object]]:
+    """The formats this host can actually produce, in menu order."""
+    tools = available_tools()
+    return [
+        {
+            "format": spec.name,
+            "label": spec.label,
+            "extension": spec.extension,
+            "media_type": spec.media_type,
+        }
+        for spec in FORMATS.values()
+        if all(tools.get(requirement, False) for requirement in spec.requires)
+    ]
+
+
+def _run(command: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> None:
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=str(cwd),
+            capture_output=True,
+            timeout=RENDER_TIMEOUT_SECONDS,
+            creationflags=subprocess_creation_flags(),
+            env=env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RenderError(
+            "render_timeout",
+            f"{command[0]} did not finish within {RENDER_TIMEOUT_SECONDS}s",
+            status=504,
+        ) from exc
+    except OSError as exc:
+        raise RenderError(
+            "render_tool_unavailable", f"{command[0]} could not be started", status=503
+        ) from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", "replace").strip()[-800:]
+        raise RenderError(
+            "render_failed", f"{command[0]} failed: {detail}", status=422
+        )
+
+
+def _pandoc_base(fmt: str) -> list[str]:
+    command = ["pandoc", "--from", MARKDOWN_READER, "--to", fmt, "--standalone"]
+    if _sandbox_supported():
+        command.append("--sandbox")
+    return command
+
+
+def _sandbox_supported() -> bool:
+    try:
+        completed = subprocess.run(
+            ["pandoc", "--help"],
+            capture_output=True,
+            timeout=20,
+            creationflags=subprocess_creation_flags(),
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return b"--sandbox" in completed.stdout
+
+
+def render(markdown: str, fmt: str) -> bytes:
+    """Convert canonical Markdown into the requested deliverable's bytes."""
+    spec = FORMATS.get(fmt)
+    if spec is None:
+        raise RenderError("unsupported_format", f"unknown render format {fmt!r}", status=400)
+
+    source = markdown.encode("utf-8")
+    if len(source) > MAX_RENDERED_BYTES:
+        raise RenderError(
+            "document_too_large",
+            "document exceeds the render size limit",
+            status=413,
+        )
+
+    if spec.name == "markdown":
+        return source
+
+    tools = available_tools()
+    missing = [name for name in spec.requires if not tools.get(name, False)]
+    if missing:
+        raise RenderError(
+            "render_tool_unavailable",
+            f"{spec.label} export needs {', '.join(missing)} on this host",
+            status=503,
+        )
+
+    with tempfile.TemporaryDirectory(prefix="wb-cowork-render-") as scratch:
+        work = Path(scratch)
+        (work / "input.md").write_bytes(source)
+
+        if spec.name == "pdf":
+            _run(_pandoc_base("latex") + ["-o", "output.tex", "input.md"], cwd=work)
+            # openin_any=p confines TeX's file reads to the scratch directory, so
+            # an \input that survived as literal text still cannot reach the host.
+            env = {
+                **_inherited_env(),
+                "openin_any": "p",
+                "openout_any": "p",
+                "TEXMFVAR": str(work / "texmf"),
+            }
+            _run(
+                [
+                    "latexmk",
+                    f"-{TEX_ENGINE}",
+                    "-no-shell-escape",
+                    "-interaction=nonstopmode",
+                    "-halt-on-error",
+                    "output.tex",
+                ],
+                cwd=work,
+                env=env,
+            )
+            produced = work / "output.pdf"
+        else:
+            produced = work / f"output{spec.extension}"
+            _run(
+                _pandoc_base(spec.name) + ["-o", produced.name, "input.md"], cwd=work
+            )
+
+        if not produced.is_file():
+            raise RenderError(
+                "render_failed", f"{spec.label} export produced no file", status=422
+            )
+        return produced.read_bytes()
+
+
+def _inherited_env() -> dict[str, str]:
+    import os
+
+    return dict(os.environ)

--- a/work_buddy/document_kernel/projection.py
+++ b/work_buddy/document_kernel/projection.py
@@ -1,0 +1,88 @@
+"""Canonical Markdown projection of a structured document at its current head.
+
+Python treats Y.Doc state as opaque bytes. The packaged DOM-free worker owns the
+ProseMirror/Yjs schema and the Markdown mapping, so producing text means handing
+the compacted snapshot plus every un-compacted update to that worker and reading
+back what it serializes.
+
+The result is the *canonical projection*: the same text the browser's own
+serializer produces, and the text space in which proposal anchors, expression
+marks, and content hashes resolve. Callers that need publication-shaped output
+convert from this, never instead of it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+from work_buddy.document_kernel.client import DocumentKernelClient
+from work_buddy.document_kernel.runtime_service import shared_document_kernel
+from work_buddy.truth import documents, ydoc_store
+from work_buddy.truth.contracts import InvariantViolation
+from work_buddy.truth.store import TruthStore
+
+
+@dataclass(frozen=True, slots=True)
+class DocumentProjection:
+    """One document's canonical Markdown, bound to the head it came from."""
+
+    markdown: str
+    structured_head_sha256: str
+    projection_sha256: str
+
+    @property
+    def byte_length(self) -> int:
+        return len(self.markdown.encode("utf-8"))
+
+
+def project_document(
+    store: TruthStore,
+    document_id: str,
+    *,
+    kernel: DocumentKernelClient | None = None,
+) -> DocumentProjection:
+    """Serialize the document's current head to canonical Markdown.
+
+    ``ydoc_store.current_structured_head`` is the head authority rather than a
+    bare hash over whatever the three reads happened to observe. Compaction
+    rotates the update log separately from the snapshot pointer, so a head
+    computed from an unchecked pair can name state that no longer exists. The
+    authority raises on an in-flight compaction marker instead, which turns a
+    silently stale projection into a retryable failure.
+    """
+
+    document = documents.get_document(store, document_id)
+    if document.ydoc_snapshot_sha256 is None:
+        raise InvariantViolation("document has no structured snapshot to project")
+
+    head = ydoc_store.current_structured_head(
+        store,
+        document_id=document.id,
+        snapshot_sha256=document.ydoc_snapshot_sha256,
+    )
+    snapshot = ydoc_store.read_snapshot(
+        store,
+        snapshot_sha256=document.ydoc_snapshot_sha256,
+    )
+    updates, _cursor = ydoc_store.read_updates(store, document_id=document.id)
+
+    client = kernel or shared_document_kernel()
+    outcome = client.request(
+        {
+            "kind": "project_markdown",
+            "snapshotBase64": snapshot,
+            "updatesBase64": updates,
+            "expectedBaseStructuredHeadSha256": head,
+        },
+        request_id=f"project_{hashlib.sha256(f'{document.id}:{head}'.encode()).hexdigest()[:24]}",
+    )
+    projection = outcome.projection
+    if projection is None:
+        raise InvariantViolation("document kernel returned no projection")
+
+    return DocumentProjection(
+        markdown=projection.decode("utf-8"),
+        structured_head_sha256=head,
+        projection_sha256=hashlib.sha256(projection).hexdigest(),
+    )


### PR DESCRIPTION
## Summary

Co-work could not produce a document. There was no UI affordance, no format conversion, and for a `never`-writeback import (every **From file** document) the live text had no path out at all: the repo file freezes at import while the document moves on, so the newest prose was reachable only inside the editor.

Three layers:

- **`cowork_doc_serialize`** returns a document's canonical Markdown at its current head. The projection helper is lifted out of the tasks domain into `document_kernel/projection.py` and corrected on the way. It resolves the head through `ydoc_store.current_structured_head` rather than hashing whatever three separate reads observed, because compaction rotates the update log separately from the snapshot pointer and an unchecked pair can name state that no longer exists. It also reuses the shared kernel client instead of spawning a Node worker per call.
- **A render service** converting that Markdown to HTML, LaTeX, DOCX or PDF where the host has pandoc and a TeX engine, discovered at runtime so a host without them never offers a format whose only outcome is an error.
- **An Export control** in the document bar: Markdown on the primary click, a menu for the rest, delivered as a browser download so nothing is written into the folder.

Also documents the React dashboard's five test surfaces, which nothing in the knowledge store described.

## The injection boundary

Document text is untrusted input, since agents write into documents through proposals. Handed to pandoc's default reader, a code span carrying a raw-format attribute stops being text:

```
$ printf 'Text `\input{/etc/passwd}`{=latex} more.\n' | pandoc -f markdown -t latex
Text \input{/etc/passwd} more.
```

The reader therefore disables raw TeX, raw HTML and raw attributes; the engine runs with no shell escape and reads confined to a per-request scratch directory; and the canonical projection's own backslash escaping is preserved end to end rather than "cleaned up". Tests assert the injection stays inert.

## Two corrections worth flagging for review

**The canonical form is returned unmodified.** An earlier draft normalized entity encoding and bracket escaping on the way out, assuming a renderer would emit them literally. Measurement refuted that (pandoc decodes both), and the transform is not injective, so it would have corrupted an author's literal `&amp;` or a `<script>` written as prose.

**The capability is deliberately absent from `_COWORK_EXECUTION_CAPABILITIES`.** Ordinary sessions are default-open. The frozenset constrains the generation-fenced hosted document agent, which grounds its work in frozen action snapshots with consumption receipts, and a live-head read would quietly bypass that.

## Live-suite repairs, and one failure that is not fixed

Two stale assertions in `cowork-live.spec.ts` were masking each other and are fixed. Route identities are a presentation form (a unique eight-character prefix when the catalog admits one), so values threaded from the route into exact-match API calls are now widened to registry identities first. Relaxing the assertion alone would have moved the failure one test later. The component `.gitignore` assertion tested a deny-list that had since become an allow-list, and now tests the invariant instead.

**A third failure underneath them is pre-existing and remains:** document creation in the harness silently does nothing. An isolation run with the Export control removed fails identically, so it is not from this change. It was previously invisible because the suite aborted earlier.

## Test plan

- [ ] `uv run pytest tests/unit/cowork/` (full suite green here)
- [ ] `cd dashboard-react && npm test`
- [ ] `uv run python -m work_buddy.knowledge.validate` exits 0
- [ ] After a sidecar restart and Ctrl+R: open a Co-work folder, open a document, click **Export**. The Markdown should be the live head, not the repo file.
- [ ] With pandoc installed, check the dropdown offers LaTeX and PDF; without it, check only Markdown appears.

Known: two pre-existing failures, both verified by isolation. A vitest `ViewHost.assistance` timing flake that passes 3/3 alone, and the live-suite document creation above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)