### PR TITLE
docs(tasks): name the parameter that actually provisions a task note

### DIFF
--- a/knowledge/store/tasks/handoff-directions.md
+++ b/knowledge/store/tasks/handoff-directions.md
@@ -2,7 +2,7 @@
 name: Task Handoff Directions
 kind: directions
 description: How to write a structured session handoff prompt and package it as native task knowledge.
-summary: 'Write from what you already know. Use the exact section structure: Task, Context, What I Already Know, Key Files, System Notes, Suggested Approach. Create via task_create with initial Co-work knowledge in summary.'
+summary: 'Write from what you already know. Use the exact section structure: Task, Context, What I Already Know, Key Files, System Notes, Suggested Approach. Create via task_create, asking for the task note explicitly with requested_note_role and passing the prompt as initial_note.'
 trigger: user wants to hand off in-progress work to a new agent session via a task
 command: wb-task-handoff
 capabilities:
@@ -41,11 +41,24 @@ Be specific. File paths absolute. Decisions include rationale.
 
 ## Create the task
 
-mcp__work-buddy__wb_run("task_create", {"task_text": "<concise summary>", "summary": "<full handoff prompt>"})
+```
+mcp__work-buddy__wb_run("task_create", {
+    "task_text": "<concise single-line description>",
+    "requested_note_role": "working_document/v1",
+    "initial_note": "<full handoff prompt>",
+})
+```
 
-The `summary` parameter provisions the Co-work document. `task_create` carries a
-stable mutation ID, so a response-loss retry through the gateway replays the
-same native task instead of creating a duplicate. Do not use `obsidian_retry`.
+`requested_note_role` is what provisions the Co-work document, and `initial_note`
+is its body. Pass both: the role alone yields an empty document, and the text alone
+is refused outright with "Choose a task note role before supplying note text". The
+`summary` parameter is a scalar field on the task record and creates no document at
+all, so a handoff passed there is not knowledge the next session can open, only a
+string it has to be told about.
+
+`task_create` carries a stable mutation ID, so a response-loss retry through the
+gateway replays the same native task instead of creating a duplicate. Do not use
+`obsidian_retry`.
 
 ## Confirm
 


### PR DESCRIPTION
## Summary

The task-handoff directions told the agent to pass the whole handoff prompt as `task_create`'s `summary`, and stated that this parameter "provisions the Co-work document".

It does not. `summary` is a scalar field on the task record. Following the directions verbatim produces a handoff task with **no knowledge document at all**, which inverts the point of a handoff: the prompt becomes a string the next session has to be told about rather than a document it can open.

The Co-work document is provisioned by `requested_note_role`, with `initial_note` as its body.

## What the code says

`work_buddy/work_item/task_adapter.py` opens its `create` docstring with, verbatim:

> A scalar summary never selects a document role. Callers must request the task note, initial content, and optional Truth activation explicitly.

and the implementation matches:

- `summary` is routed into `summary_text` on the task record and goes nowhere near a document.
- The aggregate-creation path is gated on `requested_note_role`, from which `initial_note` reaches the document as `initial_markdown` (`work_buddy/tasks/aggregate_creation.py`).
- Supplying the text without the role raises `ValueError("Choose a task note role before supplying note text")`.
- Supplying the role without text is allowed and yields an empty document.

## Scope

The capability unit `tasks/task_create` already carried the correct wording ("Optional scalar task summary. This does not create a Co-work document."), so the store disagreed with itself. I grepped the whole store for the same stale claim and found it nowhere else. The sibling directions units for task creation and the completeness sweep do not repeat it. This is confined to one unit, in two places: the frontmatter `summary` line and the body.

## Also in this change

- The example is a fenced block rather than a bare line.
- Its `task_text` placeholder now reads "concise single-line description" instead of "concise summary", which previously read as though it named the `summary` parameter.

## How this was found

Writing a real handoff. `/wb-task-handoff` followed the directions, the schema rejected the shape, and the resulting task would have carried the prompt as a scalar. The task was created correctly by using the schema's parameters instead.

## Test plan

- [ ] `docs_validate` passes with 0 errors (it does: 517 units, 15 checks, 40 advisory warnings, all pre-existing and none against this unit)
- [ ] `agent_docs(path="tasks/handoff-directions", depth="full")` renders the corrected body
- [ ] A subsequent `/wb-task-handoff` produces a task whose `note_uuid` resolves to a Co-work document containing the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
