### PR TITLE
fix(index): restore long-history partition refreshes

### DIFF
--- a/knowledge/store/architecture/consolidated-index.md
+++ b/knowledge/store/architecture/consolidated-index.md
@@ -155,6 +155,10 @@ and invalidate the partition's resident matrices. It runs under a DB-wide writer
 per-partition lock, so concurrent builds (across partitions or processes) serialize safely
 rather than colliding on the shared DB. Default is incremental (`force=false`).
 
+Legacy IR-backed partitions whose source accepts a `days` parameter use an explicit 3650-day
+discovery window. The wrapper does not inherit the shorter rolling defaults used by the live IR
+jobs, so older conversations and summaries remain eligible for reconciliation.
+
 For a database partition, the facade additionally snapshots its transactional search outbox,
 builds and verifies source/index parity, then acknowledges exactly the snapshot. The returned
 `outbox` receipt uses `wb.search-outbox-delivery/v1`; `ready=true` requires zero remaining lag
@@ -199,10 +203,10 @@ score-guarded, so a genuinely dominant document with no competitive alternative 
 
 - **`index_rebuild`** (`context/index-rebuild`) — incremental per-partition build; self-skips
   while any index build is running.
-- **Nine `index-<partition>-refresh` sidecar crons** keep the active partitions fresh at
-  corpus-matched cadences, including Journal every five minutes and Projects, Contracts, and
-  Personal Knowledge every fifteen minutes. One job per partition preserves replay and
-  backfill isolation.
+- **Ten `index-<partition>-refresh` sidecar crons** keep the active partitions fresh at
+  corpus-matched cadences, including Journal every five minutes and Projects, Contracts,
+  Personal Knowledge, and Task Notes every fifteen minutes. One job per partition preserves
+  replay and backfill isolation.
 - **Embedding-service endpoints** `/index/search`, `/index/search_many`, `/index/build`, with
   `index_search` / `index_search_many` clients (see `architecture/embedding-service`).
 - **Status/dashboard seam** — registered as the `consolidated` index in `work_buddy/indexing/`

--- a/knowledge/store/context/session-identify.md
+++ b/knowledge/store/context/session-identify.md
@@ -94,16 +94,42 @@ mcp__work-buddy__wb_run("summary_search", {
 
 ### 3. Fallback: raw-span sweep when summaries miss
 
-If `summary_search` returned an `error`, an empty `candidate_items`, or weak top scores (single-digit hits across queries, no token co-occurrence), fall back to the raw-span sweep:
+Choose the raw-span search method based on how `summary_search` failed.
 
-- Use `context_search(query=..., source="conversation", top_k=15, recency=false)` to scan raw spans across all sessions. `source="conversation"` is mandatory — otherwise tabs and docs dilute the ranking. `recency=false` for older targets (default `true` biases toward this week and buries multi-month-old hits).
-- Returned hits are tagged `[<cwd-name>]` and a short session-ID prefix. The same conversation often appears under multiple short IDs — resumed-session forks of the same JSONL. Treat clustered IDs as a single conversation.
-- Drill into clustered candidates via `session_search(session_id=..., query=...)`.
+If it returned an empty `candidate_items` list or weak top scores without a service error, use the default hybrid method:
 
-The fallback is the right path for:
-- Very recent sessions (the summarization cron runs every 2 hours; today's session may not be summarized yet).
-- Sessions whose summarization landed with `status='error'` (the framework records the failure without overwriting prior good summaries; the row exists but has no nodes to search).
-- Queries needing exact-string match (use `method="substring"`).
+```
+mcp__work-buddy__wb_run("context_search", {
+  "query": "<topic phrase>",
+  "source": "conversation",
+  "top_k": 15,
+  "recency": false
+})
+```
+
+`source="conversation"` is mandatory because omitting it lets tabs and docs dilute the ranking. Use `recency=false` for older targets because the default recency bias can bury multi-month-old hits.
+
+If `summary_search` returned an error, or embedding-backed search is timing out or unavailable, do not use the default `context_search` method. It calls the same embedding-service search path. Use two or three separate in-process substring probes instead:
+
+```
+mcp__work-buddy__wb_run("context_search", {
+  "query": "<short literal term>",
+  "source": "conversation",
+  "method": "substring",
+  "top_k": 15,
+  "recency": false
+})
+```
+
+`method="substring"` matches the entire query string literally. It does not tokenize or interpret a natural-language question. Probe with one distinctive identifier, file-path fragment, error string, or short exact phrase per call, then combine the returned session candidates. A long conceptual query will usually match nothing even when the target session is present.
+
+For either raw-span path:
+
+- Returned hits are tagged `[<cwd-name>]` and a short session-ID prefix. The same conversation often appears under multiple short IDs because resumed-session forks have distinct JSONL files. Treat clustered IDs as a single conversation.
+- After the default hybrid sweep, drill into clustered candidates with `session_search(session_id=..., query=...)`.
+- During an embedding-service outage, keep the drill local too: call `session_search(session_id=..., query="<short literal term>", method="substring")`. Do not switch back to the default hybrid method until the service path recovers.
+
+Raw-span search is the right path for very recent sessions, sessions whose summarization has `status='error'`, and exact strings that compressed summaries may omit. The substring method is also the outage-safe path because it reads the local IR store without calling the embedding service.
 
 ### 4. Score and sanity-check candidates
 
@@ -140,6 +166,6 @@ Return:
 - The rank-first `summary_search` (`drill=False`) is the load-bearing step. Spend phrasing effort there; drill only the winner, never the whole top-N.
 - Resumed-session forks share content but have distinct UUIDs. Pick the longest / latest fork as the canonical one to cite.
 - The 8-char session prefix is canonical for display; the full UUID is canonical for storage. Always show the full UUID once in the report.
-- If `summary_search` returns nothing, check whether the IR `summary` index is built via `ir_index(action='status', source='summary')`. If `dense_eligible_docs` is 0, the embedding service is down; fall back to `context_search` (raw-span sweep).
+- Do not diagnose a search outage with `ir_index(action='status')` in this flow. It calls the same service with the same client timeout, so congestion can make a healthy service look unreachable. Use the explicit substring fallback above.
 - The drill stage is per-item bounded; if a single session has many topic hits, increase `drill_per_item_top_k` rather than `drill_top_k`.
 - Cached summaries (`conversation_observability_summary_get`) are not authoritative for content matching — they exist as a read shortcut, not as a replacement for drill confirmation.

--- a/sidecar_jobs/index-task-note-refresh.md
+++ b/sidecar_jobs/index-task-note-refresh.md
@@ -1,0 +1,17 @@
+---
+schedule: "*/15 * * * *"  # task-note cadence: small, low-volume corpus
+recurring: true
+jitter_seconds: 90  # distinct offset across consolidated-index refresh jobs
+type: capability
+capability: index_rebuild
+params:
+  partition: task_note
+  force: false
+---
+Keep the index's **`task_note` partition** current so task-linked Co-work documents stay
+searchable. The source discovers document heads and uses content fingerprints to skip unchanged
+documents, so recurring builds are incremental. The `index_rebuild` op self-skips while any index
+build is running because all partitions share one single-writer database.
+
+**One job per partition by design.** This job is a sibling of the other
+`index-<partition>-refresh` jobs and is not folded into a shared `build_all` cron.

--- a/tests/unit/test_index_partitions.py
+++ b/tests/unit/test_index_partitions.py
@@ -128,6 +128,21 @@ class TestIRSourcePartition:
         assert {r.item_id for r in refs} == {"sess1", "sess2"}
         assert {r.mtime for r in refs} == {100.0, 200.0}
 
+    def test_discover_requests_full_history_window_when_supported(self):
+        class WindowedSource(_FakeIRSource):
+            def __init__(self):
+                self.days = None
+
+            def discover(self, days=30):
+                self.days = days
+                return super().discover()
+
+        source = WindowedSource()
+        refs = list(IRSourcePartition(source).discover())
+
+        assert source.days == 3650
+        assert {r.item_id for r in refs} == {"sess1", "sess2"}
+
     def test_parse_converts_ir_doc(self):
         p = IRSourcePartition(_FakeIRSource())
         docs = p.parse("sess1")

--- a/tests/unit/test_index_refresh_jobs.py
+++ b/tests/unit/test_index_refresh_jobs.py
@@ -22,6 +22,7 @@ _PARTITION_JOBS = {
     "projects": "index-projects-refresh",
     "contracts": "index-contracts-refresh",
     "personal_knowledge": "index-personal-knowledge-refresh",
+    "task_note": "index-task-note-refresh",
 }
 _RANGES = [(0, 59), (0, 23), (1, 31), (1, 12), (0, 6)]  # min hour dom mon dow
 

--- a/work_buddy/index/partitions/ir_source.py
+++ b/work_buddy/index/partitions/ir_source.py
@@ -20,8 +20,10 @@ Two OPTIONAL, source-interpreted capabilities make the wrapper extensible to arb
   (``change_key`` becomes ``"hash"``), and (b) stamps a uniform ``lifecycle_state``
   metadata key so ANY source's states are filterable by ANY query with one key.
 
-Both are duck-typed (``getattr``/signature introspection), so a brand-new source opts in
-by implementing them and is otherwise byte-identical to today.
+Coverage and lifecycle are duck-typed (``getattr``/signature introspection), so a
+brand-new source opts into either by implementing it. Separately, a source whose
+``discover`` accepts ``days`` receives the consolidated index's explicit long-history
+window instead of its rolling default.
 
 NOTE: the IR ``docs`` source is intentionally NOT wrapped — it's the redundant second
 index of the knowledge store, replaced by ``KnowledgePartition``.
@@ -51,6 +53,10 @@ logger = get_logger(__name__)
 # domain-owned stable-ID adapters, so wrapping their legacy IR sources would
 # overwrite those registrations.
 _IR_PARTITIONS = ("conversation", "chrome", "summary", "task_note")
+
+# Consolidated partitions retain a long-lived search corpus, so sources with a
+# rolling ``days`` parameter must receive the intended history window explicitly.
+_DISCOVERY_WINDOW_DAYS = 3650
 
 
 def _accepts(fn: Any, param: str) -> bool:
@@ -124,16 +130,14 @@ class IRSourcePartition:
         return {"content": ProjectionSpec(kind=ProjectionKind.PASSAGE)}
 
     def discover(self):
-        # Forward coverage only when the source understands it (else byte-identical
-        # to today). Keep the existing `days`-fallback for sources that require it.
+        # Forward optional source controls only when the source understands them.
         disc = self._src.discover
         kwargs: dict[str, Any] = {}
+        if _accepts(disc, "days"):
+            kwargs["days"] = _DISCOVERY_WINDOW_DAYS
         if self._coverage and self._coverage != "active" and _accepts(disc, "coverage"):
             kwargs["coverage"] = self._coverage
-        try:
-            raw = disc(**kwargs)
-        except TypeError:
-            raw = disc(days=3650, **kwargs)  # some sources require a lookback arg
+        raw = disc(**kwargs)
 
         pairs: list[tuple[str, float]] = []
         for entry in raw or []:


### PR DESCRIPTION
## Summary
- Pass a 3650-day discovery window to IR sources that accept `days`, restoring intended long-history reconciliation without masking internal `TypeError` failures.
- Add the missing 15-minute `task_note` partition refresh job and cover it in the job-shape tests.
- Split session-identify fallback between healthy hybrid misses and outage-safe substring probes, including local substring drilling.

## Activation plan
Merge and activate the historical catch-up immediately. No configuration gate or per-run builder budget will be added to this PR.

A current read-only probe shows that full-history discovery expands:
- `summary` from 274 to 868 source items
- `conversation` from 867 to 1,164 source items

That is 891 additional source items. These can expand into many more searchable passages during embedding. The scheduled builder commits in 256-document transactions but continues until the catch-up is complete, so interactive search may be slow or time out during the initial run. This temporary degradation is an explicitly accepted tradeoff in favor of starting the catch-up as soon as possible.

The first scheduled refresh after deployment will start the catch-up. No manual live rebuild is part of this PR.

## Task-note scheduling boundary
The `task_note` cron is a freshness stopgap pending transactional search-outbox hooks. The recurring scheduler will remain useful as reconciliation after those hooks land. Its first run is expected to index roughly 251 native documents, including 89 non-archived documents.

## Scope
- No configuration gate
- No builder-level run budget
- No cutover or legacy-index retirement
- No search-outbox implementation

## Test plan
- [x] `uv run python -m pytest tests/unit/test_index_partitions.py tests/unit/test_index_refresh_jobs.py -q --tb=short` (45 passed)
- [x] `docs_validate` (525 units, 0 failures, 40 pre-existing advisory warnings)
- [x] Read-only discovery-count probe
- [x] Sidecar job-loader parse for schedule, jitter, capability, and params

Task: t-4d29559093e2
