### PR TITLE
fix(index): bound embedding memory and refresh work

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -117,27 +117,15 @@ embedding:
       name: "MongoDB/mdbr-leaf-ir-asym"
       dims: 768
       eager: false
-      # Optional: offload document-side passage encoding to LM Studio.
-      # When omitted (default), bulk document encoding uses the
-      # sentence-transformers model above. When set to "lmstudio",
-      # _encode_bulk_direct POSTs to LM Studio's /v1/embeddings
-      # endpoint instead — moves ~500 MB of model RSS off the main
-      # machine and lets a remote compute device (via LM Link) do
-      # the work.
-      #
-      # Setup procedure (including the mandatory GGUF audit and drift
-      # test): docs/handbook/features_lmstudio-offload-setup.md.
-      # provider: lmstudio
+      # The large document-side route is selected in Dashboard Settings:
+      # System -> Embeddings (Local only / Prefer LM Studio / Require LM Studio).
+      # Settings is authoritative after bootstrap; do not set provider/on_error
+      # here. The HF name remains the local implementation used by Local mode and
+      # Prefer mode's deliberate fallback. Supply the LM Studio model alias below
+      # before selecting either remote mode. LM Studio may place it on an LM Link
+      # peer, so absence from one /v1/models snapshot is not proof it cannot load.
+      # Setup: knowledge/store/features/lmstudio-offload-setup.md.
       # lmstudio_model: text-embedding-snowflake-arctic-embed-m-v1.5
-      # on_error: fallback   # "fallback" (default) silently falls
-      #                      # back to sentence_transformer when LM
-      #                      # Studio errors. "fail" re-raises — use
-      #                      # for research workflows that require
-      #                      # single-provenance vectors in the
-      #                      # index. Observed drift between Q8
-      #                      # GGUF and fp32 sentence-transformers
-      #                      # is ~0.0002 cosine, so "fallback" is
-      #                      # safe for retrieval quality.
 
     # ---- Pluggable embedding models for the consolidated index (work_buddy/index/) ----
     # Point a projection at a model via ProjectionSpec.model_key. The OPTIONAL `encoding`
@@ -323,6 +311,12 @@ inference:
 index:
   enabled: false
   db_path: null            # null → paths.resolve("db/index-consolidated")
+  # RAM-aware default: materialize a partition's float32 search matrix only when a
+  # query needs it. The warming signal serves lexical results immediately, warms that
+  # partition in the background, and retries once; the idle evictor later releases it.
+  # Set "all" to restore eager startup warming of every built partition when first-query
+  # latency matters more than the startup peak and resident matrix footprint.
+  startup_prewarm: lazy    # "lazy" | "all"
   partitions:
     knowledge:
       rrf_k: 20            # smaller per-partition default (A/B: k=60≈k=15 at top-k)

--- a/dashboard-react/src/settings/EmbeddingRuntimePanel.test.tsx
+++ b/dashboard-react/src/settings/EmbeddingRuntimePanel.test.tsx
@@ -1,0 +1,390 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { EmbeddingRuntimePanel } from "./EmbeddingRuntimePanel";
+
+describe("EmbeddingRuntimePanel", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("makes a required-remote outage and no-local-fallback guarantee explicit", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({
+      service_status: "ok",
+      policy: {
+        effective: "require-lmstudio",
+        configured: "require-lmstudio",
+        pending: null,
+        apply_status: "effective",
+        running: "require-lmstudio",
+        authority_matches_runtime: true,
+      },
+      document_model: {
+        loaded_locally: false,
+        routing: {
+          requested_provider: "lmstudio",
+          provider_model: "remote-leaf-ir",
+          on_error: "fail",
+          cooldown_remaining_s: 87.2,
+          last_route: {
+            provider: "lmstudio",
+            fallback: false,
+            status: "error",
+            reason: "provider_unavailable",
+            error: "LM Link peer disconnected",
+            provider_error: "LM Link peer disconnected",
+            provider_error_kind: "connection",
+            provider_error_hint: "Check LM Link and retry.",
+          },
+        },
+      },
+      lmstudio: {
+        ok: false,
+        detail: "Port 1234 is unavailable",
+        model_advertised: null,
+        model_ids: [],
+      },
+    })));
+
+    render(<EmbeddingRuntimePanel />);
+
+    expect(await screen.findByRole("heading", { name: "Active document route" }))
+      .toBeInTheDocument();
+    expect(screen.getByText(/Dense document and passage features cannot produce vectors/)).toBeInTheDocument();
+    expect(screen.getByText("Not loaded")).toBeInTheDocument();
+    expect(screen.getByText("Unavailable")).toBeInTheDocument();
+    expect(screen.getByText("remote-leaf-ir")).toBeInTheDocument();
+    expect(screen.getByText("Cannot inspect while LM Studio is unreachable"))
+      .toBeInTheDocument();
+    expect(screen.getByText("~526 MB local weight load currently avoided"))
+      .toBeInTheDocument();
+    expect(screen.getByText(/Remote retry cooldown: 88 seconds/)).toBeInTheDocument();
+    expect(screen.getByText(/Remote provider \(connection\): LM Link peer disconnected/))
+      .toHaveTextContent("Check LM Link and retry.");
+    expect(screen.getByText(/not a guaranteed change in process private commit/))
+      .toBeInTheDocument();
+  });
+
+  it("renders a recoverable verification error", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(null, { status: 503 })));
+
+    render(<EmbeddingRuntimePanel />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Runtime verification is unavailable",
+    );
+    expect(screen.getByRole("button", { name: "Refresh status" })).toBeEnabled();
+  });
+
+  it("does not claim the remote route is reachable when probe evidence is absent", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({
+      service_status: "ok",
+      policy: {
+        effective: "prefer-lmstudio",
+        configured: "prefer-lmstudio",
+        pending: null,
+        apply_status: "effective",
+        running: "prefer-lmstudio",
+        authority_matches_runtime: true,
+      },
+      document_model: {
+        loaded_locally: false,
+        routing: {
+          requested_provider: "lmstudio",
+          provider_model: "remote-leaf-ir",
+          on_error: "fallback",
+          cooldown_remaining_s: 0,
+          last_route: null,
+        },
+      },
+      lmstudio: null,
+    })));
+
+    render(<EmbeddingRuntimePanel />);
+
+    expect(await screen.findByText(/LM Studio reachability was not reported/))
+      .toBeInTheDocument();
+    expect(screen.getAllByText("Not reported")).toHaveLength(2);
+    expect(screen.queryByText(/advertises the configured document model/))
+      .not.toBeInTheDocument();
+  });
+
+  it("retains the remote failure cause after a successful local fallback", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({
+      service_status: "ok",
+      policy: {
+        effective: "prefer-lmstudio",
+        configured: "prefer-lmstudio",
+        apply_status: "effective",
+        running: "prefer-lmstudio",
+        authority_matches_runtime: true,
+      },
+      document_model: {
+        loaded_locally: true,
+        routing: {
+          requested_provider: "lmstudio",
+          provider_model: "remote-leaf-ir",
+          on_error: "fallback",
+          configuration_status: "ok",
+          last_route: {
+            provider: "local",
+            fallback: true,
+            status: "ok",
+            reason: "provider_fallback",
+            provider_error: "HTTP 503 from LM Studio",
+            provider_error_kind: "http",
+            provider_error_hint: "Check that the embedding model can load on the peer.",
+          },
+        },
+      },
+      lmstudio: { ok: true, model_advertised: false, model_ids: [] },
+    })));
+
+    render(<EmbeddingRuntimePanel />);
+
+    expect(await screen.findByText(/Prefer mode may load/)).toBeInTheDocument();
+    expect(screen.getByText(/Remote provider \(http\): HTTP 503 from LM Studio/))
+      .toHaveTextContent("Check that the embedding model can load on the peer.");
+    expect(screen.getByText("Local fallback")).toBeInTheDocument();
+  });
+
+  it("surfaces deterministic remote-route misconfiguration before a batch runs", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({
+      service_status: "ok",
+      policy: {
+        effective: "require-lmstudio",
+        configured: "require-lmstudio",
+        apply_status: "effective",
+        running: "require-lmstudio",
+        authority_matches_runtime: true,
+      },
+      document_model: {
+        loaded_locally: false,
+        routing: {
+          requested_provider: "lmstudio",
+          provider_model: null,
+          on_error: "fail",
+          configuration_status: "error",
+          configuration_error: "lmstudio_model is required",
+          authority_error: null,
+          last_route: null,
+        },
+      },
+      lmstudio: { ok: true, model_advertised: null, model_ids: [] },
+    })));
+
+    render(<EmbeddingRuntimePanel />);
+
+    expect(await screen.findByText(/remote document route is misconfigured/))
+      .toHaveTextContent("lmstudio_model is required");
+    expect(screen.getByText(/Require mode blocks document vectors/)).toBeInTheDocument();
+    expect(screen.queryByText(/cannot yet verify the complete route/))
+      .not.toBeInTheDocument();
+  });
+
+  it("surfaces the fail-closed authority safety mode", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({
+      service_status: "ok",
+      policy: {
+        effective: "local",
+        configured: "local",
+        apply_status: "effective",
+        running: "require-lmstudio",
+        authority_matches_runtime: false,
+      },
+      document_model: {
+        loaded_locally: false,
+        routing: {
+          requested_provider: "lmstudio",
+          on_error: "fail",
+          configuration_status: "error",
+          configuration_error: "lmstudio_model is required",
+          authority_error: "RuntimeError: settings database unavailable",
+          last_route: null,
+        },
+      },
+      lmstudio: null,
+    })));
+
+    render(<EmbeddingRuntimePanel />);
+
+    expect(await screen.findByText(/Settings authority could not be read/))
+      .toHaveTextContent("fail-closed LM Studio route");
+    expect(screen.getByText(/RuntimeError: settings database unavailable/))
+      .toBeInTheDocument();
+  });
+
+  it("does not mistake a model absent from the advertised list for an unusable route", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({
+      service_status: "ok",
+      policy: {
+        effective: "require-lmstudio",
+        configured: "require-lmstudio",
+        pending: null,
+        apply_status: "effective",
+        running: "require-lmstudio",
+        authority_matches_runtime: true,
+      },
+      document_model: {
+        loaded_locally: false,
+        routing: {
+          requested_provider: "lmstudio",
+          provider_model: "remote-leaf-ir",
+          on_error: "fail",
+          cooldown_remaining_s: 0,
+          last_route: null,
+        },
+      },
+      lmstudio: {
+        ok: true,
+        model_advertised: false,
+        model_ids: ["text-embedding-nomic-embed-text-v1.5", "other-model"],
+      },
+    })));
+
+    render(<EmbeddingRuntimePanel />);
+
+    expect(await screen.findByText(/It may still load on demand/))
+      .toBeInTheDocument();
+    expect(screen.getByText("Not advertised now (may load on demand)")).toBeInTheDocument();
+    expect(screen.getByText(/text-embedding-nomic-embed-text-v1\.5, other-model/))
+      .toBeInTheDocument();
+    expect(screen.queryByText(/advertises the configured document model/))
+      .not.toBeInTheDocument();
+  });
+
+  it("confirms a remote route from an actual successful document batch", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({
+      service_status: "ok",
+      policy: {
+        effective: "prefer-lmstudio",
+        configured: "prefer-lmstudio",
+        pending: null,
+        apply_status: "effective",
+        running: "prefer-lmstudio",
+        authority_matches_runtime: true,
+      },
+      document_model: {
+        loaded_locally: false,
+        routing: {
+          requested_provider: "lmstudio",
+          provider_model: "remote-leaf-ir",
+          on_error: "fallback",
+          cooldown_remaining_s: 0,
+          last_route: { provider: "lmstudio", fallback: false, status: "ok" },
+        },
+      },
+      lmstudio: {
+        ok: true,
+        model_advertised: true,
+        model_ids: ["remote-leaf-ir"],
+      },
+    })));
+
+    render(<EmbeddingRuntimePanel />);
+
+    expect(await screen.findByText(
+      "The last document batch completed through LM Studio.",
+    )).toBeInTheDocument();
+    expect(screen.getByText("Advertised now")).toBeInTheDocument();
+  });
+
+  it("does not present a historical route failure as a current outage", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({
+      service_status: "ok",
+      policy: {
+        effective: "require-lmstudio",
+        configured: "require-lmstudio",
+        apply_status: "effective",
+        running: "require-lmstudio",
+        authority_matches_runtime: true,
+      },
+      document_model: {
+        loaded_locally: false,
+        routing: {
+          requested_provider: "lmstudio",
+          provider_model: "remote-leaf-ir",
+          on_error: "fail",
+          configuration_status: "ok",
+          cooldown_remaining_s: 0,
+          last_route: {
+            provider: "lmstudio",
+            status: "error",
+            reason: "provider_unavailable",
+            provider_error: "Previous timeout",
+            provider_error_kind: "timeout",
+          },
+        },
+      },
+      lmstudio: {
+        ok: true,
+        model_advertised: true,
+        model_ids: ["remote-leaf-ir"],
+      },
+    })));
+
+    render(<EmbeddingRuntimePanel />);
+
+    expect(await screen.findByText(/last document batch failed through LM Studio/))
+      .toHaveTextContent("successful document batch is still needed");
+    expect(screen.queryByText(/cannot produce vectors until/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Remote provider \(timeout\): Previous timeout/))
+      .toBeInTheDocument();
+  });
+
+  it("does not mistake missing service evidence for unloaded local weights", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({
+      service_status: "unavailable",
+      policy: null,
+      document_model: null,
+      lmstudio: null,
+      service_error: "Connection refused",
+    })));
+
+    render(<EmbeddingRuntimePanel />);
+
+    expect(await screen.findByText(/The Embedding service is unavailable/))
+      .toBeInTheDocument();
+    expect(screen.getAllByText("Not reported")).toHaveLength(4);
+    expect(screen.getByText("Not reported (~526 MB when leaf-ir loads)"))
+      .toBeInTheDocument();
+    expect(screen.queryByText("Not loaded")).not.toBeInTheDocument();
+  });
+
+  it("uses service health as runtime truth and flags settings-authority drift", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({
+      service_status: "ok",
+      policy: {
+        effective: "require-lmstudio",
+        configured: "require-lmstudio",
+        pending: null,
+        apply_status: "effective",
+        running: "local",
+        authority_matches_runtime: false,
+      },
+      document_model: {
+        loaded_locally: true,
+        routing: {
+          requested_provider: "local",
+          provider_model: "remote-leaf-ir",
+          on_error: "fallback",
+          cooldown_remaining_s: 0,
+          last_route: { provider: "local", fallback: false, status: "ok" },
+        },
+      },
+      lmstudio: null,
+    })));
+
+    render(<EmbeddingRuntimePanel />);
+
+    const mismatch = await screen.findByText((_, element) =>
+      element?.getAttribute("role") === "status" &&
+      element.textContent?.includes("Settings authority reports Require LM Studio") === true,
+    );
+    expect(mismatch).toHaveTextContent("Embedding service health reports Local only");
+    const activePolicy = screen.getByText("Active policy").closest("div");
+    expect(activePolicy).toHaveTextContent("Local only");
+    const authority = screen.getByText("Settings effective policy").closest("div");
+    expect(authority).toHaveTextContent("Require LM Studio");
+    expect(screen.queryByText(/Dense document and passage features cannot produce vectors/))
+      .not.toBeInTheDocument();
+  });
+});

--- a/dashboard-react/src/settings/EmbeddingRuntimePanel.tsx
+++ b/dashboard-react/src/settings/EmbeddingRuntimePanel.tsx
@@ -1,0 +1,407 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { asSettingsPageId } from "../dashboard/contributions/contracts";
+import { Button, InlineAlert } from "../ui";
+
+export const EMBEDDING_SETTINGS_PAGE_ID = asSettingsPageId(
+  "wb.settings.system.embeddings",
+);
+
+interface LastRoute {
+  readonly provider?: string;
+  readonly provider_model?: string;
+  readonly fallback?: boolean;
+  readonly status?: string;
+  readonly reason?: string;
+  readonly at?: number;
+  readonly error?: string | null;
+  readonly provider_error?: string | null;
+  readonly provider_error_kind?: string | null;
+  readonly provider_error_hint?: string | null;
+}
+
+interface RoutingStatus {
+  readonly requested_provider?: string;
+  readonly provider_model?: string;
+  readonly on_error?: string;
+  readonly configuration_status?: string;
+  readonly configuration_error?: string | null;
+  readonly authority_error?: string | null;
+  readonly cooldown_remaining_s?: number;
+  readonly last_route?: LastRoute | null;
+}
+
+interface EmbeddingRuntimeStatus {
+  readonly service_status?: string;
+  readonly policy?: {
+    readonly effective?: string;
+    readonly configured?: string;
+    readonly pending?: string | null;
+    readonly apply_status?: string;
+    readonly revision?: string;
+    readonly running?: string | null;
+    readonly authority_matches_runtime?: boolean | null;
+  } | null;
+  readonly document_model?: {
+    readonly key?: string;
+    readonly name?: string;
+    readonly dims?: number;
+    readonly load_status?: string;
+    readonly loaded_locally?: boolean;
+    readonly error?: string | null;
+    readonly routing?: RoutingStatus | null;
+  } | null;
+  readonly lmstudio?: {
+    readonly ok?: boolean;
+    readonly detail?: string;
+    readonly model_advertised?: boolean | null;
+    readonly model_ids?: readonly string[];
+  } | null;
+  readonly settings_error?: string;
+  readonly service_error?: string;
+}
+
+const POLICY_LABELS: Record<string, string> = {
+  local: "Local only",
+  "prefer-lmstudio": "Prefer LM Studio",
+  "require-lmstudio": "Require LM Studio",
+};
+
+function policyLabel(value?: string | null): string {
+  return value ? POLICY_LABELS[value] ?? value : "Unknown";
+}
+
+function routeLabel(route?: LastRoute | null): string {
+  if (!route) return "No document batch recorded since restart";
+  if (route.status === "error" || route.status === "unavailable") {
+    return `Failed (${route.reason ?? "provider unavailable"})`;
+  }
+  if (route.provider === "lmstudio") return "LM Studio";
+  if (route.provider === "local" && route.fallback) return "Local fallback";
+  if (route.provider === "local") return "Local encoder";
+  return route.provider ?? "Unknown";
+}
+
+function routeTime(at?: number): string | undefined {
+  if (typeof at !== "number" || !Number.isFinite(at)) return undefined;
+  return new Date(at * 1000).toLocaleString();
+}
+
+function remoteModelObservation(
+  policy: string | undefined,
+  lmstudio: EmbeddingRuntimeStatus["lmstudio"],
+): string {
+  if (policy === "local") return "Not checked (local-only policy)";
+  if (lmstudio?.ok === false) return "Cannot inspect while LM Studio is unreachable";
+  if (lmstudio?.model_advertised === true) return "Advertised now";
+  if (lmstudio?.model_advertised === false) {
+    return "Not advertised now (may load on demand)";
+  }
+  return "Not reported";
+}
+
+function localMemoryImpact(
+  loadedLocally: boolean | undefined,
+  policy: string | undefined,
+): string {
+  if (loadedLocally) return "~526 MB leaf-ir weight payload loaded";
+  if (loadedLocally === false) {
+    if (policy === "local") return "~526 MB weights not loaded yet";
+    if (policy === "prefer-lmstudio" || policy === "require-lmstudio") {
+      return "~526 MB local weight load currently avoided";
+    }
+    return "Weights not loaded; running policy not reported";
+  }
+  return "Not reported (~526 MB when leaf-ir loads)";
+}
+
+function advertisedModels(modelIds?: readonly string[]): string | undefined {
+  if (!modelIds?.length) return undefined;
+  const visible = modelIds.slice(0, 4);
+  const remainder = modelIds.length - visible.length;
+  return `${visible.join(", ")}${remainder > 0 ? `, +${remainder} more` : ""}`;
+}
+
+export function EmbeddingRuntimePanel() {
+  const [runtime, setRuntime] = useState<EmbeddingRuntimeStatus>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  const load = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      const response = await fetch("/api/embeddings/runtime", {
+        headers: { Accept: "application/json" },
+        signal,
+      });
+      if (!response.ok) {
+        throw new Error(`Runtime status request failed (${response.status})`);
+      }
+      setRuntime((await response.json()) as EmbeddingRuntimeStatus);
+    } catch (reason) {
+      if (signal?.aborted) return;
+      setError(reason instanceof Error ? reason.message : String(reason));
+    } finally {
+      if (!signal?.aborted) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void load(controller.signal);
+    return () => controller.abort();
+  }, [load]);
+
+  const model = runtime?.document_model;
+  const routing = model?.routing;
+  const route = routing?.last_route;
+  const runningPolicy = runtime?.policy?.running ?? undefined;
+  const authorityPolicy = runtime?.policy?.effective;
+  const requiresRemote = runningPolicy === "require-lmstudio";
+  const prefersRemote = runningPolicy === "prefer-lmstudio";
+  const remoteReachable = runtime?.lmstudio?.ok === true;
+  const remoteUnavailable = runtime?.lmstudio?.ok === false;
+  const remoteModelAdvertised = runtime?.lmstudio?.model_advertised;
+  const routeFailed = route?.status === "error" || route?.status === "unavailable";
+  const activeCooldown = (routing?.cooldown_remaining_s ?? 0) > 0;
+  const remoteRouteSucceeded = route?.provider === "lmstudio" && route?.status === "ok";
+  const lastRouteAt = useMemo(() => routeTime(route?.at), [route?.at]);
+  const availableModels = advertisedModels(runtime?.lmstudio?.model_ids);
+  const nonProviderError = route?.error !== route?.provider_error
+    ? route?.error
+    : undefined;
+
+  let stateAlert = null;
+  if (runtime?.service_status === "unavailable") {
+    stateAlert = (
+      <InlineAlert tone="danger">
+        The Embedding service is unavailable. Document vectors are not being produced;
+        lexical search remains available where supported.
+      </InlineAlert>
+    );
+  } else if (routing?.authority_error) {
+    stateAlert = (
+      <InlineAlert tone="danger">
+        Settings authority could not be read when the Embedding service started.
+        Document and passage embedding is forced to the fail-closed LM Studio route,
+        so the local document encoder will not load. Fix the settings error and restart
+        the service: {routing.authority_error}
+      </InlineAlert>
+    );
+  } else if (
+    routing?.configuration_status === "error" ||
+    routing?.configuration_error
+  ) {
+    stateAlert = (
+      <InlineAlert tone="danger">
+        The remote document route is misconfigured: {routing.configuration_error ??
+          "configuration validation failed"}. Require mode blocks document vectors;
+        Prefer mode uses its intentional local fallback. Correct the configuration and
+        restart the Embedding service.
+      </InlineAlert>
+    );
+  } else if (requiresRemote && (remoteUnavailable || (routeFailed && activeCooldown))) {
+    stateAlert = (
+      <InlineAlert tone="danger">
+        Dense document and passage features cannot produce vectors until LM Studio
+        can serve the configured model. Index refreshes still commit lexical documents
+        and resumable ledger progress, while dense completion stays pending; similarity
+        features use their available non-dense fallback. Required-remote mode will not
+        load the document encoder locally.
+      </InlineAlert>
+    );
+  } else if (requiresRemote && routeFailed) {
+    stateAlert = (
+      <InlineAlert tone="warning">
+        The last document batch failed through LM Studio. The current probe does not
+        prove that embedding has recovered; a successful document batch is still
+        needed to confirm the route. Required-remote mode will not load the document
+        encoder locally.
+      </InlineAlert>
+    );
+  } else if (prefersRemote && (remoteUnavailable || route?.fallback)) {
+    stateAlert = (
+      <InlineAlert tone="warning">
+        LM Studio is unavailable or the last request fell back. Prefer mode may load
+        the large document encoder in this process until the remote route recovers.
+      </InlineAlert>
+    );
+  } else if (
+    (requiresRemote || prefersRemote) &&
+    remoteReachable &&
+    (remoteModelAdvertised === true || remoteRouteSucceeded)
+  ) {
+    stateAlert = (
+      <InlineAlert tone="success">
+        {remoteRouteSucceeded
+          ? "The last document batch completed through LM Studio."
+          : "LM Studio is reachable and currently advertises the configured document model."}
+      </InlineAlert>
+    );
+  } else if (
+    (requiresRemote || prefersRemote) &&
+    remoteReachable &&
+    remoteModelAdvertised === false
+  ) {
+    stateAlert = (
+      <InlineAlert tone="info">
+        LM Studio is reachable, but the configured document model is not currently
+        advertised. It may still load on demand; only an embedding request can confirm
+        the route.
+      </InlineAlert>
+    );
+  } else if ((requiresRemote || prefersRemote) && remoteReachable) {
+    stateAlert = (
+      <InlineAlert tone="warning">
+        LM Studio is reachable, but availability of the configured document model
+        was not reported. The dashboard cannot yet verify the complete route.
+      </InlineAlert>
+    );
+  } else if (requiresRemote || prefersRemote) {
+    stateAlert = (
+      <InlineAlert tone="warning">
+        LM Studio reachability was not reported. The dashboard cannot yet verify the
+        active remote document-encoding route.
+      </InlineAlert>
+    );
+  }
+
+  return (
+    <section className="wb-embedding-runtime" aria-labelledby="embedding-runtime-title">
+      <header className="wb-embedding-runtime__header">
+        <div>
+          <p className="wb-settings-content__eyebrow">Live verification</p>
+          <h2 id="embedding-runtime-title">Active document route</h2>
+          <p>
+            This is runtime evidence from the Embedding service, not merely the saved
+            preference. Query-side models stay local in every mode.
+          </p>
+        </div>
+        <Button
+          variant="secondary"
+          size="small"
+          disabled={loading}
+          onClick={() => void load()}
+        >
+          {loading ? "Checking…" : "Refresh status"}
+        </Button>
+      </header>
+
+      {error ? (
+        <InlineAlert tone="warning" role="alert">
+          Runtime verification is unavailable: {error}
+        </InlineAlert>
+      ) : null}
+      {!error && loading && !runtime ? (
+        <InlineAlert tone="info" role="status">Checking the running route…</InlineAlert>
+      ) : null}
+      {runtime?.policy?.apply_status === "restart-required" ? (
+        <InlineAlert tone="info">
+          {runningPolicy
+            ? `${policyLabel(runtime.policy.configured)} is saved, but the running service remains on ${policyLabel(runningPolicy)} until restart.`
+            : `${policyLabel(runtime.policy.configured)} is saved and waiting for an Embedding service restart. The current running policy was not reported.`}
+        </InlineAlert>
+      ) : null}
+      {runtime?.policy?.authority_matches_runtime === false ? (
+        <InlineAlert tone="warning" role="status">
+          Settings authority reports {policyLabel(authorityPolicy)}, but Embedding
+          service health reports {policyLabel(runningPolicy)}. The running-service
+          value is authoritative for current behavior; restart the service and refresh
+          this check.
+        </InlineAlert>
+      ) : null}
+      {stateAlert}
+
+      {runtime ? (
+        <dl className="wb-embedding-runtime__facts">
+          <div>
+            <dt>Embedding service</dt>
+            <dd>{runtime.service_status ?? "Unknown"}</dd>
+          </div>
+          <div>
+            <dt>Active policy</dt>
+            <dd>{policyLabel(runningPolicy)}</dd>
+          </div>
+          <div>
+            <dt>Settings effective policy</dt>
+            <dd>{policyLabel(authorityPolicy)}</dd>
+          </div>
+          <div>
+            <dt>Local document weights</dt>
+            <dd>
+              {model?.loaded_locally === true
+                ? "Loaded in this process"
+                : model?.loaded_locally === false
+                  ? "Not loaded"
+                  : "Not reported"}
+            </dd>
+          </div>
+          <div>
+            <dt>LM Studio</dt>
+            <dd>
+              {runtime.lmstudio == null
+                ? runningPolicy === "local"
+                  ? "Not used by the active policy"
+                  : "Not reported"
+                : runtime.lmstudio.ok
+                  ? "Reachable"
+                  : "Unavailable"}
+            </dd>
+          </div>
+          <div>
+            <dt>Configured provider model</dt>
+            <dd><code>{routing?.provider_model ?? "Not reported"}</code></dd>
+          </div>
+          <div>
+            <dt>Configured remote model observation</dt>
+            <dd>{remoteModelObservation(runningPolicy, runtime.lmstudio)}</dd>
+          </div>
+          <div>
+            <dt>Estimated local-memory impact</dt>
+            <dd>{localMemoryImpact(model?.loaded_locally, runningPolicy)}</dd>
+          </div>
+          <div>
+            <dt>Last document batch</dt>
+            <dd>
+              {routeLabel(route)}
+              {lastRouteAt ? <small>{lastRouteAt}</small> : null}
+            </dd>
+          </div>
+        </dl>
+      ) : null}
+
+      {routing?.cooldown_remaining_s && routing.cooldown_remaining_s > 0 ? (
+        <p className="wb-embedding-runtime__detail">
+          Remote retry cooldown: {Math.ceil(routing.cooldown_remaining_s)} seconds.
+        </p>
+      ) : null}
+      {runtime?.lmstudio?.detail ? (
+        <p className="wb-embedding-runtime__detail">{runtime.lmstudio.detail}</p>
+      ) : null}
+      {remoteModelAdvertised === false && availableModels ? (
+        <p className="wb-embedding-runtime__detail">
+          Models currently advertised by LM Studio: <code>{availableModels}</code>
+        </p>
+      ) : null}
+      {route?.provider_error ? (
+        <p className="wb-embedding-runtime__detail wb-embedding-runtime__detail--error">
+          Remote provider{route.provider_error_kind
+            ? ` (${route.provider_error_kind})`
+            : ""}: {route.provider_error}
+          {route.provider_error_hint ? ` ${route.provider_error_hint}` : ""}
+        </p>
+      ) : null}
+      <p className="wb-embedding-runtime__detail">
+        The ~526 MB figure estimates leaf-ir's model-weight payload, not a guaranteed
+        change in process private commit. Runtime buffers vary, and allocator
+        high-water commit can persist until the Embedding service restarts.
+      </p>
+      {nonProviderError || model?.error || runtime?.settings_error || runtime?.service_error ? (
+        <p className="wb-embedding-runtime__detail wb-embedding-runtime__detail--error">
+          {nonProviderError ?? model?.error ?? runtime?.settings_error ?? runtime?.service_error}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/dashboard-react/src/settings/EmbeddingSettings.test.tsx
+++ b/dashboard-react/src/settings/EmbeddingSettings.test.tsx
@@ -1,0 +1,183 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TypographyScaleProvider } from "../theme/TypographyScaleProvider";
+import { SettingsPage } from "./SettingsPage";
+import { SettingsRegistry } from "./registry";
+import {
+  asSettingId,
+  asSettingPlacementId,
+  type SettingsContribution,
+} from "./contracts";
+import { EMBEDDING_SETTINGS_PAGE_ID } from "./EmbeddingRuntimePanel";
+
+const settingId = asSettingId("wb.embedding.document-execution");
+
+const contribution: SettingsContribution = {
+  sourceId: "test.embedding-settings",
+  definitions: [{
+    schemaVersion: 1,
+    settingId,
+    definitionVersion: 1,
+    valueVersion: 1,
+    ownerId: "wb.embedding",
+    ownerLabel: "Embeddings",
+    provenance: {
+      complementId: "wb.embedding",
+      complementVersion: "test",
+      trustTier: "native",
+      label: "Embedding service",
+    },
+    title: "Document embedding execution",
+    summary: "Choose where the large passage encoder runs for document similarity and indexing.",
+    details: "Query encoders stay local.",
+    defaultValue: "local",
+    allowedScopes: ["profile"],
+    defaultScope: "profile",
+    control: {
+      kind: "select",
+      options: [
+        { value: "local", label: "Local only", description: "Always encode locally." },
+        { value: "prefer-lmstudio", label: "Prefer LM Studio", description: "Fall back locally." },
+        { value: "require-lmstudio", label: "Require LM Studio", description: "Never load locally." },
+      ],
+    },
+    appliesTo: [{ kind: "system", id: "wb.embedding", label: "Embeddings" }],
+    applyBehavior: "restart-component",
+    sensitivity: "ordinary",
+    visibility: "frontend",
+  }],
+  pages: [{
+    schemaVersion: 1,
+    pageId: EMBEDDING_SETTINGS_PAGE_ID,
+    ownerId: "wb.embedding",
+    route: "/settings/system/embeddings",
+    label: "Embeddings",
+    description: "Control document-encoding placement and inspect the active route.",
+    navigationGroup: "system",
+    navigationLabel: "Embeddings",
+    navigationOrder: 20,
+    context: { kind: "system", id: "wb.embedding", label: "Embeddings" },
+    sections: [{ sectionId: "execution", label: "Execution", order: 10 }],
+  }],
+  placements: [{
+    schemaVersion: 1,
+    placementId: asSettingPlacementId("test.embedding.placement"),
+    settingId,
+    pageId: EMBEDDING_SETTINGS_PAGE_ID,
+    sectionId: "execution",
+    order: 10,
+  }],
+};
+
+const registry = new SettingsRegistry([contribution]);
+
+function value(overrides: Record<string, unknown> = {}) {
+  return {
+    setting_id: settingId,
+    scope: { kind: "profile", subject_id: "default" },
+    effective_value: "local",
+    configured_value: "local",
+    source: "default",
+    is_modified: false,
+    revision: "value:0",
+    pending_value: null,
+    apply_status: "effective",
+    diagnostics: [],
+    ...overrides,
+  };
+}
+
+describe("Embedding settings", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("saves a restart-gated route without claiming it is already active", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.startsWith("/api/settings/values?")) {
+        return Response.json({
+          schema_version: 1,
+          registry_revision: "settings-registry:8",
+          observed_at: "2026-09-08T12:00:00Z",
+          read_only: false,
+          diagnostics: [],
+          values: [value()],
+        });
+      }
+      if (url === "/api/embeddings/runtime") {
+        return Response.json({
+          service_status: "ok",
+          policy: {
+            effective: "local",
+            configured: "local",
+            pending: null,
+            apply_status: "effective",
+            running: "local",
+            authority_matches_runtime: true,
+          },
+          document_model: {
+            loaded_locally: false,
+            routing: {
+              requested_provider: "local",
+              provider_model: "leaf-ir",
+              on_error: "fallback",
+              cooldown_remaining_s: 0,
+              last_route: null,
+            },
+          },
+          lmstudio: null,
+        });
+      }
+      if (url === `/api/settings/values/${settingId}` && init?.method === "PATCH") {
+        expect(JSON.parse(String(init.body))).toMatchObject({
+          value: "require-lmstudio",
+          expected_revision: "value:0",
+        });
+        return Response.json({
+          schema_version: 1,
+          registry_revision: "settings-registry:8",
+          value: value({
+            configured_value: "require-lmstudio",
+            pending_value: "require-lmstudio",
+            is_modified: true,
+            revision: "value:1",
+            apply_status: "restart-required",
+          }),
+        });
+      }
+      return new Response(null, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <MemoryRouter initialEntries={["/settings/system/embeddings"]}>
+        <TypographyScaleProvider initialScale="standard">
+          <SettingsPage registryOverride={registry} />
+        </TypographyScaleProvider>
+      </MemoryRouter>,
+    );
+
+    const select = await screen.findByRole("combobox", {
+      name: "Document embedding execution",
+    });
+    await waitFor(() => expect(select).toBeEnabled());
+    fireEvent.change(select, { target: { value: "require-lmstudio" } });
+    const saveButton = screen.getByRole("button", { name: "Save change" });
+    expect(saveButton).toBeEnabled();
+    fireEvent.click(saveButton);
+
+    expect(await screen.findByText(
+      "Saved. Restart the Embedding service to apply this choice.",
+    )).toBeInTheDocument();
+    const restartStatus = screen.getByText((_, element) =>
+      element?.getAttribute("role") === "status" &&
+      element.textContent?.includes("effective setting remains Local only") === true,
+    );
+    expect(restartStatus).toHaveTextContent("Restart Embedding service to activate Require LM Studio");
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      "/api/embeddings/runtime",
+      expect.objectContaining({ headers: { Accept: "application/json" } }),
+    ));
+  });
+});

--- a/dashboard-react/src/settings/SettingsPage.tsx
+++ b/dashboard-react/src/settings/SettingsPage.tsx
@@ -14,6 +14,10 @@ import { Button, IconButton, InlineAlert } from "../ui";
 import { HelpTarget } from "../dashboard/help";
 import { ChatExecutionPicker, useChatExecutionProfile } from "../widget-library/chat";
 import { JournalProfileConfigurator } from "../apps/journal/JournalProfileConfigurator";
+import {
+  EMBEDDING_SETTINGS_PAGE_ID,
+  EmbeddingRuntimePanel,
+} from "./EmbeddingRuntimePanel";
 import { SettingsExecutionProfileProvider } from "./SettingsExecutionProfileProvider";
 import { DASHBOARD_ASSISTANCE_HELP, DASHBOARD_ASSISTANCE_SETTING_ID } from "./dashboardAiContributions";
 import type {
@@ -567,6 +571,12 @@ function SelectSetting({
     values.mutationSettingId === definition.settingId;
   const changed = draft !== initialValue;
   const selectedOption = options.find((option) => option.value === draft);
+  const effectiveOption = options.find(
+    (option) => option.value === String(value?.effectiveValue),
+  );
+  const configuredOption = options.find(
+    (option) => option.value === String(value?.configuredValue),
+  );
   const controlId = `control-${settingElementId(definition.settingId)}`;
 
   return (
@@ -603,6 +613,15 @@ function SelectSetting({
           </Button>
         </InlineAlert>
       ) : null}
+      {definition.applyBehavior === "restart-component" &&
+      value?.applyStatus === "restart-required" ? (
+        <InlineAlert tone="info" role="status" aria-live="polite">
+          The effective setting remains{" "}
+          <strong>{effectiveOption?.label ?? String(value.effectiveValue)}</strong>.
+          Restart {definition.provenance.label} to activate{" "}
+          <strong>{configuredOption?.label ?? String(value.configuredValue)}</strong>.
+        </InlineAlert>
+      ) : null}
 
       <div className="wb-select-setting-control">
         <label htmlFor={controlId}>{definition.title}</label>
@@ -635,7 +654,11 @@ function SelectSetting({
       </div>
 
       <div className="wb-settings-control-actions">
-        <p>Changes apply as soon as they are saved.</p>
+        <p>
+          {definition.applyBehavior === "restart-component"
+            ? "Saved choices take effect when the owning service restarts. The running service keeps its current document route until then."
+            : "Changes apply as soon as they are saved."}
+        </p>
         <Button
           variant="secondary"
           size="small"
@@ -1006,6 +1029,9 @@ function PageProjection({
       ))}
       {page.pageId === JOURNAL_APP_SETTINGS_PAGE_ID && !pageSearchQuery.trim() ? (
         <JournalProfileConfigurator />
+      ) : null}
+      {page.pageId === EMBEDDING_SETTINGS_PAGE_ID && !pageSearchQuery.trim() ? (
+        <EmbeddingRuntimePanel />
       ) : null}
       {pageSearchQuery.trim() && visibleSettingCount === 0 ? (
         <p className="wb-settings-page-search-empty">

--- a/dashboard-react/src/settings/styles.css
+++ b/dashboard-react/src/settings/styles.css
@@ -712,6 +712,93 @@
     font-weight: var(--wb-font-weight-semibold);
   }
 
+  .wb-embedding-runtime {
+    display: grid;
+    gap: var(--wb-space-5);
+    margin-top: var(--wb-space-10);
+    padding: var(--wb-space-7);
+    border: var(--wb-border-width) solid var(--wb-color-border-subtle);
+    border-radius: var(--wb-radius-panel);
+    background: var(--wb-color-surface-raised);
+    box-shadow: var(--wb-shadow-raised);
+  }
+
+  .wb-embedding-runtime__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--wb-space-7);
+  }
+
+  .wb-embedding-runtime__header > div {
+    display: grid;
+    gap: var(--wb-space-2);
+  }
+
+  .wb-embedding-runtime__header h2 {
+    color: var(--wb-color-text-strong);
+    font-size: var(--wb-font-size-lg);
+    font-weight: var(--wb-font-weight-semibold);
+  }
+
+  .wb-embedding-runtime__header > div > p:last-child {
+    max-width: 40rem;
+    color: var(--wb-color-text-secondary);
+    font-size: var(--wb-font-size-sm);
+  }
+
+  .wb-embedding-runtime__facts {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--wb-space-3);
+  }
+
+  .wb-embedding-runtime__facts > div {
+    display: grid;
+    gap: var(--wb-space-2);
+    min-width: 0;
+    padding: var(--wb-space-4);
+    border-radius: var(--wb-radius-surface);
+    background: var(--wb-color-surface-inset);
+  }
+
+  .wb-embedding-runtime__facts dt {
+    color: var(--wb-color-text-muted);
+    font-size: var(--wb-font-size-xs);
+    font-weight: var(--wb-font-weight-semibold);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .wb-embedding-runtime__facts dd {
+    overflow-wrap: anywhere;
+    color: var(--wb-color-text-strong);
+    font-size: var(--wb-font-size-sm);
+    font-weight: var(--wb-font-weight-semibold);
+  }
+
+  .wb-embedding-runtime__facts code {
+    font-family: var(--wb-font-mono);
+    font-weight: var(--wb-font-weight-regular);
+  }
+
+  .wb-embedding-runtime__facts small {
+    display: block;
+    margin-top: var(--wb-space-1);
+    color: var(--wb-color-text-muted);
+    font-size: var(--wb-font-size-xs);
+    font-weight: var(--wb-font-weight-regular);
+  }
+
+  .wb-embedding-runtime__detail {
+    color: var(--wb-color-text-secondary);
+    font-size: var(--wb-font-size-sm);
+  }
+
+  .wb-embedding-runtime__detail--error {
+    color: var(--wb-color-status-danger);
+  }
+
   @media (max-width: 48rem) {
     .wb-settings-shell {
       display: block;
@@ -767,6 +854,19 @@
 
     .wb-settings-card__footer .wb-button {
       width: 100%;
+    }
+
+    .wb-embedding-runtime__header {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .wb-embedding-runtime__header .wb-button {
+      width: 100%;
+    }
+
+    .wb-embedding-runtime__facts {
+      grid-template-columns: 1fr;
     }
 
     .wb-type-scale-control__ticks span {

--- a/dashboard-react/src/settings/useSettingsValues.ts
+++ b/dashboard-react/src/settings/useSettingsValues.ts
@@ -137,7 +137,9 @@ export function useSettingsValues(
           previous ? replaceValue(previous, result.value) : previous,
         );
         setMessage(
-          result.value.pendingValue !== undefined
+          result.value.applyStatus === "restart-required"
+            ? "Saved. Restart the Embedding service to apply this choice."
+            : result.value.pendingValue !== undefined
             ? "Saved. The change is pending."
             : "Setting saved.",
         );
@@ -164,7 +166,11 @@ export function useSettingsValues(
         setSnapshot((previous) =>
           previous ? replaceValue(previous, result.value) : previous,
         );
-        setMessage("Override reset to default.");
+        setMessage(
+          result.value.applyStatus === "restart-required"
+            ? "Default saved. Restart the Embedding service to apply it."
+            : "Override reset to default.",
+        );
       } catch (reason) {
         handleMutationError(reason);
       } finally {

--- a/dashboard-react/tests/e2e/embedding-settings.spec.ts
+++ b/dashboard-react/tests/e2e/embedding-settings.spec.ts
@@ -1,0 +1,195 @@
+import { expect, test } from "@playwright/test";
+
+const SETTING_ID = "wb.embedding.document-execution";
+
+test("Embedding settings distinguish saved policy from the running route", { tag: "@ci" }, async ({
+  page,
+}) => {
+  let configuredPolicy = "local";
+  let revision = "value:0";
+
+  await page.route("**/api/settings/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+
+    if (url.pathname === "/api/settings/registry") {
+      await route.fulfill({
+        json: {
+          schema_version: 1,
+          registry_revision: "settings-registry:e2e",
+          definitions: [{
+            setting_id: SETTING_ID,
+            definition_version: 1,
+            value_version: 1,
+            owner: { kind: "system", id: "wb.embedding", label: "Embeddings" },
+            provenance: {
+              complement_id: "wb.embedding",
+              complement_version: "e2e",
+              trust_tier: "native",
+              label: "Embedding service",
+            },
+            title: "Document embedding execution",
+            short_description: "Choose where the large passage encoder runs for document similarity and indexing.",
+            long_description: "Query encoders stay local.",
+            default_value: "local",
+            allowed_scopes: ["profile"],
+            default_scope: "profile",
+            applies_to: [{ kind: "system", id: "wb.embedding", label: "Embeddings" }],
+            presentation: {
+              control: "select",
+              apply_behavior: "restart-component",
+              options: [
+                { value: "local", label: "Local only", description: "Always encode locally." },
+                { value: "prefer-lmstudio", label: "Prefer LM Studio", description: "Fall back locally." },
+                { value: "require-lmstudio", label: "Require LM Studio", description: "Never load locally." },
+              ],
+            },
+            visibility: "frontend",
+            sensitivity: "ordinary",
+          }],
+          pages: [{
+            page_id: "wb.settings.system.embeddings",
+            context: { kind: "system", id: "wb.embedding", label: "Embeddings" },
+            owner: { kind: "system", id: "wb.embedding", label: "Embeddings" },
+            route: "/app/settings/system/embeddings",
+            label: "Embeddings",
+            description: "Control document-encoding placement and inspect the active route.",
+            navigation_group: "system",
+            navigation_label: "Embeddings",
+            navigation_order: 20,
+            sections: [{ section_id: "execution", label: "Execution" }],
+          }],
+          placements: [{
+            placement_id: "wb.settings.placement.system.embeddings.document-execution",
+            setting_id: SETTING_ID,
+            page_id: "wb.settings.system.embeddings",
+            section_id: "execution",
+          }],
+        },
+      });
+      return;
+    }
+
+    if (url.pathname === "/api/settings/values" && request.method() === "GET") {
+      const pending = configuredPolicy === "local" ? null : configuredPolicy;
+      await route.fulfill({
+        json: {
+          schema_version: 1,
+          registry_revision: "settings-registry:e2e",
+          observed_at: "2026-09-08T12:00:00Z",
+          read_only: false,
+          diagnostics: [],
+          values: [{
+            setting_id: SETTING_ID,
+            scope: { kind: "profile", subject_id: "default" },
+            effective_value: "local",
+            configured_value: configuredPolicy,
+            pending_value: pending,
+            source: configuredPolicy === "local" ? "default" : "profile",
+            is_modified: configuredPolicy !== "local",
+            revision,
+            apply_status: pending ? "restart-required" : "effective",
+            diagnostics: [],
+          }],
+        },
+      });
+      return;
+    }
+
+    if (
+      url.pathname === `/api/settings/values/${SETTING_ID}` &&
+      request.method() === "PATCH"
+    ) {
+      const body = request.postDataJSON() as {
+        value: string;
+        expected_revision: string;
+      };
+      expect(body).toEqual(expect.objectContaining({
+        value: "require-lmstudio",
+        expected_revision: "value:0",
+      }));
+      configuredPolicy = body.value;
+      revision = "value:1";
+      await route.fulfill({
+        json: {
+          schema_version: 1,
+          registry_revision: "settings-registry:e2e",
+          value: {
+            setting_id: SETTING_ID,
+            scope: { kind: "profile", subject_id: "default" },
+            effective_value: "local",
+            configured_value: configuredPolicy,
+            pending_value: configuredPolicy,
+            source: "profile",
+            is_modified: true,
+            revision,
+            apply_status: "restart-required",
+            diagnostics: [],
+          },
+        },
+      });
+      return;
+    }
+
+    await route.fulfill({ status: 404 });
+  });
+
+  await page.route("**/api/embeddings/runtime", async (route) => {
+    await route.fulfill({
+      json: {
+        service_status: "ok",
+        policy: {
+          effective: "local",
+          configured: configuredPolicy,
+          pending: configuredPolicy === "local" ? null : configuredPolicy,
+          apply_status: configuredPolicy === "local" ? "effective" : "restart-required",
+          running: "local",
+          authority_matches_runtime: true,
+        },
+        document_model: {
+          loaded_locally: false,
+          routing: {
+            requested_provider: "local",
+            provider_model: "leaf-ir",
+            on_error: "fallback",
+            cooldown_remaining_s: 0,
+            last_route: null,
+          },
+        },
+        lmstudio: null,
+      },
+    });
+  });
+
+  await page.goto("/app/settings/system/embeddings");
+
+  await expect(page.getByRole("heading", { name: "Embeddings", level: 1 }))
+    .toBeVisible();
+  await expect(page.getByRole("heading", { name: "Active document route" }))
+    .toBeVisible();
+  await expect(page.getByText("Not loaded", { exact: true })).toBeVisible();
+  await expect(page.getByText("Not checked (local-only policy)")).toBeVisible();
+  await expect(page.getByText("~526 MB weights not loaded yet")).toBeVisible();
+  await expect(page.getByText(/not a guaranteed change in process private commit/))
+    .toBeVisible();
+
+  const selector = page.getByRole("combobox", {
+    name: "Document embedding execution",
+  });
+  await expect(selector).toBeEnabled();
+  await selector.selectOption("require-lmstudio");
+  await page.getByRole("button", { name: "Save change" }).click();
+
+  await expect(page.getByText(
+    "Saved. Restart the Embedding service to apply this choice.",
+  )).toBeVisible();
+  await expect(page.getByRole("status").filter({
+    hasText: "The effective setting remains Local only",
+  })).toContainText("Restart Embedding service to activate Require LM Studio");
+
+  await page.getByRole("button", { name: "Refresh status" }).click();
+  await expect(page.getByText(
+    "Require LM Studio is saved, but the running service remains on Local only until restart.",
+  )).toBeVisible();
+  await expect(page.getByText("Local only", { exact: true }).last()).toBeVisible();
+});

--- a/knowledge/store/architecture/consolidated-index.md
+++ b/knowledge/store/architecture/consolidated-index.md
@@ -58,7 +58,7 @@ dev_notes: |-
 
   ## FTS storage schema and rollout
 
-  Schema version 2 makes `doc_fts` an external-content FTS5 table keyed to
+  The current FTS storage schema makes `doc_fts` an external-content FTS5 table keyed to
   `documents.rowid`; canonical title/body/tags stay in `documents`, and validated triggers
   keep the index synchronized. Item deletion is therefore proportional to the deleted rows
   instead of scanning the entire FTS corpus once per document. Upserts preserve rowids when
@@ -66,7 +66,7 @@ dev_notes: |-
   the resumable encoder always rebuilds them from the just-written projection text.
 
   Ordinary opens, including dashboard status, search, and scheduled builds, do not repair an
-  existing version-1 database. Status uses an existing-file, query-only connection and
+  existing legacy-layout database. Status uses an existing-file, query-only connection and
   reports `repair_required`; builders fail closed. An operator must call the explicit
   `IndexStore.prepare_schema()` boundary, which holds the same DB-wide writer gate as every
   build, gives a competing legacy build up to eleven minutes to release it, and performs one
@@ -76,7 +76,7 @@ dev_notes: |-
   Plan a stop-the-world restart of every process that opens the consolidated database and
   keep enough free space for the rebuilt table plus WAL. A production-sized rehearsal
   produced roughly 1 GB of transient WAL and held a concurrent opener for several minutes.
-  Old code expects `doc_fts.doc_id` and cannot search a version-2 database, so rollback is
+  Old code expects `doc_fts.doc_id` and cannot search a rowid-aligned database, so rollback is
   database restore or forward-fix, not simply restarting an older binary. The safe order is:
   stop the sidecar and every old DB opener, checkpoint and back up the DB, run the explicit
   preparation once with the new binary, verify schema/integrity/counts, then start only new
@@ -278,7 +278,7 @@ chunker. Each consumer is re-pointed onto the consolidated partition behind its 
 validated (blind A/B) before the corresponding legacy index is retired. See
 `architecture/vault-index`, `architecture/knowledge-system`, and `context/index-rebuild`.
 
-The consolidated-index FTS storage-schema v2 repair and backfill are prerequisites,
+The consolidated-index rowid-aligned FTS storage repair and backfill are prerequisites,
 not consumer cutover. Until parity and
 the consumer's cutover evidence pass, legacy search remains authoritative and its database and
 scheduled maintenance remain intact.

--- a/knowledge/store/architecture/consolidated-index.md
+++ b/knowledge/store/architecture/consolidated-index.md
@@ -49,6 +49,56 @@ dev_notes: |-
   every batch, short writer holds, resumes from the last batch after an interruption.
   Builds never lose committed progress (per-item + per-batch commits).
 
+  The scheduled conversation refresh uses both limits: at most 25 changed/deleted source
+  items and four 256-document vector batches per run. An item is the atomic source unit, so
+  one unusually large conversation can exceed 25 parsed documents and makes `max_items` a
+  soft work bound rather than a wall-clock deadline. `max_vector_batches` is a hard cap on
+  document-vector batches. Partial runs do not stamp `last_build` or acknowledge the source
+  outbox until the full partition reconciliation reaches parity.
+
+  ## FTS storage schema and rollout
+
+  Schema version 2 makes `doc_fts` an external-content FTS5 table keyed to
+  `documents.rowid`; canonical title/body/tags stay in `documents`, and validated triggers
+  keep the index synchronized. Item deletion is therefore proportional to the deleted rows
+  instead of scanning the entire FTS corpus once per document. Upserts preserve rowids when
+  a document identity is unchanged and deliberately invalidate that document's vectors so
+  the resumable encoder always rebuilds them from the just-written projection text.
+
+  Ordinary opens, including dashboard status, search, and scheduled builds, do not repair an
+  existing version-1 database. Status uses an existing-file, query-only connection and
+  reports `repair_required`; builders fail closed. An operator must call the explicit
+  `IndexStore.prepare_schema()` boundary, which holds the same DB-wide writer gate as every
+  build, gives a competing legacy build up to eleven minutes to release it, and performs one
+  atomic rebuild with progress logs. A future schema version is rejected without DDL rather
+  than being destructively downgraded.
+
+  Plan a stop-the-world restart of every process that opens the consolidated database and
+  keep enough free space for the rebuilt table plus WAL. A production-sized rehearsal
+  produced roughly 1 GB of transient WAL and held a concurrent opener for several minutes.
+  Old code expects `doc_fts.doc_id` and cannot search a version-2 database, so rollback is
+  database restore or forward-fix, not simply restarting an older binary. The safe order is:
+  stop the sidecar and every old DB opener, checkpoint and back up the DB, run the explicit
+  preparation once with the new binary, verify schema/integrity/counts, then start only new
+  binaries and resume bounded refresh jobs.
+
+  This is a storage-layout migration inside the consolidated index. It does not enable a
+  consumer gate, salvage legacy-only records, route searches away from a legacy engine, or
+  delete any legacy database or cron.
+
+  ## Resident generation fence and startup warming
+
+  A build writes `build_dirty:<partition>` before its first durable mutation. Resident
+  readers refuse to publish a matrix while that fence exists; a successful completion
+  atomically bumps the build generation and clears the fence. A replay finalizes a fence
+  left by interruption. Slow loaders check the generation both before and after loading so
+  a mid-load build cannot publish stale vectors.
+
+  `index.startup_prewarm` defaults to `lazy`: startup does not materialize every partition.
+  A cold query returns lexical results, singleflights a background matrix warm, and can retry
+  once for hybrid results. `all` restores eager all-partition warming for an operator who
+  explicitly accepts the memory and startup cost.
+
   ## Database outboxes and cutover evidence
   Journal, Projects, Contracts, and Personal Knowledge expose a small optional outbox
   port. `IndexPartition.build` snapshots a bounded pending batch, completes the locked
@@ -140,9 +190,10 @@ and kept fresh without changing live search behavior.
 ## Store
 
 One **single-writer** SQLite DB (`db/index-consolidated.db`) holds all partitions in shared
-tables keyed by a `partition` column: `documents`, `doc_fts` (standalone FTS5 over
-title/body/tags), `doc_vectors` (float16 blobs, FK-cascaded to documents), `indexed_items`
-(the mtime/content-hash change ledger), and `index_meta` (KV — per-partition `build_version`).
+tables keyed by a `partition` column: `documents`; `doc_fts`, an external-content FTS5 index
+over the canonical document row's title/body/tags; `doc_vectors` (float16 blobs,
+FK-cascaded to documents); `indexed_items` (the mtime/content-hash change ledger); and
+`index_meta` (KV, including schema and per-partition build generations).
 A fresh connection per operation (WAL, foreign keys on). Because one DB has many would-be
 writers across processes, writes use a busy timeout plus backoff-retry (see dev notes).
 
@@ -164,6 +215,11 @@ builds and verifies source/index parity, then acknowledges exactly the snapshot.
 `outbox` receipt uses `wb.search-outbox-delivery/v1`; `ready=true` requires zero remaining lag
 and zero parity mismatches. `force=true` is the explicit per-partition restore/backfill path.
 
+Incremental callers may bound changed/deleted source items and missing-vector batches.
+Reaching either limit returns explicit partial progress; the next run resumes from durable
+rows. The scheduled conversation job uses this path hourly so catch-up work yields the serial
+sidecar dispatch lane between slices.
+
 ## Search
 
 `HybridSearcher` (`search.py`) fuses three signals: FTS5 `bm25()` (title/body/tags column
@@ -178,6 +234,7 @@ bias and an optional per-source diversity cap (`max_per_source`). `UnifiedIndex.
 ```yaml
 index:
   enabled: false                   # master kill-switch — whole index inert when false
+  startup_prewarm: lazy            # lazy lexical-first warming; "all" eagerly warms matrices
   consumers:                       # per-consumer routing gates; a consumer routes here
     agent_docs: false              #   only when index.enabled AND its gate are true
   partitions:
@@ -206,7 +263,8 @@ score-guarded, so a genuinely dominant document with no competitive alternative 
 - **Ten `index-<partition>-refresh` sidecar crons** keep the active partitions fresh at
   corpus-matched cadences, including Journal every five minutes and Projects, Contracts,
   Personal Knowledge, and Task Notes every fifteen minutes. One job per partition preserves
-  replay and backfill isolation.
+  replay and backfill isolation. Conversation refresh runs hourly in bounded, resumable
+  slices so it cannot monopolize the serial dispatch lane for a full backlog drain.
 - **Embedding-service endpoints** `/index/search`, `/index/search_many`, `/index/build`, with
   `index_search` / `index_search_many` clients (see `architecture/embedding-service`).
 - **Status/dashboard seam** — registered as the `consolidated` index in `work_buddy/indexing/`
@@ -219,6 +277,11 @@ knowledge store, `IRSourcePartition` over the IR sources, `VaultChunkPartition` 
 chunker. Each consumer is re-pointed onto the consolidated partition behind its own flag and
 validated (blind A/B) before the corresponding legacy index is retired. See
 `architecture/vault-index`, `architecture/knowledge-system`, and `context/index-rebuild`.
+
+The consolidated-index FTS storage-schema v2 repair and backfill are prerequisites,
+not consumer cutover. Until parity and
+the consumer's cutover evidence pass, legacy search remains authoritative and its database and
+scheduled maintenance remain intact.
 
 Authority-sealed Journal, Projects, Contracts, and Personal Knowledge Markdown roots are never
 ordinary Vault-search inputs. The filesystem source prunes each root before `os.walk` descends,

--- a/knowledge/store/architecture/embedding-service.md
+++ b/knowledge/store/architecture/embedding-service.md
@@ -31,6 +31,26 @@ dev_notes: |-
 
   Keep this boundary intact on Windows. Calling `model.encode` from a fresh request thread can leave that thread's native OpenMP team resident after the Python thread exits, causing native workers to accumulate across requests. New in-service SentenceTransformer encode paths should go through `_brokered_encode` rather than calling `model.encode` directly.
 
+  `work_buddy.__init__` sets `OPENBLAS_NUM_THREADS=1` before NumPy can initialize,
+  and `compat.build_child_env` gives supervised children the same default. This is a
+  process-wide memory policy, not an encode-batch knob: OpenBLAS otherwise creates a
+  native worker team per Python service and reserves a large amount of private commit.
+  Both sites use `setdefault`, so an explicit operator override is preserved.
+
+  ## One document-routing authority
+
+  The embedding process owns one `ProviderRouter` singleton for document encodes.
+  In-process index work reuses it directly; sidecar and CLI index work call the local
+  service's `/embed` endpoint through `embedding.client.embed_with_route`. Do not add a
+  second config-backed router to a caller: it would bypass restart-gated Settings,
+  split circuit-breaker state, hide the actual route from `/health`, and could load the
+  local document model against a remote-only policy.
+
+  Provider availability probes are intentionally separated from provider execution.
+  `embedding/providers/lmstudio_config.py` resolves the endpoint and model alias without
+  importing NumPy, SentenceTransformers, or the model registry. Health and dashboard
+  probes must stay on that lightweight boundary.
+
   ## doc_count vs vector_count — read ``dense_eligible_docs``
 
   The IR index status output (``ir_index(action='status')``) exposes three count fields per source. Do **not** treat ``doc_count - vector_count`` as a "backlog" — it usually isn't. The right reading:
@@ -127,7 +147,7 @@ dev_notes: |-
 
   ## Adding a new model
 
-  Add an entry to `config.yaml` under `embedding.models` (or `_DEFAULT_MODELS` in `service.py` for the fallback). Required fields: HF name, dims, `eager` (bool). Eager-load only models on the critical path for interactive work; lazy-load large models (e.g. the 526 MB `leaf-ir` passage encoder) that are used only during indexing.
+  Add an entry to `config.yaml` under `embedding.models` (or `_DEFAULT_MODELS` in `service.py` for the fallback). Required fields: HF name, dims, `eager` (bool). Eager-load only models on the critical path for interactive work; lazy-load large models (e.g. the 526 MB `leaf-ir` passage encoder) that are used only for document and passage embedding workloads.
 
   ## Lazy models: cold-load timeout tolerance
 
@@ -141,13 +161,19 @@ dev_notes: |-
 
   'Default model for all' is a tempting shortcut. Every new semantic-scoring site should ask: am I comparing query-shaped things to query-shaped things (use `leaf-mt`), or query-shaped to passage-shaped (use `embed_for_ir` with the correct role)? The wrong answer produces subtle quality loss, not visible errors.
 
-  ## Consolidated index: resident-matrix prewarm at startup
+  ## Consolidated index: resident-matrix startup policy
 
-  The consolidated index (``work_buddy/index/``) serves search from per-(partition, projection) dense matrices held resident in this process (``index/resident.py`` — the generic ResidentCache the vault matrix and model registry reuse). They are lazy-loaded on a partition's first search, so a large partition (vault is ~88k×768) pays a tens-of-seconds load on that first query — long enough to exceed the request timeout, returning ``None`` and silently missing the consolidated index until something queries it again.
+  The consolidated index (``work_buddy/index/``) serves search from per-(partition,
+  projection) dense matrices held resident in this process. `index.startup_prewarm`
+  selects the startup policy. The default `lazy` mode does not materialize every built
+  partition; the first cold query serves lexical results and uses the warming signal
+  below. `all` starts the background largest-first prewarm for operators who explicitly
+  accept its memory and startup cost.
 
-  ``main()`` prewarms them: when ``index.enabled``, a background daemon (``index/partitioned.py::start_prewarm`` -> ``prewarm_resident_matrices``) loads every BUILT partition's matrices up front, **largest partition first** (so the slowest-to-load, highest-cold-cost partitions are protected soonest). It goes through the same ``HybridSearcher._resident`` caches the serving path reads (no key drift), does NO model encode (pure SQLite read + numpy reshape, so it doesn't contend for the inference broker / GPU), and is idempotent with the consolidated-index idle evictor (``resident.start_idle_evictor``: warm -> serve -> release after the idle TTL -> re-warm on next query). It is gated — a disabled or unbuilt index warms nothing, and the daemon never blocks ``/health`` or query serving.
-
-  Caveat: prewarm shrinks but does not eliminate the first-query cold window. Matrix loading is GIL-heavy (a ``b"".join`` over a partition's vector blobs), so on a contended boot — eager model load plus concurrent query-encodes competing for one GIL — warming all partitions can take minutes, and a query can still arrive while its partition is mid-warm. The **warming signal** (below) is what makes that residual window cheap to ride out instead of a hard cold-load stall.
+  Eager prewarm goes through the same ``HybridSearcher._resident`` caches as serving,
+  performs no model encode, and remains idempotent with the idle evictor. It can still
+  take minutes for a large corpus because matrix construction is allocation- and
+  GIL-heavy, which is why it is opt-in rather than the default.
 
   ## Consolidated index: warming signal (non-blocking cold serve)
 
@@ -159,7 +185,17 @@ dev_notes: |-
 
   **Client distinguishes three states.** ``embedding/client.py::index_search`` / ``index_search_many`` take ``warm_retry``. When enabled, a ``warming`` response waits ``min(retry_after_s, cap)`` then retries ONCE with ``block_until_warm=true`` and an extended timeout (mirrors ``knowledge/index.py::_CONTENT_COLD_LOAD_TIMEOUT_S``). This distinguishes ``None`` (service down, fall back), ``warming`` (cold, retry against the warming matrix), and a final result. ``knowledge/search.py`` and ``mcp_server/ops/context_consolidated.py`` opt in and retain their live-index or IR-engine fallback. ``dev/document.py`` explicitly disables warm retry: its single 25-second request accepts cold lexical results, while failure or empty hits use the existing grep matcher and canonical-entrypoint inclusion. This avoids starting a cold local dense rebuild inside the scan workflow's 90-second deadline; the non-consolidated scan path still uses the local index normally.
 
-  **Hot-path readiness invariant (load-bearing).** The readiness predicate (``UnifiedIndex.cold_partitions`` → ``IndexPartition.is_warm``) runs on every cold-eligible query, so it must stay O(projections) in RAM: it checks ONLY ``ResidentCache.is_cached()`` (a pure in-memory flag) and must NEVER call ``store.vector_count()`` — that's a ``COUNT(DISTINCT) … JOIN`` across the whole (all-partition) ``doc_vectors`` table, ~40s at vault scale, i.e. a 40-second query on the serving path. ``warm_eta_s`` likewise uses the cheap partition-indexed ``doc_count``, not ``vector_count``. The trade-off: a projection that legitimately has no vectors reads as "cold" forever (one redundant warm-retry, then graceful fallback) — deliberately accepted over probing vector counts per query.
+  **Hot-path readiness invariant (load-bearing).** The readiness predicate
+  (``UnifiedIndex.cold_partitions`` → ``IndexPartition.is_warm``) runs on every
+  cold-eligible query. It uses ``ResidentCache.is_current()`` so an allocated matrix or a
+  settled-empty result counts as warm only when its generation is still current; it never
+  loads a matrix.
+  It must NEVER call ``store.vector_count()``. That is a ``COUNT(DISTINCT) … JOIN``
+  across the whole all-partition ``doc_vectors`` table and is far too expensive per
+  query. ``warm_eta_s`` likewise uses the partition-indexed ``doc_count``. A projection
+  with no vectors caches a settled-empty result for the current generation, so it does
+  not advertise perpetual warming or force a redundant retry. A later generation bump
+  invalidates the sentinel and makes it eligible to warm again.
 
   ## Key dev files
 
@@ -176,11 +212,14 @@ dev_notes: |-
 
 ## Overview
 
-A long-running sidecar service providing dense vector embeddings for work-buddy's search and similarity features. Exposes an HTTP API on `localhost:5124` with eager-loaded models, so interactive calls are fast.
+A long-running sidecar service providing dense vector embeddings for work-buddy's search and similarity features. Exposes an HTTP API on `localhost:5124`. Interactive query models are eager; the larger document model is lazy and loads only if a document request actually resolves to a local route.
 
 ## Endpoints
 
-- `POST /embed` — embed a batch of texts, return vectors
+- `POST /embed`: embed a batch of texts. Document-model requests pass through the
+  service's authoritative provider router and return route provenance with the vectors.
+  A required remote route that cannot run returns a structured 503 instead of loading
+  the local model
 - `POST /similarity` — cosine similarity between a query and candidate texts
 - `POST /search` — BM25 + embedding hybrid search over candidates
 - `POST /ir/search`, `POST /ir/index` — indexed IR search over registered sources. Every IR
@@ -196,13 +235,17 @@ A long-running sidecar service providing dense vector embeddings for work-buddy'
   `POST /index/build` — incremental build of a partition (or all) into the separate
   `db/index-consolidated` DB. Run in-process so the resident matrices stay warm and the bulk
   encode shares the broker (see `architecture/consolidated-index`)
-- `GET /health` — liveness probe
+- `GET /health`: liveness plus model-residency and document-route evidence, including
+  configured policy, circuit-breaker cooldown, and the last actual provider route
 
 ## Client
 
 `work_buddy/embedding/client.py` wraps the HTTP API:
 
 - `embed(texts)` — plain batch embedding, uses the service's default model
+- `embed_with_route(texts)`: document-oriented batch embedding that preserves the
+  service's structured route or failure envelope
+- `health_status()`: full health and route-provenance snapshot for operator surfaces
 - `embed_for_ir(texts, role="query"|"document")` — asymmetric IR encoding via the query↔document model pair
 - `similarity_search(query, candidates)` — rank candidates by similarity
 - `hybrid_search(query, candidates)` — BM25 + dense blend
@@ -215,34 +258,61 @@ A long-running sidecar service providing dense vector embeddings for work-buddy'
 
 ## Graceful degradation
 
-Every client function returns `None` (or an empty list) when the service is unavailable. Callers must handle this — typically by falling back to BM25 alone or skipping the semantic step. Never assume the service is up; always handle the `None` path.
+Connection failures still return `None` (or an empty list) for clients that opt into
+graceful degradation. Provider failures are different: the route-aware client preserves
+the service's structured error. Under **Require LM Studio**, document and passage
+embedding fails closed; it must not silently load the local document model. Index builds
+remain resumable, while similarity and search callers use their lexical path or skip
+dense ranking where that fallback is supported.
 
 ## Consumers
 
-Knowledge search, IR conversation search, native vault search, task-triage similarity, and other semantic-scoring sites throughout the codebase all route through this service. Model loading happens once here; all callers share the loaded weights.
+Knowledge search, IR conversation search, native vault search, task-triage similarity,
+and other semantic-scoring sites throughout the codebase all route through this service.
+Local model loading happens once here; remote document vectors require no local
+`leaf-ir` load.
 
-## Optional: LM Studio offload for bulk document encoding
+## Document execution policy
 
-Bulk document encoding (the big passage-side model, ``leaf-ir`` / ``snowflake-arctic-embed-m-v1.5``) can route through LM Studio instead of loading locally — moves ~500 MB of RSS off the main machine, optionally via LM Link to a remote compute device. Opt-in per model via ``embedding.models.<key>.provider: lmstudio`` in config.
+The large passage encoder (`leaf-ir` / `snowflake-arctic-embed-m-v1.5`) has three
+restart-gated modes under **System → Embeddings**:
 
-When enabled, the call path is:
+- **Local only** runs every document batch in this process.
+- **Prefer LM Studio** tries the configured LM Studio model and deliberately loads the
+  local model as fallback when the remote route is unavailable.
+- **Require LM Studio** never loads `leaf-ir` locally. An unavailable endpoint, missing
+  model alias, failed embedding request, or provider cooldown blocks document-vector
+  production with a structured failure. Index refreshes still commit lexical documents
+  and durable ledger progress, but remain incomplete while dense work is pending;
+  similarity/search consumers use their supported non-dense fallback. Absence from
+  LM Studio's `/v1/models` snapshot alone is not treated as failure because LM Studio
+  may load the configured model on demand.
 
-```
-ir.dense._encode_bulk_direct
-  → work_buddy.embedding.providers.lmstudio.encode
-    → LocalInferenceBroker.slot(profile=f"lmstudio:{model_id}", priority=BACKGROUND, ...)
-      → httpx POST to LM Studio /v1/embeddings
-```
+The route is `caller → local /embed → ProviderRouter → LM Studio or local provider`.
+LM Studio may in turn place the model on an LM Link peer. Query-side encoders
+(`leaf-ir-query`, `leaf-mt`) remain local for latency and are unaffected by this setting.
 
-Query-side encoding (``leaf-ir-query``, ``leaf-mt``) is NOT offloaded — query latency is user-facing and the network hop would hurt.
+The dashboard distinguishes endpoint reachability from whether the configured model ID
+is currently advertised, without claiming that an unadvertised model is unavailable,
+and distinguishes the saved/effective setting from the policy reported by the running
+service. It also reports whether local document weights are
+resident and the last actual provider/fallback. Its approximately 526 MB figure is a
+model-weight estimate, not a guaranteed reduction in process private commit; runtime
+buffers and allocator high-water commit vary and may persist until process restart.
 
-On LM Studio errors, per-model ``on_error: fallback | fail`` decides the behavior. ``fallback`` (default) drops to the in-process sentence-transformers path. Measured drift between Q8 GGUF and fp32 sentence-transformers is ~0.0002 cosine, so mixed-provenance vectors in the same index cluster correctly.
-
-See ``architecture/inference/broker`` for the admission-control / priority / metrics layer, and ``features/lmstudio-offload-setup`` for the end-to-end setup procedure (GGUF download, metadata audit, drift test, config flip).
+YAML supplies the bootstrap default, LM Studio base URL, and remote model alias. Settings
+owns the user's execution mode after bootstrap, and the embedding service promotes a
+pending choice only when it starts. If Settings authority cannot be read at startup,
+the service keeps query models available but forces the document route to LM Studio with
+no local fallback and `eager: false`; `/health` and the dashboard expose that authority
+error. This fail-closed safety state avoids accidentally loading the large local model
+from stale YAML. See `architecture/inference/broker` for admission
+control and `features/lmstudio-offload-setup` for model setup and verification.
 
 ## Key files
 
 - `work_buddy/embedding/service.py` — Flask service, model registry, lazy loading. ``_get_model()`` uses a per-entry Condition so a cold load of one model doesn't block concurrent access to another.
-- `work_buddy/embedding/client.py` — HTTP client with role-aware wrappers.
+- `work_buddy/embedding/client.py`: HTTP client with role-aware and route-preserving wrappers.
+- `work_buddy/embedding/providers/lmstudio_config.py`: lightweight endpoint/model configuration used by probes.
 - `work_buddy/embedding/providers/lmstudio.py` — optional LM Studio provider (broker-wrapped).
 - `work_buddy/embedding/__main__.py` — service entry point (launched by the sidecar).

--- a/knowledge/store/context/index-rebuild.md
+++ b/knowledge/store/context/index-rebuild.md
@@ -15,6 +15,14 @@ parameters:
     type: bool
     description: Full partition backfill using the same build-verify-ack delivery boundary (default False = incremental replay/content diff)
     required: false
+  max_items:
+    type: int
+    description: Positive per-run cap on changed/deleted source items for a named incremental partition build; partial progress resumes automatically (incompatible with force)
+    required: false
+  max_vector_batches:
+    type: int
+    description: Positive per-run cap on 256-document missing-vector batches for a named incremental partition build; partial progress resumes automatically (incompatible with force)
+    required: false
 tags:
 - context
 - index

--- a/knowledge/store/features/lmstudio-offload-setup.md
+++ b/knowledge/store/features/lmstudio-offload-setup.md
@@ -28,23 +28,35 @@ parents:
 
 # LM Studio Embedding Offload — Setup
 
-One-time procedure for offloading work-buddy's document-side passage encoder to LM Studio. The default sentence-transformers path remains a fallback — this procedure is additive, not a migration.
+One-time procedure for making LM Studio available for work-buddy's document-side passage encoder. The execution policy then chooses local-only, remote-with-local-fallback, or remote-required behavior.
 
 ## What this gets you
 
-The passage encoder (`snowflake-arctic-embed-m-v1.5`, ~110M params, ~500 MB RSS) normally loads into the work-buddy embedding service on the main machine. With offload enabled, bulk document encoding routes to LM Studio's `/v1/embeddings` endpoint instead — which can forward to a remote compute device via LM Link. Net effect: ~500 MB of model RSS no longer pinned on the main machine, without touching query latency (queries stay local).
+The passage encoder (`snowflake-arctic-embed-m-v1.5`, ~110M params, approximately
+526 MB of weights) can run through LM Studio's `/v1/embeddings` endpoint, which may
+place the model on a remote compute device via LM Link. In **Require LM Studio** mode,
+the local embedding process never loads those document weights. **Prefer LM Studio**
+retains deliberate local fallback. The process-private-commit reduction is not a fixed
+526 MB: runtime buffers vary, and allocator high-water commit can remain until the
+embedding process restarts.
 
 ## What this does NOT touch
 
-- Query encoding — small, latency-sensitive, always local.
-- The online `/embed` endpoint on the work-buddy embedding service — same reason.
-- The LLM stack — LM Studio's chat endpoints are unrelated to this config.
+- Query encoding: the smaller latency-sensitive encoders remain local.
+- Search-consumer routing: this changes where document vectors are computed, not which
+  index answers a search.
+- The LLM stack: LM Studio's chat endpoints are unrelated to this policy.
+
+All document callers still use work-buddy's local `/embed` endpoint. That endpoint is
+the policy and observability boundary and then invokes either LM Studio or the local
+provider.
 
 ## Prerequisites
 
 - LM Studio installed on the machine that will serve the embeddings (main machine, or via LM Link from a remote compute device).
 - Network access to HuggingFace for the initial GGUF download.
-- The user's existing ir-index is healthy — if the current passage encoder is stalling, fix that first (task `t-ea501359` covers the ir-index cold-start checkpointing fix).
+- Enough free memory and disk for the one-time drift comparison against the local
+  sentence-transformers model.
 
 ## Procedure
 
@@ -146,9 +158,11 @@ Interpretation:
 - **`MARGINAL` (mean 0.95–0.98, or outliers)** — usually a tokenization edge case. Inspect the `LOW` pairs. Proceed only if you understand why those specific texts drift.
 - **`FAIL` (mean < 0.95)** — stop. Something is wrong. Most common causes: wrong model loaded in LM Studio; GGUF converted with bad pooling; the baseline model isn't loading correctly. Fix before continuing.
 
-### 5. Configure work-buddy
+### 5. Configure the endpoint and model alias
 
-Edit `config.yaml` (or your `config.local.yaml`):
+Edit `config.yaml` (or your `config.local.yaml`) to identify the transport and the exact
+LM Studio model. `provider` and `on_error` also supply the first-run Settings default;
+after a profile value exists, the Settings record is authoritative for execution mode.
 
 ```yaml
 # Optional top-level — defaults to http://localhost:1234 if omitted.
@@ -161,39 +175,58 @@ embedding:
       name: "MongoDB/mdbr-leaf-ir-asym"
       dims: 768
       eager: false
-      # Opt in to LM Studio for bulk document encoding.
+      # Bootstrap the Settings policy as Prefer LM Studio.
       provider: lmstudio
       lmstudio_model: "text-embedding-snowflake-arctic-embed-m-v1.5"
-      # fallback: silently fall back to sentence_transformer on LM Studio
-      #   errors. Observed drift is 0.0002 cosine, so mixed-provenance
-      #   vectors in the same index cluster correctly.
-      # fail: re-raise the error. Use for research workflows that
-      #   require single-provenance vectors.
+      # fallback -> Prefer LM Studio; fail -> Require LM Studio.
       on_error: fallback
 ```
 
-### 6. Restart the sidecar
+Then open **System → Embeddings** and choose:
 
-The embedding service reads the provider config at startup. Restart it so the new config takes effect. Watch the logs — the startup validator will print either a verification line or a WARN if LM Studio or the model id look wrong:
+- **Prefer LM Studio** to use the remote model with intentional local fallback.
+- **Require LM Studio** to prevent any local document-model load and fail document
+  embedding closed when the endpoint or an actual remote request is unavailable.
+- **Local only** to keep document execution in work-buddy.
+
+### 6. Restart the embedding service
+
+The saved choice is restart-gated. Restart the embedding service (normally by restarting
+the sidecar) and refresh the Embeddings page. The startup validator reports whether the
+endpoint is reachable and whether the configured model ID is currently advertised:
 
 ```
 LM Studio provider for embedding.models.leaf-ir verified — model
 'text-embedding-snowflake-arctic-embed-m-v1.5' is loaded at http://localhost:1234.
 ```
 
-### 7. Let ir-index-rebuild converge
+### 7. Let scheduled indexes converge
 
-The next scheduled `ir-index-rebuild` cron run (every 5 minutes by default) will start using the new provider for any new or changed documents. Existing vectors stay on disk and continue to match because the drift is negligible. There is no need for a one-shot re-encode unless you specifically want single-provenance vectors — in which case, delete `~/.claude/projects/work_buddy_ir.<source>.*.npz` and let the cron rebuild from scratch.
+Legacy IR refreshes and consolidated-index refreshes both cross the same `/embed` policy
+boundary. Their next eligible runs use the active provider for new or changed documents.
+Existing vectors remain compatible because the verified quantization drift is negligible;
+offloading does not itself require rebuilding or deleting an index.
 
 ## Verification
 
-- Settings page: LM Studio appears as a reachable external component. The embedding component shows `lmstudio` under soft dependencies with the "falls back to local sentence-transformers" note.
-- Embedding service logs: bulk encodes print `via LM Studio` instead of the `Encoded N/N documents...` progress line.
-- Task Manager / Activity Monitor: the passage encoder model is no longer loaded by the work-buddy embedding service process.
+- **System → Embeddings** reports the active policy from service health, independently
+  from the configured/effective Settings values.
+- **LM Studio** reads Reachable. **Configured remote model observation** may read
+  Advertised now; if it is not advertised, LM Studio may still load it on demand, so the
+  first actual document batch is the definitive route check.
+- After one document batch, **Last document batch** reports LM Studio with no fallback.
+- In Require mode, **Local document weights** remains Not loaded. In Prefer mode it may
+  become loaded after a remote failure, by design.
+- A model-alias configuration error or Settings-authority startup error appears as a
+  hard alert before the first batch. On an authority read failure, document execution is
+  forced remote and fail-closed so stale YAML cannot load the local passage model.
 
 ## Rollback
 
-To disable offloading, remove the three lines (`provider`, `lmstudio_model`, `on_error`) from the `leaf-ir` model config and restart the sidecar. The sentence_transformers path resumes without any other cleanup. Existing LM-Studio-sourced vectors stay valid — they're numerically compatible with the fp32 baseline, so there's no index corruption.
+Choose **Local only**, save, and restart the embedding service. The endpoint and model
+alias may remain configured for a later switch; they do not cause remote execution while
+Local only is active. Existing LM-Studio-sourced vectors remain valid because the audited
+remote model shares the local model's vector space.
 
 ## Troubleshooting
 
@@ -201,9 +234,12 @@ To disable offloading, remove the three lines (`provider`, `lmstudio_model`, `on
 
 Check: (1) `curl http://<base_url>/v1/models` — is the server actually running? (2) Did you override `lmstudio.base_url` but not point it at a reachable address? (3) On LM Studio with LM Link to a remote device: is the link connected? (LM Studio's Connections panel on the main machine will say.)
 
-### "not in LM Studio's loaded models" at startup
+### "not currently advertised by LM Studio" at startup
 
-The configured `lmstudio_model` id doesn't match what LM Studio is serving. Run `curl <base_url>/v1/models` and copy the exact id (usually prefixed `text-embedding-`) into config.
+This is an observation, not a definitive failure: LM Studio can load a configured model
+on demand. If the first document request fails, run `curl <base_url>/v1/models`, verify
+the exact model id (usually prefixed `text-embedding-`), and compare it with
+`lmstudio_model` in config.
 
 ### Drift test reports MARGINAL or FAIL
 
@@ -212,7 +248,9 @@ Do NOT proceed until you understand why. Common causes, ordered by likelihood: (
 ## Related code
 
 - `work_buddy/embedding/providers/lmstudio.py` — provider module.
-- `work_buddy/ir/dense.py::_encode_bulk_direct` — dispatch.
+- `work_buddy/index/encode.py::ProviderRouter`: policy resolution, fallback, and fail-closed routing.
+- `work_buddy/embedding/providers/lmstudio_config.py`: lightweight endpoint/model configuration for probes.
+- `work_buddy/ir/dense.py::_encode_bulk_direct`: legacy IR document caller through `/embed`.
 - `work_buddy/embedding/service.py::_validate_lmstudio_providers` — startup validator.
 - `work_buddy/health/components.py` — `lmstudio` ComponentDef and `embedding.soft_depends_on`.
 - `work_buddy/health/requirements.py` — `services/lmstudio/reachable` setup-time requirement (severity: recommended; fix_kind: agent_handoff).

--- a/knowledge/store/settings.md
+++ b/knowledge/store/settings.md
@@ -22,6 +22,12 @@ dev_notes: |-
   The broker owns typed validation, authority checks, optimistic revision matching, preview, mutation, reset, immediate values, policy transitions, and event publication. React code consumes same-origin endpoints and keeps page-local lexical search controls mounted while filtering.
 
   Dashboard chat defaults use the shared execution-profile control and GET /api/settings/execution-catalog. Provider catalog reads do not resolve global defaults. Keep revisions/errors under Settings authority; do not treat a swallowed mutation failure as a successful model selection.
+
+  `wb.embedding.document-execution` uses `restart-component` semantics. The
+  Settings record owns configured, pending, and effective values; the embedding service
+  promotes the pending value only during startup. The runtime endpoint must derive
+  `policy.running` exclusively from embedding `/health`. If service health is unavailable
+  or omits routing, running stays unknown rather than borrowing the effective setting.
 ---
 
 Settings is the authority and information architecture for configurable Work Buddy behavior.
@@ -34,6 +40,11 @@ Cross-dashboard model behavior belongs under **System → Dashboard AI** at
 `/app/settings/system/dashboard-ai`, not Apps. The former
 `/app/settings/apps/dashboard` route redirects while preserving navigation
 state, query and fragment. Existing opt-in identity/value is unchanged.
+
+Document-encoding placement belongs under **System → Embeddings** at
+`/app/settings/system/embeddings`. The page combines one restart-gated setting with
+read-only evidence from the running embedding service; it does not treat a saved
+preference as proof of current execution.
 
 The canonical Journal route is `/app/settings/apps/journal`. Contextual settings launchers navigate directly to the owning page. Compatibility routes may redirect there while preserving navigation state; they do not create a second setting identity.
 
@@ -51,6 +62,38 @@ A definition may have several placements without duplicating its stored value.
 ## Authority
 
 Authority is declared per setting. Device-local settings cover presentation and accessibility behavior such as typography. Server/profile settings cover shared domain meaning, such as the Journal day boundary. Native and community contributions can use the same registry shape while receiving different trust and permission grants.
+
+## Embedding execution
+
+`wb.embedding.document-execution` controls the large document-side encoder used by
+document and passage similarity as well as indexing:
+
+- **Local only** always permits local `leaf-ir` execution.
+- **Prefer LM Studio** uses the configured remote model when available and permits an
+  intentional local fallback.
+- **Require LM Studio** fails document-vector production closed when the remote route
+  cannot run and never loads the document model locally. Index refreshes still commit
+  lexical documents and durable ledger progress, but remain incomplete while dense work
+  is pending; similarity/search consumers use their supported non-dense fallback.
+
+Interactive query encoders remain local in every mode. Saving a change creates a
+restart-required state: the selector shows the configured choice, the Settings record
+retains the currently effective choice, and the runtime panel shows the policy actually
+reported by the running service. A service restart promotes the pending choice.
+
+The same page reports endpoint reachability separately from the configured model's
+current advertisement state, local document-model residency, last route/fallback, and
+provider cooldown or error details. An absent advertisement is inconclusive because LM
+Studio may load the model on demand; an actual route result is stronger evidence. The
+approximately 526 MB local-memory figure describes model weights,
+not guaranteed private-commit savings; buffers and allocator high-water state can persist
+until the process restarts.
+
+The runtime panel also surfaces deterministic route-configuration failures (for example,
+a missing LM Studio model alias) before the first document batch. If Settings authority
+could not be read at service startup, it explains the enforced fail-closed remote route:
+query models stay available, while the document model remains non-eager and cannot fall
+back locally until the authority problem is fixed and the service restarts.
 
 ## Dashboard AI defaults
 

--- a/sidecar_jobs/index-conversation-refresh.md
+++ b/sidecar_jobs/index-conversation-refresh.md
@@ -7,11 +7,17 @@ capability: index_rebuild
 params:
   partition: conversation
   force: false
+  max_items: 25
+  max_vector_batches: 4
 ---
 Keep the index's **`conversation` partition** current so past sessions stay searchable. A no-op
 while `index.enabled` is false; once on, an incremental content-hash-diffed pass — embeds only
-new/changed spans (cheap when nothing changed), full on the first run. This is a heavy partition, so
-it runs hourly — far less frequently than the small partitions. The `index_rebuild` op self-skips
+new/changed spans (cheap when nothing changed). Each invocation reconciles at most 25 source items
+and four 256-document vector batches; any remaining backlog is durable and resumes on the next run.
+This sharply bounds ordinary finite catch-up work so it does not monopolize the serial scheduler.
+One transcript remains an atomic source item. An unusually huge JSONL can still exceed the usual
+slice duration while it is parsed and written. The job runs
+hourly, far less frequently than the small partitions. The `index_rebuild` op self-skips
 (read-only advisory-lock probe) while any index build is running — all partitions share one
 single-writer DB, so builds serialize on a DB-wide writer gate and a refresh never piles onto an
 in-flight build.

--- a/tests/component/test_index_store_fts_scale.py
+++ b/tests/component/test_index_store_fts_scale.py
@@ -1,0 +1,82 @@
+"""Opt-in scale regression for consolidated-index FTS maintenance.
+
+The production failure involved roughly 215k FTS rows.  Keeping that corpus in the
+ordinary CI suite would add unnecessary I/O on every change, so this test is opt-in:
+
+    WB_RUN_INDEX_SCALE_TESTS=1 pytest tests/component/test_index_store_fts_scale.py
+
+The always-on unit suite separately asserts the rowid-aligned schema/query plan and
+all deletion-path correctness.  This test proves the same design remains bounded at
+the observed production scale.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from work_buddy.index.store import IndexStore
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("WB_RUN_INDEX_SCALE_TESTS") != "1",
+    reason="set WB_RUN_INDEX_SCALE_TESTS=1 to run the 200k-row FTS regression",
+)
+
+
+def test_deleting_large_item_is_bounded_at_200k_fts_rows(tmp_path):
+    store = IndexStore(tmp_path / "scale.db")
+    store.prepare_schema()
+    conn = store._connect()
+    try:
+        now = "2026-01-01T00:00:00+00:00"
+        batch_size = 5000
+        corpus_size = 200_000
+        changed_size = 2_000
+        for start in range(0, corpus_size, batch_size):
+            rows = []
+            for index in range(start, min(start + batch_size, corpus_size)):
+                is_changed = index < changed_size
+                rows.append(
+                    (
+                        f"conversation:{index}",
+                        "conversation",
+                        "changed-session" if is_changed else f"stable:{index // 100}",
+                        "{}",
+                        "{}",
+                        "",
+                        "{}",
+                        "",
+                        now,
+                        "changedtoken" if is_changed else "survivortoken",
+                        f"body {index}",
+                        "",
+                    )
+                )
+            conn.executemany(
+                "INSERT INTO documents "
+                "(doc_id, partition, item_id, fields, projections, display_text, "
+                "metadata, content_hash, indexed_at, title, body, tags) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+                rows,
+            )
+        conn.commit()
+        assert conn.execute("SELECT count(*) FROM documents").fetchone()[0] == corpus_size
+        assert conn.execute("SELECT count(*) FROM doc_fts").fetchone()[0] == corpus_size
+    finally:
+        conn.close()
+
+    started = time.perf_counter()
+    deleted = store.delete_item_docs("changed-session", partition="conversation")
+    elapsed = time.perf_counter() - started
+    print(f"deleted {deleted:,} rows from {corpus_size:,}-row FTS corpus in {elapsed:.3f}s")
+
+    assert deleted == changed_size
+    # Rowid trigger deletion is normally well below one second on this corpus.  Ten
+    # seconds leaves broad CI/antivirus headroom while still rejecting the legacy
+    # per-document full scan, which took hours for a comparable production batch.
+    assert elapsed < 10.0, f"2k-row deletion from 200k FTS corpus took {elapsed:.2f}s"
+    assert store.search_lexical("changedtoken", partition="conversation") == {}
+    assert store.search_lexical("survivortoken", partition="conversation")

--- a/tests/unit/document_kernel/test_runtime_service.py
+++ b/tests/unit/document_kernel/test_runtime_service.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+
+from work_buddy.document_kernel import runtime_service
+from work_buddy.document_kernel.direct_edit import DirectDocumentEditService
+from work_buddy.document_kernel.domain_service import RunningNoteDocumentService
+from work_buddy.tasks.documents import TaskDocumentService
+
+
+class _FakeKernel:
+    instances: list["_FakeKernel"] = []
+
+    def __init__(self) -> None:
+        self.close_calls = 0
+        self.instances.append(self)
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+@pytest.fixture(autouse=True)
+def _isolated_runtime(monkeypatch: pytest.MonkeyPatch):
+    runtime_service.reset_document_kernel()
+    _FakeKernel.instances.clear()
+    monkeypatch.setattr(runtime_service, "DocumentKernelClient", _FakeKernel)
+    yield
+    runtime_service.reset_document_kernel()
+
+
+def test_default_document_services_share_one_process_scoped_kernel() -> None:
+    task_services = [TaskDocumentService() for _ in range(20)]
+    direct_services = [DirectDocumentEditService() for _ in range(20)]
+    note_services = [RunningNoteDocumentService() for _ in range(20)]
+
+    kernels = {
+        id(service.kernel)
+        for service in (*task_services, *direct_services, *note_services)
+    }
+    assert len(kernels) == 1
+    assert len(_FakeKernel.instances) == 1
+
+
+def test_reset_closes_shared_kernel_and_next_request_gets_a_fresh_one() -> None:
+    first = runtime_service.shared_document_kernel()
+
+    runtime_service.reset_document_kernel()
+
+    assert first.close_calls == 1
+    second = runtime_service.shared_document_kernel()
+    assert second is not first
+    assert len(_FakeKernel.instances) == 2

--- a/tests/unit/test_dashboard_embeddings.py
+++ b/tests/unit/test_dashboard_embeddings.py
@@ -75,3 +75,224 @@ def test_degrades_per_section(monkeypatch):
     out = api._build_embeddings_summary()
     assert "system_error" in out          # system failed...
     assert out["vaults"] and out["system"] == []  # ...but vaults still populated
+
+
+def test_runtime_summary_reports_effective_pending_and_actual_route(monkeypatch):
+    monkeypatch.setattr(
+        "work_buddy.settings.broker.get_values",
+        lambda **_kwargs: ({
+            "values": [{
+                "effective_value": "prefer-lmstudio",
+                "configured_value": "require-lmstudio",
+                "pending_value": "require-lmstudio",
+                "apply_status": "restart-required",
+                "revision": "value:4",
+            }],
+        }, []),
+    )
+    monkeypatch.setattr(
+        "work_buddy.embedding.client.health_status",
+        lambda **_kwargs: {
+            "status": "ok",
+            "default_model": "leaf-mt",
+            "models": [{
+                "key": "leaf-ir",
+                "name": "MongoDB/mdbr-leaf-ir-asym",
+                "dims": 768,
+                "status": "pending",
+                "routing": {
+                    "requested_provider": "lmstudio",
+                    "provider_model": "remote-leaf",
+                    "on_error": "fallback",
+                    "cooldown_remaining_s": 0,
+                    "last_route": {
+                        "provider": "lmstudio",
+                        "fallback": False,
+                        "status": "ok",
+                        "reason": "provider_success",
+                    },
+                },
+            }],
+        },
+    )
+    monkeypatch.setattr(
+        "work_buddy.health.checks.check_lmstudio",
+        lambda: {
+            "ok": True,
+            "detail": "reachable",
+            "model_ids": ["remote-leaf", "another-model"],
+        },
+    )
+
+    out = api.get_embedding_runtime_summary()
+
+    assert out["policy"] == {
+        "effective": "prefer-lmstudio",
+        "configured": "require-lmstudio",
+        "pending": "require-lmstudio",
+        "apply_status": "restart-required",
+        "revision": "value:4",
+        "running": "prefer-lmstudio",
+        "authority_matches_runtime": True,
+    }
+    assert out["document_model"]["loaded_locally"] is False
+    assert out["document_model"]["routing"]["last_route"]["provider"] == "lmstudio"
+    assert out["lmstudio"] == {
+        "ok": True,
+        "detail": "reachable",
+        "model_ids": ["remote-leaf", "another-model"],
+        "configured_model": "remote-leaf",
+        "model_advertised": True,
+        "model_available": True,
+    }
+
+
+def test_runtime_summary_does_not_treat_unadvertised_model_as_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        "work_buddy.settings.broker.get_values",
+        lambda **_kwargs: ({"values": [{
+            "effective_value": "require-lmstudio",
+            "configured_value": "require-lmstudio",
+            "pending_value": None,
+            "apply_status": "effective",
+            "revision": "value:1",
+        }]}, []),
+    )
+    monkeypatch.setattr(
+        "work_buddy.embedding.client.health_status",
+        lambda **_kwargs: {
+            "status": "ok",
+            "models": [{
+                "key": "leaf-ir",
+                "status": "pending",
+                "routing": {
+                    "requested_provider": "lmstudio",
+                    "provider_model": "required-model",
+                    "on_error": "fail",
+                    "last_route": None,
+                },
+            }],
+        },
+    )
+    monkeypatch.setattr(
+        "work_buddy.health.checks.check_lmstudio",
+        lambda: {"ok": True, "detail": "reachable", "model_ids": ["other-model"]},
+    )
+
+    out = api.get_embedding_runtime_summary()
+
+    assert out["lmstudio"]["ok"] is True
+    assert out["lmstudio"]["configured_model"] == "required-model"
+    assert out["lmstudio"]["model_advertised"] is False
+    assert out["lmstudio"]["model_available"] is None
+
+
+def test_runtime_summary_does_not_probe_lmstudio_for_local_policy(monkeypatch):
+    monkeypatch.setattr(
+        "work_buddy.settings.broker.get_values",
+        lambda **_kwargs: ({"values": [{
+            "effective_value": "local",
+            "configured_value": "local",
+            "pending_value": None,
+            "apply_status": "effective",
+            "revision": "value:0",
+        }]}, []),
+    )
+    monkeypatch.setattr(
+        "work_buddy.embedding.client.health_status",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "work_buddy.health.checks.check_lmstudio",
+        lambda: (_ for _ in ()).throw(AssertionError("local policy must not probe remote")),
+    )
+
+    out = api.get_embedding_runtime_summary()
+
+    assert out["service_status"] == "unavailable"
+    assert out["policy"]["running"] is None
+    assert out["policy"]["authority_matches_runtime"] is None
+    assert out["lmstudio"] is None
+
+
+def test_runtime_summary_exposes_running_policy_mismatch(monkeypatch):
+    monkeypatch.setattr(
+        "work_buddy.settings.broker.get_values",
+        lambda **_kwargs: ({"values": [{
+            "effective_value": "require-lmstudio",
+            "configured_value": "require-lmstudio",
+            "pending_value": None,
+            "apply_status": "effective",
+            "revision": "value:5",
+        }]}, []),
+    )
+    monkeypatch.setattr(
+        "work_buddy.embedding.client.health_status",
+        lambda **_kwargs: {
+            "status": "ok",
+            "models": [{
+                "key": "leaf-ir",
+                "name": "MongoDB/mdbr-leaf-ir-asym",
+                "dims": 768,
+                "status": "pending",
+                "routing": {
+                    "requested_provider": "local",
+                    "provider_model": "leaf-ir",
+                    "on_error": "fallback",
+                    "last_route": None,
+                },
+            }],
+        },
+    )
+    monkeypatch.setattr(
+        "work_buddy.health.checks.check_lmstudio",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("actual local runtime must not probe LM Studio")
+        ),
+    )
+
+    out = api.get_embedding_runtime_summary()
+
+    assert out["policy"]["effective"] == "require-lmstudio"
+    assert out["policy"]["running"] == "local"
+    assert out["policy"]["authority_matches_runtime"] is False
+    assert out["lmstudio"] is None
+
+
+def test_runtime_summary_keeps_service_truth_when_settings_authority_fails(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "work_buddy.settings.broker.get_values",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("settings offline")),
+    )
+    monkeypatch.setattr(
+        "work_buddy.embedding.client.health_status",
+        lambda **_kwargs: {
+            "status": "ok",
+            "models": [{
+                "key": "leaf-ir",
+                "name": "MongoDB/mdbr-leaf-ir-asym",
+                "dims": 768,
+                "status": "pending",
+                "routing": {
+                    "requested_provider": "lmstudio",
+                    "provider_model": "remote-leaf",
+                    "on_error": "fail",
+                    "last_route": None,
+                },
+            }],
+        },
+    )
+    monkeypatch.setattr(
+        "work_buddy.health.checks.check_lmstudio",
+        lambda: {"ok": True, "model_ids": ["remote-leaf"]},
+    )
+
+    out = api.get_embedding_runtime_summary()
+
+    assert out["settings_error"] == "settings offline"
+    assert out["policy"]["effective"] is None
+    assert out["policy"]["running"] == "require-lmstudio"
+    assert out["policy"]["authority_matches_runtime"] is None
+    assert out["lmstudio"]["ok"] is True

--- a/tests/unit/test_dashboard_settings.py
+++ b/tests/unit/test_dashboard_settings.py
@@ -13,6 +13,8 @@ from work_buddy.settings import broker, store
 
 SETTING_ID = "wb.journal.day-boundary"
 COWORK_SETTING_ID = "wb.cowork.review.nav-binding"
+EMBEDDING_SETTING_ID = "wb.embedding.document-execution"
+EMBEDDING_CONTEXT_ID = "wb.settings.system.embeddings"
 DEFAULT_SHORTCUTS = {
     "previous": "j",
     "next": "k",
@@ -49,10 +51,10 @@ def test_registry_and_context_value_snapshot(client) -> None:
     assert registry.headers["Cache-Control"] == "no-store"
     body = registry.get_json()
     assert body["definitions"][0]["setting_id"] == SETTING_ID
-    assert len(body["placements"]) == 6
-    assert body["pages"][0]["navigation_group"] == "system"
-    assert body["pages"][0]["label"] == "Dashboard AI"
-    assert "navigation_category" not in body["pages"][0]
+    assert len(body["placements"]) == 7
+    dashboard_page = next(page for page in body["pages"] if page["label"] == "Dashboard AI")
+    assert dashboard_page["navigation_group"] == "system"
+    assert "navigation_category" not in dashboard_page
 
     values = client.get(
         "/api/settings/values?context_id=wb.settings.app.journal"
@@ -62,6 +64,62 @@ def test_registry_and_context_value_snapshot(client) -> None:
     assert snapshot["timezone"] == "America/New_York"
     assert snapshot["read_only"] is False
     assert snapshot["values"][0]["effective_value"] == "05:00"
+
+
+def test_embedding_setting_api_exposes_restart_required_state(client, monkeypatch) -> None:
+    monkeypatch.setattr(wb_config, "load_config", lambda: {})
+    snapshot = client.get(
+        f"/api/settings/values?context_id={EMBEDDING_CONTEXT_ID}"
+    )
+    assert snapshot.status_code == 200
+    initial = snapshot.get_json()["values"][0]
+    assert initial["setting_id"] == EMBEDDING_SETTING_ID
+    assert initial["effective_value"] == "local"
+
+    changed = client.patch(
+        f"/api/settings/values/{EMBEDDING_SETTING_ID}",
+        json={
+            "scope": "profile",
+            "value": "require-lmstudio",
+            "expected_revision": initial["revision"],
+        },
+    )
+    assert changed.status_code == 200
+    value = changed.get_json()["value"]
+    assert value["configured_value"] == "require-lmstudio"
+    assert value["effective_value"] == "local"
+    assert value["pending_value"] == "require-lmstudio"
+    assert value["apply_status"] == "restart-required"
+
+    preview = client.post(
+        f"/api/settings/values/{EMBEDDING_SETTING_ID}/preview",
+        json={
+            "scope": "profile",
+            "value": "prefer-lmstudio",
+            "expected_revision": value["revision"],
+        },
+    )
+    assert preview.status_code == 200
+    assert preview.get_json()["preview"]["apply_status"] == "restart-required"
+
+
+def test_embedding_runtime_endpoint_is_live_and_uncached(client, monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(
+        dash_service,
+        "get_embedding_runtime_summary",
+        lambda *, probe_remote: calls.append(probe_remote) or {
+            "service_status": "ok",
+            "policy": {"effective": "local"},
+        },
+    )
+
+    response = client.get("/api/embeddings/runtime?probe=0")
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "no-store"
+    assert response.get_json()["policy"]["effective"] == "local"
+    assert calls == [False]
 
 
 def test_execution_catalog_is_probe_only_no_store_and_available_in_read_only(client, monkeypatch, tmp_path):
@@ -98,7 +156,7 @@ def test_cowork_context_and_immediate_shortcut_map_contract(client) -> None:
     )
     assert values.status_code == 200
     snapshot = values.get_json()
-    assert snapshot["registry_revision"] == "settings-registry:7"
+    assert snapshot["registry_revision"] == "settings-registry:8"
     assert snapshot["values"] == [
         {
             "apply_status": "effective",

--- a/tests/unit/test_embedding_provider_routing.py
+++ b/tests/unit/test_embedding_provider_routing.py
@@ -1,0 +1,817 @@
+"""End-to-end provider policy coverage for the online /embed document path."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from work_buddy.index.encode import LocalProvider, ProviderRouter, default_encoder
+from work_buddy.inference import Priority
+
+
+class _Provider:
+    def __init__(self, name: str, *, available: bool = True) -> None:
+        self.name = name
+        self.available = available
+        self.calls: list[dict] = []
+
+    def encode(
+        self,
+        texts,
+        *,
+        model_id,
+        prompt_name=None,
+        priority=Priority.BACKGROUND,
+        batch_size=None,
+    ):
+        self.calls.append({
+            "texts": list(texts),
+            "model_id": model_id,
+            "prompt_name": prompt_name,
+            "priority": priority,
+            "batch_size": batch_size,
+        })
+        if not self.available:
+            return None
+        return np.ones((len(texts), 3), dtype=np.float32)
+
+
+def _cfg(*, on_error: str = "fallback", alias: str | None = "remote-leaf-ir"):
+    model = {
+        "provider": "lmstudio",
+        "on_error": on_error,
+    }
+    if alias is not None:
+        model["lmstudio_model"] = alias
+    return {"embedding": {"models": {"leaf-ir": model}}}
+
+
+@pytest.fixture
+def service(monkeypatch):
+    import work_buddy.embedding.service as service_module
+    from work_buddy.llm import provenance
+
+    rows: list[dict] = []
+    monkeypatch.setattr(
+        provenance,
+        "record_inference_call",
+        lambda **kwargs: rows.append(kwargs),
+    )
+    monkeypatch.setattr(service_module, "_provider_router", None)
+    monkeypatch.setattr(service_module, "_document_policy_authority_error", None)
+    return service_module, rows
+
+
+def test_document_embed_uses_remote_alias_without_loading_local(service, monkeypatch):
+    svc, rows = service
+    local = _Provider("local")
+    remote = _Provider("lmstudio")
+    router = ProviderRouter(
+        providers={"local": local, "lmstudio": remote},
+        cfg=_cfg(on_error="fail"),
+    )
+    monkeypatch.setattr(svc, "_provider_router", router)
+    monkeypatch.setattr(
+        svc,
+        "_get_model",
+        lambda _key: (_ for _ in ()).throw(
+            AssertionError("remote document encode must not load a local model")
+        ),
+    )
+
+    with svc.app.test_client() as client:
+        response = client.post("/embed", json={
+            "texts": ["one", "two"],
+            "model": "leaf-ir",
+            "prompt_name": "document",
+            "call_id": "caller-batch-1",
+        })
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["vectors"] == [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]
+    assert body["dims"] == 3 and body["count"] == 2 and body["model"] == "leaf-ir"
+    assert body["route"]["provider"] == "lmstudio"
+    assert body["route"]["fallback"] is False
+    assert remote.calls == [{
+        "texts": ["one", "two"],
+        "model_id": "remote-leaf-ir",
+        "prompt_name": "document",
+        "priority": Priority.BACKGROUND,
+        "batch_size": 32,
+    }]
+    assert not local.calls
+    assert rows[-1]["provider"] == "lmstudio"
+    assert rows[-1]["status"] == "ok"
+    assert rows[-1]["call_id"] == "caller-batch-1"
+
+
+def test_document_embed_can_suppress_per_request_provenance(service, monkeypatch):
+    """An aggregate caller can prevent N service rows for its N chunks."""
+    svc, rows = service
+    remote = _Provider("lmstudio")
+    monkeypatch.setattr(
+        svc,
+        "_provider_router",
+        ProviderRouter(
+            providers={"local": _Provider("local"), "lmstudio": remote},
+            cfg=_cfg(on_error="fail"),
+        ),
+    )
+
+    with svc.app.test_client() as client:
+        response = client.post("/embed", json={
+            "texts": ["one"],
+            "model": "leaf-ir",
+            "routing_role": "document",
+            "record_provenance": False,
+        })
+
+    assert response.status_code == 200
+    assert response.get_json()["route"]["provider"] == "lmstudio"
+    assert rows == []
+
+
+def test_document_embed_local_only_uses_service_registry_not_remote(
+    service, monkeypatch,
+):
+    svc, rows = service
+    remote = _Provider("lmstudio")
+    cfg = {"embedding": {"models": {"leaf-ir": {
+        "provider": "local",
+        "on_error": "fail",
+    }}}}
+    router = ProviderRouter(
+        providers={
+            "local": LocalProvider(in_service=True),
+            "lmstudio": remote,
+        },
+        cfg=cfg,
+    )
+    loaded: list[str] = []
+
+    class _Model:
+        def encode(self, texts, **_kwargs):
+            return np.full((len(texts), 2), 4.0, dtype=np.float32)
+
+    def _get_model(key, **_kwargs):
+        loaded.append(key)
+        return _Model()
+
+    monkeypatch.setattr(svc, "_provider_router", router)
+    monkeypatch.setattr(svc, "_get_model", _get_model)
+    monkeypatch.setattr(
+        svc,
+        "_brokered_encode",
+        lambda model, texts, **kwargs: model.encode(texts, **kwargs),
+    )
+
+    with svc.app.test_client() as client:
+        response = client.post("/embed", json={
+            "texts": ["one"], "model": "leaf-ir", "prompt_name": "document",
+        })
+
+    assert response.status_code == 200
+    assert response.get_json()["route"]["reason"] == "configured_local"
+    assert loaded == ["leaf-ir"]
+    assert not remote.calls
+    assert rows[-1]["provider"] == "local"
+
+
+def test_document_embed_fallback_reports_actual_local_route(service, monkeypatch):
+    svc, rows = service
+    local = _Provider("local")
+    remote = _Provider("lmstudio", available=False)
+    monkeypatch.setattr(
+        svc,
+        "_provider_router",
+        ProviderRouter(
+            providers={"local": local, "lmstudio": remote},
+            cfg=_cfg(on_error="fallback"),
+        ),
+    )
+
+    with svc.app.test_client() as client:
+        response = client.post("/embed", json={
+            "texts": ["one"], "model": "leaf-ir", "prompt_name": "document",
+        })
+
+    assert response.status_code == 200
+    route = response.get_json()["route"]
+    assert route["requested_provider"] == "lmstudio"
+    assert route["provider"] == "local"
+    assert route["fallback"] is True
+    assert route["reason"] == "provider_unavailable"
+    assert len(remote.calls) == 1 and len(local.calls) == 1
+    assert local.calls[0]["model_id"] == "leaf-ir"
+    assert rows[-1]["provider"] == "local"
+    assert "requested=lmstudio; actual=local" in rows[-1]["detail"]
+    assert "provider_error=" in rows[-1]["detail"]
+    assert "unavailable" in rows[-1]["error"]
+
+
+def test_document_embed_required_remote_missing_alias_is_503_without_local_load(
+    service, monkeypatch,
+):
+    svc, rows = service
+    local = _Provider("local")
+    remote = _Provider("lmstudio")
+    monkeypatch.setattr(
+        svc,
+        "_provider_router",
+        ProviderRouter(
+            providers={"local": local, "lmstudio": remote},
+            cfg=_cfg(on_error="fail", alias=None),
+        ),
+    )
+    monkeypatch.setattr(
+        svc,
+        "_get_model",
+        lambda _key: (_ for _ in ()).throw(
+            AssertionError("required-remote failure must not load local weights")
+        ),
+    )
+
+    with svc.app.test_client() as client:
+        response = client.post("/embed", json={
+            "texts": ["one"], "model": "leaf-ir", "prompt_name": "document",
+        })
+
+    assert response.status_code == 503
+    body = response.get_json()
+    assert body["code"] == "embedding_provider_misconfigured"
+    assert body["route"]["reason"] == "missing_lmstudio_model"
+    assert body["route"]["fallback"] is False
+    assert not local.calls and not remote.calls
+    assert rows[-1]["status"] == "error"
+    assert rows[-1]["provider"] == "lmstudio"
+    configured = svc._provider_router.describe("leaf-ir")
+    assert configured["configuration_status"] == "error"
+    assert "lmstudio_model is required" in configured["configuration_error"]
+
+
+def test_document_embed_required_remote_honors_cooldown_without_local_load(
+    service, monkeypatch,
+):
+    svc, _rows = service
+    local = _Provider("local")
+    remote = _Provider("lmstudio", available=False)
+    router = ProviderRouter(
+        providers={"local": local, "lmstudio": remote},
+        cfg=_cfg(on_error="fail"),
+    )
+    monkeypatch.setattr(svc, "_provider_router", router)
+
+    with svc.app.test_client() as client:
+        first = client.post("/embed", json={
+            "texts": ["one"], "model": "leaf-ir", "prompt_name": "document",
+        })
+        second = client.post("/embed", json={
+            "texts": ["two"], "model": "leaf-ir", "prompt_name": "document",
+        })
+
+    assert first.status_code == 503 and second.status_code == 503
+    assert first.get_json()["route"]["reason"] == "provider_unavailable"
+    assert second.get_json()["code"] == "embedding_provider_cooldown"
+    assert second.get_json()["route"]["reason"] == "provider_cooldown"
+    assert len(remote.calls) == 1
+    assert not local.calls
+    assert router.describe("leaf-ir")["cooldown_remaining_s"] > 0
+
+
+def test_query_model_keeps_existing_local_endpoint_path(service, monkeypatch):
+    svc, rows = service
+    seen: list[str] = []
+
+    class _Model:
+        def encode(self, texts, **_kwargs):
+            return np.full((len(texts), 2), 2.0, dtype=np.float32)
+
+    monkeypatch.setattr(
+        svc,
+        "_get_provider_router",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("query models must not enter document provider routing")
+        ),
+    )
+
+    def _get_model(key):
+        seen.append(key)
+        return _Model()
+
+    monkeypatch.setattr(svc, "_get_model", _get_model)
+    monkeypatch.setattr(
+        svc,
+        "_brokered_encode",
+        lambda model, texts, **kwargs: model.encode(texts, **kwargs),
+    )
+
+    with svc.app.test_client() as client:
+        response = client.post("/embed", json={
+            "texts": ["query"],
+            "model": "leaf-ir-query",
+            "prompt_name": "query",
+        })
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body == {
+        "vectors": [[2.0, 2.0]],
+        "dims": 2,
+        "count": 1,
+        "model": "leaf-ir-query",
+    }
+    assert seen == ["leaf-ir-query"]
+    assert rows == []
+
+
+def test_explicit_document_role_routes_custom_prompt_through_provider_policy(
+    service, monkeypatch,
+):
+    """Model-specific prompt names must not hide the semantic document role."""
+    svc, _rows = service
+    local = _Provider("local")
+    remote = _Provider("lmstudio")
+    monkeypatch.setattr(
+        svc,
+        "_provider_router",
+        ProviderRouter(
+            providers={"local": local, "lmstudio": remote},
+            cfg={"embedding": {"models": {"nomic": {
+                "provider": "lmstudio",
+                "lmstudio_model": "remote-nomic",
+                "on_error": "fail",
+            }}}},
+        ),
+    )
+    monkeypatch.setattr(
+        svc,
+        "_get_model",
+        lambda _key: (_ for _ in ()).throw(
+            AssertionError("custom document route must not bypass provider policy")
+        ),
+    )
+
+    with svc.app.test_client() as client:
+        response = client.post("/embed", json={
+            "texts": ["one"],
+            "model": "nomic",
+            "prompt_name": "search_document",
+            "routing_role": "document",
+        })
+
+    assert response.status_code == 200
+    assert response.get_json()["route"]["provider"] == "lmstudio"
+    assert remote.calls[0]["model_id"] == "remote-nomic"
+    assert not local.calls
+
+
+def test_explicit_query_role_overrides_legacy_leaf_ir_document_heuristic(
+    service, monkeypatch,
+):
+    """A semantic query remains local even when a legacy model-key heuristic matches."""
+    svc, rows = service
+    seen: list[str] = []
+
+    class _Model:
+        def encode(self, texts, **_kwargs):
+            return np.full((len(texts), 2), 3.0, dtype=np.float32)
+
+    monkeypatch.setattr(svc, "_get_model", lambda key: seen.append(key) or _Model())
+    monkeypatch.setattr(
+        svc,
+        "_brokered_encode",
+        lambda model, texts, **kwargs: model.encode(texts, **kwargs),
+    )
+    monkeypatch.setattr(
+        svc,
+        "_get_provider_router",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("explicit query role must not enter document routing")
+        ),
+    )
+
+    with svc.app.test_client() as client:
+        response = client.post("/embed", json={
+            "texts": ["query"],
+            "model": "leaf-ir",
+            "prompt_name": "search_query",
+            "routing_role": "query",
+        })
+
+    assert response.status_code == 200
+    assert seen == ["leaf-ir"]
+    assert rows == []
+
+
+def test_health_exposes_policy_breaker_and_last_route(service, monkeypatch):
+    svc, _rows = service
+    local = _Provider("local")
+    remote = _Provider("lmstudio")
+    router = ProviderRouter(
+        providers={"local": local, "lmstudio": remote},
+        cfg=_cfg(on_error="fallback"),
+    )
+    monkeypatch.setattr(svc, "_provider_router", router)
+    monkeypatch.setattr(svc, "_registry", {
+        "leaf-ir": svc.ModelEntry(
+            key="leaf-ir",
+            hf_name="MongoDB/mdbr-leaf-ir-asym",
+            dims=768,
+            eager=False,
+        ),
+    })
+
+    router.encode(["one"], model_id="leaf-ir", prompt_name="document")
+    with svc.app.test_client() as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    [model] = response.get_json()["models"]
+    routing = model["routing"]
+    assert routing["requested_provider"] == "lmstudio"
+    assert routing["provider_model"] == "remote-leaf-ir"
+    assert routing["on_error"] == "fallback"
+    assert routing["configuration_status"] == "ok"
+    assert routing["configuration_error"] is None
+    assert routing["authority_error"] is None
+    assert routing["last_route"]["provider"] == "lmstudio"
+    assert routing["last_route"]["reason"] == "provider_success"
+
+
+def test_in_service_bulk_index_uses_same_router_and_bounded_batches(
+    service, monkeypatch,
+):
+    from work_buddy.ir import dense
+
+    svc, rows = service
+    local = _Provider("local")
+    remote = _Provider("lmstudio")
+    router = ProviderRouter(
+        providers={"local": local, "lmstudio": remote},
+        cfg=_cfg(on_error="fail"),
+    )
+    monkeypatch.setattr(svc, "_provider_router", router)
+    monkeypatch.setattr(dense, "_IN_SERVICE", True)
+    texts = [f"document {i}" for i in range(65)]
+
+    vectors = dense._encode_bulk_direct(texts, batch_size=32, kind="passage")
+
+    assert vectors.shape == (65, 3)
+    assert [len(call["texts"]) for call in remote.calls] == [32, 32, 1]
+    assert all(call["model_id"] == "remote-leaf-ir" for call in remote.calls)
+    assert not local.calls
+    assert rows[-1]["provider"] == "lmstudio"
+    assert "route=provider_success" in rows[-1]["detail"]
+
+
+def test_sidecar_default_encoder_delegates_document_policy_to_service(
+    monkeypatch,
+):
+    """A dashboard override must not race a second YAML router in the sidecar."""
+    from work_buddy.embedding import client
+    from work_buddy.index import encode as encode_module
+    from work_buddy.ir import dense
+
+    monkeypatch.setattr(dense, "_IN_SERVICE", False)
+    monkeypatch.setattr(
+        "work_buddy.config.load_config",
+        lambda: {"embedding": {"models": {"leaf-ir": {"provider": "st"}}}},
+    )
+    monkeypatch.setattr(
+        encode_module.LmStudioProvider,
+        "encode",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("sidecar must not route documents around /embed")
+        ),
+    )
+    calls: list[dict] = []
+
+    def _embed(
+        texts,
+        *,
+        model=None,
+        prompt_name=None,
+        timeout_s=None,
+        routing_role=None,
+    ):
+        calls.append({
+            "texts": list(texts),
+            "model": model,
+            "prompt_name": prompt_name,
+            "timeout_s": timeout_s,
+            "routing_role": routing_role,
+        })
+        return [[7.0, 8.0]] * len(texts)
+
+    monkeypatch.setattr(client, "embed", _embed)
+
+    vectors = default_encoder().encode_documents(
+        ["one", "two"], "passage", batch_size=32,
+    )
+
+    assert vectors.tolist() == [[7.0, 8.0], [7.0, 8.0]]
+    assert calls == [{
+        "texts": ["one", "two"],
+        "model": "leaf-ir",
+        "prompt_name": "document",
+        "timeout_s": 120,
+        "routing_role": "document",
+    }]
+
+
+def test_sidecar_default_encoder_preserves_explicit_direct_st_evaluation(
+    monkeypatch,
+):
+    """Custom provider:st A/B models remain independent of the live service."""
+    from work_buddy.index import encode as encode_module
+    from work_buddy.ir import dense
+
+    cfg = {"embedding": {"models": {"nomic": {
+        "name": "nomic-ai/nomic-embed-text-v1.5",
+        "provider": "st",
+        "encoding": {
+            "query_model": "nomic",
+            "document_model": "nomic",
+            "query_prompt": "search_query",
+            "document_prompt": "search_document",
+        },
+    }}}}
+    monkeypatch.setattr(dense, "_IN_SERVICE", False)
+    monkeypatch.setattr("work_buddy.config.load_config", lambda: cfg)
+    monkeypatch.setattr(
+        encode_module,
+        "_REGISTRY_CACHE",
+        encode_module._build_registry(cfg),
+    )
+    calls: list[dict] = []
+
+    def _direct(self, texts, **kwargs):
+        calls.append({"texts": list(texts), **kwargs})
+        return np.ones((len(texts), 2), dtype=np.float32)
+
+    monkeypatch.setattr(encode_module.SentenceTransformerProvider, "encode", _direct)
+    monkeypatch.setattr(
+        "work_buddy.embedding.client.embed",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("provider:st evaluation must not call the live service")
+        ),
+    )
+
+    vectors = default_encoder().encode_documents(
+        ["one", "two"], "passage", model_key="nomic",
+    )
+
+    assert vectors.tolist() == [[1.0, 1.0], [1.0, 1.0]]
+    assert calls == [{
+        "texts": ["one", "two"],
+        "model_id": "nomic",
+        "prompt_name": "search_document",
+        "priority": Priority.BACKGROUND,
+    }]
+
+
+def test_failed_direct_st_evaluation_never_falls_through_to_live_service(
+    monkeypatch,
+):
+    """Missing deps/OOM degrade without mutating the service's model residency."""
+    from work_buddy.index import encode as encode_module
+    from work_buddy.ir import dense
+
+    cfg = {"embedding": {"models": {"nomic": {
+        "name": "nomic-ai/nomic-embed-text-v1.5",
+        "provider": "st",
+        "encoding": {
+            "query_model": "nomic",
+            "document_model": "nomic",
+            "document_prompt": "search_document",
+        },
+    }}}}
+    monkeypatch.setattr(dense, "_IN_SERVICE", False)
+    monkeypatch.setattr("work_buddy.config.load_config", lambda: cfg)
+    monkeypatch.setattr(
+        encode_module,
+        "_REGISTRY_CACHE",
+        encode_module._build_registry(cfg),
+    )
+    monkeypatch.setattr(
+        encode_module.SentenceTransformerProvider,
+        "encode",
+        lambda *_args, **_kwargs: None,
+    )
+    service_calls: list[dict] = []
+    monkeypatch.setattr(
+        "work_buddy.embedding.client.embed",
+        lambda *_args, **kwargs: service_calls.append(kwargs) or [[9.0, 9.0]],
+    )
+
+    vectors = default_encoder().encode_documents(
+        ["one"], "passage", model_key="nomic",
+    )
+
+    assert vectors is None
+    assert service_calls == []
+
+
+def test_in_service_default_encoder_reuses_authoritative_router(
+    service, monkeypatch,
+):
+    svc, _rows = service
+    from work_buddy.ir import dense
+
+    local = _Provider("local")
+    remote = _Provider("lmstudio")
+    router = ProviderRouter(
+        providers={"local": local, "lmstudio": remote},
+        cfg=_cfg(on_error="fail"),
+    )
+    monkeypatch.setattr(dense, "_IN_SERVICE", True)
+    monkeypatch.setattr(svc, "_provider_router", router)
+
+    vectors = default_encoder().encode_documents(["one"], "passage")
+
+    assert vectors.tolist() == [[1.0, 1.0, 1.0]]
+    assert len(remote.calls) == 1
+    assert not local.calls
+
+
+@pytest.mark.parametrize(
+    ("mode", "provider", "on_error"),
+    [
+        ("local", "local", "fallback"),
+        ("prefer-lmstudio", "lmstudio", "fallback"),
+        ("require-lmstudio", "lmstudio", "fail"),
+    ],
+)
+def test_restart_setting_authoritatively_overlays_document_route(
+    service, monkeypatch, mode, provider, on_error,
+):
+    svc, _rows = service
+    from work_buddy.settings import broker
+
+    original = {
+        "embedding": {
+            "service_port": 5999,
+            "models": {
+                "leaf-ir": {
+                    "name": "local-leaf",
+                    "dims": 768,
+                    "eager": False,
+                    "provider": "lmstudio" if mode == "local" else "local",
+                    "lmstudio_model": "remote-leaf",
+                    "on_error": "fail" if mode == "local" else "fallback",
+                }
+            },
+        }
+    }
+    monkeypatch.setattr(
+        broker,
+        "get_embedding_document_execution_mode",
+        lambda **_kwargs: (
+            mode,
+            {"revision": "value:3"},
+            {"reason": "restart-value-applied"},
+        ),
+    )
+
+    effective = svc._activate_document_execution_setting(original)
+
+    leaf = effective["embedding"]["models"]["leaf-ir"]
+    assert leaf["provider"] == provider
+    assert leaf["on_error"] == on_error
+    assert leaf["lmstudio_model"] == "remote-leaf"
+    assert effective["embedding"]["service_port"] == 5999
+    assert original["embedding"]["models"]["leaf-ir"]["provider"] != provider
+
+
+def test_restart_setting_activation_failure_fails_document_route_safe(
+    service, monkeypatch,
+):
+    svc, _rows = service
+    from work_buddy.settings import broker
+
+    config = {
+        "embedding": {
+            "models": {
+                "leaf-ir": {
+                    "provider": "local",
+                    "on_error": "fallback",
+                    "eager": True,
+                },
+            }
+        }
+    }
+    monkeypatch.setattr(
+        broker,
+        "get_embedding_document_execution_mode",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("settings unavailable")),
+    )
+
+    effective = svc._activate_document_execution_setting(config)
+
+    assert effective["embedding"]["models"]["leaf-ir"] == {
+        "provider": "lmstudio",
+        "on_error": "fail",
+        "eager": False,
+    }
+    assert config == {
+        "embedding": {
+            "models": {
+                "leaf-ir": {
+                    "provider": "local",
+                    "on_error": "fallback",
+                    "eager": True,
+                },
+            }
+        }
+    }
+    assert svc._document_policy_authority_error == "RuntimeError: settings unavailable"
+
+
+@pytest.mark.parametrize("on_error", ["fallback", "fail"])
+def test_remote_document_policy_suppresses_stale_eager_local_warmup(
+    service, monkeypatch, on_error,
+):
+    """Remote-preferred and remote-required startup never prewarm leaf-ir locally."""
+    svc, _rows = service
+    monkeypatch.setattr(svc, "_registry", {})
+    monkeypatch.setattr(svc, "_resolve_device", lambda _device="auto": "cpu")
+
+    svc._init_registry({
+        "embedding": {
+            "device": "cpu",
+            "models": {
+                "leaf-ir": {
+                    "name": "MongoDB/mdbr-leaf-ir-asym",
+                    "dims": 768,
+                    # Hostile historical config: routing policy must override this
+                    # preload hint before main's warmup loop sees the entry.
+                    "eager": True,
+                    "provider": "lmstudio",
+                    "lmstudio_model": "remote-leaf",
+                    "on_error": on_error,
+                },
+            },
+        },
+    })
+
+    assert svc._registry["leaf-ir"].eager is False
+
+
+def test_local_document_policy_preserves_explicit_eager_warmup(service, monkeypatch):
+    svc, _rows = service
+    monkeypatch.setattr(svc, "_registry", {})
+    monkeypatch.setattr(svc, "_resolve_device", lambda _device="auto": "cpu")
+
+    svc._init_registry({
+        "embedding": {
+            "device": "cpu",
+            "models": {
+                "leaf-ir": {
+                    "name": "MongoDB/mdbr-leaf-ir-asym",
+                    "dims": 768,
+                    "eager": True,
+                    "provider": "local",
+                },
+            },
+        },
+    })
+
+    assert svc._registry["leaf-ir"].eager is True
+
+
+@pytest.mark.parametrize("on_error", ["fallback", "fail"])
+def test_direct_model_lookup_cannot_bypass_remote_leaf_ir_policy(
+    service, monkeypatch, on_error,
+):
+    """Prewarm/search helpers cannot load leaf-ir around the provider router."""
+    svc, _rows = service
+    entry = svc.ModelEntry(
+        key="leaf-ir",
+        hf_name="MongoDB/mdbr-leaf-ir-asym",
+        dims=768,
+        eager=False,
+    )
+    monkeypatch.setattr(svc, "_registry", {"leaf-ir": entry})
+    monkeypatch.setattr(
+        svc,
+        "_provider_router",
+        ProviderRouter(
+            providers={
+                "local": _Provider("local"),
+                "lmstudio": _Provider("lmstudio"),
+            },
+            cfg=_cfg(on_error=on_error),
+        ),
+    )
+    monkeypatch.setattr(
+        svc,
+        "_load_model",
+        lambda _entry: (_ for _ in ()).throw(
+            AssertionError("direct lookup must not instantiate remote-routed leaf-ir")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="document-provider routing"):
+        svc._get_model("leaf-ir")
+    assert entry.model is None

--- a/tests/unit/test_index_build.py
+++ b/tests/unit/test_index_build.py
@@ -390,7 +390,8 @@ class TestBuild:
             _builder(store, part).build()
 
         # The committed vector remains fenced after the crash. No resident reader
-        # can load it under v1; replay atomically publishes generation v2.
+        # can load it under the prior generation; replay atomically publishes the
+        # next generation.
         assert store.vector_count("fake", "content") == 1
         assert store.build_version("fake") == 1
         assert store.partition_mutation_in_progress("fake") is True

--- a/tests/unit/test_index_build.py
+++ b/tests/unit/test_index_build.py
@@ -207,6 +207,21 @@ class TestBuild:
         assert default_vectors[1] == deferred_vectors[1]
         assert callback_observation == {"vector_count": 5, "docs_indexed": 5}
 
+    def test_plain_completion_hook_observes_final_completion_state(self, store):
+        part = FakePartition({
+            "i1": {"hash": "h1", "docs": [("a", "alpha", "alpha passage")]},
+        })
+        callback_observation: dict = {}
+
+        result = _builder(store, part).build(
+            after_build=lambda stats: callback_observation.update(dict(stats)),
+        )
+
+        assert callback_observation["index_complete"] is True
+        assert callback_observation["delivery_complete"] is True
+        assert callback_observation["complete"] is True
+        assert result["complete"] is True
+
     def test_deferred_vector_build_resumes_after_lexical_progress(self, store):
         class InterruptingPartition(FakePartition):
             fail_item = "i2"
@@ -237,6 +252,191 @@ class TestBuild:
         assert set(store.get_indexed_items("fake")) == {"i1", "i2"}
         assert store.vector_count("fake", "content") == 2
         assert encoder.document_calls == [["alpha passage", "beta passage"]]
+
+    def test_bounded_build_commits_slices_without_claiming_completion(self, store):
+        items = {
+            f"i{n}": {
+                "hash": f"h{n}",
+                "docs": [(f"d{n}", f"name{n}", f"text {n}")],
+            }
+            for n in range(5)
+        }
+        part = FakePartition(items)
+        completed: list[dict] = []
+        builder = _builder(store, part, encoder=RecordingEncoder())
+
+        first = builder.build(
+            max_items=2,
+            max_vector_batches=1,
+            after_build=completed.append,
+        )
+        assert first["changed"] == 2
+        assert first["changed_total"] == 5
+        assert first["complete"] is False
+        assert first["remaining"] == {"items": 3, "vectors": {"content": 0}}
+        assert store.doc_count("fake") == 2
+        assert store.vector_count("fake", "content") == 2
+        assert store.get_meta("last_build:fake") is None
+        assert completed == []
+
+        second = builder.build(
+            max_items=2,
+            max_vector_batches=1,
+            after_build=completed.append,
+        )
+        assert second["changed_total"] == 3
+        assert second["remaining"]["items"] == 1
+        assert second["complete"] is False
+        assert completed == []
+
+        final = builder.build(
+            max_items=2,
+            max_vector_batches=1,
+            after_build=completed.append,
+        )
+        assert final["changed_total"] == 1
+        assert final["remaining"] == {"items": 0, "vectors": {"content": 0}}
+        assert final["complete"] is True
+        assert store.doc_count("fake") == 5
+        assert store.vector_count("fake", "content") == 5
+        assert store.get_meta("last_build:fake") is not None
+        assert completed == [final]
+
+    def test_bounded_first_build_prioritizes_unindexed_tail_over_rechanged_head(self, store):
+        part = FakePartition({
+            "head": {"hash": "h1", "docs": [("head", "head", "head text")]},
+            "middle": {"hash": "m1", "docs": [("middle", "middle", "middle text")]},
+            "tail": {"hash": "t1", "docs": [("tail", "tail", "tail text")]},
+        })
+        builder = _builder(store, part)
+        builder.build(max_items=1, max_vector_batches=1)
+        assert set(store.get_indexed_items("fake")) == {"head"}
+
+        # Simulate the newest/head session changing again before the next tick.
+        part.items["head"]["hash"] = "h2"
+        part.items["head"]["docs"] = [("head", "head changed", "changed text")]
+        second = builder.build(max_items=1, max_vector_batches=1)
+
+        assert second["changed_total"] == 3
+        assert set(store.get_indexed_items("fake")) == {"head", "middle"}
+        assert "fake:middle" in store.search_lexical("middle", partition="fake")
+
+    def test_vector_budget_resumes_missing_vectors_in_bounded_batches(
+        self, store, monkeypatch,
+    ):
+        items = {
+            f"i{n}": {
+                "hash": f"h{n}",
+                "docs": [(f"d{n}", f"name{n}", f"text {n}")],
+            }
+            for n in range(5)
+        }
+        part = FakePartition(items)
+        monkeypatch.setattr(IndexBuilder, "_ENCODE_MISSING_BATCH", 2)
+        unavailable = _builder(store, part, encoder=FakeEncoder(down=True)).build(
+            defer_changed_vectors=True,
+        )
+        assert unavailable["complete"] is False
+        assert unavailable["remaining"]["vectors"] == {"content": 5}
+
+        builder = _builder(store, part, encoder=RecordingEncoder())
+        first = builder.build(max_vector_batches=1)
+        assert first["changed"] == 0
+        assert first["vectors_encoded"] == 2
+        assert first["vector_batches"] == 1
+        assert first["remaining"]["vectors"] == {"content": 3}
+        assert first["complete"] is False
+
+        second = builder.build(max_vector_batches=2)
+        assert second["vectors_encoded"] == 3
+        assert second["remaining"]["vectors"] == {"content": 0}
+        assert second["complete"] is True
+        assert store.vector_count("fake", "content") == 5
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"max_items": 0},
+            {"max_items": True},
+            {"max_vector_batches": -1},
+            {"max_vector_batches": 1.5},
+            {"force": True, "max_items": 1},
+            {"force": True, "max_vector_batches": 1},
+        ],
+    )
+    def test_build_rejects_invalid_or_non_resumable_budgets(self, store, kwargs):
+        part = FakePartition({})
+        with pytest.raises(ValueError):
+            _builder(store, part).build(**kwargs)
+
+    def test_vector_generation_advances_before_a_committed_batch(self, store, monkeypatch):
+        part = FakePartition({
+            "i1": {"hash": "h1", "docs": [("a", "alpha", "alpha passage")]},
+        })
+        _builder(store, part, encoder=FakeEncoder(down=True)).build(
+            defer_changed_vectors=True,
+        )
+        assert store.build_version("fake") == 1
+        assert store.vector_count("fake", "content") == 0
+
+        original = store.upsert_vectors
+
+        def commit_then_crash(projection, rows):
+            original(projection, rows)
+            raise RuntimeError("synthetic crash after vector commit")
+
+        monkeypatch.setattr(store, "upsert_vectors", commit_then_crash)
+        with pytest.raises(RuntimeError, match="after vector commit"):
+            _builder(store, part).build()
+
+        # The committed vector remains fenced after the crash. No resident reader
+        # can load it under v1; replay atomically publishes generation v2.
+        assert store.vector_count("fake", "content") == 1
+        assert store.build_version("fake") == 1
+        assert store.partition_mutation_in_progress("fake") is True
+        with pytest.raises(RuntimeError, match="being mutated"):
+            store.resident_version("fake")
+        assert store.get_meta("last_build:fake") is None
+
+        monkeypatch.setattr(store, "upsert_vectors", original)
+        recovered = _builder(store, part).build()
+        assert recovered["complete"] is True
+        assert recovered["version"] == 2
+        assert store.partition_mutation_in_progress("fake") is False
+        assert store.resident_version("fake") == "2"
+        assert store.get_meta("last_build:fake") is not None
+
+    def test_empty_pooled_projection_does_not_wedge_completion(self, store):
+        class EmptyPoolPartition(FakePartition):
+            def projection_schema(self):
+                return {"aliases": ProjectionSpec(kind=ProjectionKind.LABEL, pool="max")}
+
+            def parse(self, item_id):
+                return [Document(
+                    doc_id="fake:a",
+                    partition="fake",
+                    fields={"name": "alpha"},
+                    projections={"aliases": Projection(text=[""])},
+                )]
+
+        part = EmptyPoolPartition({
+            "i1": {"hash": "h1", "docs": [("a", "alpha", "")]},
+        })
+        first = _builder(store, part).build(
+            max_items=1,
+            max_vector_batches=1,
+        )
+        second = _builder(store, part).build(
+            max_items=1,
+            max_vector_batches=1,
+        )
+
+        assert first["complete"] is True
+        assert first["remaining"]["vectors"] == {"aliases": 0}
+        assert second["complete"] is True
+        assert second["remaining"]["vectors"] == {"aliases": 0}
+        assert store.vector_count("fake", "aliases") == 0
+        assert store.get_meta("last_build:fake") is not None
 
     def test_pooled_projection_build(self, store):
         class PooledPartition(FakePartition):

--- a/tests/unit/test_index_database_outbox.py
+++ b/tests/unit/test_index_database_outbox.py
@@ -121,6 +121,10 @@ def test_build_then_ack_snapshots_events_and_replays_concurrent_lag(tmp_path):
         "parity_mismatches": 0,
         "ready": False,
     }
+    assert first["index_complete"] is True
+    assert first["delivery_complete"] is False
+    assert first["complete"] is False
+    assert index.store.get_meta(f"last_build:{partition.name}") is None
     assert partition.acknowledged == ["event-1"]
     assert lock_observations == [(True, True)]
 
@@ -129,6 +133,9 @@ def test_build_then_ack_snapshots_events_and_replays_concurrent_lag(tmp_path):
     assert replay["outbox"]["delivered"] == 1
     assert replay["outbox"]["pending_after"] == 0
     assert replay["outbox"]["ready"] is True
+    assert replay["delivery_complete"] is True
+    assert replay["complete"] is True
+    assert index.store.get_meta(f"last_build:{partition.name}") is not None
     assert partition.acknowledged == ["event-1", "event-2"]
     assert lock_observations == [(True, True), (True, True)]
 
@@ -164,6 +171,10 @@ def test_parity_mismatch_retains_entire_snapshot_until_replay(tmp_path):
     assert raced["outbox"]["delivered"] == 0
     assert raced["outbox"]["pending_after"] == 2
     assert raced["outbox"]["ready"] is False
+    assert raced["index_complete"] is True
+    assert raced["delivery_complete"] is False
+    assert raced["complete"] is False
+    assert index.store.get_meta(f"last_build:{partition.name}") is None
     assert partition.acknowledged == []
 
     replayed = index.build(partition.name)
@@ -171,7 +182,28 @@ def test_parity_mismatch_retains_entire_snapshot_until_replay(tmp_path):
     assert replayed["outbox"]["parity_mismatches"] == 0
     assert replayed["outbox"]["delivered"] == 2
     assert replayed["outbox"]["ready"] is True
+    assert replayed["delivery_complete"] is True
+    assert replayed["complete"] is True
+    assert index.store.get_meta(f"last_build:{partition.name}") is not None
     assert partition.acknowledged == ["event-1", "event-2"]
+
+
+def test_optional_pending_counter_does_not_wedge_acknowledged_delivery(tmp_path):
+    class NoCounterPartition(_OutboxPartition):
+        pending_search_event_count = None
+
+    partition = NoCounterPartition()
+    index = _unified(tmp_path, partition)
+
+    result = index.build(partition.name)
+
+    assert partition.events == []
+    assert result["outbox"]["pending_after"] is None
+    assert result["outbox"]["delivered"] == 1
+    assert result["outbox"]["ready"] is True
+    assert result["delivery_complete"] is True
+    assert result["complete"] is True
+    assert index.store.get_meta(f"last_build:{partition.name}") is not None
 
 
 def test_contract_and_personal_partitions_register_with_bootstrap():

--- a/tests/unit/test_index_encode.py
+++ b/tests/unit/test_index_encode.py
@@ -6,10 +6,12 @@ No real embedding service: a FakeProvider records calls + returns deterministic 
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from work_buddy.index.encode import (
     BrokeredEncoder,
     ProviderRouter,
+    ProviderRoutingError,
     resolve_model,
     score_dense,
 )
@@ -144,6 +146,13 @@ class TestBrokeredEncoder:
         assert out is not None and out.shape == (1, 4)  # fell back to local
         assert local.calls[-1][1] == "leaf-ir"  # alias never leaks into local fallback
 
+        route = router.describe("leaf-ir")["last_route"]
+        assert route["requested_provider"] == "lmstudio"
+        assert route["provider"] == "local"
+        assert route["fallback"] is True
+        assert route["reason"] == "provider_unavailable"
+        assert "unavailable" in route["provider_error"]
+
     def test_router_uses_configured_lmstudio_model_alias(self):
         local = FakeProvider(name="local")
         remote = FakeProvider(name="lmstudio")
@@ -206,6 +215,245 @@ class TestBrokeredEncoder:
         now[0] += 301.0
         router.encode(["probe"], model_id="leaf-ir")
         assert [call[0] for call in remote.calls] == [["first"], ["probe"]]
+
+    def test_concurrent_remote_failure_is_singleflight_then_cooldown(self):
+        """A burst at a dead peer makes one network attempt, not one per request."""
+        import threading
+        from concurrent.futures import ThreadPoolExecutor
+
+        worker_count = 8
+        ready = threading.Barrier(worker_count)
+        entered = threading.Event()
+        release = threading.Event()
+
+        class _BlockingDown:
+            name = "lmstudio"
+
+            def __init__(self):
+                self.calls = 0
+                self.lock = threading.Lock()
+
+            def encode(self, texts, **_kwargs):
+                with self.lock:
+                    self.calls += 1
+                entered.set()
+                assert release.wait(timeout=5)
+                return None
+
+        remote = _BlockingDown()
+        local = FakeProvider(name="local")
+        router = ProviderRouter(
+            providers={"local": local, "lmstudio": remote},
+            cfg={"embedding": {"models": {"leaf-ir": {
+                "provider": "lmstudio",
+                "lmstudio_model": "remote-leaf-ir",
+                "on_error": "fail",
+            }}}},
+        )
+
+        def _call(index):
+            ready.wait(timeout=5)
+            try:
+                router.encode([str(index)], model_id="leaf-ir")
+            except ProviderRoutingError as exc:
+                return exc.route.reason
+            raise AssertionError("remote-required request unexpectedly succeeded")
+
+        with ThreadPoolExecutor(max_workers=worker_count) as pool:
+            futures = [pool.submit(_call, index) for index in range(worker_count)]
+            assert entered.wait(timeout=5)
+            release.set()
+            reasons = [future.result(timeout=5) for future in futures]
+
+        assert remote.calls == 1
+        assert reasons.count("provider_unavailable") == 1
+        assert reasons.count("provider_cooldown") == worker_count - 1
+        assert not local.calls
+
+    def test_router_fail_closed_never_calls_local_when_remote_is_down(self):
+        local = FakeProvider(name="local")
+        remote = _NoneProvider()
+        router = ProviderRouter(
+            providers={"local": local, "lmstudio": remote},
+            cfg={"embedding": {"models": {"leaf-ir": {
+                "provider": "lmstudio",
+                "lmstudio_model": "remote-leaf-ir",
+                "on_error": "fail",
+            }}}},
+        )
+
+        with pytest.raises(ProviderRoutingError) as raised:
+            router.encode(["x"], model_id="leaf-ir")
+
+        assert raised.value.code == "embedding_provider_unavailable"
+        assert raised.value.route.fallback is False
+        assert not local.calls
+
+    def test_router_preserves_typed_remote_error_on_successful_fallback(self):
+        from work_buddy.llm.backends._errors import LocalInferenceError
+
+        class _TypedFailure:
+            name = "lmstudio"
+
+            def encode(self, texts, **_kwargs):
+                raise LocalInferenceError(
+                    "LM Link dropped",
+                    kind="lm_link_dropped",
+                    hint="Reconnect the peer.",
+                )
+
+        local = FakeProvider(name="local")
+        router = ProviderRouter(
+            providers={"local": local, "lmstudio": _TypedFailure()},
+            cfg={"embedding": {"models": {"leaf-ir": {
+                "provider": "lmstudio",
+                "lmstudio_model": "remote-leaf-ir",
+                "on_error": "fallback",
+            }}}},
+        )
+
+        routed = router.encode_with_route(["x"], model_id="leaf-ir")
+
+        assert routed.vectors is not None
+        assert routed.route.status == "ok"
+        assert routed.route.provider == "local"
+        assert routed.route.error is None
+        assert "Reconnect the peer." in routed.route.provider_error
+        assert routed.route.provider_error_kind == "lm_link_dropped"
+        assert routed.route.provider_error_hint == "Reconnect the peer."
+
+    def test_router_preserves_typed_remote_error_on_fail_closed(self):
+        from work_buddy.llm.backends._errors import LocalInferenceError
+
+        class _TypedFailure:
+            name = "lmstudio"
+
+            def encode(self, texts, **_kwargs):
+                raise LocalInferenceError(
+                    "LM Studio timed out",
+                    kind="timeout",
+                    hint="Retry after the cold load.",
+                )
+
+        router = ProviderRouter(
+            providers={"local": FakeProvider(name="local"), "lmstudio": _TypedFailure()},
+            cfg={"embedding": {"models": {"leaf-ir": {
+                "provider": "lmstudio",
+                "lmstudio_model": "remote-leaf-ir",
+                "on_error": "fail",
+            }}}},
+        )
+
+        with pytest.raises(ProviderRoutingError) as raised:
+            router.encode(["x"], model_id="leaf-ir")
+
+        route = raised.value.route
+        assert route.provider_error_kind == "timeout"
+        assert route.provider_error_hint == "Retry after the cold load."
+        assert "Retry after the cold load." in str(raised.value)
+
+    def test_router_fail_closed_missing_alias_never_calls_any_provider(self):
+        local = FakeProvider(name="local")
+        remote = FakeProvider(name="lmstudio")
+        router = ProviderRouter(
+            providers={"local": local, "lmstudio": remote},
+            cfg={"embedding": {"models": {"leaf-ir": {
+                "provider": "lmstudio",
+                "on_error": "fail",
+            }}}},
+        )
+
+        with pytest.raises(ProviderRoutingError) as raised:
+            router.encode(["x"], model_id="leaf-ir")
+
+        assert raised.value.code == "embedding_provider_misconfigured"
+        assert raised.value.route.reason == "missing_lmstudio_model"
+        assert not local.calls and not remote.calls
+
+    def test_router_fail_closed_cooldown_does_not_retry_or_load_local(
+        self, monkeypatch,
+    ):
+        local = FakeProvider(name="local")
+        remote = _NoneProvider()
+        calls = []
+
+        def _remote_encode(texts, **kwargs):
+            calls.append((list(texts), kwargs))
+            return None
+
+        remote.encode = _remote_encode
+        now = [100.0]
+        monkeypatch.setattr("work_buddy.index.encode.monotonic", lambda: now[0])
+        router = ProviderRouter(
+            providers={"local": local, "lmstudio": remote},
+            cfg={"embedding": {"models": {"leaf-ir": {
+                "provider": "lmstudio",
+                "lmstudio_model": "remote-leaf-ir",
+                "on_error": "fail",
+            }}}},
+        )
+
+        with pytest.raises(ProviderRoutingError) as first:
+            router.encode(["first"], model_id="leaf-ir")
+        with pytest.raises(ProviderRoutingError) as second:
+            router.encode(["second"], model_id="leaf-ir")
+
+        assert first.value.route.reason == "provider_unavailable"
+        assert second.value.code == "embedding_provider_cooldown"
+        assert second.value.route.reason == "provider_cooldown"
+        assert len(calls) == 1
+        assert not local.calls
+
+    def test_router_local_only_never_touches_remote(self):
+        local = FakeProvider(name="local")
+        remote = FakeProvider(name="lmstudio")
+        router = ProviderRouter(
+            providers={"local": local, "lmstudio": remote},
+            cfg={"embedding": {"models": {"leaf-ir": {
+                "provider": "local",
+                "lmstudio_model": "remote-leaf-ir",
+                "on_error": "fail",
+            }}}},
+        )
+
+        routed = router.encode_with_route(["x"], model_id="leaf-ir")
+
+        assert routed.vectors is not None
+        assert local.calls and not remote.calls
+        assert routed.route.reason == "configured_local"
+        assert routed.route.fallback is False
+
+    def test_sentence_transformer_provider_name_is_local_alias(self):
+        local = FakeProvider(name="local")
+        router = ProviderRouter(
+            providers={"local": local},
+            cfg={"embedding": {"models": {"leaf-ir": {
+                "provider": "sentence_transformer",
+            }}}},
+        )
+
+        routed = router.encode_with_route(["x"], model_id="leaf-ir")
+
+        assert routed.route.requested_provider == "local"
+        assert routed.route.provider == "local"
+        assert local.calls
+
+    def test_unknown_provider_honors_fail_closed_policy(self):
+        local = FakeProvider(name="local")
+        router = ProviderRouter(
+            providers={"local": local},
+            cfg={"embedding": {"models": {"leaf-ir": {
+                "provider": "not-installed",
+                "on_error": "fail",
+            }}}},
+        )
+
+        with pytest.raises(ProviderRoutingError) as raised:
+            router.encode(["x"], model_id="leaf-ir")
+
+        assert raised.value.code == "embedding_provider_not_configured"
+        assert raised.value.route.reason == "provider_not_configured"
+        assert not local.calls
 
     def test_router_routes_provider_st(self):
         from work_buddy.index.encode import SentenceTransformerProvider
@@ -367,7 +615,9 @@ class TestLocalProvider:
             return model.encode(texts, **kwargs)
 
         monkeypatch.setattr(dense, "_IN_SERVICE", True, raising=False)
-        monkeypatch.setattr(svc, "_get_model", lambda key: fake_model, raising=False)
+        monkeypatch.setattr(
+            svc, "_get_model", lambda key, **_kwargs: fake_model, raising=False,
+        )
         monkeypatch.setattr(svc, "_brokered_encode", _brokered, raising=False)
         out = LocalProvider().encode(
             ["x"], model_id="leaf-ir", prompt_name="document",
@@ -387,7 +637,7 @@ class TestLocalProvider:
         import work_buddy.embedding.service as svc
         from work_buddy.index.encode import LocalProvider
 
-        def _boom(key):
+        def _boom(key, **_kwargs):
             raise RuntimeError("model load failed")
 
         monkeypatch.setattr(dense, "_IN_SERVICE", True, raising=False)
@@ -429,7 +679,7 @@ class TestLmStudioProvider:
         out = LmStudioProvider().encode(["a", "b"], model_id="arctic")
         assert out.shape == (2, 3)
 
-    def test_returns_none_on_error(self, monkeypatch):
+    def test_preserves_provider_error_for_router_diagnostics(self, monkeypatch):
         import work_buddy.embedding.providers.lmstudio as lm
         from work_buddy.index.encode import LmStudioProvider
 
@@ -437,4 +687,5 @@ class TestLmStudioProvider:
             raise RuntimeError("peer down")
 
         monkeypatch.setattr(lm, "encode", _boom)
-        assert LmStudioProvider().encode(["a"], model_id="arctic") is None
+        with pytest.raises(RuntimeError, match="peer down"):
+            LmStudioProvider().encode(["a"], model_id="arctic")

--- a/tests/unit/test_index_model.py
+++ b/tests/unit/test_index_model.py
@@ -148,10 +148,22 @@ class TestConfig:
         assert cfg.enabled is False
         assert cfg.db_path is None
         assert cfg.partitions == {}
+        assert cfg.startup_prewarm == "lazy"
 
     def test_load_disabled_by_default_even_with_block(self):
         cfg = load_index_config({"index": {}})
         assert cfg.enabled is False
+
+    def test_startup_prewarm_accepts_all_and_defaults_invalid_to_lazy(self):
+        assert load_index_config(
+            {"index": {"startup_prewarm": "all"}}
+        ).startup_prewarm == "all"
+        assert load_index_config(
+            {"index": {"startup_prewarm": "everything"}}
+        ).startup_prewarm == "lazy"
+        assert load_index_config(
+            {"index": {"startup_prewarm": None}}
+        ).startup_prewarm == "lazy"
 
     def test_partition_fallback_for_unlisted(self):
         cfg = load_index_config({"index": {"enabled": True}})

--- a/tests/unit/test_index_refresh_jobs.py
+++ b/tests/unit/test_index_refresh_jobs.py
@@ -41,6 +41,12 @@ def test_index_refresh_job_well_formed(jobs_by_name, partition):
     assert job.capability == "index_rebuild"
     assert job.params.get("partition") == partition
     assert job.params.get("force") is False  # incremental, never force, on a recurring job
+    if partition == "conversation":
+        assert job.params.get("max_items") == 25
+        assert job.params.get("max_vector_batches") == 4
+    else:
+        assert "max_items" not in job.params
+        assert "max_vector_batches" not in job.params
     assert job.recurring is True
     fields = job.schedule.split()
     assert len(fields) == 5, f"index-{partition}-refresh: 5-field cron, got {job.schedule!r}"
@@ -124,3 +130,53 @@ def test_op_self_skips_when_any_build_holds_the_db_gate(tmp_path, monkeypatch):
         dt = time.time() - t0
     assert out == {"skipped": "build_in_progress", "partition": "chrome"}
     assert dt < 5.0
+
+
+def test_op_forwards_named_partition_work_budgets(tmp_path, monkeypatch):
+    from work_buddy.mcp_server.ops import index_ops
+    from work_buddy.index.config import IndexConfig
+
+    cfg = IndexConfig(enabled=True, db_path=tmp_path / "idx.db")
+    monkeypatch.setattr("work_buddy.index.config.load_index_config", lambda *a, **k: cfg)
+    monkeypatch.setattr("work_buddy.utils.index_lock.is_locked", lambda *a, **k: False)
+    calls = []
+
+    class FakeIndex:
+        def __init__(self, *, config):
+            assert config is cfg
+
+        def build(self, name, **kwargs):
+            calls.append((name, kwargs))
+            return {"partition": name, "complete": False, "remaining": {"items": 7}}
+
+    monkeypatch.setattr("work_buddy.index.partitioned.UnifiedIndex", FakeIndex)
+    out = json.loads(
+        index_ops._index_rebuild_dispatch(
+            partition="conversation",
+            max_items=25,
+            max_vector_batches=4,
+        )
+    )
+    assert calls == [(
+        "conversation",
+        {"force": False, "max_items": 25, "max_vector_batches": 4},
+    )]
+    assert out["result"]["complete"] is False
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"partition": "conversation", "max_items": 0},
+        {"partition": "conversation", "max_vector_batches": True},
+        {"max_items": 1},
+        {"partition": "   ", "max_items": 1},
+        {"partition": "conversation", "force": True, "max_items": 1},
+        {"partition": "conversation", "force": True, "max_vector_batches": 1},
+    ],
+)
+def test_op_rejects_invalid_or_ambiguous_work_budgets(kwargs):
+    from work_buddy.mcp_server.ops import index_ops
+
+    with pytest.raises(ValueError):
+        index_ops._index_rebuild_dispatch(**kwargs)

--- a/tests/unit/test_index_resident.py
+++ b/tests/unit/test_index_resident.py
@@ -44,7 +44,7 @@ class TestResidentCache:
 
         cache = ResidentCache(loader, version_fn=lambda: version["v"])
         assert cache.get() == 1
-        version["v"] = "v2"          # rebuild bumped the version
+        version["v"] = "next"        # rebuild bumped the version
         assert cache.get() == 2      # reloaded
         assert calls["n"] == 2
 
@@ -107,7 +107,7 @@ class TestResidentCache:
         assert not cache.is_cached()
 
     def test_value_loaded_across_a_generation_change_is_discarded(self):
-        versions = iter(["v1", "v2"])
+        versions = iter(["prior", "current"])
         cache = ResidentCache(lambda: ["old snapshot"], version_fn=lambda: next(versions))
         assert cache.get() is None
         assert not cache.is_cached()
@@ -130,7 +130,7 @@ class TestResidentCache:
         version = {"v": "v1"}
         cache = ResidentCache(lambda: 1, version_fn=lambda: version["v"])
         cache.get()
-        version["v"] = "v2"                    # a rebuild bumped the version
+        version["v"] = "next"                  # a rebuild bumped the version
         assert cache.get_if_cached() is None   # stale cached value counts as absent
 
     def test_get_if_cached_none_after_invalidate(self):
@@ -144,7 +144,7 @@ class TestResidentCache:
         cache = ResidentCache(lambda: None, version_fn=lambda: version["v"])
         assert cache.get() is None
         assert cache.is_current()
-        version["v"] = "v2"
+        version["v"] = "next"
         assert not cache.is_current()
 
     def test_concurrent_callers_join_one_slow_load(self):

--- a/tests/unit/test_index_resident.py
+++ b/tests/unit/test_index_resident.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+
 from work_buddy.index.resident import ResidentCache, ResidentCacheRegistry
 
 
@@ -60,10 +62,19 @@ class TestResidentCache:
         cache.get()
         assert calls["n"] == 2
 
-    def test_none_loader_not_cached(self):
-        cache = ResidentCache(lambda: None, version_fn=lambda: "v1")
+    def test_none_loader_caches_settled_empty_generation(self):
+        calls = {"n": 0}
+
+        def loader():
+            calls["n"] += 1
+            return None
+
+        cache = ResidentCache(loader, version_fn=lambda: "v1")
         assert cache.get() is None
-        assert not cache.is_cached()
+        assert cache.get() is None
+        assert calls["n"] == 1
+        assert cache.is_cached()
+        assert cache.is_current()
 
     def test_release_if_idle(self):
         clock = _Clock()
@@ -81,6 +92,25 @@ class TestResidentCache:
 
         cache = ResidentCache(lambda: [1], version_fn=boom)
         assert cache.get() is None
+
+    def test_value_loaded_across_a_writer_fence_is_discarded(self):
+        checks = {"n": 0}
+
+        def version():
+            checks["n"] += 1
+            if checks["n"] == 1:
+                return "v1"
+            raise RuntimeError("partition is being mutated")
+
+        cache = ResidentCache(lambda: ["mixed snapshot"], version_fn=version)
+        assert cache.get() is None
+        assert not cache.is_cached()
+
+    def test_value_loaded_across_a_generation_change_is_discarded(self):
+        versions = iter(["v1", "v2"])
+        cache = ResidentCache(lambda: ["old snapshot"], version_fn=lambda: next(versions))
+        assert cache.get() is None
+        assert not cache.is_cached()
 
     def test_get_if_cached_never_loads(self):
         calls = {"n": 0}
@@ -108,6 +138,41 @@ class TestResidentCache:
         cache.get()
         cache.invalidate()
         assert cache.get_if_cached() is None
+
+    def test_settled_empty_becomes_stale_after_generation_change(self):
+        version = {"v": "v1"}
+        cache = ResidentCache(lambda: None, version_fn=lambda: version["v"])
+        assert cache.get() is None
+        assert cache.is_current()
+        version["v"] = "v2"
+        assert not cache.is_current()
+
+    def test_concurrent_callers_join_one_slow_load(self):
+        entered = threading.Event()
+        release = threading.Event()
+        calls = {"n": 0}
+
+        def loader():
+            calls["n"] += 1
+            entered.set()
+            assert release.wait(timeout=5)
+            return ["matrix"]
+
+        cache = ResidentCache(loader, version_fn=lambda: "v1")
+        results: list[list[str] | None] = []
+        first = threading.Thread(target=lambda: results.append(cache.get()))
+        second = threading.Thread(target=lambda: results.append(cache.get()))
+
+        first.start()
+        assert entered.wait(timeout=5)
+        second.start()
+        release.set()
+        first.join(timeout=5)
+        second.join(timeout=5)
+
+        assert not first.is_alive() and not second.is_alive()
+        assert calls["n"] == 1
+        assert results == [["matrix"], ["matrix"]]
 
 
 class TestResidentCacheRegistry:

--- a/tests/unit/test_index_retention.py
+++ b/tests/unit/test_index_retention.py
@@ -51,7 +51,9 @@ class FakePartition:
 
 @pytest.fixture
 def store(tmp_path):
-    return IndexStore(tmp_path / "ret.db")
+    value = IndexStore(tmp_path / "ret.db")
+    value.prepare_schema()
+    return value
 
 
 def _builder(store, part, retention="track_source", ttl_days=None):
@@ -157,6 +159,27 @@ class TestPrune:
         _builder(store, part, retention="ttl", ttl_days=30).build()
         assert _state(store, "fake:recent") == "orphaned"  # within window → kept
         assert not _exists(store, "fake:old")              # past window → swept
+
+    def test_later_ttl_sweep_publishes_a_new_resident_generation(
+        self, store, monkeypatch,
+    ):
+        now = time.time()
+        part = FakePartition({"recent": {"hash": "1", "ts": now}})
+        builder = _builder(store, part, retention="ttl", ttl_days=1)
+        builder.build()
+        del part.items["recent"]
+        builder.build()
+        assert store.doc_count("fake") == 1
+        assert store.build_version("fake") == 2
+
+        monkeypatch.setattr(time, "time", lambda: now + 2 * 86400)
+        swept = builder.build()
+
+        assert swept["changed"] == 0 and swept["deleted"] == 0
+        assert store.doc_count("fake") == 0
+        assert store.build_version("fake") == 3
+        assert store.partition_mutation_in_progress("fake") is False
+        assert store.resident_version("fake") == "3"
 
 
 class TestStorePrimitives:

--- a/tests/unit/test_index_search.py
+++ b/tests/unit/test_index_search.py
@@ -35,7 +35,9 @@ class FakeEncoder:
 
 @pytest.fixture
 def store(tmp_path):
-    return IndexStore(tmp_path / "search-index.db")
+    value = IndexStore(tmp_path / "search-index.db")
+    value.prepare_schema()
+    return value
 
 
 class TestSourceCap:

--- a/tests/unit/test_index_store.py
+++ b/tests/unit/test_index_store.py
@@ -5,16 +5,25 @@ Uses a tmp_path DB; no embedding service. Vectors are synthetic numpy arrays.
 
 from __future__ import annotations
 
+import json
+import sqlite3
+
 import numpy as np
 import pytest
 
 from work_buddy.index.model import Document, Projection
-from work_buddy.index.store import IndexStore
+from work_buddy.index.store import (
+    IndexSchemaRepairRequired,
+    IndexStore,
+    UnsupportedIndexSchemaVersion,
+)
 
 
 @pytest.fixture
 def store(tmp_path):
-    return IndexStore(tmp_path / "t-index.db")
+    value = IndexStore(tmp_path / "t-index.db")
+    value.prepare_schema()
+    return value
 
 
 def _doc(doc_id, partition="knowledge", *, name="", body="", tags="", meta=None, ts=None):
@@ -87,6 +96,32 @@ class TestUpsertAndLexical:
         store.upsert_documents([_doc("knowledge:a", name="replaced")], item_id="i")
         assert store.search_lexical("original") == {}
         assert "knowledge:a" in store.search_lexical("replaced")
+
+    def test_reupsert_preserves_rowid_and_invalidates_stale_vectors(self, store):
+        store.upsert_documents([_doc("knowledge:a", name="original")], item_id="i")
+        store.upsert_vectors("content", [("knowledge:a", np.ones(4, dtype=np.float32))])
+        conn = store._connect()
+        try:
+            before = conn.execute(
+                "SELECT rowid FROM documents WHERE doc_id = 'knowledge:a'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+        store.upsert_documents([_doc("knowledge:a", name="replacement")], item_id="i")
+
+        conn = store._connect()
+        try:
+            after = conn.execute(
+                "SELECT rowid FROM documents WHERE doc_id = 'knowledge:a'"
+            ).fetchone()[0]
+            fts_rowid = conn.execute(
+                "SELECT rowid FROM doc_fts WHERE doc_fts MATCH 'replacement'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert after == before == fts_rowid
+        assert store.vector_count("knowledge", "content") == 0
 
 
 class TestMetadataFilter:
@@ -182,6 +217,604 @@ class TestVectors:
         work2 = store.docs_missing_vectors("knowledge", "content")
         assert {d for d, _ in work2} == {"knowledge:b"}
 
+    def test_docs_missing_vectors_limit_and_database_side_count(self, store):
+        store.upsert_documents([
+            Document(
+                doc_id=f"knowledge:{i}",
+                partition="knowledge",
+                fields={"name": str(i)},
+                projections={"content": Projection(text=f"body {i}")},
+            )
+            for i in range(5)
+        ] + [
+            Document(
+                doc_id="knowledge:empty",
+                partition="knowledge",
+                fields={"name": "empty"},
+                projections={"content": Projection(text=[""])},
+            )
+        ], item_id="i")
+
+        work = store.docs_missing_vectors("knowledge", "content", limit=2)
+        assert len(work) == 2
+        # Empty scalar/list projections are not actionable remaining work.
+        assert store.missing_vector_count("knowledge", "content") == 5
+        store.upsert_vectors(
+            "content",
+            [(doc_id, np.ones(4, dtype=np.float32)) for doc_id, _ in work],
+        )
+        assert store.missing_vector_count("knowledge", "content") == 3
+
+    def test_docs_missing_vectors_rejects_non_positive_limit(self, store):
+        with pytest.raises(ValueError, match="positive integer"):
+            store.docs_missing_vectors("knowledge", "content", limit=0)
+
+
+def _create_legacy_fts_database(path, *, malformed_fields: bool = False):
+    """Create the pre-rowid FTS schema without importing private production SQL."""
+    conn = sqlite3.connect(str(path))
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.executescript(
+        """
+        CREATE TABLE documents (
+            doc_id TEXT PRIMARY KEY,
+            partition TEXT NOT NULL,
+            item_id TEXT NOT NULL DEFAULT '',
+            fields TEXT NOT NULL DEFAULT '{}',
+            projections TEXT NOT NULL DEFAULT '{}',
+            display_text TEXT NOT NULL DEFAULT '',
+            metadata TEXT NOT NULL DEFAULT '{}',
+            content_hash TEXT NOT NULL DEFAULT '',
+            timestamp REAL,
+            indexed_at TEXT NOT NULL
+        );
+        CREATE TABLE doc_vectors (
+            doc_id TEXT NOT NULL REFERENCES documents(doc_id) ON DELETE CASCADE,
+            projection TEXT NOT NULL,
+            sub INTEGER NOT NULL DEFAULT 0,
+            dim INTEGER NOT NULL,
+            vector BLOB NOT NULL,
+            PRIMARY KEY (doc_id, projection, sub)
+        );
+        CREATE TABLE indexed_items (
+            item_id TEXT NOT NULL,
+            partition TEXT NOT NULL DEFAULT '',
+            mtime REAL NOT NULL DEFAULT 0,
+            content_hash TEXT NOT NULL DEFAULT '',
+            doc_count INTEGER NOT NULL DEFAULT 0,
+            indexed_at TEXT NOT NULL,
+            PRIMARY KEY (item_id, partition)
+        );
+        CREATE TABLE index_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        CREATE VIRTUAL TABLE doc_fts USING fts5(
+            doc_id UNINDEXED, title, body, tags
+        );
+        """
+    )
+    fields_a = "not-json" if malformed_fields else json.dumps(
+        {"name": "canonical alpha", "body": "fresh searchable body", "tags": "one"}
+    )
+    conn.executemany(
+        "INSERT INTO documents "
+        "(doc_id, partition, item_id, fields, indexed_at) VALUES (?,?,?,?,?)",
+        [
+            ("knowledge:a", "knowledge", "item-a", fields_a, "then"),
+            (
+                "knowledge:b",
+                "knowledge",
+                "item-b",
+                json.dumps({"name": "canonical beta", "body": "second body"}),
+                "then",
+            ),
+        ],
+    )
+    # Deliberately use unrelated FTS rowids and stale text.  Migration must rebuild
+    # from documents, not assume old FTS consistency or copy these rowids.
+    conn.executemany(
+        "INSERT INTO doc_fts(rowid, doc_id, title, body, tags) VALUES (?,?,?,?,?)",
+        [
+            (9001, "knowledge:a", "stale alpha", "obsolete", ""),
+            (9002, "knowledge:b", "stale beta", "obsolete", ""),
+        ],
+    )
+    conn.execute(
+        "INSERT INTO doc_vectors(doc_id, projection, sub, dim, vector) VALUES (?,?,?,?,?)",
+        ("knowledge:a", "content", 0, 2, np.ones(2, dtype=np.float16).tobytes()),
+    )
+    conn.execute(
+        "INSERT INTO indexed_items VALUES (?,?,?,?,?,?)",
+        ("item-a", "knowledge", 1.0, "hash", 1, "then"),
+    )
+    rowids = {
+        row[0]: row[1]
+        for row in conn.execute("SELECT doc_id, rowid FROM documents").fetchall()
+    }
+    conn.commit()
+    conn.close()
+    return rowids
+
+
+class TestFtsSchemaMigration:
+    def test_legacy_database_is_atomically_rebuilt_and_rowid_aligned(self, tmp_path):
+        path = tmp_path / "legacy.db"
+        original_rowids = _create_legacy_fts_database(path)
+
+        migrated = IndexStore(path)
+        migrated.prepare_schema()
+        assert "knowledge:a" in migrated.search_lexical("fresh searchable")
+        assert migrated.search_lexical("obsolete") == {}
+        assert migrated.vector_count("knowledge", "content") == 1
+        assert migrated.get_indexed_items("knowledge")["item-a"] == (1.0, "hash")
+
+        conn = sqlite3.connect(str(path))
+        try:
+            fts_sql = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name = 'doc_fts'"
+            ).fetchone()[0]
+            aligned = conn.execute(
+                "SELECT d.doc_id, d.rowid, f.rowid FROM doc_fts f "
+                "JOIN documents d ON d.rowid = f.rowid ORDER BY d.doc_id"
+            ).fetchall()
+            version = conn.execute(
+                "SELECT value FROM index_meta WHERE key = 'fts_schema_version'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert "content='documents'" in fts_sql
+        assert version == "2"
+        assert {doc_id: doc_rowid for doc_id, doc_rowid, _ in aligned} == original_rowids
+        assert all(doc_rowid == fts_rowid for _, doc_rowid, fts_rowid in aligned)
+
+        # Reopening is idempotent, and deletion uses the synchronized trigger.
+        reopened = IndexStore(path)
+        assert reopened.delete_item_docs("item-a", partition="knowledge") == 1
+        assert reopened.search_lexical("fresh searchable") == {}
+        assert reopened.vector_count("knowledge", "content") == 0
+
+    def test_same_named_malformed_trigger_is_repaired_before_write(self, tmp_path):
+        path = tmp_path / "malformed-trigger.db"
+        store = IndexStore(path)
+        store.prepare_schema()
+        store.upsert_documents(
+            [_doc("knowledge:a", name="original")], item_id="item-a"
+        )
+
+        conn = sqlite3.connect(str(path))
+        try:
+            conn.executescript(
+                """
+                DROP TRIGGER documents_fts_update;
+                CREATE TRIGGER documents_fts_update
+                AFTER UPDATE OF title, body, tags ON documents BEGIN
+                    SELECT 1;
+                END;
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # An ordinary write refuses the malformed layout. Only the explicit repair
+        # may rebuild FTS from authoritative documents and install the canonical body.
+        with pytest.raises(IndexSchemaRepairRequired):
+            store.upsert_documents(
+                [_doc("knowledge:a", name="replacement")], item_id="item-a"
+            )
+        store.prepare_schema()
+        store.upsert_documents(
+            [_doc("knowledge:a", name="replacement")], item_id="item-a"
+        )
+
+        assert store.search_lexical("original") == {}
+        assert "knowledge:a" in store.search_lexical("replacement")
+
+    def test_concurrent_explicit_prepare_waits_for_sqlite_writer(self, tmp_path):
+        import threading
+        import time
+
+        path = tmp_path / "concurrent-legacy.db"
+        _create_legacy_fts_database(path)
+        locker = sqlite3.connect(str(path))
+        # The production consolidated index already runs in WAL mode. Avoid
+        # making this test about a concurrent DELETE->WAL journal conversion,
+        # whose PRAGMA does not honor SQLite's ordinary busy wait.
+        locker.execute("PRAGMA journal_mode=WAL")
+        locker.execute("BEGIN IMMEDIATE")
+        outcome: dict[str, object] = {}
+
+        def open_store() -> None:
+            try:
+                # The ordinary timeout is intentionally much shorter than the
+                # held SQLite lock. Explicit preparation has its own migration wait.
+                candidate = IndexStore(path, busy_timeout_s=0.001)
+                candidate.prepare_schema()
+                outcome["count"] = candidate.doc_count()
+            except Exception as exc:  # pragma: no cover - asserted below
+                outcome["error"] = exc
+
+        worker = threading.Thread(target=open_store)
+        worker.start()
+        time.sleep(0.1)
+        locker.commit()
+        locker.close()
+        worker.join(timeout=10)
+
+        assert not worker.is_alive()
+        assert outcome == {"count": 2}
+
+    def test_malformed_legacy_fields_do_not_block_the_migration(self, tmp_path):
+        path = tmp_path / "malformed.db"
+        _create_legacy_fts_database(path, malformed_fields=True)
+
+        migrated = IndexStore(path)
+        migrated.prepare_schema()
+        # The malformed document remains in the authoritative table; only its
+        # unparseable lexical projection is empty.  Healthy rows are still rebuilt.
+        assert migrated.doc_count("knowledge") == 2
+        assert "knowledge:b" in migrated.search_lexical("second body")
+
+    def test_failed_migration_rolls_back_the_complete_legacy_layout(
+        self, tmp_path, monkeypatch
+    ):
+        from work_buddy.index import store as store_mod
+
+        path = tmp_path / "rollback.db"
+        _create_legacy_fts_database(path)
+        monkeypatch.setattr(store_mod, "_CREATE_FTS_SQL", "CREATE definitely invalid")
+
+        with pytest.raises(sqlite3.OperationalError):
+            IndexStore(path).prepare_schema()
+
+        conn = sqlite3.connect(str(path))
+        try:
+            columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(documents)").fetchall()
+            }
+            fts_sql = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name = 'doc_fts'"
+            ).fetchone()[0]
+            fts_count = conn.execute("SELECT count(*) FROM doc_fts").fetchone()[0]
+            version = conn.execute(
+                "SELECT value FROM index_meta WHERE key = 'fts_schema_version'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert not {"title", "body", "tags"}.intersection(columns)
+        assert "doc_id UNINDEXED" in fts_sql
+        assert fts_count == 2
+        assert version is None
+
+    def test_status_on_missing_path_is_side_effect_free(self, tmp_path):
+        path = tmp_path / "missing" / "index.db"
+        snapshot = IndexStore(path).status_snapshot()
+
+        assert snapshot["state"] == "absent"
+        assert snapshot["partitions"] == []
+        assert not path.parent.exists()
+
+    def test_status_on_legacy_schema_does_not_repair_or_change_bytes(
+        self, tmp_path, monkeypatch
+    ):
+        from work_buddy.index import store as store_mod
+
+        path = tmp_path / "legacy-status.db"
+        _create_legacy_fts_database(path)
+        before = path.read_bytes()
+        monkeypatch.setattr(
+            store_mod,
+            "_ensure_fts_schema",
+            lambda _conn: pytest.fail("read-only status attempted schema repair"),
+        )
+
+        snapshot = IndexStore(path).status_snapshot()
+
+        assert snapshot["state"] == "repair_required"
+        assert snapshot["partitions"][0]["total_items"] == 2
+        assert "did not run it" in snapshot["partitions"][0]["detail"]
+        assert path.read_bytes() == before
+
+    def test_ordinary_open_refuses_legacy_schema_until_explicit_repair(self, tmp_path):
+        path = tmp_path / "legacy-refusal.db"
+        _create_legacy_fts_database(path)
+
+        with pytest.raises(IndexSchemaRepairRequired, match="never run it implicitly"):
+            IndexStore(path).doc_count()
+
+        IndexStore(path).prepare_schema()
+        assert IndexStore(path).doc_count() == 2
+
+    def test_scheduled_preparation_may_create_but_not_repair_existing_schema(self, tmp_path):
+        fresh = IndexStore(tmp_path / "fresh.db")
+        fresh.prepare_schema(repair_existing=False)
+        assert fresh.status_snapshot()["state"] == "current"
+
+        v1_path = tmp_path / "v1-scheduled.db"
+        _create_legacy_fts_database(v1_path)
+        before = v1_path.read_bytes()
+        with pytest.raises(IndexSchemaRepairRequired, match="scheduled builds"):
+            IndexStore(v1_path).prepare_schema(repair_existing=False)
+        assert v1_path.read_bytes() == before
+
+    def test_scheduled_preparation_recovers_crash_created_empty_file(self, tmp_path):
+        path = tmp_path / "empty.db"
+        path.write_bytes(b"")
+
+        store = IndexStore(path)
+        store.prepare_schema(repair_existing=False)
+
+        assert store.status_snapshot()["state"] == "current"
+        assert store.doc_count() == 0
+
+    def test_scheduled_preparation_recovers_interrupted_fresh_bootstrap(
+        self, tmp_path, monkeypatch
+    ):
+        from work_buddy.index import store as store_mod
+
+        path = tmp_path / "partial-bootstrap.db"
+        store = IndexStore(path)
+        real_ensure = store_mod._ensure_fts_schema
+
+        monkeypatch.setattr(
+            store_mod,
+            "_ensure_fts_schema",
+            lambda _conn: (_ for _ in ()).throw(RuntimeError("synthetic interruption")),
+        )
+        with pytest.raises(RuntimeError, match="synthetic interruption"):
+            store.prepare_schema(repair_existing=False)
+        assert store.status_snapshot()["state"] == "absent"
+
+        monkeypatch.setattr(store_mod, "_ensure_fts_schema", real_ensure)
+        store.prepare_schema(repair_existing=False)
+        assert store.status_snapshot()["state"] == "current"
+
+    def test_scheduled_preparation_rolls_back_mid_base_schema_failure(
+        self, tmp_path, monkeypatch
+    ):
+        from work_buddy.index import store as store_mod
+
+        path = tmp_path / "mid-schema-bootstrap.db"
+        store = IndexStore(path)
+        real_schema = store_mod._SCHEMA
+        first_boundary = real_schema.index("CREATE INDEX")
+        broken_schema = (
+            real_schema[:first_boundary]
+            + "SELECT definitely_missing_bootstrap_function();\n"
+            + real_schema[first_boundary:]
+        )
+
+        monkeypatch.setattr(store_mod, "_SCHEMA", broken_schema)
+        with pytest.raises(sqlite3.OperationalError, match="missing_bootstrap"):
+            store.prepare_schema(repair_existing=False)
+        assert store.status_snapshot()["state"] == "absent"
+
+        monkeypatch.setattr(store_mod, "_SCHEMA", real_schema)
+        store.prepare_schema(repair_existing=False)
+        assert store.status_snapshot()["state"] == "current"
+
+    def test_prepare_runs_repair_while_shared_writer_gate_is_held(
+        self, tmp_path, monkeypatch
+    ):
+        from work_buddy.index import store as store_mod
+        from work_buddy.utils.index_lock import is_locked
+
+        path = tmp_path / "gated-repair.db"
+        _create_legacy_fts_database(path)
+        observed: list[bool] = []
+        real_ensure = store_mod._ensure_fts_schema
+
+        def observed_ensure(conn):
+            observed.append(is_locked(path.parent / f"{path.name}.build"))
+            return real_ensure(conn)
+
+        monkeypatch.setattr(store_mod, "_ensure_fts_schema", observed_ensure)
+        IndexStore(path).prepare_schema()
+
+        assert observed == [True]
+
+    def test_prepare_waits_for_existing_advisory_builder(self, tmp_path):
+        import threading
+
+        from work_buddy.index.locking import index_writer_gate
+
+        path = tmp_path / "advisory-wait.db"
+        _create_legacy_fts_database(path)
+        entered = threading.Event()
+        finished = threading.Event()
+
+        def repair():
+            entered.set()
+            IndexStore(path).prepare_schema()
+            finished.set()
+
+        with index_writer_gate(path):
+            worker = threading.Thread(target=repair)
+            worker.start()
+            assert entered.wait(timeout=5)
+            assert not finished.wait(timeout=0.2)
+        worker.join(timeout=10)
+
+        assert not worker.is_alive()
+        assert finished.is_set()
+        assert IndexStore(path).status_snapshot()["state"] == "current"
+
+    def test_concurrent_explicit_repairs_elect_one_migrator(self, tmp_path, monkeypatch):
+        import threading
+        import time
+
+        from work_buddy.index import store as store_mod
+
+        path = tmp_path / "repair-election.db"
+        _create_legacy_fts_database(path)
+        real_ensure = store_mod._ensure_fts_schema
+        calls = {"n": 0}
+        calls_lock = threading.Lock()
+        start = threading.Barrier(3)
+
+        def counted_ensure(conn):
+            with calls_lock:
+                calls["n"] += 1
+            time.sleep(0.1)
+            return real_ensure(conn)
+
+        monkeypatch.setattr(store_mod, "_ensure_fts_schema", counted_ensure)
+        errors: list[Exception] = []
+
+        def repair():
+            start.wait(timeout=5)
+            try:
+                IndexStore(path).prepare_schema()
+            except Exception as exc:  # pragma: no cover - asserted below
+                errors.append(exc)
+
+        workers = [threading.Thread(target=repair) for _ in range(2)]
+        for worker in workers:
+            worker.start()
+        start.wait(timeout=5)
+        for worker in workers:
+            worker.join(timeout=10)
+
+        assert not errors
+        assert all(not worker.is_alive() for worker in workers)
+        assert calls == {"n": 1}
+        assert IndexStore(path).status_snapshot()["state"] == "current"
+
+    def test_prepare_fails_closed_when_writer_gate_is_unavailable(
+        self, tmp_path, monkeypatch
+    ):
+        import builtins
+
+        from work_buddy.index import store as store_mod
+
+        path = tmp_path / "ungated-repair.db"
+        _create_legacy_fts_database(path)
+        before = path.read_bytes()
+        ensure_calls: list[bool] = []
+        real_ensure = store_mod._ensure_fts_schema
+        real_import = builtins.__import__
+
+        def observed_ensure(conn):
+            ensure_calls.append(True)
+            return real_ensure(conn)
+
+        def import_without_gate(name, *args, **kwargs):
+            if name == "work_buddy.utils.index_lock":
+                raise ImportError("synthetic missing writer gate")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(store_mod, "_ensure_fts_schema", observed_ensure)
+        monkeypatch.setattr(builtins, "__import__", import_without_gate)
+        with pytest.raises(RuntimeError, match="writer gate is required"):
+            IndexStore(path).prepare_schema()
+
+        assert ensure_calls == []
+        assert path.read_bytes() == before
+
+    def test_future_schema_is_preserved_and_fails_closed(self, tmp_path):
+        path = tmp_path / "future.db"
+        current = IndexStore(path)
+        current.prepare_schema()
+        conn = sqlite3.connect(path)
+        try:
+            conn.execute(
+                "UPDATE index_meta SET value='3' WHERE key='fts_schema_version'"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        before = path.read_bytes()
+
+        with pytest.raises(UnsupportedIndexSchemaVersion, match="newer"):
+            IndexStore(path).prepare_schema()
+
+        assert path.read_bytes() == before
+        assert IndexStore(path).status_snapshot()["state"] == "unsupported"
+
+    def test_status_rejects_future_schema_before_assuming_v2_table_names(self, tmp_path):
+        path = tmp_path / "future-renamed.db"
+        conn = sqlite3.connect(path)
+        try:
+            conn.execute("CREATE TABLE index_meta (key TEXT PRIMARY KEY, value TEXT)")
+            conn.execute(
+                "INSERT INTO index_meta(key, value) VALUES "
+                "('fts_schema_version', '3')"
+            )
+            conn.execute("CREATE TABLE future_documents (opaque BLOB)")
+            conn.commit()
+        finally:
+            conn.close()
+        before = path.read_bytes()
+
+        snapshot = IndexStore(path).status_snapshot()
+
+        assert snapshot["state"] == "unsupported"
+        assert "newer than this binary" in snapshot["detail"]
+        assert snapshot["partitions"] == []
+        assert path.read_bytes() == before
+
+
+class TestFtsDeletionPlans:
+    def test_all_bulk_delete_paths_leave_fts_in_sync(self, store):
+        now = 1000.0
+        store.upsert_documents(
+            [
+                _doc("a:one", partition="a", name="itemtoken", ts=now - 10),
+                _doc("a:two", partition="a", name="partitiontoken", ts=now - 20),
+                _doc("b:old", partition="b", name="orphantoken", ts=now - 30),
+                _doc("b:live", partition="b", name="livetoken", ts=now - 30),
+            ],
+            item_id="shared",
+        )
+        # Give the paths distinct item boundaries after one efficient batch insert.
+        conn = store._connect()
+        try:
+            conn.execute("UPDATE documents SET item_id = 'partition' WHERE doc_id = 'a:two'")
+            conn.execute("UPDATE documents SET item_id = 'old' WHERE doc_id = 'b:old'")
+            conn.execute("UPDATE documents SET item_id = 'live' WHERE doc_id = 'b:live'")
+            conn.commit()
+        finally:
+            conn.close()
+
+        assert store.delete_item_docs("shared", partition="a") == 1
+        assert store.search_lexical("itemtoken") == {}
+        assert store.delete_partition("a") == 1
+        assert store.search_lexical("partitiontoken") == {}
+        store.mark_items_orphaned(["old"], "b")
+        assert store.prune_orphans_older_than("b", now) == 1
+        assert store.search_lexical("orphantoken") == {}
+        assert "b:live" in store.search_lexical("livetoken")
+
+    def test_item_delete_query_uses_the_documents_index(self, store):
+        store.upsert_documents([_doc("knowledge:a", name="alpha")], item_id="item-a")
+        conn = store._connect()
+        try:
+            plan = " ".join(
+                row[3]
+                for row in conn.execute(
+                    "EXPLAIN QUERY PLAN DELETE FROM documents "
+                    "WHERE item_id = ? AND partition = ?",
+                    ("item-a", "knowledge"),
+                ).fetchall()
+            )
+            fts_rowid_plan = " ".join(
+                row[3]
+                for row in conn.execute(
+                    "EXPLAIN QUERY PLAN SELECT rowid FROM doc_fts WHERE rowid = ?",
+                    (1,),
+                ).fetchall()
+            )
+            fts_sql = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name = 'doc_fts'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert "idx_documents_item" in plan
+        assert "item_id=? AND partition=?" in plan
+        # FTS5 denotes an equality-constrained rowid lookup as virtual index ``:=``;
+        # the legacy UNINDEXED-doc_id plan was bare ``INDEX 0:`` (a full scan).
+        assert "INDEX 0:=" in fts_rowid_plan
+        assert "UNINDEXED" not in fts_sql
+        assert "content_rowid='rowid'" in fts_sql
+
 
 class TestLedgerAndVersion:
     def test_indexed_items_ledger(self, store):
@@ -236,6 +869,7 @@ class TestWriteContention:
         from work_buddy.index import store as store_mod
 
         st = IndexStore(tmp_path / "contend.db", busy_timeout_s=0.1)
+        st.prepare_schema()
         st.set_meta("warm", "1")  # create the schema before contending
         monkeypatch.setattr(store_mod, "_WRITE_RETRY_DELAYS_S", (0.1, 0.2, 0.4, 0.8))
 

--- a/tests/unit/test_index_unified.py
+++ b/tests/unit/test_index_unified.py
@@ -18,6 +18,7 @@ from work_buddy.index.partition import PartitionRegistry
 from work_buddy.index.partitioned import (
     UnifiedIndex,
     prewarm_resident_matrices,
+    start_configured_prewarm,
     start_prewarm,
     warm_partitions_async,
 )
@@ -306,6 +307,37 @@ class TestPrewarm:
         assert not t.is_alive()
         assert t.daemon
 
+    def test_configured_prewarm_is_lazy_by_default(self):
+        def factory(_cfg):
+            raise AssertionError("lazy startup must not open or load the index")
+
+        thread = start_configured_prewarm(
+            IndexConfig(enabled=True), index_factory=factory
+        )
+        assert thread is None
+
+    def test_configured_prewarm_unknown_policy_fails_safe_to_lazy(self):
+        def factory(_cfg):
+            raise AssertionError("unknown startup policy must not eagerly load the index")
+
+        thread = start_configured_prewarm(
+            IndexConfig(enabled=True, startup_prewarm="unexpected"),
+            index_factory=factory,
+        )
+        assert thread is None
+
+    def test_configured_prewarm_all_restores_eager_behavior(self, tmp_path):
+        ui = self._unified(tmp_path)
+        ui.build("p1")
+        thread = start_configured_prewarm(
+            IndexConfig(enabled=True, startup_prewarm="all"),
+            index_factory=lambda _cfg: ui,
+        )
+        assert thread is not None
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+        assert ui._residents.get("p1:default").is_cached()
+
     def test_prewarm_only_warms_named_subset(self, tmp_path):
         ui = self._unified(tmp_path)
         ui.build("p1")
@@ -340,6 +372,50 @@ class TestWarmingSignal:
         ui.partition("proj").prewarm()
         assert ui.cold_partitions(["proj", "lex"]) == []  # warmed → no longer cold
 
+    def test_zero_vector_projection_settles_without_perpetual_warm_retry(self, tmp_path):
+        store = CountingStore(tmp_path / "uni.db")
+        ui = self._unified(tmp_path, store=store)
+        ui.build("proj")
+        # Simulate a document route that could not produce vectors. The lexical
+        # document remains useful and the empty dense generation is a stable state.
+        conn = store._connect()
+        try:
+            conn.execute("DELETE FROM doc_vectors WHERE doc_id = 'proj:a'")
+            conn.commit()
+        finally:
+            conn.close()
+        ui._residents.invalidate("proj:default")
+
+        assert ui.cold_partitions(["proj"]) == ["proj"]
+        assert ui.partition("proj").prewarm() == 0
+        assert ui.cold_partitions(["proj"]) == []
+        assert store.load_calls == 1
+        assert ui.search(
+            Query(text="alpha", top_k=5),
+            partitions=["proj"],
+            block_until_warm=False,
+        )[0].doc_id == "proj:a"
+        assert store.load_calls == 1
+
+    def test_cross_process_generation_change_marks_allocated_cache_cold(self, tmp_path):
+        ui = self._unified(tmp_path)
+        ui.build("proj")
+        ui.partition("proj").prewarm()
+        cache = ui._residents.get("proj:default")
+        assert cache is not None and cache.is_cached()
+        assert ui.cold_partitions(["proj"]) == []
+
+        # A scheduled build runs in the sidecar process, whose registry cannot
+        # invalidate this embedding-process object directly. The durable generation
+        # is therefore the authority: the still-allocated v1 matrix must be reported
+        # cold so the endpoint emits its warming signal and starts a v2 reload.
+        ui.store.begin_partition_mutation("proj")
+        ui.store.finish_partition_mutation("proj")
+
+        assert cache.is_cached()  # allocated does not imply current
+        assert cache.get_if_cached() is None
+        assert ui.cold_partitions(["proj"]) == ["proj"]
+
     def test_warm_eta_scales_with_vector_count(self, tmp_path):
         ui = self._unified(tmp_path)
         ui.build("proj")
@@ -348,7 +424,8 @@ class TestWarmingSignal:
 
     def test_readiness_check_avoids_heavy_vector_count(self, tmp_path):
         # cold_partitions runs on the serving hot path; it must NOT issue the heavy
-        # COUNT(DISTINCT) JOIN that vector_count is — only in-RAM is_cached() checks.
+        # COUNT(DISTINCT) JOIN that vector_count is. A cheap version lookup is allowed
+        # so stale cross-process residents are not mistaken for warm matrices.
         store = CountingStore(tmp_path / "uni.db")
         ui = self._unified(tmp_path, store=store)
         ui.build("proj")
@@ -393,7 +470,9 @@ class TestWarmingSignal:
 
         # Nothing in flight → it actually warms (and clears the guard afterwards).
         t = P.warm_partitions_async(
-            ["proj"], config=IndexConfig(enabled=True), index_factory=lambda cfg: ui
+            ["proj"],
+            config=IndexConfig(enabled=True, startup_prewarm="lazy"),
+            index_factory=lambda cfg: ui,
         )
         assert t is not None
         t.join(timeout=5)

--- a/tests/unit/test_index_unified.py
+++ b/tests/unit/test_index_unified.py
@@ -407,8 +407,9 @@ class TestWarmingSignal:
 
         # A scheduled build runs in the sidecar process, whose registry cannot
         # invalidate this embedding-process object directly. The durable generation
-        # is therefore the authority: the still-allocated v1 matrix must be reported
-        # cold so the endpoint emits its warming signal and starts a v2 reload.
+        # is therefore the authority: the still-allocated prior matrix must be reported
+        # cold so the endpoint emits its warming signal and starts a current-generation
+        # reload.
         ui.store.begin_partition_mutation("proj")
         ui.store.finish_partition_mutation("proj")
 

--- a/tests/unit/test_lmstudio_embedding.py
+++ b/tests/unit/test_lmstudio_embedding.py
@@ -11,10 +11,9 @@ Covers:
 - ``work_buddy.embedding.providers.lmstudio.resolve_base_url`` honors
   the ``lmstudio.base_url`` config key and falls back to the LM Studio
   default.
-- ``work_buddy.ir.dense._encode_bulk_direct`` dispatches to the LM
-  Studio provider when a model opts in, falls back to sentence-
-  transformers on error (when ``on_error=fallback``), and re-raises
-  when ``on_error=fail``.
+- ``work_buddy.ir.dense._encode_bulk_direct`` delegates external builds
+  to the shared embedding-service policy boundary and preserves its
+  actual LM Studio/fallback/fail route provenance.
 
 No actual HTTP calls — the provider encode function is monkeypatched
 for the dispatch tests. No actual sentence-transformers load either —
@@ -27,8 +26,6 @@ machinery, so it's safe to run on CI boxes.
 """
 
 from __future__ import annotations
-
-from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -127,171 +124,146 @@ def test_resolve_base_url_ignores_non_string() -> None:
 # _encode_bulk_direct dispatch behavior
 # ---------------------------------------------------------------------------
 
-@pytest.fixture
-def fake_cfg_lmstudio_on_error(monkeypatch):
-    """Return a factory that installs a fake load_config with configurable
-    on_error and lmstudio_model. Used by dispatch tests below."""
-    import work_buddy.config as cfg_module
-
-    def _build(on_error: str, lmstudio_model: str = "fake-model-id"):
-        def _fake():
-            return {
-                "lmstudio": {"base_url": "http://localhost:1234"},
-                "embedding": {
-                    "models": {
-                        "leaf-ir": {
-                            "name": "MongoDB/mdbr-leaf-ir-asym",
-                            "dims": 768,
-                            "eager": False,
-                            "provider": "lmstudio",
-                            "lmstudio_model": lmstudio_model,
-                            "on_error": on_error,
-                        },
-                    },
-                },
-            }
-        monkeypatch.setattr(cfg_module, "load_config", _fake)
-
-    return _build
-
-
-def test_encode_bulk_direct_routes_to_lmstudio(
-    fake_cfg_lmstudio_on_error, monkeypatch
-) -> None:
-    """Happy path: provider=lmstudio with a working endpoint routes there
-    and returns whatever the provider produces, without touching the
-    sentence-transformers fallback."""
-    fake_cfg_lmstudio_on_error(on_error="fail")
-
+def test_encode_bulk_direct_routes_external_build_through_service(monkeypatch) -> None:
+    """An external legacy build must not re-read YAML and route independently."""
     captured_kwargs: dict = {}
     fake_vecs = np.ones((3, 768), dtype=np.float32)
 
-    def _fake_encode(texts, *, model_id, base_url, batch_size):
+    def _fake_embed(
+        texts,
+        *,
+        model=None,
+        prompt_name=None,
+        timeout_s=None,
+        routing_role=None,
+        record_provenance=True,
+        call_id=None,
+    ):
         captured_kwargs["texts"] = list(texts)
-        captured_kwargs["model_id"] = model_id
-        captured_kwargs["base_url"] = base_url
-        captured_kwargs["batch_size"] = batch_size
-        return fake_vecs
+        captured_kwargs["model"] = model
+        captured_kwargs["prompt_name"] = prompt_name
+        captured_kwargs["timeout_s"] = timeout_s
+        captured_kwargs["routing_role"] = routing_role
+        captured_kwargs["record_provenance"] = record_provenance
+        captured_kwargs["call_id"] = call_id
+        return {
+            "vectors": fake_vecs.tolist(),
+            "route": {
+                "model": "leaf-ir",
+                "requested_provider": "lmstudio",
+                "provider": "lmstudio",
+                "provider_model": "fake-model-id",
+                "on_error": "fail",
+                "status": "ok",
+                "fallback": False,
+                "reason": "provider_success",
+                "at": 1.0,
+            },
+        }
 
-    import work_buddy.embedding.providers.lmstudio as prov
-    monkeypatch.setattr(prov, "encode", _fake_encode)
+    from work_buddy.embedding import client
+    monkeypatch.setattr(client, "embed_with_route", _fake_embed)
 
     # Also ensure _IN_SERVICE is False so a bug forcing the fallback path
     # would try to load SentenceTransformer — which we'd catch below.
-    import work_buddy.ir.dense as dense
+    from work_buddy.ir import dense
     monkeypatch.setattr(dense, "_IN_SERVICE", False)
-
-    def _boom(*a, **kw):
-        raise AssertionError(
-            "SentenceTransformer must not be touched on the happy LM "
-            "Studio path"
-        )
-    # Guard: if the dispatcher accidentally falls through, this trips.
-    monkeypatch.setattr(
-        "sentence_transformers.SentenceTransformer", _boom
-    )
 
     result = dense._encode_bulk_direct(["a", "b", "c"], kind="passage")
 
-    assert result is fake_vecs
-    assert captured_kwargs["model_id"] == "fake-model-id"
-    assert captured_kwargs["base_url"] == "http://localhost:1234"
+    assert np.array_equal(result, fake_vecs)
+    assert captured_kwargs["model"] == "leaf-ir"
+    assert captured_kwargs["prompt_name"] == "document"
+    assert captured_kwargs["timeout_s"] == 120
+    assert captured_kwargs["routing_role"] == "document"
+    assert captured_kwargs["record_provenance"] is False
+    assert isinstance(captured_kwargs["call_id"], str)
+    assert len(captured_kwargs["call_id"]) == 12
     assert captured_kwargs["texts"] == ["a", "b", "c"]
 
 
-def test_encode_bulk_direct_fallback_on_error(
-    fake_cfg_lmstudio_on_error, monkeypatch
-) -> None:
-    """When on_error=fallback and the provider raises, we must drop to
-    the sentence-transformers path without propagating."""
-    fake_cfg_lmstudio_on_error(on_error="fallback")
+def test_encode_bulk_direct_preserves_service_fallback_route(monkeypatch) -> None:
+    from work_buddy.embedding import client
+    from work_buddy.ir import dense
 
-    def _fake_encode(texts, **_kw):
-        raise RuntimeError("simulated LM Studio outage")
-
-    import work_buddy.embedding.providers.lmstudio as prov
-    monkeypatch.setattr(prov, "encode", _fake_encode)
-
-    import work_buddy.ir.dense as dense
     monkeypatch.setattr(dense, "_IN_SERVICE", False)
-
-    # Stub SentenceTransformer so the fallback returns deterministic
-    # vectors without loading any real weights.
     fake_vecs = np.full((2, 768), 0.5, dtype=np.float32)
-
-    class _FakeST:
-        def __init__(self, *_a, **_kw):
-            pass
-
-        def encode(self, _texts, **_kw):
-            return fake_vecs
-
-    import sentence_transformers as st_pkg
-    monkeypatch.setattr(st_pkg, "SentenceTransformer", _FakeST)
+    monkeypatch.setattr(
+        client,
+        "embed_with_route",
+        lambda *_args, **_kwargs: {
+            "vectors": fake_vecs.tolist(),
+            "route": {
+                "model": "leaf-ir",
+                "requested_provider": "lmstudio",
+                "provider": "local",
+                "provider_model": "leaf-ir",
+                "on_error": "fallback",
+                "status": "ok",
+                "fallback": True,
+                "reason": "provider_unavailable",
+                "at": 1.0,
+            },
+        },
+    )
 
     result = dense._encode_bulk_direct(["x", "y"], kind="passage")
     assert result.shape == (2, 768)
-    # Our fake was used, not the real loader
     assert np.allclose(result, 0.5)
 
 
-def test_encode_bulk_direct_fail_propagates(
-    fake_cfg_lmstudio_on_error, monkeypatch
-) -> None:
-    """on_error=fail must re-raise the provider's exception untouched."""
-    fake_cfg_lmstudio_on_error(on_error="fail")
+def test_encode_bulk_direct_propagates_service_fail_closed_route(monkeypatch) -> None:
+    from work_buddy.embedding import client
+    from work_buddy.ir import dense
 
-    class _Sentinel(Exception):
-        pass
-
-    def _fake_encode(_texts, **_kw):
-        raise _Sentinel("boom")
-
-    import work_buddy.embedding.providers.lmstudio as prov
-    monkeypatch.setattr(prov, "encode", _fake_encode)
-
-    import work_buddy.ir.dense as dense
     monkeypatch.setattr(dense, "_IN_SERVICE", False)
+    monkeypatch.setattr(
+        client,
+        "embed_with_route",
+        lambda *_args, **_kwargs: {
+            "error": "remote unavailable",
+            "code": "embedding_provider_unavailable",
+            "status": 503,
+            "route": {
+                "model": "leaf-ir",
+                "requested_provider": "lmstudio",
+                "provider": "lmstudio",
+                "provider_model": "fake-model-id",
+                "on_error": "fail",
+                "status": "error",
+                "fallback": False,
+                "reason": "provider_unavailable",
+                "at": 1.0,
+                "error": "remote unavailable",
+            },
+        },
+    )
 
-    with pytest.raises(_Sentinel):
+    from work_buddy.index.encode import ProviderRoutingError
+
+    with pytest.raises(ProviderRoutingError) as raised:
         dense._encode_bulk_direct(["x"], kind="passage")
+    assert raised.value.code == "embedding_provider_unavailable"
+    assert raised.value.route.provider == "lmstudio"
 
 
-def test_encode_bulk_direct_missing_lmstudio_model_falls_back(
-    fake_cfg_lmstudio_on_error, monkeypatch
+def test_encode_bulk_direct_accepts_legacy_service_response_without_route(
+    monkeypatch,
 ) -> None:
-    """Guard-rail: provider=lmstudio without lmstudio_model should fall
-    back (on on_error=fallback) rather than calling provider.encode with
-    an empty id."""
-    fake_cfg_lmstudio_on_error(on_error="fallback", lmstudio_model="")
+    """Rolling startup against an older service remains vector-compatible."""
+    from work_buddy.embedding import client
+    from work_buddy.ir import dense
 
-    called = SimpleNamespace(encode_ran=False)
-
-    def _fake_encode(*_a, **_kw):
-        called.encode_ran = True
-        raise AssertionError("should not be called with empty model id")
-
-    import work_buddy.embedding.providers.lmstudio as prov
-    monkeypatch.setattr(prov, "encode", _fake_encode)
-
-    import work_buddy.ir.dense as dense
     monkeypatch.setattr(dense, "_IN_SERVICE", False)
-
     fake_vecs = np.zeros((1, 768), dtype=np.float32)
-
-    class _FakeST:
-        def __init__(self, *_a, **_kw):
-            pass
-
-        def encode(self, _texts, **_kw):
-            return fake_vecs
-
-    import sentence_transformers as st_pkg
-    monkeypatch.setattr(st_pkg, "SentenceTransformer", _FakeST)
+    monkeypatch.setattr(
+        client,
+        "embed_with_route",
+        lambda *_args, **_kwargs: {"vectors": fake_vecs.tolist()},
+    )
 
     result = dense._encode_bulk_direct(["z"], kind="passage")
     assert result.shape == (1, 768)
-    assert called.encode_ran is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_runtime_memory_policy.py
+++ b/tests/unit/test_runtime_memory_policy.py
@@ -1,0 +1,150 @@
+"""Process-boundary regressions for Work Buddy's native-memory defaults."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _fresh_python(code: str, *, openblas_threads: str | None) -> dict:
+    env = os.environ.copy()
+    if openblas_threads is None:
+        env.pop("OPENBLAS_NUM_THREADS", None)
+    else:
+        env["OPENBLAS_NUM_THREADS"] = openblas_threads
+    completed = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        cwd=_REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def test_package_bootstrap_limits_real_openblas_pool_and_scores_quickly():
+    """The default must reach the native runtime, not just set an env string."""
+    result = _fresh_python(
+        """
+        import json
+        import os
+        import time
+        import work_buddy
+        import numpy as np
+        from threadpoolctl import threadpool_info
+        from work_buddy.index.encode import score_dense
+
+        candidates = np.ones((20_000, 768), dtype=np.float32)
+        query = np.ones(768, dtype=np.float32)
+        doc_ids = [f"doc-{i}" for i in range(len(candidates))]
+        started = time.perf_counter()
+        scores = score_dense(query, candidates, doc_ids)
+        elapsed = time.perf_counter() - started
+        openblas = [
+            item for item in threadpool_info()
+            if item.get("internal_api") == "openblas"
+        ]
+        print(json.dumps({
+            "env": os.environ.get("OPENBLAS_NUM_THREADS"),
+            "threads": [item["num_threads"] for item in openblas],
+            "elapsed": elapsed,
+            "score_count": len(scores),
+            "last": scores[doc_ids[-1]],
+        }))
+        """,
+        openblas_threads=None,
+    )
+    assert result["env"] == "1"
+    assert result["threads"], "test environment must expose the OpenBLAS runtime"
+    assert result["threads"] == [1] * len(result["threads"])
+    assert result["score_count"] == 20_000
+    assert result["last"] == 1.0
+    # Wide enough for heavily shared CI, but catches accidental scalar/Python scoring.
+    assert result["elapsed"] < 5.0
+
+
+def test_package_bootstrap_preserves_operator_native_thread_override():
+    result = _fresh_python(
+        """
+        import json
+        import os
+        import work_buddy
+        import numpy as np
+        from threadpoolctl import threadpool_info
+
+        np.ones((8, 8), dtype=np.float32) @ np.ones(8, dtype=np.float32)
+        openblas = [
+            item for item in threadpool_info()
+            if item.get("internal_api") == "openblas"
+        ]
+        print(json.dumps({
+            "env": os.environ.get("OPENBLAS_NUM_THREADS"),
+            "threads": [item["num_threads"] for item in openblas],
+        }))
+        """,
+        openblas_threads="3",
+    )
+    assert result["env"] == "3"
+    assert result["threads"] == [3] * len(result["threads"])
+
+
+def test_lmstudio_liveness_probe_does_not_import_numpy():
+    """Component discovery must not initialize BLAS merely to check an HTTP URL."""
+    result = _fresh_python(
+        """
+        import http.client
+        import json
+        import sys
+        import socket
+
+        class FakeSocket:
+            def __enter__(self):
+                return self
+            def __exit__(self, *_args):
+                return False
+
+        class FakeResponse:
+            status = 200
+            def read(self):
+                return b'{}'
+
+        class FakeConnection:
+            def __init__(self, *_args, **_kwargs):
+                pass
+            def request(self, *_args, **_kwargs):
+                pass
+            def getresponse(self):
+                return FakeResponse()
+            def close(self):
+                pass
+
+        socket.create_connection = lambda *_args, **_kwargs: FakeSocket()
+        http.client.HTTPConnection = FakeConnection
+
+        from work_buddy.tools import _probe_lmstudio
+        from work_buddy.health.checks import check_lmstudio
+        ok = _probe_lmstudio()
+        health = check_lmstudio()
+        print(json.dumps({
+            "ok": ok,
+            "health_ok": health.get("ok"),
+            "model_ids": health.get("model_ids"),
+            "numpy_imported": "numpy" in sys.modules,
+        }))
+        """,
+        openblas_threads=None,
+    )
+    assert result == {
+        "ok": True,
+        "health_ok": True,
+        "model_ids": [],
+        "numpy_imported": False,
+    }

--- a/tests/unit/test_scheduler_result_summary.py
+++ b/tests/unit/test_scheduler_result_summary.py
@@ -1,0 +1,36 @@
+"""Structured summaries for bounded sidecar capability results."""
+
+from __future__ import annotations
+
+from work_buddy.sidecar.scheduler.engine import _summarize_job_result
+
+
+def test_bounded_index_result_unwraps_and_reports_partial_backlog():
+    detail = {
+        "result": {
+            "partition": "conversation",
+            "complete": False,
+            "remaining": {
+                "items": 75,
+                "vectors": {"content": 3000, "aliases": 2},
+            },
+        }
+    }
+
+    assert _summarize_job_result("ok", detail) == (
+        "ok: conversation partial; 75 items, 3002 vectors remaining"
+    )
+
+
+def test_bounded_index_result_reports_completion():
+    detail = {
+        "result": {
+            "partition": "conversation",
+            "complete": True,
+            "remaining": {"items": 0, "vectors": {"content": 0}},
+        }
+    }
+
+    assert _summarize_job_result("ok", detail) == (
+        "ok: conversation complete; 0 items, 0 vectors remaining"
+    )

--- a/tests/unit/test_search_cutover_evidence.py
+++ b/tests/unit/test_search_cutover_evidence.py
@@ -258,7 +258,7 @@ def test_targeted_prune_ignores_ordinary_churn_and_replay_invalidates(
         "vault:content",
         ResidentCache(
             lambda: object(),
-            lambda: str(store.build_version("vault")),
+            lambda: store.resident_version("vault"),
         ),
     )
     assert cache.get() is not None and cache.is_cached()
@@ -267,14 +267,25 @@ def test_targeted_prune_ignores_ordinary_churn_and_replay_invalidates(
     gate = index_path.parent / f"{index_path.name}.build"
     identity = index_path.parent / f"{index_path.name}.vault"
     lock_observations = []
-    original_bump = store.bump_version
+    delete_fence_observations = []
+    original_finish = store.finish_partition_mutation
+    original_delete = store.delete_item_docs
 
-    def observed_bump(partition):
+    def observed_finish(partition):
         lock_observations.append((is_locked(gate), is_locked(identity)))
-        return original_bump(partition)
+        return original_finish(partition)
+
+    def observed_delete(item_id, partition=None):
+        assert partition == "vault"
+        delete_fence_observations.append((
+            store.partition_mutation_in_progress("vault"),
+            cache.get_if_cached(),
+        ))
+        return original_delete(item_id, partition=partition)
 
     with monkeypatch.context() as patch:
-        patch.setattr(store, "bump_version", observed_bump)
+        patch.setattr(store, "finish_partition_mutation", observed_finish)
+        patch.setattr(store, "delete_item_docs", observed_delete)
         patch.setattr(
             VaultChunkPartition,
             "discover",
@@ -322,6 +333,8 @@ def test_targeted_prune_ignores_ordinary_churn_and_replay_invalidates(
         assert not cache.is_cached()
 
     assert lock_observations == [(True, True), (True, True)]
+    assert delete_fence_observations
+    assert all(fenced and resident is None for fenced, resident in delete_fence_observations)
     assert encoder.document_batches == []
     assert store.get_meta("last_build:vault") == initial_last_build
     assert set(store.get_indexed_items("vault")) == {
@@ -363,7 +376,7 @@ def test_checkpoint_step_is_config_bounded_and_prepares_immutable_reads(tmp_path
     cfg, _roots, authority, index_path = _fixture(tmp_path)
     # Initialize the consolidated schema, then keep one idle WAL connection open
     # per database so every sidecar remains observable until the bounded step.
-    IndexStore(index_path).doc_count("vault")
+    IndexStore(index_path).prepare_schema()
     writers = []
     try:
         paths = [declaration[0] for declaration in authority.values()] + [index_path]

--- a/tests/unit/test_settings_broker.py
+++ b/tests/unit/test_settings_broker.py
@@ -10,6 +10,11 @@ from work_buddy import config as wb_config
 from work_buddy.settings import broker, store
 from work_buddy.settings.registry import (
     COWORK_REVIEW_NAV_BINDING_ID,
+    EMBEDDING_DOCUMENT_EXECUTION_ID,
+    EMBEDDING_EXECUTION_LOCAL,
+    EMBEDDING_EXECUTION_PREFER_LMSTUDIO,
+    EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO,
+    EMBEDDING_SETTINGS_CONTEXT_ID,
     JOURNAL_DAY_BOUNDARY_ID,
     JOURNAL_SMART_EXECUTION_ID,
     JOURNAL_SMART_PROCESSING_ID,
@@ -49,13 +54,14 @@ def _value(at: datetime):
 
 def test_registry_defines_app_owned_settings_with_canonical_placements() -> None:
     payload = broker.get_registry()
-    assert payload["registry_revision"] == "settings-registry:7"
+    assert payload["registry_revision"] == "settings-registry:8"
     assert [item["setting_id"] for item in payload["definitions"]] == [
         JOURNAL_DAY_BOUNDARY_ID,
         COWORK_REVIEW_NAV_BINDING_ID,
         DASHBOARD_ASSISTANCE_ID,
         DASHBOARD_ASSISTANCE_TIER_ID,
         DASHBOARD_CHAT_EXECUTION_DEFAULT_ID,
+        EMBEDDING_DOCUMENT_EXECUTION_ID,
         JOURNAL_SMART_PROCESSING_ID,
         JOURNAL_SMART_EXECUTION_ID,
     ]
@@ -70,6 +76,7 @@ def test_registry_defines_app_owned_settings_with_canonical_placements() -> None
     assert definition["default_value"] == "05:00"
     assert definition["allowed_scopes"] == ["profile"]
     assert [item["context_id"] for item in payload["placements"]] == [
+        EMBEDDING_SETTINGS_CONTEXT_ID,
         "wb.settings.system.dashboard-ai",
         "wb.settings.system.dashboard-ai",
         "wb.settings.app.journal",
@@ -94,6 +101,22 @@ def test_registry_defines_app_owned_settings_with_canonical_placements() -> None
         if page["page_id"] == "wb.settings.app.cowork"
     )
     assert cowork_page["fallback_return_path"] == "/app/cowork"
+
+    embedding = next(
+        item
+        for item in payload["definitions"]
+        if item["setting_id"] == EMBEDDING_DOCUMENT_EXECUTION_ID
+    )
+    assert embedding["presentation"]["apply_behavior"] == "restart-component"
+    assert [option["value"] for option in embedding["presentation"]["options"]] == [
+        EMBEDDING_EXECUTION_LOCAL,
+        EMBEDDING_EXECUTION_PREFER_LMSTUDIO,
+        EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO,
+    ]
+    embedding_page = next(
+        page for page in payload["pages"] if page["page_id"] == EMBEDDING_SETTINGS_CONTEXT_ID
+    )
+    assert embedding_page["route"] == "/app/settings/system/embeddings"
 
 
 def test_assistance_settings_keep_privacy_disclosure_without_repeating_it() -> None:
@@ -124,6 +147,136 @@ def test_model_features_are_off_until_explicit_settings_opt_in(monkeypatch):
     assert broker.get_dashboard_assistance_settings() == {"enabled": True, "tier": "frontier_balanced"}
     with pytest.raises(broker.SettingsError):
         broker.update_value(DASHBOARD_ASSISTANCE_ID, scope="profile", value=True, expected_revision="value:1")
+
+
+def test_embedding_execution_setting_is_restart_gated(monkeypatch) -> None:
+    monkeypatch.setattr(
+        wb_config,
+        "load_config",
+        lambda: {
+            "embedding": {
+                "models": {
+                    "leaf-ir": {"provider": "local"},
+                }
+            }
+        },
+    )
+    initial, events = broker.get_values(
+        context_id=EMBEDDING_SETTINGS_CONTEXT_ID,
+        observed_at=_at(15, 12),
+    )
+    assert events == []
+    value = initial["values"][0]
+    assert value["effective_value"] == EMBEDDING_EXECUTION_LOCAL
+    assert value["configured_value"] == EMBEDDING_EXECUTION_LOCAL
+    assert value["default_source"] == "config-bootstrap"
+    assert value["apply_status"] == "effective"
+
+    preview = broker.preview_value(
+        EMBEDDING_DOCUMENT_EXECUTION_ID,
+        scope="profile",
+        value=EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO,
+        expected_revision="value:0",
+        observed_at=_at(15, 12, 1),
+    )
+    assert preview["preview"]["apply_status"] == "restart-required"
+    assert preview["preview"]["impact_preview"]["component"] == "embedding"
+
+    saved, event = broker.update_value(
+        EMBEDDING_DOCUMENT_EXECUTION_ID,
+        scope="profile",
+        value=EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO,
+        expected_revision="value:0",
+        observed_at=_at(15, 12, 2),
+    )
+    assert saved["configured_value"] == EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO
+    assert saved["effective_value"] == EMBEDDING_EXECUTION_LOCAL
+    assert saved["pending_value"] == EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO
+    assert saved["apply_status"] == "restart-required"
+    assert event["reason"] == "restart-value-saved"
+
+    active, activated, event = broker.activate_restart_component_value(
+        EMBEDDING_DOCUMENT_EXECUTION_ID,
+        observed_at=_at(15, 12, 3),
+    )
+    assert active == EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO
+    assert activated["effective_value"] == EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO
+    assert activated["pending_value"] is None
+    assert activated["source"] == "profile"
+    assert activated["apply_status"] == "effective"
+    assert event is not None and event["reason"] == "restart-value-applied"
+
+
+def test_embedding_execution_reset_waits_for_restart_then_clears_override(monkeypatch) -> None:
+    monkeypatch.setattr(
+        wb_config,
+        "load_config",
+        lambda: {
+            "embedding": {
+                "models": {
+                    "leaf-ir": {
+                        "provider": "lmstudio",
+                        "on_error": "fallback",
+                    }
+                }
+            }
+        },
+    )
+    assert broker.get_embedding_document_execution_mode()[0] == EMBEDDING_EXECUTION_PREFER_LMSTUDIO
+    configured, _ = broker.update_value(
+        EMBEDDING_DOCUMENT_EXECUTION_ID,
+        scope="profile",
+        value=EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO,
+        expected_revision="value:0",
+        observed_at=_at(15, 12),
+    )
+    broker.activate_restart_component_value(
+        EMBEDDING_DOCUMENT_EXECUTION_ID,
+        observed_at=_at(15, 12, 1),
+    )
+
+    reset, event = broker.reset_value(
+        EMBEDDING_DOCUMENT_EXECUTION_ID,
+        scope="profile",
+        expected_revision="value:2",
+        observed_at=_at(15, 12, 2),
+    )
+    assert configured["configured_value"] == EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO
+    assert reset["effective_value"] == EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO
+    assert reset["configured_value"] == EMBEDDING_EXECUTION_PREFER_LMSTUDIO
+    assert reset["configured_source"] == "default"
+    assert reset["apply_status"] == "restart-required"
+    assert event is not None and event["reason"] == "restart-value-saved"
+
+    active, applied, _ = broker.activate_restart_component_value(
+        EMBEDDING_DOCUMENT_EXECUTION_ID,
+        observed_at=_at(15, 12, 3),
+    )
+    assert active == EMBEDDING_EXECUTION_PREFER_LMSTUDIO
+    assert applied["source"] == "default"
+    assert applied["is_modified"] is False
+
+
+def test_embedding_execution_setting_rejects_invalid_values_and_read_only(monkeypatch) -> None:
+    monkeypatch.setattr(wb_config, "load_config", lambda: {})
+    with pytest.raises(broker.SettingsError) as invalid:
+        broker.update_value(
+            EMBEDDING_DOCUMENT_EXECUTION_ID,
+            scope="profile",
+            value="automatic",
+            expected_revision="value:0",
+        )
+    assert invalid.value.code == "validation_error"
+
+    with pytest.raises(broker.SettingsError) as blocked:
+        broker.update_value(
+            EMBEDDING_DOCUMENT_EXECUTION_ID,
+            scope="profile",
+            value=EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO,
+            expected_revision="value:0",
+            read_only=True,
+        )
+    assert blocked.value.code == "read_only"
 
 
 def test_cowork_review_navigation_values_apply_immediately_and_reset() -> None:

--- a/tests/unit/test_sidecar_child_env.py
+++ b/tests/unit/test_sidecar_child_env.py
@@ -1,7 +1,7 @@
 """Tests for the child-spawn env injection shared by work-buddy's launchers.
 
-``compat.build_child_env()`` must emit PYTHONUTF8=1 so every spawned service
-starts in UTF-8 mode and cannot crash on non-ASCII log output.
+``compat.build_child_env()`` must emit the UTF-8 and native numerical runtime
+defaults every supervised child needs before its Python imports begin.
 """
 
 import os
@@ -23,10 +23,23 @@ def test_build_child_env_preserves_user_override(monkeypatch):
     assert env["PYTHONUTF8"] == "0"
 
 
+def test_build_child_env_caps_openblas_by_default(monkeypatch):
+    monkeypatch.delenv("OPENBLAS_NUM_THREADS", raising=False)
+    env = compat.build_child_env()
+    assert env["OPENBLAS_NUM_THREADS"] == "1"
+
+
+def test_build_child_env_preserves_openblas_override(monkeypatch):
+    monkeypatch.setenv("OPENBLAS_NUM_THREADS", "4")
+    env = compat.build_child_env()
+    assert env["OPENBLAS_NUM_THREADS"] == "4"
+
+
 def test_build_child_env_does_not_mutate_os_environ(monkeypatch):
     """Returning a copy is load-bearing: mutating os.environ would leak
     PYTHONUTF8 into the parent and any subprocess that bypasses this helper."""
     monkeypatch.delenv("PYTHONUTF8", raising=False)
+    monkeypatch.delenv("OPENBLAS_NUM_THREADS", raising=False)
     snapshot = dict(os.environ)
     _ = compat.build_child_env()
     assert dict(os.environ) == snapshot

--- a/tests/unit/test_sidecar_daemon_helpers.py
+++ b/tests/unit/test_sidecar_daemon_helpers.py
@@ -17,8 +17,10 @@ import logging
 from pathlib import Path
 
 from work_buddy.sidecar.daemon import (
+    ChildService,
     TickFailureTracker,
     _dispatch_stall_message,
+    _print_startup_banner,
     _run_dispatch_cycle,
     safe_port,
 )
@@ -47,6 +49,18 @@ class TestSafePort:
 
     def test_none_is_rejected(self):
         assert safe_port(None, service_name="telegram") is None
+
+
+class TestStartupBanner:
+    def test_windowless_python_without_stdout_is_a_noop(self, monkeypatch):
+        dashboard = ChildService(
+            name="dashboard",
+            module="work_buddy.dashboard.service",
+            port=5127,
+        )
+        monkeypatch.setattr("work_buddy.sidecar.daemon.sys.stdout", None)
+
+        _print_startup_banner([dashboard], {"dashboard": {}})
 
 
 class TestTickFailureTracker:

--- a/work_buddy/__init__.py
+++ b/work_buddy/__init__.py
@@ -1,4 +1,19 @@
-"""work-buddy: Context bundle collector for PhD research scaffolding."""
+"""work-buddy: Context bundle collector for PhD research scaffolding.
+
+The package bootstrap also establishes conservative defaults for native
+numerical runtimes.  This file is imported before any ``work_buddy.*`` module,
+including every supported ``python -m work_buddy.<service>`` entry point, so it
+is the one reliable place to configure OpenBLAS before NumPy initializes it.
+"""
+
+import os as _os
+
+# Work Buddy's vector operations are request-sized and run in several separate
+# long-lived Python processes.  Letting each NumPy import create the machine-wide
+# OpenBLAS worker pool commits hundreds of MiB per process without a material
+# scoring benefit.  ``setdefault`` is intentional: an operator benchmarking a
+# different value remains authoritative.
+_os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
 
 from importlib.metadata import PackageNotFoundError, version
 

--- a/work_buddy/compat.py
+++ b/work_buddy/compat.py
@@ -114,17 +114,23 @@ def pythonw_variant(python_exe: str) -> str:
 def build_child_env() -> dict[str, str]:
     """Build the environment dict for a subprocess spawned by work-buddy.
 
-    Sets ``PYTHONUTF8=1`` so child interpreters wrap stdout/stderr in UTF-8
-    ``TextIOWrapper``s. Without it, on Windows the child picks cp1252 (the system
-    ANSI code page) and ``logging.StreamHandler`` raises ``UnicodeEncodeError``
-    on any non-Latin-1 codepoint reaching a log line, a recurring bug class since
-    log messages routinely interpolate vault content and other user data.
+    Sets two process-start defaults:
 
-    ``setdefault`` preserves an explicit user override (e.g. ``PYTHONUTF8=0``).
+    * ``PYTHONUTF8=1`` so child interpreters wrap stdout/stderr in UTF-8
+      ``TextIOWrapper``s. Without it, on Windows the child picks cp1252 (the
+      system ANSI code page) and ``logging.StreamHandler`` raises
+      ``UnicodeEncodeError`` on non-Latin-1 log content.
+    * ``OPENBLAS_NUM_THREADS=1`` before a child can import NumPy. Work Buddy
+      supervises several independent Python services, and a machine-wide BLAS
+      pool in every service reserves far more memory than request-sized vector
+      scoring needs.
+
+    ``setdefault`` preserves explicit user overrides for either variable.
     Returns a fresh dict; never mutates ``os.environ``.
     """
     env = os.environ.copy()
     env.setdefault("PYTHONUTF8", "1")
+    env.setdefault("OPENBLAS_NUM_THREADS", "1")
     return env
 
 

--- a/work_buddy/dashboard/api.py
+++ b/work_buddy/dashboard/api.py
@@ -1531,6 +1531,135 @@ def get_embeddings_summary() -> dict[str, Any]:
         return _embeddings_cache
 
 
+def get_embedding_runtime_summary(*, probe_remote: bool = True) -> dict[str, Any]:
+    """Live document-embedding placement, provenance, and reachability.
+
+    This intentionally bypasses the slower aggregate embeddings cache: the Settings
+    control needs to distinguish the saved restart-gated choice from the policy active
+    in the running embedding component, and to show the last provider that actually
+    produced vectors. The optional LM Studio probe runs only for a remote policy.
+    """
+    result: dict[str, Any] = {
+        "service_status": "unavailable",
+        "policy": {
+            "effective": None,
+            "configured": None,
+            "pending": None,
+            "apply_status": None,
+            "revision": None,
+            "running": None,
+            "authority_matches_runtime": None,
+        },
+        "document_model": None,
+        "lmstudio": None,
+    }
+
+    try:
+        from work_buddy.settings import broker as settings_broker
+        from work_buddy.settings.registry import EMBEDDING_SETTINGS_CONTEXT_ID
+
+        snapshot, _events = settings_broker.get_values(
+            context_id=EMBEDDING_SETTINGS_CONTEXT_ID,
+        )
+        values = snapshot.get("values") or []
+        if values:
+            value = values[0]
+            result["policy"] = {
+                "effective": value.get("effective_value"),
+                "configured": value.get("configured_value"),
+                "pending": value.get("pending_value"),
+                "apply_status": value.get("apply_status"),
+                "revision": value.get("revision"),
+                # Filled only from the running component's /health routing below.
+                # The settings database records authority, not proof that a process
+                # successfully restarted with that value.
+                "running": None,
+                "authority_matches_runtime": None,
+            }
+    except Exception as exc:
+        result["settings_error"] = str(exc)
+
+    try:
+        from work_buddy.embedding.client import health_status
+
+        health = health_status(timeout_s=3)
+        if health is not None:
+            result["service_status"] = health.get("status", "unknown")
+            result["default_model"] = health.get("default_model")
+            model = next(
+                (
+                    item
+                    for item in health.get("models", [])
+                    if isinstance(item, dict) and item.get("key") == "leaf-ir"
+                ),
+                None,
+            )
+            if model is not None:
+                result["document_model"] = {
+                    "key": model.get("key"),
+                    "name": model.get("name"),
+                    "dims": model.get("dims"),
+                    "load_status": model.get("status"),
+                    "loaded_locally": model.get("status") == "loaded",
+                    "error": model.get("error"),
+                    "routing": model.get("routing"),
+                }
+    except Exception as exc:
+        result["service_error"] = str(exc)
+
+    # Derive runtime mode exclusively from the service's own router snapshot. A
+    # restart may consume a pending setting and then fail before it owns the port;
+    # in that case the broker's effective value is not evidence about the process
+    # still answering /health. Preserve both facts and make disagreement explicit.
+    policy = result.get("policy")
+    routing = (result.get("document_model") or {}).get("routing") or {}
+    running_mode = None
+    requested_provider = routing.get("requested_provider")
+    on_error = routing.get("on_error")
+    if requested_provider == "local":
+        running_mode = "local"
+    elif requested_provider == "lmstudio":
+        running_mode = (
+            "require-lmstudio" if on_error == "fail" else "prefer-lmstudio"
+        )
+    if isinstance(policy, dict):
+        policy["running"] = running_mode
+        authoritative_mode = policy.get("effective")
+        policy["authority_matches_runtime"] = (
+            authoritative_mode == running_mode
+            if authoritative_mode is not None and running_mode is not None
+            else None
+        )
+
+    policy = policy or {}
+    wants_remote = running_mode in {"prefer-lmstudio", "require-lmstudio"}
+    if wants_remote and probe_remote:
+        try:
+            from work_buddy.health.checks import check_lmstudio
+
+            lmstudio = check_lmstudio()
+            provider_model = routing.get("provider_model")
+            model_ids = lmstudio.get("model_ids")
+            lmstudio["configured_model"] = provider_model
+            model_advertised = (
+                provider_model in model_ids
+                if lmstudio.get("ok") is True
+                and isinstance(provider_model, str)
+                and isinstance(model_ids, list)
+                else None
+            )
+            # /v1/models is an advertised/loaded snapshot. Absence is not proof
+            # of unavailability because LM Studio can JIT-load a cataloged model
+            # on the first embedding request. Only a successful advertisement is
+            # conclusive here; actual route failures remain in routing.last_route.
+            lmstudio["model_advertised"] = model_advertised
+            lmstudio["model_available"] = True if model_advertised is True else None
+            result["lmstudio"] = lmstudio
+        except Exception as exc:
+            result["lmstudio"] = {"ok": False, "detail": str(exc)}
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Inference activity (Settings › Inference — cross-provider provenance feed)
 # ---------------------------------------------------------------------------

--- a/work_buddy/dashboard/service.py
+++ b/work_buddy/dashboard/service.py
@@ -31,6 +31,7 @@ from work_buddy.conversations.store import UserMessageIdConflictError
 from work_buddy.dashboard.api import (
     get_chats_summary,
     get_contracts_summary,
+    get_embedding_runtime_summary,
     get_embeddings_summary,
     get_fleet_summary,
     get_inference_activity,
@@ -1764,6 +1765,17 @@ def api_contracts():
 def api_embeddings():
     """System (IR/knowledge) + User (vaults) status for Settings › Embeddings."""
     return jsonify(get_embeddings_summary())
+
+
+@app.get("/api/embeddings/runtime")
+def api_embedding_runtime():
+    """Live document-provider policy and last-route diagnostics for Settings."""
+    probe_remote = request.args.get("probe", "1").strip().lower() not in {
+        "0", "false", "no",
+    }
+    response = jsonify(get_embedding_runtime_summary(probe_remote=probe_remote))
+    response.headers["Cache-Control"] = "no-store"
+    return response
 
 
 @app.get("/api/inference-activity")

--- a/work_buddy/document_kernel/direct_edit.py
+++ b/work_buddy/document_kernel/direct_edit.py
@@ -18,6 +18,7 @@ from work_buddy.document_kernel.protocol import (
     sha256_bytes,
     structured_head_sha256,
 )
+from work_buddy.document_kernel.runtime_service import shared_document_kernel
 from work_buddy.truth import documents, ydoc_store
 from work_buddy.truth.store import TruthStore
 
@@ -38,7 +39,7 @@ class DirectDocumentEditService:
     """
 
     def __init__(self, *, kernel: DocumentKernelClient | None = None) -> None:
-        self.kernel = kernel or DocumentKernelClient()
+        self.kernel = kernel or shared_document_kernel()
 
     def apply(
         self,

--- a/work_buddy/document_kernel/domain_service.py
+++ b/work_buddy/document_kernel/domain_service.py
@@ -23,6 +23,7 @@ from work_buddy.document_kernel.protocol import (
     sha256_bytes,
     structured_head_sha256,
 )
+from work_buddy.document_kernel.runtime_service import shared_document_kernel
 from work_buddy.paths import data_dir
 from work_buddy.sources import ReservedResolution, SourceStore
 from work_buddy.truth import documents, ydoc_store
@@ -180,7 +181,7 @@ class RunningNoteDocumentService:
         kernel: DocumentKernelClient | None = None,
         stores: DomainContentStoreManager | None = None,
     ) -> None:
-        self.kernel = kernel or DocumentKernelClient()
+        self.kernel = kernel or shared_document_kernel()
         self.stores = stores or DomainContentStoreManager()
 
     def _ensure_document(

--- a/work_buddy/document_kernel/runtime_service.py
+++ b/work_buddy/document_kernel/runtime_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import atexit
 import threading
 
 from work_buddy.document_kernel.client import DocumentKernelClient
@@ -28,6 +29,9 @@ def reset_document_kernel() -> None:
         _client = None
     if current is not None:
         current.close()
+
+
+atexit.register(reset_document_kernel)
 
 
 __all__ = ["reset_document_kernel", "shared_document_kernel"]

--- a/work_buddy/embedding/client.py
+++ b/work_buddy/embedding/client.py
@@ -83,13 +83,21 @@ def _request(
         if not return_http_error:
             return None
         message = raw or f"HTTP {exc.code}"
+        parsed_error: dict[str, Any] | None = None
         if raw:
             try:
                 parsed = json.loads(raw)
-                if isinstance(parsed, dict) and parsed.get("error"):
-                    message = parsed["error"]
+                if isinstance(parsed, dict):
+                    parsed_error = parsed
+                    if parsed.get("error"):
+                        message = parsed["error"]
             except ValueError:
                 pass
+        if parsed_error is not None:
+            # Preserve structured endpoint diagnostics (for example /embed's
+            # provider route) while retaining the numeric status contract used
+            # by existing callers such as ir_index.
+            return {**parsed_error, "status": exc.code}
         return {"error": message, "status": exc.code}
     except (URLError, TimeoutError) as exc:
         logger.debug("Embedding service request failed: %s", exc)
@@ -103,6 +111,16 @@ def is_available() -> bool:
     available = result is not None and result.get("status") == "ok"
     _debug(f"Embedding health check: {available} ({time.time()-t:.2f}s)")
     return available
+
+
+def health_status(*, timeout_s: int = 3) -> dict[str, Any] | None:
+    """Return the embedding service's full health/provenance snapshot.
+
+    Unlike :func:`is_available`, this preserves per-model routing diagnostics for
+    operator surfaces. Connection failures remain ``None`` so callers can render an
+    honest unavailable state without parsing transport exceptions.
+    """
+    return _request("GET", "/health", timeout=timeout_s)
 
 
 def wait_until_available(
@@ -142,19 +160,33 @@ def wait_until_available(
     return False
 
 
-def embed(
+def embed_with_route(
     texts: list[str],
     *,
     model: str | None = None,
     prompt_name: str | None = None,
     timeout_s: int | None = None,
-) -> list[list[float]] | None:
-    """Embed texts via the shared service. Returns None if unavailable.
+    routing_role: str | None = None,
+    record_provenance: bool = True,
+    call_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Embed texts and preserve the service's provider-route diagnostics.
+
+    Returns the complete JSON response on success or structured HTTP failure,
+    and ``None`` only when the service itself is unreachable.  Most callers
+    should continue using :func:`embed`; index-maintenance paths use this form
+    so their aggregate provenance records the provider that actually ran.
 
     Args:
         texts: Texts to embed.
         model: Model key (e.g. "leaf-mt", "leaf-ir"). Defaults to service default.
         prompt_name: Prompt name for asymmetric models (e.g. "query", "document").
+        routing_role: Semantic side of the operation (``query`` or ``document``).
+            This is distinct from a model-specific prompt name and lets the service
+            apply document-provider policy to custom registered encoders.
+        record_provenance: Let the service persist one record for this call. Aggregate
+            callers that write their own batch record can disable it to avoid duplicates.
+        call_id: Optional provenance/broker correlation id supplied by an aggregate caller.
         timeout_s: Override the per-request timeout in seconds. When None,
             uses ``max(30, len(texts) * 2)``. Indexing callers should pass a
             larger value when targeting a lazy-loaded model — the first
@@ -167,12 +199,40 @@ def embed(
         payload["model"] = model
     if prompt_name:
         payload["prompt_name"] = prompt_name
+    if routing_role in {"query", "document"}:
+        payload["routing_role"] = routing_role
+    if not record_provenance:
+        payload["record_provenance"] = False
+    if isinstance(call_id, str) and call_id.strip():
+        payload["call_id"] = call_id.strip()
     if timeout_s is None:
         # Larger batches need more time (especially leaf-ir doc encoding on CPU/GPU)
         timeout = max(30, len(texts) * 2)
     else:
         timeout = timeout_s
-    result = _request("POST", "/embed", payload, timeout=timeout)
+    return _request(
+        "POST", "/embed", payload, timeout=timeout, return_http_error=True,
+    )
+
+
+def embed(
+    texts: list[str],
+    *,
+    model: str | None = None,
+    prompt_name: str | None = None,
+    timeout_s: int | None = None,
+    routing_role: str | None = None,
+    record_provenance: bool = True,
+) -> list[list[float]] | None:
+    """Embed texts via the shared service. Returns None if unavailable/failing."""
+    result = embed_with_route(
+        texts,
+        model=model,
+        prompt_name=prompt_name,
+        timeout_s=timeout_s,
+        routing_role=routing_role,
+        record_provenance=record_provenance,
+    )
     if result is None:
         return None
     return result.get("vectors")
@@ -188,14 +248,14 @@ def embed_for_ir(
 
     Query encoding uses ``leaf-ir-query`` (MongoDB/mdbr-leaf-ir, 90 MB,
     eager-loaded at startup) so search is instant.  Document encoding uses
-    ``leaf-ir`` (MongoDB/mdbr-leaf-ir-asym, 526 MB, lazy-loaded only when
-    indexing).  Both produce compatible 768-d vectors — the asymmetric model
+    ``leaf-ir`` (MongoDB/mdbr-leaf-ir-asym, 526 MB, lazy-loaded only for
+    document/passage embedding workloads). Both produce compatible 768-d vectors. The asymmetric model
     card documents this split usage pattern.
 
     Args:
         texts: Texts to embed.
-        role: "query" for search queries, "document" for indexing documents.
-        timeout_s: Override the per-request timeout. Indexing callers using
+        role: "query" for search queries, "document" for passage-like inputs.
+        timeout_s: Override the per-request timeout. Document callers using
             ``role="document"`` should pass a value large enough to absorb a
             cold ``leaf-ir`` SentenceTransformer load. See ``embed()`` for
             the underlying rationale; see
@@ -205,8 +265,20 @@ def embed_for_ir(
     if role not in ("query", "document"):
         raise ValueError(f"role must be 'query' or 'document', got '{role}'")
     if role == "query":
-        return embed(texts, model="leaf-ir-query", prompt_name="query", timeout_s=timeout_s)
-    return embed(texts, model="leaf-ir", prompt_name="document", timeout_s=timeout_s)
+        return embed(
+            texts,
+            model="leaf-ir-query",
+            prompt_name="query",
+            timeout_s=timeout_s,
+            routing_role="query",
+        )
+    return embed(
+        texts,
+        model="leaf-ir",
+        prompt_name="document",
+        timeout_s=timeout_s,
+        routing_role="document",
+    )
 
 
 def ir_search(

--- a/work_buddy/embedding/providers/lmstudio.py
+++ b/work_buddy/embedding/providers/lmstudio.py
@@ -29,42 +29,13 @@ from typing import Any
 import httpx
 import numpy as np
 
+from work_buddy.embedding.providers.lmstudio_config import resolve_base_url
 from work_buddy.llm.backends._errors import (
     LocalInferenceError,
     interpret_httpx_exception,
 )
 
 logger = logging.getLogger(__name__)
-
-# Default base URL when ``lmstudio.base_url`` isn't set in config.
-# Matches LM Studio's out-of-box server binding.
-_DEFAULT_BASE_URL = "http://localhost:1234"
-
-
-def resolve_base_url(cfg: dict[str, Any] | None = None) -> str:
-    """Return the LM Studio base URL from config, or the default.
-
-    The ``lmstudio.base_url`` config key is the single source of truth
-    for both the embedding provider and the ``work_buddy.health``
-    reachable check. The URL is the bare server root — paths like
-    ``/v1/embeddings`` and ``/v1/models`` are appended at use time.
-
-    Args:
-        cfg: Loaded config dict (from ``work_buddy.config.load_config``).
-            If None, loads lazily so this helper can be called from
-            contexts that don't want to pay the config-load cost.
-
-    Returns:
-        Base URL without trailing slash, e.g. ``http://localhost:1234``.
-    """
-    if cfg is None:
-        from work_buddy.config import load_config
-        cfg = load_config()
-    url = cfg.get("lmstudio", {}).get("base_url", _DEFAULT_BASE_URL)
-    if not isinstance(url, str) or not url:
-        url = _DEFAULT_BASE_URL
-    return url.rstrip("/")
-
 
 def _profile_name(model_id: str) -> str:
     """Broker profile name for an LM Studio embedding call.

--- a/work_buddy/embedding/providers/lmstudio_config.py
+++ b/work_buddy/embedding/providers/lmstudio_config.py
@@ -1,0 +1,30 @@
+"""Lightweight LM Studio connection configuration.
+
+This module deliberately has no NumPy, SciPy, Torch, or ``httpx`` dependency.
+Health checks and component discovery need only resolve the server URL; importing
+the full embedding provider there would initialize OpenBLAS in processes that
+have not performed any numerical work.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Default base URL when ``lmstudio.base_url`` isn't set in config.
+# Matches LM Studio's out-of-box server binding.
+DEFAULT_BASE_URL = "http://localhost:1234"
+
+
+def resolve_base_url(cfg: dict[str, Any] | None = None) -> str:
+    """Return the configured LM Studio server root without a trailing slash."""
+    if cfg is None:
+        from work_buddy.config import load_config
+
+        cfg = load_config()
+    url = cfg.get("lmstudio", {}).get("base_url", DEFAULT_BASE_URL)
+    if not isinstance(url, str) or not url:
+        url = DEFAULT_BASE_URL
+    return url.rstrip("/")
+
+
+__all__ = ["DEFAULT_BASE_URL", "resolve_base_url"]

--- a/work_buddy/embedding/service.py
+++ b/work_buddy/embedding/service.py
@@ -21,6 +21,7 @@ Model registry:
 from __future__ import annotations
 
 import contextlib
+import copy
 import json
 import re
 import sys
@@ -107,6 +108,9 @@ class ModelEntry:
 _registry: dict[str, ModelEntry] = {}
 _default_model_key: str = _DEFAULT_MODEL
 _device: str | None = None  # resolved device string ("cpu", "cuda", etc.)
+_provider_router: Any | None = None
+_provider_router_lock = threading.RLock()
+_document_policy_authority_error: str | None = None
 # Only protects the _registry dict itself (init, iteration for eviction).
 # Loading is coordinated per-entry via ModelEntry.load_cond so a slow
 # load of one model never blocks access to another.
@@ -190,15 +194,136 @@ def _init_registry(cfg: dict | None = None) -> None:
     print(f"Embedding device: {_device}", file=sys.stderr)
 
     for key, mcfg in models_cfg.items():
+        eager = bool(mcfg.get("eager", False))
+        provider = str(mcfg.get("provider") or "local").strip().lower()
+        if key == "leaf-ir" and provider == "lmstudio":
+            # A remote document policy must not preload the large local model.
+            # ``prefer`` may still load it later as one deliberate fallback;
+            # ``require`` never reaches the local provider at all.
+            eager = False
         _registry[key] = ModelEntry(
             key=key,
             hf_name=mcfg["name"],
             dims=mcfg.get("dims", 0),
-            eager=mcfg.get("eager", False),
+            eager=eager,
         )
 
     print(f"Model registry: {list(_registry.keys())} (default: {_default_model_key})",
           file=sys.stderr)
+
+
+def _configure_provider_router(cfg: dict | None = None) -> None:
+    """Install the process-wide provider policy used by document encodes."""
+    global _provider_router
+
+    from work_buddy.index.encode import (
+        LmStudioProvider,
+        LocalProvider,
+        ProviderRouter,
+        SentenceTransformerProvider,
+    )
+
+    router = ProviderRouter(
+        providers={
+            # Explicit service locus: local fallback must use this process's
+            # registry, never make an HTTP call back into the same Flask app.
+            "local": LocalProvider(in_service=True),
+            "lmstudio": LmStudioProvider(),
+            "st": SentenceTransformerProvider(),
+        },
+        cfg=cfg,
+    )
+    with _provider_router_lock:
+        _provider_router = router
+
+
+def _activate_document_execution_setting(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Overlay the restart-gated document-route setting onto process config.
+
+    The Settings broker owns the user's desired/effective choice; YAML remains the
+    bootstrap default and still supplies the LM Studio model alias. Promotion happens
+    exactly here, while the embedding component is starting, so the dashboard never
+    claims a pending value is active in an already-running process. A settings-store
+    failure keeps query/service startup available but forces document embedding into
+    a deterministic remote-required, fail-closed state until a clean restart.
+    """
+    global _document_policy_authority_error
+
+    effective_cfg = copy.deepcopy(cfg)
+
+    def _leaf_ir_config() -> dict[str, Any]:
+        embedding_cfg = effective_cfg.setdefault("embedding", {})
+        raw_models = embedding_cfg.get("models")
+        if not isinstance(raw_models, dict):
+            raw_models = copy.deepcopy(_DEFAULT_MODELS)
+            embedding_cfg["models"] = raw_models
+        raw_leaf = raw_models.get("leaf-ir")
+        if not isinstance(raw_leaf, dict):
+            raw_leaf = copy.deepcopy(_DEFAULT_MODELS["leaf-ir"])
+            raw_models["leaf-ir"] = raw_leaf
+        return raw_leaf
+
+    try:
+        from work_buddy.settings.broker import get_embedding_document_execution_mode
+        from work_buddy.settings.registry import (
+            EMBEDDING_EXECUTION_LOCAL,
+            EMBEDDING_EXECUTION_PREFER_LMSTUDIO,
+            EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO,
+        )
+
+        mode, record, event = get_embedding_document_execution_mode(
+            activate_pending=True,
+        )
+        raw_leaf = _leaf_ir_config()
+
+        if mode == EMBEDDING_EXECUTION_LOCAL:
+            raw_leaf["provider"] = "local"
+            raw_leaf["on_error"] = "fallback"
+        elif mode == EMBEDDING_EXECUTION_PREFER_LMSTUDIO:
+            raw_leaf["provider"] = "lmstudio"
+            raw_leaf["on_error"] = "fallback"
+        elif mode == EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO:
+            raw_leaf["provider"] = "lmstudio"
+            raw_leaf["on_error"] = "fail"
+        else:  # defensive: registry validation should make this unreachable
+            raise ValueError(f"unsupported document embedding execution mode: {mode!r}")
+
+        transition = " (new saved choice applied)" if event is not None else ""
+        print(
+            "Document embedding execution: "
+            f"{mode}; setting revision={record['revision']}{transition}",
+            file=sys.stderr,
+        )
+        _document_policy_authority_error = None
+    except Exception as exc:
+        # The settings database is authoritative. If its state cannot be read,
+        # starting from a possibly-stale local YAML route would violate a saved
+        # remote-required policy before the dashboard could report the mismatch.
+        # Keep the service/query models available but fail the large document
+        # route safely until a clean component restart can read authority again.
+        raw_leaf = _leaf_ir_config()
+        raw_leaf["provider"] = "lmstudio"
+        raw_leaf["on_error"] = "fail"
+        raw_leaf["eager"] = False
+        _document_policy_authority_error = f"{type(exc).__name__}: {exc}"
+        print(
+            "Document embedding setting activation failed; document routing is "
+            f"fail-closed until restart: {exc}",
+            file=sys.stderr,
+        )
+    return effective_cfg
+
+
+def _get_provider_router() -> Any:
+    """Return the service router, lazily configuring imports used by tests/WSGI."""
+    with _provider_router_lock:
+        if _provider_router is None:
+            from work_buddy.config import load_config
+
+            _configure_provider_router(
+                _activate_document_execution_setting(load_config())
+            )
+        return _provider_router
 
 
 def _validate_lmstudio_providers(cfg: dict | None = None) -> None:
@@ -294,7 +419,11 @@ def _load_model(entry: ModelEntry) -> None:
         print(f"  FAILED to load '{entry.key}': {exc}", file=sys.stderr)
 
 
-def _get_model(key: str | None = None) -> Any:
+def _get_model(
+    key: str | None = None,
+    *,
+    provider_authorized: bool = False,
+) -> Any:
     """Return a loaded model by key, loading lazily if needed.
 
     Concurrency contract:
@@ -310,6 +439,16 @@ def _get_model(key: str | None = None) -> Any:
         5-second SentenceTransformer instantiation.
     """
     key = key or _default_model_key
+    if key == "leaf-ir" and not provider_authorized:
+        with _provider_router_lock:
+            router = _provider_router
+        if router is not None:
+            policy = router.describe(key)
+            if policy.get("requested_provider") != "local":
+                raise RuntimeError(
+                    "Model 'leaf-ir' is controlled by document-provider routing; "
+                    "use the provider-aware /embed document route"
+                )
     entry = _registry.get(key)
     if entry is None:
         raise ValueError(
@@ -440,6 +579,8 @@ def health():
     """Check model registry status."""
     models_info = []
     any_loaded = False
+    with _provider_router_lock:
+        router = _provider_router
     for key, entry in _registry.items():
         info: dict[str, Any] = {
             "key": key,
@@ -454,6 +595,11 @@ def health():
             info["error"] = entry.error
         if entry.status == "loaded":
             any_loaded = True
+        if router is not None:
+            routing = router.describe(key)
+            if key == "leaf-ir":
+                routing["authority_error"] = _document_policy_authority_error
+            info["routing"] = routing
         models_info.append(info)
 
     return jsonify({
@@ -469,7 +615,11 @@ def health():
 # (dashboard/api.py::_build_inference_activity).
 
 
-def _embed_priority(data: dict[str, Any], prompt_name: str | None) -> Any:
+def _embed_priority(
+    data: dict[str, Any],
+    prompt_name: str | None,
+    routing_role: str | None = None,
+) -> Any:
     """Pick a broker priority for an encode request.
 
     Explicit ``priority`` in the request body wins; otherwise derive from the
@@ -487,9 +637,9 @@ def _embed_priority(data: dict[str, Any], prompt_name: str | None) -> Any:
         explicit = None
     if explicit is not None:
         return explicit
-    if prompt_name == "query":
+    if routing_role == "query" or prompt_name == "query":
         return Priority.INTERACTIVE
-    if prompt_name == "document":
+    if routing_role == "document" or prompt_name == "document":
         return Priority.BACKGROUND
     return Priority.WORKFLOW
 
@@ -514,6 +664,68 @@ def _brokered_encode(model: Any, texts: list[str], *, priority: Any, **encode_kw
         return _run_on_encode_worker(model.encode, texts, **encode_kwargs)
 
 
+def _uses_document_provider_policy(
+    model_key: str,
+    prompt_name: str | None,
+    routing_role: str | None = None,
+) -> bool:
+    """Whether an online encode is document-side and therefore offloadable.
+
+    ``routing_role`` is the authoritative semantic signal for model-specific
+    prompts such as ``search_document``. The legacy model/prompt inference keeps
+    older clients compatible during a rolling restart.
+    """
+    if routing_role == "document":
+        return True
+    if routing_role == "query":
+        return False
+    return prompt_name == "document" or model_key == "leaf-ir"
+
+
+def _record_document_embed_route(
+    route: Any,
+    *,
+    count: int,
+    call_id: str,
+    latency_ms: float,
+) -> None:
+    """Persist actual provider/fallback provenance without affecting the call."""
+    try:
+        from work_buddy.llm.provenance import record_inference_call
+
+        actual = route.provider or route.requested_provider
+        detail = (
+            f"{count} document{'s' if count != 1 else ''}; "
+            f"requested={route.requested_provider}; actual={actual}; "
+            f"route={route.reason}"
+        )
+        provider_error = getattr(route, "provider_error", None)
+        provider_error_kind = getattr(route, "provider_error_kind", None)
+        if provider_error:
+            qualifier = (
+                f"{provider_error_kind}: " if provider_error_kind else ""
+            )
+            detail = f"{detail}; provider_error={qualifier}{provider_error}"
+        record_inference_call(
+            kind="embedding",
+            model=route.model,
+            provider=actual,
+            execution_mode="local",
+            status=route.status,
+            item_count=count,
+            call_id=call_id,
+            call_site="Embed",
+            detail=detail,
+            latency_ms=latency_ms,
+            # A successful local fallback is still operationally degraded.
+            # Keep status="ok" (vectors were produced), while preserving why
+            # the requested provider failed for diagnosis and trend analysis.
+            error=route.error or (provider_error if route.fallback else None),
+        )
+    except Exception:
+        pass
+
+
 @app.route("/embed", methods=["POST"])
 def embed():
     """Embed one or more texts.
@@ -521,7 +733,10 @@ def embed():
     Request body: {
         "texts": ["text1", "text2", ...],
         "model": "leaf-mt",          // optional, defaults to default_model
-        "prompt_name": "query"       // optional, for asymmetric models
+        "prompt_name": "query",      // optional, model-specific prompt
+        "routing_role": "query",     // optional semantic role: query | document
+        "record_provenance": true,    // optional; aggregate callers may disable
+        "call_id": "abc123"          // optional broker/provenance correlation id
     }
     Response: {"vectors": [[...], ...], "dims": 768, "count": 2, "model": "leaf-mt"}
     """
@@ -534,6 +749,83 @@ def embed():
 
     model_key = data.get("model") or _default_model_key
     prompt_name = data.get("prompt_name")
+    routing_role = data.get("routing_role")
+    record_provenance = data.get("record_provenance", True) is not False
+
+    if _uses_document_provider_policy(model_key, prompt_name, routing_role):
+        import uuid
+
+        from work_buddy.index.encode import ProviderRoutingError
+        from work_buddy.inference.call_context import bind_call_id
+
+        started = time.monotonic()
+        supplied_call_id = data.get("call_id")
+        call_id = (
+            supplied_call_id.strip()[:128]
+            if isinstance(supplied_call_id, str) and supplied_call_id.strip()
+            else uuid.uuid4().hex[:12]
+        )
+        route = None
+        try:
+            with bind_call_id(call_id):
+                routed = _get_provider_router().encode_with_route(
+                    list(texts),
+                    model_id=model_key,
+                    prompt_name=prompt_name,
+                    priority=_embed_priority(data, prompt_name, routing_role),
+                    batch_size=32,
+                    routing_role="document",
+                )
+            route = routed.route
+        except ProviderRoutingError as exc:
+            route = exc.route
+            if record_provenance:
+                _record_document_embed_route(
+                    route,
+                    count=len(texts),
+                    call_id=call_id,
+                    latency_ms=(time.monotonic() - started) * 1000.0,
+                )
+            return jsonify({
+                "error": str(exc),
+                "code": exc.code,
+                "model": model_key,
+                "route": route.as_dict(),
+            }), 503
+
+        if routed.vectors is None:
+            if record_provenance:
+                _record_document_embed_route(
+                    route,
+                    count=len(texts),
+                    call_id=call_id,
+                    latency_ms=(time.monotonic() - started) * 1000.0,
+                )
+            return jsonify({
+                "error": f"Embedding provider unavailable for model '{model_key}'",
+                "code": "embedding_provider_unavailable",
+                "model": model_key,
+                "route": route.as_dict(),
+            }), 503
+
+        vectors = np.asarray(routed.vectors, dtype=np.float32)
+        if record_provenance:
+            _record_document_embed_route(
+                route,
+                count=len(texts),
+                call_id=call_id,
+                latency_ms=(time.monotonic() - started) * 1000.0,
+            )
+        return Response(
+            json.dumps({
+                "vectors": vectors.tolist(),
+                "dims": int(vectors.shape[1]),
+                "count": len(texts),
+                "model": model_key,
+                "route": route.as_dict(),
+            }),
+            mimetype="application/json",
+        )
 
     try:
         model = _get_model(model_key)
@@ -545,7 +837,10 @@ def embed():
         encode_kwargs["prompt_name"] = prompt_name
 
     vectors = _brokered_encode(
-        model, texts, priority=_embed_priority(data, prompt_name), **encode_kwargs,
+        model,
+        texts,
+        priority=_embed_priority(data, prompt_name, routing_role),
+        **encode_kwargs,
     )
 
     return Response(
@@ -1184,11 +1479,12 @@ def main():
 
     from work_buddy.config import load_config
 
-    cfg = load_config()
+    cfg = _activate_document_execution_setting(load_config())
     port = cfg.get("embedding", {}).get("service_port", 5124)
 
     # Build model registry from config (cheap — just metadata)
     _init_registry(cfg)
+    _configure_provider_router(cfg)
     _configure_encode_executor(cfg)
 
     # Recover the IR vector store before serving: quarantine any crash-corrupted
@@ -1264,14 +1560,18 @@ def main():
         _start_index_evictor()
     except Exception as exc:  # never block service startup
         print(f"consolidated-index evictor start failed (non-fatal): {exc}", file=sys.stderr)
-    # Prewarm the consolidated index's resident matrices at startup (flag-gated; runs in
-    # a background daemon so it never blocks /health or query serving). Without it the
-    # FIRST post-restart search of a large partition pays the full cold matrix-load and
-    # can time out to None; warming up front removes that first-query penalty. Pairs with
-    # the idle evictor above (warm → serve → release when idle → re-warm on next query).
+    # Apply the consolidated index's configurable startup matrix policy. The RAM-aware
+    # default is lazy: a cold query serves lexical results, singleflights a background
+    # warm, and retries once through the existing warming-signal protocol. Operators who
+    # value first-query latency over startup/idle RAM can opt back into all-partition
+    # prewarming. Both modes pair with the idle evictor above.
     try:
-        from work_buddy.index.partitioned import start_prewarm as _start_index_prewarm
-        _start_index_prewarm()
+        from work_buddy.index.config import load_index_config
+        from work_buddy.index.partitioned import (
+            start_configured_prewarm as _start_index_prewarm,
+        )
+
+        _start_index_prewarm(load_index_config(cfg))
     except Exception as exc:  # never block service startup
         print(f"consolidated-index prewarm start failed (non-fatal): {exc}", file=sys.stderr)
     # Persist completed broker calls so the dashboard Inference panel keeps

--- a/work_buddy/health/checks.py
+++ b/work_buddy/health/checks.py
@@ -98,8 +98,8 @@ def check_lmstudio() -> dict[str, Any]:
     Probes ``GET /v1/models`` — a ``200`` confirms the server is both
     up and responding to the OpenAI-compatible API surface.
     """
-    from work_buddy.embedding.providers.lmstudio import resolve_base_url
     from work_buddy.config import load_config
+    from work_buddy.embedding.providers.lmstudio_config import resolve_base_url
 
     base_url = resolve_base_url(load_config())
     # Parse host/port from base_url for the TCP pre-check. Falls back
@@ -126,7 +126,56 @@ def check_lmstudio() -> dict[str, Any]:
                 f"local server (Developer tab → Start Server)."
             ),
         }
-    return _http_check(port, "/v1/models", timeout=5.0)
+    import http.client
+
+    models_path = f"{parsed.path.rstrip('/')}/v1/models" if parsed.path else "/v1/models"
+    connection_type = (
+        http.client.HTTPSConnection
+        if parsed.scheme.lower() == "https"
+        else http.client.HTTPConnection
+    )
+    connection = None
+    try:
+        connection = connection_type(host, port, timeout=5.0)
+        connection.request("GET", models_path)
+        response = connection.getresponse()
+        raw_body = response.read().decode("utf-8", errors="replace")
+        if response.status != 200:
+            return {
+                "ok": False,
+                "base_url": base_url,
+                "status_code": response.status,
+                "detail": (
+                    f"LM Studio returned HTTP {response.status} on "
+                    f"{models_path}: {raw_body[:200]}"
+                ),
+            }
+        body = json.loads(raw_body)
+        models = body.get("data") if isinstance(body, dict) else None
+        model_ids = [
+            item.get("id")
+            for item in (models or [])
+            if isinstance(item, dict) and isinstance(item.get("id"), str)
+        ]
+        return {
+            "ok": True,
+            "base_url": base_url,
+            "status_code": response.status,
+            "model_ids": model_ids,
+            "detail": (
+                f"LM Studio at {base_url} reports {len(model_ids)} available "
+                f"model{'s' if len(model_ids) != 1 else ''}"
+            ),
+        }
+    except Exception as exc:
+        return {
+            "ok": False,
+            "base_url": base_url,
+            "detail": f"LM Studio model probe failed: {type(exc).__name__}: {exc}",
+        }
+    finally:
+        if connection is not None:
+            connection.close()
 
 
 def check_obsidian_bridge() -> dict[str, Any]:

--- a/work_buddy/index/build.py
+++ b/work_buddy/index/build.py
@@ -74,6 +74,8 @@ class IndexBuilder:
         on_progress: Callable[[dict], None] | None = None,
         after_build: Callable[[dict[str, Any]], None] | None = None,
         defer_changed_vectors: bool = False,
+        max_items: int | None = None,
+        max_vector_batches: int | None = None,
     ) -> dict[str, Any]:
         """Reconcile the partition and finish any missing-vector backfill.
 
@@ -82,12 +84,65 @@ class IndexBuilder:
         change-ledger entry durable as usual, but leaves vector work to the global,
         resumable ``_encode_missing`` pass below.  Ordinary builds retain immediate
         per-item encoding by default.
+
+        ``max_items`` caps changed/deleted source items reconciled in this invocation;
+        ``max_vector_batches`` caps global missing-vector batches. These deterministic
+        budgets turn large scheduled backlogs into resumable slices. A partial slice
+        deliberately does not stamp ``last_build`` or invoke ``after_build`` (which is
+        the outbox acknowledgement boundary). ``force`` cannot be combined with either
+        budget because every pass would reselect source items and invalidate their vectors
+        without a persisted force-phase cursor.
+
+        A source item is the atomic lexical unit: the budget does not split one parsed
+        item's documents or avoid full source discovery. It bounds ordinary backlog
+        catch-up, while an exceptionally large individual item can still take longer.
         """
+        if max_items is not None and (
+            isinstance(max_items, bool) or not isinstance(max_items, int) or max_items <= 0
+        ):
+            raise ValueError("max_items must be a positive integer")
+        if max_vector_batches is not None and (
+            isinstance(max_vector_batches, bool)
+            or not isinstance(max_vector_batches, int)
+            or max_vector_batches <= 0
+        ):
+            raise ValueError("max_vector_batches must be a positive integer")
+        if force and (max_items is not None or max_vector_batches is not None):
+            raise ValueError("work budgets cannot be combined with force=True")
+        if max_items is not None or max_vector_batches is not None:
+            defer_changed_vectors = True
+        # Schema creation/repair is an explicit operation with its own long-lived
+        # acquisition of the same DB-wide writer gate. Ordinary reads, including
+        # dashboard status, never reach this forward-only boundary.
+        self._store.prepare_schema(repair_existing=False)
         pname = self._partition.name
         change_key = get_change_key(self._partition)
         schema = get_projection_schema(self._partition)
 
         with self._lock_ctx():
+            mutation_started = self._store.partition_mutation_in_progress(pname)
+            if mutation_started:
+                # A prior interrupted writer left the durable fence in place. Keep
+                # dense readers out until this reconciliation successfully finalizes.
+                for projection_name in schema:
+                    self._residents.invalidate(f"{pname}:{projection_name}")
+
+            def _begin_mutation() -> None:
+                """Fence resident readers before the first durable mutation.
+
+                Vector/document writes commit in their own short transactions. The dirty
+                marker makes version reads unavailable throughout that multi-transaction
+                window; successful finalization atomically bumps the generation and clears
+                the marker. A crash leaves the fence durable for the next replay.
+                """
+                nonlocal mutation_started
+                if mutation_started:
+                    return
+                self._store.begin_partition_mutation(pname)
+                for projection_name in schema:
+                    self._residents.invalidate(f"{pname}:{projection_name}")
+                mutation_started = True
+
             indexed = self._store.get_indexed_items(pname)  # {item_id: (mtime, hash)}
             discovered = list(self._partition.discover())
             disc_ids = {ref.item_id for ref in discovered}
@@ -106,7 +161,24 @@ class IndexBuilder:
                         changed.append(ref)
 
             deleted = [iid for iid in indexed if iid not in disc_ids]
-            self._prune(pname, deleted)
+            # A cursorless bounded first build must make forward progress even when
+            # newly indexed head items change again before the next tick. Preserve
+            # discovery order within each class, but always drain never-indexed work
+            # before refreshing entries that already have a durable ledger row.
+            changed.sort(key=lambda ref: ref.item_id in indexed)
+            changed_total = len(changed)
+            deleted_total = len(deleted)
+            if max_items is not None:
+                # Remove stale source items first, then spend the remainder on changed
+                # items. Both operations are ledger-backed, so the unprocessed tail is
+                # rediscovered naturally on the next run without a second cursor store.
+                deleted = deleted[:max_items]
+                remaining_slots = max_items - len(deleted)
+                changed = changed[:remaining_slots]
+            if changed or deleted:
+                _begin_mutation()
+            self._prune(pname, deleted, before_write=_begin_mutation)
+            remaining_items = (changed_total - len(changed)) + (deleted_total - len(deleted))
 
             # --- parse + upsert + encode changed items ---
             n_docs = 0
@@ -129,43 +201,89 @@ class IndexBuilder:
                     on_progress({"phase": "indexing", "done": i + 1, "total": len(changed)})
 
             # --- resume: encode any docs still missing a vector ---
+            vector_batches = 0
+            vectors_encoded = 0
+            remaining_vectors: dict[str, int] = {}
             for proj_name, spec in schema.items():
-                self._encode_missing(pname, proj_name, spec)
+                batch_budget = (
+                    None
+                    if max_vector_batches is None
+                    else max(0, max_vector_batches - vector_batches)
+                )
+                encoded, batches, remaining = self._encode_missing(
+                    pname,
+                    proj_name,
+                    spec,
+                    max_batches=batch_budget,
+                    before_write=_begin_mutation,
+                )
+                vectors_encoded += encoded
+                vector_batches += batches
+                remaining_vectors[proj_name] = remaining
 
-            changed_any = bool(changed or deleted)
-            if changed_any:
-                self._store.bump_version(pname)
-                for proj_name in schema:
-                    self._residents.invalidate(f"{pname}:{proj_name}")
+            if mutation_started:
+                self._store.finish_partition_mutation(pname)
+                for projection_name in schema:
+                    self._residents.invalidate(f"{pname}:{projection_name}")
 
-            # A successful empty/no-op build is still material cutover evidence:
-            # it proves the registered native source was reconciled, including a
-            # legitimately empty corpus. Keep version bumps change-only, but stamp
-            # every completed build so read-only certification can distinguish it
-            # from a partition that has never run.
-            from datetime import datetime, timezone
-            self._store.set_meta(
-                f"last_build:{pname}", datetime.now(timezone.utc).isoformat()
-            )
-
+            index_complete = remaining_items == 0 and not any(remaining_vectors.values())
             stats = {
                 "partition": pname,
                 "changed": len(changed),
+                "changed_total": changed_total,
                 "deleted": len(deleted),
+                "deleted_total": deleted_total,
                 "docs_indexed": n_docs,
+                "vectors_encoded": vectors_encoded,
+                "vector_batches": vector_batches,
+                "remaining": {
+                    "items": remaining_items,
+                    "vectors": remaining_vectors,
+                },
+                "index_complete": index_complete,
+                # A plain completion hook has no delivery phase, so it should
+                # observe a completed build immediately.  Domain adapters with
+                # a real delivery boundary (for example the database outbox)
+                # mark these provisional values false before reconciling it.
+                "delivery_complete": index_complete,
+                "complete": index_complete,
                 "doc_count": self._store.doc_count(pname),
                 "version": self._store.build_version(pname),
             }
             # Domain delivery reconciliation belongs to the same writer-gate
             # hold. The index commit is already durable, but no second builder
             # can interleave between its parity check and exact outbox ack.
-            if after_build is not None:
+            if index_complete and after_build is not None:
                 after_build(stats)
+            delivery_complete = index_complete and (
+                not isinstance(stats.get("outbox"), dict)
+                or bool(stats["outbox"].get("ready"))
+            )
+            complete = index_complete and delivery_complete
+            stats["delivery_complete"] = delivery_complete
+            stats["complete"] = complete
+
+            # A successful empty/no-op build is still material cutover evidence:
+            # it proves the registered native source and any durable outbox boundary
+            # were reconciled, including a legitimately empty corpus. A bounded,
+            # inference-deferred, parity-raced, or newly-appended-outbox run must not
+            # masquerade as an end-to-end completed build.
+            if complete:
+                from datetime import datetime, timezone
+                self._store.set_meta(
+                    f"last_build:{pname}", datetime.now(timezone.utc).isoformat()
+                )
             logger.info("index build [%s]: %s", pname, stats)
             return stats
 
     # -- retention --------------------------------------------------------
-    def _prune(self, pname: str, deleted: list[str]) -> None:
+    def _prune(
+        self,
+        pname: str,
+        deleted: list[str],
+        *,
+        before_write: Callable[[], None] | None = None,
+    ) -> None:
         """Apply the partition's RETENTION policy to items the source has dropped.
 
         - ``track_source`` (default): delete them — the index mirrors the live source.
@@ -177,7 +295,7 @@ class IndexBuilder:
         if not deleted:
             # Still run the TTL sweep so orphans age out even on a no-new-deletions tick.
             if getattr(self._cfg, "retention", "track_source") == "ttl":
-                self._sweep_orphans(pname)
+                self._sweep_orphans(pname, before_write=before_write)
             return
         retention = getattr(self._cfg, "retention", "track_source") if self._cfg else "track_source"
         if retention == "track_source":
@@ -187,14 +305,23 @@ class IndexBuilder:
         # retain / ttl: newly-gone items become orphans (kept, ledger forgotten).
         self._store.mark_items_orphaned(deleted, pname)
         if retention == "ttl":
-            self._sweep_orphans(pname)
+            self._sweep_orphans(pname, before_write=before_write)
 
-    def _sweep_orphans(self, pname: str) -> None:
+    def _sweep_orphans(
+        self,
+        pname: str,
+        *,
+        before_write: Callable[[], None] | None = None,
+    ) -> None:
         """TTL mode: delete orphans whose newest doc timestamp is older than the window."""
         ttl_days = getattr(self._cfg, "retention_ttl_days", None) or 0
         if ttl_days and ttl_days > 0:
             import time
-            self._store.prune_orphans_older_than(pname, time.time() - ttl_days * 86400.0)
+            cutoff = time.time() - ttl_days * 86400.0
+            if self._store.has_orphans_older_than(pname, cutoff):
+                if before_write is not None:
+                    before_write()
+                self._store.prune_orphans_older_than(pname, cutoff)
 
     # -- encoding helpers -------------------------------------------------
     def _encode_docs(self, docs: list, schema: dict) -> None:
@@ -237,9 +364,33 @@ class IndexBuilder:
     # interrupted backfill resumes from the last batch, not from zero.
     _ENCODE_MISSING_BATCH = 256
 
-    def _encode_missing(self, pname: str, projection: str, spec) -> None:
-        work = self._store.docs_missing_vectors(pname, projection)
+    def _encode_missing(
+        self,
+        pname: str,
+        projection: str,
+        spec,
+        *,
+        max_batches: int | None = None,
+        before_write: Callable[[], None] | None = None,
+    ) -> tuple[int, int, int]:
+        """Encode a bounded slice, returning ``(docs, batches, remaining_docs)``."""
+        doc_limit = (
+            None
+            if max_batches is None
+            else max_batches * self._ENCODE_MISSING_BATCH
+        )
+        if doc_limit == 0:
+            return 0, 0, self._store.missing_vector_count(pname, projection)
+        work = self._store.docs_missing_vectors(
+            pname,
+            projection,
+            limit=doc_limit,
+        )
+        encoded = 0
+        batches = 0
         for batch_start in range(0, len(work), self._ENCODE_MISSING_BATCH):
+            if max_batches is not None and batches >= max_batches:
+                break
             batch = work[batch_start:batch_start + self._ENCODE_MISSING_BATCH]
             flat_texts: list[str] = []
             layout: list[tuple[str, int, int]] = []
@@ -257,6 +408,15 @@ class IndexBuilder:
                 continue
             vecs = self._encoder.encode_documents(flat_texts, spec.kind, model_key=spec.model_key)
             if vecs is None:
-                return  # encoder unavailable — leave the remainder for the next resume
+                break  # Encoder unavailable; leave the remainder for the next resume.
             rows = [(doc_id, vecs[start:start + count]) for doc_id, start, count in layout]
+            if before_write is not None:
+                before_write()
             self._store.upsert_vectors(projection, rows)
+            encoded += len(rows)
+            batches += 1
+        # The scheduled path deliberately never inferred completion from its
+        # truncated Python work-list. Keep the exact count in SQLite, where it does
+        # not allocate/JSON-decode the entire backlog in the sidecar process.
+        remaining = self._store.missing_vector_count(pname, projection)
+        return encoded, batches, remaining

--- a/work_buddy/index/config.py
+++ b/work_buddy/index/config.py
@@ -10,6 +10,7 @@ Config shape (``config.yaml`` / ``config.local.yaml``):
 index:
   enabled: false                 # master flag — OFF by default
   db_path: null                  # null → paths.resolve("db/index-consolidated")
+  startup_prewarm: lazy          # lazy (RAM-aware) | all (lowest first-query latency)
   partitions:
     knowledge:
       rrf_k: 20                  # smaller default per the A/B finding (was hardcoded 60)
@@ -182,6 +183,13 @@ class IndexConfig:
     # once and retry against the now-warm matrix. False reverts to the inline blocking
     # load (the matrix loads within the request, which can exceed the request timeout).
     warming_signal: bool = True
+    # Startup resident-matrix policy. ``lazy`` is the RAM-aware default: no dense
+    # matrix is materialized merely because the embedding service restarted. A cold
+    # query still gets the existing lexical-first response, singleflight background
+    # warm, and one-shot retry. ``all`` restores the old eager startup behavior for
+    # deployments that prefer first-query latency over roughly 2x the stored float16
+    # vector payload in long-lived float32 matrices.
+    startup_prewarm: str = "lazy"
 
     def partition(self, name: str) -> PartitionConfig:
         """Config for ``name`` — falls back to defaults for an unlisted partition."""
@@ -231,10 +239,15 @@ def load_index_config(cfg: dict[str, Any] | None = None) -> IndexConfig:
         if isinstance(consumers_raw, dict) else {}
     )
 
+    startup_prewarm = raw.get("startup_prewarm", "lazy")
+    if startup_prewarm not in ("lazy", "all"):
+        startup_prewarm = "lazy"
+
     return IndexConfig(
         enabled=bool(raw.get("enabled", False)),
         db_path=db_path,
         partitions=partitions,
         consumers=consumers,
         warming_signal=bool(raw.get("warming_signal", True)),
+        startup_prewarm=startup_prewarm,
     )

--- a/work_buddy/index/encode.py
+++ b/work_buddy/index/encode.py
@@ -19,7 +19,8 @@ live search on the shared GPU.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from time import monotonic
+from threading import Condition, Lock
+from time import monotonic, time
 from typing import Any, Protocol, runtime_checkable
 
 from work_buddy.index.model import PoolStrategy, ProjectionKind
@@ -190,8 +191,10 @@ class EmbeddingProvider(Protocol):
     def encode(
         self, texts: list[str], *, model_id: str, prompt_name: str | None = None,
         priority: Priority = Priority.BACKGROUND,
+        batch_size: int | None = None,
+        routing_role: str | None = None,
     ) -> "Any | None":
-        """Encode → ``(N, D)`` float32 ndarray, or ``None`` if unavailable."""
+        """Encode to an ``(N, D)`` array; return ``None`` or raise if unavailable."""
         ...
 
 
@@ -205,25 +208,36 @@ class LocalProvider:
 
     name = "local"
 
+    def __init__(self, *, in_service: bool | None = None) -> None:
+        # The embedding HTTP service explicitly sets this to True. Other callers
+        # retain the historical auto-detection through ``ir.dense._IN_SERVICE``.
+        self._in_service = in_service
+
     def encode(
         self, texts: list[str], *, model_id: str, prompt_name: str | None = None,
         priority: Priority = Priority.BACKGROUND,
+        batch_size: int | None = None,
+        routing_role: str | None = None,
     ) -> "Any | None":
         import numpy as np
         if not texts:
             return np.zeros((0, 0), dtype=np.float32)
 
-        try:
-            from work_buddy.ir import dense as _ir_dense
-            in_service = bool(getattr(_ir_dense, "_IN_SERVICE", False))
-        except Exception:
-            in_service = False
+        in_service = self._in_service
+        if in_service is None:
+            try:
+                from work_buddy.ir import dense as _ir_dense
+                in_service = bool(getattr(_ir_dense, "_IN_SERVICE", False))
+            except Exception:
+                in_service = False
 
         if in_service:
             try:
                 from work_buddy.embedding.service import _brokered_encode, _get_model
-                model = _get_model(model_id)
+                model = _get_model(model_id, provider_authorized=True)
                 kwargs: dict[str, Any] = {"show_progress_bar": False}
+                if batch_size is not None:
+                    kwargs["batch_size"] = batch_size
                 if prompt_name:
                     kwargs["prompt_name"] = prompt_name
                 vecs = _brokered_encode(
@@ -237,10 +251,53 @@ class LocalProvider:
         # Out-of-service: round-trip to the running service (it does the compute).
         from work_buddy.embedding.client import embed
         timeout = max(_COLD_LOAD_TIMEOUT_S, len(texts) * 2)
-        vecs = embed(list(texts), model=model_id, prompt_name=prompt_name, timeout_s=timeout)
+        request_kwargs: dict[str, Any] = {
+            "model": model_id,
+            "prompt_name": prompt_name,
+            "timeout_s": timeout,
+        }
+        if routing_role is not None:
+            request_kwargs["routing_role"] = routing_role
+        vecs = embed(list(texts), **request_kwargs)
         if vecs is None:
             return None
         return np.asarray(vecs, dtype=np.float32)
+
+
+class _SidecarServiceProvider(LocalProvider):
+    """HTTP service transport that never absorbs direct-evaluation failures.
+
+    ``provider: st`` is explicitly an isolated, in-process A/B path. If that
+    candidate cannot load (missing dependency, OOM, and so on), its normal
+    router fallback must degrade to ``None`` rather than POSTing the same model
+    to the live service and changing that process's memory/runtime state.
+    """
+
+    def __init__(self, *, direct_evaluation_models: set[str]) -> None:
+        super().__init__(in_service=False)
+        self._direct_evaluation_models = direct_evaluation_models
+
+    def encode(
+        self, texts: list[str], *, model_id: str, prompt_name: str | None = None,
+        priority: Priority = Priority.BACKGROUND,
+        batch_size: int | None = None,
+        routing_role: str | None = None,
+    ) -> "Any | None":
+        if model_id in self._direct_evaluation_models:
+            logger.warning(
+                "Direct sentence-transformers evaluation unavailable for %s; "
+                "not falling through to the live embedding service",
+                model_id,
+            )
+            return None
+        return super().encode(
+            texts,
+            model_id=model_id,
+            prompt_name=prompt_name,
+            priority=priority,
+            batch_size=batch_size,
+            routing_role=routing_role,
+        )
 
 
 class LmStudioProvider:
@@ -256,17 +313,19 @@ class LmStudioProvider:
     def encode(
         self, texts: list[str], *, model_id: str, prompt_name: str | None = None,
         priority: Priority = Priority.BACKGROUND,
+        batch_size: int | None = None,
+        routing_role: str | None = None,
     ) -> "Any | None":
         import numpy as np
         if not texts:
             return np.zeros((0, 0), dtype=np.float32)
-        try:
-            from work_buddy.embedding.providers.lmstudio import encode as lm_encode
-            arr = lm_encode(list(texts), model_id=model_id, priority=priority)
-            return np.asarray(arr, dtype=np.float32)
-        except Exception as exc:
-            logger.warning("LmStudioProvider encode failed: %s", exc)
-            return None
+        from work_buddy.embedding.providers.lmstudio import encode as lm_encode
+
+        arr = lm_encode(
+            list(texts), model_id=model_id, priority=priority,
+            batch_size=batch_size or 64,
+        )
+        return np.asarray(arr, dtype=np.float32)
 
 
 class SentenceTransformerProvider:
@@ -309,6 +368,8 @@ class SentenceTransformerProvider:
     def encode(
         self, texts: list[str], *, model_id: str, prompt_name: str | None = None,
         priority: Priority = Priority.BACKGROUND,
+        batch_size: int | None = None,
+        routing_role: str | None = None,
     ) -> "Any | None":
         import numpy as np
         if not texts:
@@ -319,30 +380,135 @@ class SentenceTransformerProvider:
             registered = set(getattr(model, "prompts", {}) or {})
             with local_embed_slot(priority):
                 if prompt_name and prompt_name in registered:
-                    vecs = model.encode(
-                        list(texts), prompt_name=prompt_name, show_progress_bar=False,
-                    )
+                    kwargs: dict[str, Any] = {
+                        "prompt_name": prompt_name,
+                        "show_progress_bar": False,
+                    }
+                    if batch_size is not None:
+                        kwargs["batch_size"] = batch_size
+                    vecs = model.encode(list(texts), **kwargs)
                 elif prompt_name:
                     # literal prefix (e.g. "search_query:" / "query:"); add a space if bare.
                     pre = prompt_name if prompt_name.endswith((" ", ":")) else f"{prompt_name}: "
-                    vecs = model.encode(
-                        [f"{pre}{t}" for t in texts], show_progress_bar=False,
-                    )
+                    kwargs = {"show_progress_bar": False}
+                    if batch_size is not None:
+                        kwargs["batch_size"] = batch_size
+                    vecs = model.encode([f"{pre}{t}" for t in texts], **kwargs)
                 else:
-                    vecs = model.encode(list(texts), show_progress_bar=False)
+                    kwargs = {"show_progress_bar": False}
+                    if batch_size is not None:
+                        kwargs["batch_size"] = batch_size
+                    vecs = model.encode(list(texts), **kwargs)
             return np.asarray(vecs, dtype=np.float32)
         except Exception as exc:
             logger.warning("SentenceTransformerProvider encode failed for %s: %s", model_id, exc)
             return None
 
 
+@dataclass(frozen=True)
+class RouteInfo:
+    """One resolved embedding route, safe to expose through health APIs."""
+
+    model: str
+    requested_provider: str
+    provider: str | None
+    provider_model: str | None
+    on_error: str
+    status: str
+    fallback: bool
+    reason: str
+    at: float
+    error: str | None = None
+    provider_error: str | None = None
+    provider_error_kind: str | None = None
+    provider_error_hint: str | None = None
+
+    @classmethod
+    def from_dict(
+        cls, payload: dict[str, Any], *, default_model: str,
+    ) -> "RouteInfo":
+        """Rehydrate route metadata returned across the local HTTP boundary."""
+        at = payload.get("at")
+        return cls(
+            model=str(payload.get("model") or default_model),
+            requested_provider=str(payload.get("requested_provider") or "unknown"),
+            provider=(
+                str(payload["provider"])
+                if payload.get("provider") is not None
+                else None
+            ),
+            provider_model=(
+                str(payload["provider_model"])
+                if payload.get("provider_model") is not None
+                else None
+            ),
+            on_error=str(payload.get("on_error") or "fallback"),
+            status=str(payload.get("status") or "unknown"),
+            fallback=bool(payload.get("fallback", False)),
+            reason=str(payload.get("reason") or "unknown"),
+            at=float(at) if isinstance(at, (int, float)) else time(),
+            error=(str(payload["error"]) if payload.get("error") else None),
+            provider_error=(
+                str(payload["provider_error"])
+                if payload.get("provider_error")
+                else None
+            ),
+            provider_error_kind=(
+                str(payload["provider_error_kind"])
+                if payload.get("provider_error_kind")
+                else None
+            ),
+            provider_error_hint=(
+                str(payload["provider_error_hint"])
+                if payload.get("provider_error_hint")
+                else None
+            ),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "model": self.model,
+            "requested_provider": self.requested_provider,
+            "provider": self.provider,
+            "provider_model": self.provider_model,
+            "on_error": self.on_error,
+            "status": self.status,
+            "fallback": self.fallback,
+            "reason": self.reason,
+            "at": self.at,
+            "error": self.error,
+            "provider_error": self.provider_error,
+            "provider_error_kind": self.provider_error_kind,
+            "provider_error_hint": self.provider_error_hint,
+        }
+
+
+@dataclass(frozen=True)
+class RoutedEmbedding:
+    """Vectors plus the route that produced (or failed to produce) them."""
+
+    vectors: Any | None
+    route: RouteInfo
+
+
+class ProviderRoutingError(RuntimeError):
+    """A configured fail-closed provider could not serve an encode."""
+
+    def __init__(self, message: str, *, code: str, route: RouteInfo) -> None:
+        super().__init__(message)
+        self.code = code
+        self.route = route
+
+
 class ProviderRouter:
-    """Route a registry model to its backend, with safe local fallback.
+    """Authoritatively route a registry model to its configured backend.
 
     LM Studio receives its configured external model alias, while the local
-    fallback always receives the original registry key.  A failed LM Studio
-    route is cooled down briefly so bulk batches do not hammer an unavailable
-    peer.
+    fallback always receives the original registry key. ``on_error=fallback``
+    permits that local fallback; ``on_error=fail`` never touches the local
+    provider. A failed LM Studio route is cooled down briefly so bulk batches
+    do not hammer an unavailable peer. The latest decision per model is retained
+    for the embedding health/settings surface.
     """
 
     def __init__(
@@ -359,7 +525,11 @@ class ProviderRouter:
             self._providers["local"] = LocalProvider()
         self._cfg = cfg
         self._unavailable_until: dict[tuple[str, str], float] = {}
+        self._provider_inflight: set[tuple[str, str]] = set()
+        self._breaker_condition = Condition()
         self._warned_missing_lmstudio_aliases: set[str] = set()
+        self._route_lock = Lock()
+        self._last_routes: dict[str, RouteInfo] = {}
 
     def _model_config_for(self, model_id: str) -> dict[str, Any]:
         try:
@@ -375,21 +545,212 @@ class ProviderRouter:
 
     def _encode_local(
         self, texts: list[str], *, model_id: str, prompt_name: str | None,
-        priority: Priority,
+        priority: Priority, batch_size: int | None, routing_role: str | None,
     ) -> "Any | None":
-        return self._providers["local"].encode(
-            texts, model_id=model_id, prompt_name=prompt_name, priority=priority,
+        kwargs: dict[str, Any] = {
+            "model_id": model_id,
+            "prompt_name": prompt_name,
+            "priority": priority,
+        }
+        if batch_size is not None:
+            kwargs["batch_size"] = batch_size
+        local = self._providers["local"]
+        if routing_role is not None and isinstance(local, LocalProvider):
+            # The semantic role is transport metadata for /embed. Keep it out
+            # of the provider protocol so existing injected providers remain
+            # source-compatible.
+            kwargs["routing_role"] = routing_role
+        return local.encode(texts, **kwargs)
+
+    @staticmethod
+    def _on_error(model_cfg: dict[str, Any]) -> str:
+        raw = model_cfg.get("on_error", "fallback")
+        return (
+            raw.strip().lower()
+            if isinstance(raw, str) and raw.strip().lower() == "fail"
+            else "fallback"
         )
+
+    @staticmethod
+    def _route(
+        *, model_id: str, requested_provider: str, provider: str | None,
+        provider_model: str | None, on_error: str, status: str,
+        fallback: bool, reason: str, error: str | None = None,
+        provider_error: str | None = None,
+        provider_error_kind: str | None = None,
+        provider_error_hint: str | None = None,
+    ) -> RouteInfo:
+        return RouteInfo(
+            model=model_id,
+            requested_provider=requested_provider,
+            provider=provider,
+            provider_model=provider_model,
+            on_error=on_error,
+            status=status,
+            fallback=fallback,
+            reason=reason,
+            at=time(),
+            error=error,
+            provider_error=provider_error,
+            provider_error_kind=provider_error_kind,
+            provider_error_hint=provider_error_hint,
+        )
+
+    def _remember(self, route: RouteInfo) -> RouteInfo:
+        with self._route_lock:
+            self._last_routes[route.model] = route
+        return route
+
+    def _claim_provider_attempt(self, key: tuple[str, str]) -> bool:
+        """Serialize one provider attempt and re-check cooldown after waiting."""
+        with self._breaker_condition:
+            while key in self._provider_inflight:
+                self._breaker_condition.wait()
+            if monotonic() < self._unavailable_until.get(key, 0.0):
+                return False
+            self._provider_inflight.add(key)
+            return True
+
+    def _finish_provider_attempt(
+        self,
+        key: tuple[str, str],
+        *,
+        available: bool,
+    ) -> None:
+        with self._breaker_condition:
+            if available:
+                self._unavailable_until.pop(key, None)
+            else:
+                self._unavailable_until[key] = (
+                    monotonic() + _LMSTUDIO_RETRY_COOLDOWN_S
+                )
+            self._provider_inflight.discard(key)
+            self._breaker_condition.notify_all()
+
+    def _fallback_or_fail(
+        self, texts: list[str], *, model_id: str, prompt_name: str | None,
+        priority: Priority, batch_size: int | None, routing_role: str | None,
+        requested_provider: str,
+        provider_model: str | None, on_error: str, reason: str,
+        message: str, code: str, attempted_provider: str | None = None,
+        provider_error_kind: str | None = None,
+        provider_error_hint: str | None = None,
+    ) -> RoutedEmbedding:
+        if on_error == "fail":
+            route = self._remember(self._route(
+                model_id=model_id,
+                requested_provider=requested_provider,
+                provider=attempted_provider,
+                provider_model=provider_model,
+                on_error=on_error,
+                status="error",
+                fallback=False,
+                reason=reason,
+                error=message,
+                provider_error=message,
+                provider_error_kind=provider_error_kind,
+                provider_error_hint=provider_error_hint,
+            ))
+            raise ProviderRoutingError(message, code=code, route=route)
+
+        local = self._encode_local(
+            texts, model_id=model_id, prompt_name=prompt_name,
+            priority=priority, batch_size=batch_size, routing_role=routing_role,
+        )
+        local_ok = local is not None
+        route = self._remember(self._route(
+            model_id=model_id,
+            requested_provider=requested_provider,
+            provider="local",
+            provider_model=model_id,
+            on_error=on_error,
+            status="ok" if local_ok else "unavailable",
+            fallback=True,
+            reason=reason if local_ok else "local_fallback_unavailable",
+            error=None if local_ok else message,
+            provider_error=message,
+            provider_error_kind=provider_error_kind,
+            provider_error_hint=provider_error_hint,
+        ))
+        return RoutedEmbedding(local, route)
+
+    def describe(self, model_id: str) -> dict[str, Any]:
+        """Return configured policy, breaker state, and the last actual route."""
+        model_cfg = self._model_config_for(model_id)
+        requested = model_cfg.get("provider", "local")
+        if not isinstance(requested, str):
+            requested = "local"
+        requested = requested.strip().lower()
+        if requested == "sentence_transformer":
+            requested = "local"
+        alias = model_cfg.get("lmstudio_model") if requested == "lmstudio" else None
+        alias = alias.strip() if isinstance(alias, str) and alias.strip() else None
+        configuration_error = None
+        if requested not in self._providers:
+            configuration_error = f"Embedding provider {requested!r} is not configured"
+        elif requested == "lmstudio" and alias is None:
+            configuration_error = (
+                f"embedding.models.{model_id}.lmstudio_model is required"
+            )
+        breaker_key = (requested, alias) if alias else None
+        remaining = 0.0
+        inflight = False
+        if breaker_key is not None:
+            with self._breaker_condition:
+                remaining = max(
+                    0.0,
+                    self._unavailable_until.get(breaker_key, 0.0) - monotonic(),
+                )
+                inflight = breaker_key in self._provider_inflight
+        with self._route_lock:
+            last = self._last_routes.get(model_id)
+        return {
+            "requested_provider": requested,
+            "provider_model": alias if requested == "lmstudio" else model_id,
+            "on_error": self._on_error(model_cfg),
+            "configuration_status": "error" if configuration_error else "ok",
+            "configuration_error": configuration_error,
+            "cooldown_remaining_s": round(remaining, 1),
+            "provider_inflight": inflight,
+            "last_route": last.as_dict() if last is not None else None,
+        }
 
     def encode(
         self, texts: list[str], *, model_id: str, prompt_name: str | None = None,
         priority: Priority = Priority.BACKGROUND,
+        batch_size: int | None = None,
+        routing_role: str | None = None,
     ) -> "Any | None":
+        return self.encode_with_route(
+            texts, model_id=model_id, prompt_name=prompt_name,
+            priority=priority, batch_size=batch_size, routing_role=routing_role,
+        ).vectors
+
+    def encode_with_route(
+        self, texts: list[str], *, model_id: str, prompt_name: str | None = None,
+        priority: Priority = Priority.BACKGROUND,
+        batch_size: int | None = None,
+        routing_role: str | None = None,
+    ) -> RoutedEmbedding:
         model_cfg = self._model_config_for(model_id)
         name = model_cfg.get("provider", "local")
         if not isinstance(name, str):
             name = "local"
-        provider = self._providers.get(name, self._providers["local"])
+        name = name.strip().lower()
+        if name == "sentence_transformer":
+            name = "local"
+        on_error = self._on_error(model_cfg)
+        provider = self._providers.get(name)
+
+        if provider is None:
+            return self._fallback_or_fail(
+                texts, model_id=model_id, prompt_name=prompt_name,
+                priority=priority, batch_size=batch_size, routing_role=routing_role,
+                requested_provider=name, provider_model=None, on_error=on_error,
+                reason="provider_not_configured",
+                message=f"Embedding provider {name!r} is not configured for model {model_id!r}",
+                code="embedding_provider_not_configured",
+            )
 
         # The registry key identifies the local sentence-transformers model; LM
         # Studio exposes its own model id.  Never send the registry key to the
@@ -397,45 +758,124 @@ class ProviderRouter:
         # fallback condition, and the local provider must still receive model_id.
         provider_model_id = model_id
         breaker_key: tuple[str, str] | None = None
-        if name == "lmstudio" and provider is not self._providers["local"]:
+        if name == "lmstudio":
             alias = model_cfg.get("lmstudio_model")
             if not isinstance(alias, str) or not alias.strip():
                 if model_id not in self._warned_missing_lmstudio_aliases:
                     logger.warning(
                         "embedding.models.%s.provider is 'lmstudio' but "
-                        "lmstudio_model is not set; falling back to local",
+                        "lmstudio_model is not set",
                         model_id,
                     )
                     self._warned_missing_lmstudio_aliases.add(model_id)
-                return self._encode_local(
+                return self._fallback_or_fail(
                     texts, model_id=model_id, prompt_name=prompt_name,
-                    priority=priority,
+                    priority=priority, batch_size=batch_size,
+                    routing_role=routing_role,
+                    requested_provider=name, provider_model=None, on_error=on_error,
+                    reason="missing_lmstudio_model",
+                    message=(
+                        f"embedding.models.{model_id}.provider is 'lmstudio' but "
+                        "lmstudio_model is not set"
+                    ),
+                    code="embedding_provider_misconfigured",
                 )
             provider_model_id = alias.strip()
             breaker_key = (name, provider_model_id)
-            if monotonic() < self._unavailable_until.get(breaker_key, 0.0):
-                return self._encode_local(
+            if not self._claim_provider_attempt(breaker_key):
+                return self._fallback_or_fail(
                     texts, model_id=model_id, prompt_name=prompt_name,
-                    priority=priority,
+                    priority=priority, batch_size=batch_size,
+                    routing_role=routing_role,
+                    requested_provider=name, provider_model=provider_model_id,
+                    on_error=on_error, reason="provider_cooldown",
+                    message=(
+                        f"Embedding provider {name!r} for model {model_id!r} "
+                        "is in retry cooldown after an earlier failure"
+                    ),
+                    code="embedding_provider_cooldown",
                 )
 
-        out = provider.encode(
-            texts, model_id=provider_model_id, prompt_name=prompt_name, priority=priority,
-        )
-        if out is not None:
+        provider_kwargs: dict[str, Any] = {
+            "model_id": provider_model_id,
+            "prompt_name": prompt_name,
+            "priority": priority,
+        }
+        if batch_size is not None:
+            provider_kwargs["batch_size"] = batch_size
+        if routing_role is not None and isinstance(provider, LocalProvider):
+            provider_kwargs["routing_role"] = routing_role
+        out = None
+        provider_error: Exception | None = None
+        try:
+            try:
+                out = provider.encode(texts, **provider_kwargs)
+            except Exception as exc:
+                provider_error = exc
+                logger.warning("provider %r failed for %s: %s", name, model_id, exc)
+        finally:
             if breaker_key is not None:
-                self._unavailable_until.pop(breaker_key, None)
-            return out
-        if provider.name != "local":  # on_error fallback to local
-            if breaker_key is not None:
-                self._unavailable_until[breaker_key] = (
-                    monotonic() + _LMSTUDIO_RETRY_COOLDOWN_S
+                self._finish_provider_attempt(
+                    breaker_key,
+                    available=out is not None,
                 )
-            logger.info("provider %r unavailable for %s; falling back to local", name, model_id)
-            return self._encode_local(
-                texts, model_id=model_id, prompt_name=prompt_name, priority=priority,
+        if out is not None:
+            route = self._remember(self._route(
+                model_id=model_id,
+                requested_provider=name,
+                provider=name,
+                provider_model=provider_model_id,
+                on_error=on_error,
+                status="ok",
+                fallback=False,
+                reason="configured_local" if name == "local" else "provider_success",
+            ))
+            return RoutedEmbedding(out, route)
+        if name != "local":
+            logger.info("provider %r unavailable for %s", name, model_id)
+            provider_error_kind = None
+            provider_error_hint = None
+            provider_error_message = None
+            if provider_error is not None:
+                kind = getattr(provider_error, "kind", None)
+                hint = getattr(provider_error, "hint", None)
+                provider_error_kind = kind if isinstance(kind, str) else None
+                provider_error_hint = hint if isinstance(hint, str) and hint else None
+                formatter = getattr(provider_error, "format_caller_message", None)
+                if callable(formatter):
+                    provider_error_message = str(formatter())
+                else:
+                    provider_error_message = str(provider_error)
+            failure_detail = (
+                f": {provider_error_message}" if provider_error_message else ""
             )
-        return None
+            return self._fallback_or_fail(
+                texts, model_id=model_id, prompt_name=prompt_name,
+                priority=priority, batch_size=batch_size,
+                routing_role=routing_role,
+                requested_provider=name, provider_model=provider_model_id,
+                on_error=on_error, reason="provider_unavailable",
+                message=(
+                    f"Embedding provider {name!r} is unavailable for model "
+                    f"{model_id!r}{failure_detail}"
+                ),
+                code="embedding_provider_unavailable",
+                attempted_provider=name,
+                provider_error_kind=provider_error_kind,
+                provider_error_hint=provider_error_hint,
+            )
+        route = self._remember(self._route(
+            model_id=model_id,
+            requested_provider=name,
+            provider="local",
+            provider_model=model_id,
+            on_error=on_error,
+            status="unavailable",
+            fallback=False,
+            reason="local_unavailable",
+            error=f"Local embedding provider is unavailable for model {model_id!r}",
+        ))
+        return RoutedEmbedding(None, route)
 
 
 # ---------------------------------------------------------------------------
@@ -467,6 +907,7 @@ class BrokeredEncoder:
         return self._router.encode(
             list(texts), model_id=model_id, prompt_name=prompt,
             priority=Priority.INTERACTIVE,
+            routing_role="query",
         )
 
     def encode_documents(
@@ -483,6 +924,7 @@ class BrokeredEncoder:
             v = self._router.encode(
                 batch, model_id=model_id, prompt_name=prompt,
                 priority=Priority.BACKGROUND,
+                routing_role="document",
             )
             if v is None:
                 return None  # service/provider unavailable → caller degrades
@@ -491,4 +933,60 @@ class BrokeredEncoder:
 
 
 def default_encoder() -> BrokeredEncoder:
-    return BrokeredEncoder()
+    """Return the production encoder with one authoritative document route.
+
+    Consolidated-index refreshes normally run in the sidecar process.  Letting that
+    process construct its own config-backed provider router would split policy from
+    the embedding component: a restart-gated dashboard override could say ``local``
+    while the sidecar still read ``provider: lmstudio`` from YAML and called the
+    remote endpoint directly.  It would also make those calls invisible to the
+    embedding service's breaker and route diagnostics.
+
+    Outside the embedding service, production models cross its ``/embed`` endpoint;
+    that endpoint owns provider/model/on-error resolution. Explicit ``provider: st``
+    evaluation models retain their documented direct, in-process path so an offline
+    A/B neither depends on nor reconfigures the live service. Inside the service,
+    reuse the same singleton router directly to avoid an HTTP self-call.
+    """
+    try:
+        from work_buddy.ir import dense as _ir_dense
+
+        in_service = bool(getattr(_ir_dense, "_IN_SERVICE", False))
+    except Exception:
+        in_service = False
+
+    if in_service:
+        from work_buddy.embedding.service import _get_provider_router
+
+        return BrokeredEncoder(router=_get_provider_router())
+
+    # Preserve only the explicit direct-evaluation backend. Every production
+    # route, including leaf-ir even if stale YAML says ``st``, resolves to the
+    # service transport so restart-gated runtime authority cannot be bypassed.
+    direct_models: dict[str, Any] = {}
+    try:
+        from work_buddy.config import load_config
+
+        models = (load_config().get("embedding", {}).get("models", {}) or {})
+        direct_models = {
+            str(key): value
+            for key, value in models.items()
+            if key != "leaf-ir"
+            and isinstance(value, dict)
+            and str(value.get("provider") or "").strip().lower() == "st"
+        }
+    except Exception:
+        direct_models = {}
+
+    service_transport = ProviderRouter(
+        providers={
+            "local": _SidecarServiceProvider(
+                direct_evaluation_models=set(direct_models),
+            ),
+            "st": SentenceTransformerProvider(),
+        },
+        # Unlisted models deliberately resolve to ``local``; here "local"
+        # means the shared service transport, not a local model load.
+        cfg={"embedding": {"models": direct_models}},
+    )
+    return BrokeredEncoder(router=service_transport)

--- a/work_buddy/index/locking.py
+++ b/work_buddy/index/locking.py
@@ -13,11 +13,45 @@ logger = get_logger(__name__)
 
 
 @contextmanager
+def index_writer_gate(
+    db_path: str | Path,
+    *,
+    enabled: bool = True,
+    timeout_s: float = 30.0,
+    required: bool = False,
+) -> Iterator[None]:
+    """Hold the consolidated database's shared writer gate.
+
+    Schema preparation uses this primitive directly because it must serialize with
+    every old and new builder before changing a forward-only storage layout.
+    """
+    if not enabled:
+        yield
+        return
+    try:
+        from work_buddy.utils.index_lock import index_lock
+    except Exception as exc:  # lock infra unavailable -> optional best-effort fallback
+        if required:
+            raise RuntimeError(
+                "consolidated index writer gate is required but unavailable"
+            ) from exc
+        logger.debug("index_lock unavailable (%s); writing without a lock", exc)
+        yield
+        return
+
+    db = Path(db_path)
+    gate = db.parent / f"{db.name}.build"
+    with index_lock(gate, timeout=timeout_s):
+        yield
+
+
+@contextmanager
 def index_writer_locks(
     db_path: str | Path,
     partition: str,
     *,
     enabled: bool = True,
+    timeout_s: float = 30.0,
 ) -> Iterator[None]:
     """Hold the DB-wide writer gate, then one partition's identity lock.
 
@@ -25,7 +59,6 @@ def index_writer_locks(
     remains available for isolated unit builds; production maintenance operators
     use the default and therefore share the exact build exclusion boundary.
     """
-
     if not enabled:
         yield
         return
@@ -37,11 +70,10 @@ def index_writer_locks(
         return
 
     db = Path(db_path)
-    gate = db.parent / f"{db.name}.build"
     identity = db.parent / f"{db.name}.{partition}"
-    with index_lock(gate):
+    with index_writer_gate(db, timeout_s=timeout_s):
         with index_lock(identity):
             yield
 
 
-__all__ = ["index_writer_locks"]
+__all__ = ["index_writer_gate", "index_writer_locks"]

--- a/work_buddy/index/partitioned.py
+++ b/work_buddy/index/partitioned.py
@@ -78,22 +78,22 @@ class IndexPartition:
         )
 
     def is_warm(self) -> bool:
-        """True iff every dense projection's resident matrix is loaded. Non-blocking —
-        the readiness predicate behind the warming signal, on the serving hot path, so it
-        must stay O(projections) in RAM: ``ResidentCache.is_cached()`` is a pure in-memory
-        check (no DB). A lexical-only partition (no projections) is always warm.
+        """True iff every dense projection has a current resident matrix. Non-blocking:
+        the readiness predicate never loads a matrix. It does perform the cheap generation
+        check behind ``ResidentCache.is_current()`` so a sidecar build cannot leave this
+        process treating an allocated-but-stale matrix as warm. A lexical-only partition
+        (no projections) is always warm.
 
-        A projection that legitimately has no vectors never loads, so it reads as "cold"
-        forever — a query against it costs one redundant warm-retry, then degrades
-        gracefully. That benign edge is deliberately accepted over probing vector counts
-        here: the count is a ``COUNT(DISTINCT) JOIN`` across the whole (all-partition)
-        ``doc_vectors`` table — far too heavy to run per query on the readiness path."""
+        A projection that legitimately has no vectors caches a settled-empty result for
+        the current generation. It therefore degrades immediately to lexical-only instead
+        of advertising perpetual warming, without running a heavy vector-count query on
+        the serving path."""
         schema = get_projection_schema(self._partition)
         if not schema:
             return True
         for proj in schema:
             cache = self._residents.get(f"{self.name}:{proj}")
-            if cache is None or not cache.is_cached():
+            if cache is None or not cache.is_current():
                 return False
         return True
 
@@ -108,6 +108,8 @@ class IndexPartition:
     def build(
         self, *, force: bool = False, on_progress=None,
         defer_changed_vectors: bool = False,
+        max_items: int | None = None,
+        max_vector_batches: int | None = None,
     ) -> dict[str, Any]:
         """Build, then durably acknowledge the partition's outbox snapshot.
 
@@ -128,6 +130,12 @@ class IndexPartition:
         batch = snapshot_pending_events(self._partition)
 
         def _finish_delivery(stats: dict[str, Any]) -> None:
+            if batch is not None:
+                # Delivery has not completed merely because the index commit
+                # has.  Publish the provisional state before parity/ack work so
+                # any synchronous observer sees the honest boundary.
+                stats["delivery_complete"] = False
+                stats["complete"] = False
             parity = (
                 reconciliation_evidence(self._partition, self._store)
                 if batch is not None
@@ -147,6 +155,11 @@ class IndexPartition:
             )
             if batch is not None:
                 pending_after = pending_event_count(self._partition)
+                delivery_ready = (
+                    pending_after == 0
+                    if pending_after is not None
+                    else delivered == batch.count
+                )
                 stats["outbox"] = {
                     "schema": "wb.search-outbox-delivery/v1",
                     "pending_before": batch.count,
@@ -154,7 +167,7 @@ class IndexPartition:
                     "pending_after": pending_after,
                     "mode": "backfill" if force else "incremental_replay",
                     **(parity or {}),
-                    "ready": pending_after == 0 and parity_mismatches == 0,
+                    "ready": delivery_ready and parity_mismatches == 0,
                 }
 
         return self._builder.build(
@@ -162,6 +175,8 @@ class IndexPartition:
             on_progress=on_progress,
             after_build=_finish_delivery,
             defer_changed_vectors=defer_changed_vectors,
+            max_items=max_items,
+            max_vector_batches=max_vector_batches,
         )
 
     def status(self):
@@ -223,6 +238,16 @@ class UnifiedIndex:
     def available(self) -> list[str]:
         return self._registry.names()
 
+    def _default_partitions(self) -> list[str]:
+        """Built partitions, without creating or repairing an unavailable store."""
+        from work_buddy.index.store import IndexSchemaError
+
+        try:
+            return self._store.partitions() or self.available()
+        except IndexSchemaError as exc:
+            logger.debug("consolidated index unavailable without preparation: %s", exc)
+            return []
+
     def partition(self, name: str) -> IndexPartition:
         if name not in self._partitions:
             part = self._registry.get(name)
@@ -237,9 +262,7 @@ class UnifiedIndex:
         block_until_warm: bool = True,
     ) -> list[Hit]:
         # Default: search the partitions that actually have docs in the store.
-        names = partitions if partitions is not None else (
-            self._store.partitions() or self.available()
-        )
+        names = partitions if partitions is not None else self._default_partitions()
         results: list[list[Hit]] = []
         for name in names:
             try:
@@ -265,9 +288,7 @@ class UnifiedIndex:
         """Batched federated search — one ``list[Hit]`` per query, in order. Each
         partition is searched once (batched); per query, results federate across
         partitions via RRF, exactly like :meth:`search` does for a single query."""
-        names = partitions if partitions is not None else (
-            self._store.partitions() or self.available()
-        )
+        names = partitions if partitions is not None else self._default_partitions()
         per_partition: list[list[list[Hit]]] = []
         for name in names:
             try:
@@ -296,9 +317,7 @@ class UnifiedIndex:
         """The requested (or all built) partitions whose dense matrices aren't resident
         yet — the ``warming`` set. Non-blocking. An unknown/failing partition is treated
         as warm: we never signal warming for one we can't introspect."""
-        names = partitions if partitions is not None else (
-            self._store.partitions() or self.available()
-        )
+        names = partitions if partitions is not None else self._default_partitions()
         cold: list[str] = []
         for name in names:
             try:
@@ -327,8 +346,21 @@ class UnifiedIndex:
     def hydrate(self, partition: str, hits: list[Hit], **opts) -> list[Any]:
         return self.partition(partition).hydrate(hits, **opts)
 
-    def build(self, name: str, *, force: bool = False, on_progress=None) -> dict[str, Any]:
-        return self.partition(name).build(force=force, on_progress=on_progress)
+    def build(
+        self,
+        name: str,
+        *,
+        force: bool = False,
+        on_progress=None,
+        max_items: int | None = None,
+        max_vector_batches: int | None = None,
+    ) -> dict[str, Any]:
+        return self.partition(name).build(
+            force=force,
+            on_progress=on_progress,
+            max_items=max_items,
+            max_vector_batches=max_vector_batches,
+        )
 
     def build_all(self, *, force: bool = False) -> list[dict[str, Any]]:
         out = []
@@ -341,21 +373,17 @@ class UnifiedIndex:
         return out
 
     def status(self):
-        from work_buddy.indexing.protocol import IndexStatus
-        # Report partitions present in the store (built); fall back to registered names.
-        names = self._store.partitions() or self.available()
-        parts = []
-        for name in names:
-            try:
-                parts.append(self.partition(name).status())
-            except Exception as exc:  # pragma: no cover — defensive
-                logger.debug("status for %r failed: %s", name, exc)
-        size_mb = None
-        try:
-            size_mb = round(self._store.db_path.stat().st_size / 1024 / 1024, 2)
-        except OSError:
-            pass
-        return IndexStatus(name=self.NAME, partitions=parts, size_on_disk_mb=size_mb)
+        from work_buddy.indexing.protocol import IndexStatus, PartitionStatus
+
+        # One explicitly read-only snapshot. In particular, dashboard aggregation
+        # must never turn a status request into the forward-only FTS schema repair.
+        snapshot = self._store.status_snapshot()
+        parts = [PartitionStatus(**row) for row in snapshot["partitions"]]
+        return IndexStatus(
+            name=self.NAME,
+            partitions=parts,
+            size_on_disk_mb=snapshot.get("size_on_disk_mb"),
+        )
 
 
 # Resident-matrix load throughput used to estimate warm ETA (rows/sec). Derived from the
@@ -394,7 +422,8 @@ def prewarm_resident_matrices(
 
     ``only`` restricts warming to the named subset (still intersected with what's actually
     built) — used by the on-demand warm a cold query triggers; ``None`` warms every built
-    partition (the startup path). ``index_factory`` is an injection seam for tests;
+    partition (the explicit ``startup_prewarm: all`` path). ``index_factory`` is an
+    injection seam for tests;
     production passes the resolved config and lets it construct a :class:`UnifiedIndex`
     bound to the process-global resident registry (the one the serving path reads).
 
@@ -405,7 +434,14 @@ def prewarm_resident_matrices(
         logger.debug("index prewarm: index.enabled is false; skipping")
         return {}
     ui = index_factory(cfg) if index_factory is not None else UnifiedIndex(config=cfg)
-    built = ui.store.partitions()
+    snapshot = ui.store.status_snapshot()
+    if snapshot.get("state") != "current":
+        logger.debug(
+            "index prewarm: schema state is %s; skipping",
+            snapshot.get("state", "unknown"),
+        )
+        return {}
+    built = [str(row["key"]) for row in snapshot["partitions"]]
     if only is not None:
         wanted = set(only)
         built = [p for p in built if p in wanted]
@@ -447,8 +483,9 @@ def start_prewarm(
     """Spawn a daemon thread that runs :func:`prewarm_resident_matrices`.
 
     Non-blocking: the service must keep serving ``/health`` and queries while the
-    matrices warm. Started by the embedding-service ``main()`` (additive — pairs with
-    the idle evictor, which releases what this warms after an idle TTL).
+    matrices warm. Started by the embedding-service ``main()`` only when its configured
+    startup policy is ``all`` (additive and paired with the idle evictor, which releases
+    what this warms after an idle TTL).
     """
     def _run() -> None:
         try:
@@ -459,6 +496,34 @@ def start_prewarm(
     t = threading.Thread(target=_run, name=name, daemon=True)
     t.start()
     return t
+
+
+def start_configured_prewarm(
+    config: IndexConfig | None = None,
+    *,
+    index_factory: Callable[[IndexConfig], UnifiedIndex] | None = None,
+) -> threading.Thread | None:
+    """Apply the configured startup resident-matrix policy.
+
+    ``lazy`` deliberately starts no load: the normal cold-query warming signal
+    remains responsible for a singleflight background load and bounded retry.
+    ``all`` preserves the historical all-built-partition startup prewarm. The
+    idle evictor is independent of this choice and continues to release matrices
+    loaded by either route.
+    """
+    cfg = config or load_index_config()
+    if cfg.startup_prewarm != "all":
+        if cfg.startup_prewarm != "lazy":
+            logger.warning(
+                "index prewarm: unknown startup policy %r; using RAM-safe lazy mode",
+                cfg.startup_prewarm,
+            )
+        logger.info(
+            "index prewarm: startup policy is lazy; resident matrices will "
+            "warm on demand"
+        )
+        return None
+    return start_prewarm(cfg, index_factory=index_factory)
 
 
 def warm_partitions_async(

--- a/work_buddy/index/resident.py
+++ b/work_buddy/index/resident.py
@@ -34,7 +34,10 @@ DEFAULT_EVICT_INTERVAL_S = 60.0
 
 @dataclass
 class _Cached(Generic[T]):
-    value: T
+    # ``None`` is a meaningful, cacheable result: this generation currently has
+    # no vectors.  Remembering that settled-empty state prevents every query from
+    # starting another background warm and entering the client's retry window.
+    value: T | None
     version: str
     loaded_at: float
 
@@ -44,7 +47,8 @@ class ResidentCache(Generic[T]):
 
     Args:
         loader: ``() -> T | None`` — produces the resident value (e.g. load the
-            vector matrix from SQLite blobs). ``None`` means "nothing to cache".
+            vector matrix from SQLite blobs). ``None`` records a settled-empty
+            result for the current generation.
         version_fn: ``() -> str`` — the current on-disk version; when it differs
             from the cached copy, ``get()`` reloads.
         name: label for logs.
@@ -65,29 +69,70 @@ class ResidentCache(Generic[T]):
         self._clock = clock
         self._cached: _Cached[T] | None = None
         self._lock = threading.RLock()
+        self._load_done = threading.Condition(self._lock)
+        self._load_in_progress = False
 
     def get(self) -> T | None:
         """Return the resident value, (re)loading on a version change. ``None`` if empty."""
-        try:
-            version = self._version_fn()
-        except Exception as exc:  # version source unavailable → no cache
-            logger.debug("%s: version_fn failed (%s); not caching", self._name, exc)
-            return None
-
-        with self._lock:
-            if self._cached is not None and self._cached.version == version:
-                self._cached.loaded_at = self._clock()
-                return self._cached.value
-
-        # Load OUTSIDE the lock so a slow load doesn't block readers of other caches.
-        value = self._loader()
-        with self._lock:
-            if value is None:
-                self._cached = None
+        while True:
+            try:
+                version = self._version_fn()
+            except Exception as exc:  # version source unavailable → no cache
+                logger.debug("%s: version_fn failed (%s); not caching", self._name, exc)
                 return None
-            self._cached = _Cached(value=value, version=version, loaded_at=self._clock())
-            logger.info("%s: loaded resident value (version=%s)", self._name, version)
-            return self._cached.value
+
+            with self._lock:
+                if self._cached is not None and self._cached.version == version:
+                    self._cached.loaded_at = self._clock()
+                    return self._cached.value
+                if self._load_in_progress:
+                    # Join the elected loader. Re-read the durable generation after
+                    # it finishes: the leader may have discarded a raced snapshot,
+                    # or it may have loaded an older generation than this waiter saw.
+                    self._load_done.wait()
+                    continue
+                self._load_in_progress = True
+
+            try:
+                # Load OUTSIDE the lock. Other caches remain independent, while
+                # callers for this exact cache join through ``_load_done`` above.
+                value = self._loader()
+                # Optimistic, cross-process stability check: a writer may have
+                # installed its dirty fence while the matrix loader scanned SQLite.
+                try:
+                    loaded_version = self._version_fn()
+                except Exception as exc:
+                    logger.debug(
+                        "%s: version changed to unavailable during load (%s); discarding",
+                        self._name,
+                        exc,
+                    )
+                    return None
+                if loaded_version != version:
+                    logger.debug(
+                        "%s: version changed during load (%s -> %s); discarding",
+                        self._name,
+                        version,
+                        loaded_version,
+                    )
+                    return None
+                with self._lock:
+                    self._cached = _Cached(
+                        value=value,
+                        version=loaded_version,
+                        loaded_at=self._clock(),
+                    )
+                    logger.info(
+                        "%s: loaded resident state (version=%s, empty=%s)",
+                        self._name,
+                        loaded_version,
+                        value is None,
+                    )
+                    return self._cached.value
+            finally:
+                with self._lock:
+                    self._load_in_progress = False
+                    self._load_done.notify_all()
 
     def get_if_cached(self) -> T | None:
         """Return the resident value ONLY if already loaded for the current version.
@@ -106,6 +151,23 @@ class ResidentCache(Generic[T]):
                 return self._cached.value
         return None
 
+    def is_current(self) -> bool:
+        """Whether this cache has settled the current on-disk generation.
+
+        Unlike :meth:`get_if_cached`, this distinguishes a cold cache from a
+        successfully loaded generation that contains zero vectors.  It never
+        invokes the loader.
+        """
+        try:
+            version = self._version_fn()
+        except Exception:
+            return False
+        with self._lock:
+            if self._cached is not None and self._cached.version == version:
+                self._cached.loaded_at = self._clock()
+                return True
+        return False
+
     def invalidate(self) -> None:
         """Drop the cached value (call after a rebuild bumps the version)."""
         with self._lock:
@@ -120,6 +182,7 @@ class ResidentCache(Generic[T]):
         return False
 
     def is_cached(self) -> bool:
+        """Whether a value or settled-empty result is retained in memory."""
         with self._lock:
             return self._cached is not None
 

--- a/work_buddy/index/search.py
+++ b/work_buddy/index/search.py
@@ -69,7 +69,7 @@ class HybridSearcher:
         return self._residents.get_or_create(
             key,
             loader=lambda: self._store.load_all_vectors(self._partition, projection),
-            version_fn=lambda: str(self._store.build_version(self._partition)),
+            version_fn=lambda: self._store.resident_version(self._partition),
         )
 
     def prewarm(self) -> int:
@@ -329,6 +329,12 @@ class HybridSearcher:
         hits: list[Hit] = []
         timestamps: dict[str, float | None] = {}
         for did in top_ids:
+            # Defense in depth for a cross-process writer that deletes a document
+            # after a candidate matrix was loaded but before hydration. The durable
+            # mutation fence normally suppresses that matrix; never emit a blank hit
+            # if a non-cooperating/raced writer still creates this narrow window.
+            if did not in docs:
+                continue
             d = docs.get(did, {})
             sig = {"fused": round(float(fused[did]), 6)}
             for name, sc in signal_scores.items():

--- a/work_buddy/index/store.py
+++ b/work_buddy/index/store.py
@@ -22,7 +22,7 @@ Tables:
 Thread-safety: a fresh connection per public method (sqlite3 connections aren't
 shareable across threads; the embedding service is multi-threaded). Ordinary opens
 are existing-schema-only: they never create, migrate, or repair the database. The
-one-time consolidated-index FTS storage-schema v2 repair is an explicit
+one-time rowid-aligned FTS storage repair is an explicit
 ``prepare_schema()`` operation serialized by the same advisory writer gate as every
 build and by ``BEGIN IMMEDIATE`` inside SQLite. It changes storage inside this index
 only; it is not a consumer cutover from the legacy IR engine.
@@ -309,8 +309,8 @@ def _ensure_fts_schema(conn: sqlite3.Connection) -> None:
     """Atomically migrate legacy standalone FTS rows to documents-rowid identity.
 
     The legacy table stored ``doc_id UNINDEXED`` and every replacement/deletion
-    therefore scanned the complete FTS corpus.  Version 2 materializes canonical
-    text on ``documents`` and uses an external-content FTS table whose rowid is the
+    therefore scanned the complete FTS corpus.  The rowid-aligned layout materializes
+    canonical text on ``documents`` and uses an external-content FTS table whose rowid is the
     indexed ``documents.rowid``.  FTS5's ``rebuild`` command reconstructs every row
     from the authoritative documents table.
 
@@ -335,10 +335,7 @@ def _ensure_fts_schema(conn: sqlite3.Connection) -> None:
             conn.commit()
             return
 
-        logger.info(
-            "index store: migrating FTS to rowid-aligned schema v%s",
-            _FTS_SCHEMA_VERSION,
-        )
+        logger.info("index store: starting rowid-aligned FTS storage repair")
         for trigger_name in _FTS_TRIGGER_NAMES:
             conn.execute(f"DROP TRIGGER IF EXISTS {trigger_name}")
 
@@ -399,7 +396,7 @@ def _ensure_fts_schema(conn: sqlite3.Connection) -> None:
                 != (migrated - len(updates)) // _FTS_MIGRATION_PROGRESS_EVERY
             ):
                 logger.info(
-                    "index store: FTS storage-schema v2 repair backfill "
+                    "index store: rowid-aligned FTS storage repair backfill "
                     "%d/%d documents (%.1f%%)",
                     migrated,
                     total_documents,
@@ -423,8 +420,8 @@ def _ensure_fts_schema(conn: sqlite3.Connection) -> None:
         )
         conn.commit()
         logger.info(
-            "index store: FTS schema v%s ready (%d documents, %d malformed, %.2fs)",
-            _FTS_SCHEMA_VERSION,
+            "index store: rowid-aligned FTS storage ready "
+            "(%d documents, %d malformed, %.2fs)",
             migrated,
             malformed,
             time.perf_counter() - started,
@@ -503,7 +500,7 @@ class IndexStore:
             conn.execute("PRAGMA foreign_keys=ON")
             if not _fts_layout_is_current(conn):
                 raise IndexSchemaRepairRequired(
-                    "consolidated-index FTS storage-schema v2 repair is required; "
+                    "consolidated-index rowid-aligned FTS storage repair is required; "
                     "ordinary reads and writes never run it implicitly"
                 )
             return conn
@@ -545,8 +542,8 @@ class IndexStore:
                 pass
             if not repair_existing and not logically_absent:
                 raise IndexSchemaRepairRequired(
-                    "existing consolidated index requires the explicit FTS "
-                    "storage-schema v2 repair; scheduled builds will not run it"
+                    "existing consolidated index requires the explicit "
+                    "rowid-aligned FTS storage repair; scheduled builds will not run it"
                 )
 
         from work_buddy.index.locking import index_writer_gate
@@ -580,8 +577,8 @@ class IndexStore:
                         and _database_has_user_schema(conn)
                     ):
                         raise IndexSchemaRepairRequired(
-                            "existing consolidated index requires the explicit FTS "
-                            "storage-schema v2 repair; scheduled builds will not run it"
+                            "existing consolidated index requires the explicit "
+                            "rowid-aligned FTS storage repair; scheduled builds will not run it"
                         )
                 conn.execute("PRAGMA journal_mode=WAL")
                 conn.execute("PRAGMA foreign_keys=ON")
@@ -628,7 +625,7 @@ class IndexStore:
                 ).fetchall()
             }
             try:
-                # Version rejection precedes every v2-specific table/column read.
+                # Version rejection precedes every current-layout table/column read.
                 # A future layout is free to rename those objects and must still
                 # be reported as unsupported, never absent or generically broken.
                 _fts_schema_version(conn)
@@ -648,7 +645,7 @@ class IndexStore:
             current = _fts_layout_is_current(conn)
             state = "current" if current else "repair_required"
             detail = None if current else (
-                "consolidated-index FTS storage-schema v2 repair required; "
+                "consolidated-index rowid-aligned FTS storage repair required; "
                 "status inspection did not run it"
             )
             vector_counts = {

--- a/work_buddy/index/store.py
+++ b/work_buddy/index/store.py
@@ -8,25 +8,31 @@ One DB (``index.db_path``, default ``db/index-consolidated``) holding ALL partit
 Tables:
 - ``documents`` — one row per doc (fields/projections/metadata as JSON; ``content_hash``
   for change detection; ``timestamp`` for recency).
-- ``doc_fts`` — a STANDALONE FTS5 index over canonical ``(title, body, tags)`` text
-  (not external-content: avoids rowid/trigger coupling and lets us delete by ``doc_id``).
+- ``doc_fts``: an external-content FTS5 index over canonical ``(title, body, tags)``
+  columns stored on ``documents``.  FTS rows share ``documents.rowid`` and database
+  triggers keep them synchronized.  This makes replacement and deletion indexed
+  rowid operations instead of full scans over an ``UNINDEXED doc_id`` column.
   Per-field importance is preserved via FTS5's native ``bm25(doc_fts, wt, wb, wg)``
-  column weights. Partition/metadata scoping is a JOIN to ``documents``.
+  column weights. Partition/metadata scoping is a rowid JOIN to ``documents``.
 - ``doc_vectors`` — one float16 blob per ``(doc_id, projection)``, FK-cascaded to
   ``documents`` (incremental O(1) writes; vectors auto-deleted with their doc).
 - ``indexed_items`` — the change-detection ledger (mtime + content_hash per item).
 - ``index_meta`` — KV (per-partition ``build_version`` etc.).
 
 Thread-safety: a fresh connection per public method (sqlite3 connections aren't
-shareable across threads; the embedding service is multi-threaded). ``CREATE … IF NOT
-EXISTS`` runs each open — cheap and idempotent, matching ``vault_index/store.py``.
+shareable across threads; the embedding service is multi-threaded). Ordinary opens
+are existing-schema-only: they never create, migrate, or repair the database. The
+one-time consolidated-index FTS storage-schema v2 repair is an explicit
+``prepare_schema()`` operation serialized by the same advisory writer gate as every
+build and by ``BEGIN IMMEDIATE`` inside SQLite. It changes storage inside this index
+only; it is not a consumer cutover from the legacy IR engine.
 
 Write contention: SQLite allows ONE writer per DB. Builds serialize on a DB-wide
 advisory gate (``build.py``), but writers can still live in different processes
 (sidecar jobs, the embedding service, the CLI), so every write method additionally
 rides through transient ``database is locked`` with a bounded backoff-retry. Each
 write is a small self-contained connect→commit→close transaction, which is what
-makes the retry safe (idempotent INSERT OR REPLACE / DELETE).
+makes the retry safe (idempotent UPSERT / DELETE).
 """
 
 from __future__ import annotations
@@ -56,10 +62,15 @@ CREATE TABLE IF NOT EXISTS documents (
     metadata      TEXT NOT NULL DEFAULT '{}',   -- JSON, json_extract-filterable
     content_hash  TEXT NOT NULL DEFAULT '',
     timestamp     REAL,                          -- epoch seconds, nullable (recency)
-    indexed_at    TEXT NOT NULL
+    indexed_at    TEXT NOT NULL,
+    -- Canonical lexical columns are materialized from ``fields``.  Keeping them on
+    -- the content table lets FTS5 use documents.rowid as its indexed identity.
+    title         TEXT NOT NULL DEFAULT '',
+    body          TEXT NOT NULL DEFAULT '',
+    tags          TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_documents_partition ON documents(partition);
-CREATE INDEX IF NOT EXISTS idx_documents_item ON documents(item_id);
+CREATE INDEX IF NOT EXISTS idx_documents_item ON documents(item_id, partition);
 
 -- One row per (doc_id, projection, sub). ``sub`` lets a single projection carry
 -- MULTIPLE vectors per doc (e.g. one per alias) which are pooled (max/mean) at query
@@ -89,12 +100,50 @@ CREATE TABLE IF NOT EXISTS index_meta (
     value TEXT NOT NULL
 );
 
--- Standalone FTS5 (NOT external-content): canonical title/body/tags columns +
--- an UNINDEXED doc_id so we can delete by id and JOIN back to documents.
-CREATE VIRTUAL TABLE IF NOT EXISTS doc_fts USING fts5(
-    doc_id UNINDEXED, title, body, tags
-);
 """
+
+_FTS_SCHEMA_VERSION = "2"
+_FTS_SCHEMA_META_KEY = "fts_schema_version"
+_FTS_MIGRATION_BUSY_TIMEOUT_MS = 10 * 60 * 1000
+_FTS_MIGRATION_GATE_TIMEOUT_S = 11 * 60.0
+_FTS_MIGRATION_PROGRESS_EVERY = 20_000
+_FTS_TRIGGER_NAMES = (
+    "documents_fts_insert",
+    "documents_fts_delete",
+    "documents_fts_update",
+)
+
+# Kept outside ``_SCHEMA`` because a legacy database already has a virtual table
+# named doc_fts with a materially different layout.  ``IF NOT EXISTS`` would leave
+# that table untouched, so _ensure_fts_schema performs an atomic data migration.
+_CREATE_FTS_SQL = (
+    "CREATE VIRTUAL TABLE doc_fts USING fts5("
+    "title, body, tags, content='documents', content_rowid='rowid')"
+)
+
+_CREATE_FTS_TRIGGERS_SQL = (
+    """
+    CREATE TRIGGER documents_fts_insert AFTER INSERT ON documents BEGIN
+        INSERT INTO doc_fts(rowid, title, body, tags)
+        VALUES (new.rowid, new.title, new.body, new.tags);
+    END
+    """,
+    """
+    CREATE TRIGGER documents_fts_delete AFTER DELETE ON documents BEGIN
+        INSERT INTO doc_fts(doc_fts, rowid, title, body, tags)
+        VALUES ('delete', old.rowid, old.title, old.body, old.tags);
+    END
+    """,
+    """
+    CREATE TRIGGER documents_fts_update
+    AFTER UPDATE OF title, body, tags ON documents BEGIN
+        INSERT INTO doc_fts(doc_fts, rowid, title, body, tags)
+        VALUES ('delete', old.rowid, old.title, old.body, old.tags);
+        INSERT INTO doc_fts(rowid, title, body, tags)
+        VALUES (new.rowid, new.title, new.body, new.tags);
+    END
+    """,
+)
 
 # Default FTS5 bm25() column weights (title > tags > body), overridable per partition.
 _DEFAULT_FTS_WEIGHTS = (3.0, 1.0, 2.0)  # (title, body, tags)
@@ -116,6 +165,18 @@ _BUSY_TIMEOUT_S = 30.0
 # timeout this rides out a concurrent writer's longest single transaction
 # instead of killing a multi-hour build over one collision.
 _WRITE_RETRY_DELAYS_S = (0.5, 1.0, 2.0, 4.0, 8.0)
+
+
+class IndexSchemaError(RuntimeError):
+    """Base class for consolidated-index storage-layout errors."""
+
+
+class IndexSchemaRepairRequired(IndexSchemaError):
+    """The database is absent or older than this binary's required layout."""
+
+
+class UnsupportedIndexSchemaVersion(IndexSchemaError):
+    """The database was written by a newer binary and must not be downgraded."""
 
 
 def _is_locked_error(exc: sqlite3.OperationalError) -> bool:
@@ -170,6 +231,209 @@ def _fts_columns(fields: dict[str, str]) -> tuple[str, str, str]:
     return title, body, tags
 
 
+def _fts_schema_version(conn: sqlite3.Connection) -> int | None:
+    """Read the FTS schema version and reject layouts from a newer binary."""
+    meta_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'index_meta'"
+    ).fetchone()
+    if meta_exists is None:
+        return None
+    row = conn.execute(
+        "SELECT value FROM index_meta WHERE key = ?", (_FTS_SCHEMA_META_KEY,)
+    ).fetchone()
+    if row is None:
+        return None
+    try:
+        version = int(str(row[0]))
+    except (TypeError, ValueError) as exc:
+        raise UnsupportedIndexSchemaVersion(
+            f"unrecognized consolidated-index FTS schema version {row[0]!r}"
+        ) from exc
+    current = int(_FTS_SCHEMA_VERSION)
+    if version > current:
+        raise UnsupportedIndexSchemaVersion(
+            "consolidated-index FTS schema "
+            f"v{version} is newer than this binary supports (v{current}); "
+            "refusing a destructive downgrade"
+        )
+    return version
+
+
+def _database_has_user_schema(conn: sqlite3.Connection) -> bool:
+    """Whether an existing SQLite file contains any non-internal schema object."""
+    return conn.execute(
+        "SELECT 1 FROM sqlite_master "
+        "WHERE type IN ('table', 'view', 'trigger') "
+        "AND name NOT LIKE 'sqlite_%' LIMIT 1"
+    ).fetchone() is not None
+
+
+def _fts_layout_is_current(conn: sqlite3.Connection) -> bool:
+    """Return whether the rowid-aligned external-content FTS layout is complete."""
+    if _fts_schema_version(conn) != int(_FTS_SCHEMA_VERSION):
+        return False
+
+    document_columns = {
+        str(row[1]) for row in conn.execute("PRAGMA table_info(documents)").fetchall()
+    }
+    if not {"title", "body", "tags"}.issubset(document_columns):
+        return False
+
+    fts_row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'doc_fts'"
+    ).fetchone()
+    if fts_row is None:
+        return False
+    normalized_sql = "".join(str(fts_row[0] or "").lower().split())
+    if "content='documents'" not in normalized_sql:
+        return False
+    if "content_rowid='rowid'" not in normalized_sql:
+        return False
+
+    trigger_sql = {
+        str(row[0]): "".join(str(row[1] or "").lower().split())
+        for row in conn.execute(
+            "SELECT name, sql FROM sqlite_master WHERE type = 'trigger' "
+            "AND name IN (?,?,?)",
+            _FTS_TRIGGER_NAMES,
+        ).fetchall()
+    }
+    expected_trigger_sql = {
+        name: "".join(statement.lower().split())
+        for name, statement in zip(_FTS_TRIGGER_NAMES, _CREATE_FTS_TRIGGERS_SQL)
+    }
+    return trigger_sql == expected_trigger_sql
+
+
+def _ensure_fts_schema(conn: sqlite3.Connection) -> None:
+    """Atomically migrate legacy standalone FTS rows to documents-rowid identity.
+
+    The legacy table stored ``doc_id UNINDEXED`` and every replacement/deletion
+    therefore scanned the complete FTS corpus.  Version 2 materializes canonical
+    text on ``documents`` and uses an external-content FTS table whose rowid is the
+    indexed ``documents.rowid``.  FTS5's ``rebuild`` command reconstructs every row
+    from the authoritative documents table.
+
+    ``BEGIN IMMEDIATE`` serializes concurrent explicit repair attempts. When the
+    caller has already opened a transaction for a brand-new database, this helper
+    joins it so base tables, FTS objects, and the version marker commit atomically.
+    The version and physical layout are rechecked after acquiring the writer lock,
+    and every DDL, backfill, rebuild, and version update commits as one transaction.
+    If startup is interrupted, SQLite rolls back either to no user schema (fresh
+    initialization) or to the complete legacy layout (repair).
+    """
+    if _fts_layout_is_current(conn):
+        return
+
+    started = time.perf_counter()
+    if not conn.in_transaction:
+        conn.execute("BEGIN IMMEDIATE")
+    try:
+        # A different process may have completed the migration while this
+        # connection waited for the writer lock.
+        if _fts_layout_is_current(conn):
+            conn.commit()
+            return
+
+        logger.info(
+            "index store: migrating FTS to rowid-aligned schema v%s",
+            _FTS_SCHEMA_VERSION,
+        )
+        for trigger_name in _FTS_TRIGGER_NAMES:
+            conn.execute(f"DROP TRIGGER IF EXISTS {trigger_name}")
+
+        document_columns = {
+            str(row[1]) for row in conn.execute("PRAGMA table_info(documents)").fetchall()
+        }
+        for column in ("title", "body", "tags"):
+            if column not in document_columns:
+                conn.execute(
+                    f"ALTER TABLE documents ADD COLUMN {column} "
+                    "TEXT NOT NULL DEFAULT ''"
+                )
+
+        # Legacy databases have the same index name over item_id alone.  Rebuild it
+        # as a composite so partition-scoped item deletion constrains both columns.
+        conn.execute("DROP INDEX IF EXISTS idx_documents_item")
+        conn.execute(
+            "CREATE INDEX idx_documents_item ON documents(item_id, partition)"
+        )
+
+        # Backfill in bounded batches instead of holding every document's JSON in
+        # Python at once.  Recomputing from fields also repairs stale/missing legacy
+        # FTS rows rather than copying corruption into the new layout.
+        total_documents = int(
+            conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        )
+        last_rowid = 0
+        migrated = 0
+        malformed = 0
+        while True:
+            rows = conn.execute(
+                "SELECT rowid, fields FROM documents WHERE rowid > ? "
+                "ORDER BY rowid LIMIT 2000",
+                (last_rowid,),
+            ).fetchall()
+            if not rows:
+                break
+            updates: list[tuple[str, str, str, int]] = []
+            for row in rows:
+                try:
+                    fields = json.loads(row["fields"] or "{}")
+                    if not isinstance(fields, dict):
+                        raise TypeError("fields JSON is not an object")
+                    title, body, tags = _fts_columns(fields)
+                except (AttributeError, TypeError, ValueError):
+                    title, body, tags = "", "", ""
+                    malformed += 1
+                updates.append((title, body, tags, int(row["rowid"])))
+            conn.executemany(
+                "UPDATE documents SET title = ?, body = ?, tags = ? WHERE rowid = ?",
+                updates,
+            )
+            migrated += len(updates)
+            last_rowid = int(rows[-1]["rowid"])
+            if (
+                migrated == total_documents
+                or migrated // _FTS_MIGRATION_PROGRESS_EVERY
+                != (migrated - len(updates)) // _FTS_MIGRATION_PROGRESS_EVERY
+            ):
+                logger.info(
+                    "index store: FTS storage-schema v2 repair backfill "
+                    "%d/%d documents (%.1f%%)",
+                    migrated,
+                    total_documents,
+                    100.0 * migrated / max(1, total_documents),
+                )
+
+        conn.execute("DROP TABLE IF EXISTS doc_fts")
+        conn.execute(_CREATE_FTS_SQL)
+        conn.execute("INSERT INTO doc_fts(doc_fts) VALUES ('rebuild')")
+        # rank=1 asks FTS5 to compare the rebuilt index against its external
+        # content table, not merely validate the internal b-tree structure.
+        conn.execute(
+            "INSERT INTO doc_fts(doc_fts, rank) VALUES ('integrity-check', 1)"
+        )
+        for statement in _CREATE_FTS_TRIGGERS_SQL:
+            conn.execute(statement)
+        conn.execute(
+            "INSERT INTO index_meta(key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (_FTS_SCHEMA_META_KEY, _FTS_SCHEMA_VERSION),
+        )
+        conn.commit()
+        logger.info(
+            "index store: FTS schema v%s ready (%d documents, %d malformed, %.2fs)",
+            _FTS_SCHEMA_VERSION,
+            migrated,
+            malformed,
+            time.perf_counter() - started,
+        )
+    except Exception:
+        conn.rollback()
+        raise
+
+
 def _fts_match_expr(query: str) -> str | None:
     """Reduce arbitrary user text to a safe FTS5 MATCH expr (OR of quoted tokens)."""
     terms = [t for t in re.split(r"\W+", (query or "").lower()) if len(t) > 1]
@@ -213,29 +477,251 @@ class IndexStore:
         self, db_path: str | Path, *, busy_timeout_s: float = _BUSY_TIMEOUT_S
     ) -> None:
         self._db_path = Path(db_path)
-        self._db_path.parent.mkdir(parents=True, exist_ok=True)
         self._busy_timeout_s = busy_timeout_s
 
     @property
     def db_path(self) -> Path:
         return self._db_path
 
-    # -- connection -------------------------------------------------------
+    # -- connection + explicit schema preparation ------------------------
+    def _existing_uri(self, *, mode: str) -> str:
+        return f"{self._db_path.resolve().as_uri()}?mode={mode}"
+
     def _connect(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(str(self._db_path), timeout=self._busy_timeout_s)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute("PRAGMA foreign_keys=ON")
-        conn.executescript(_SCHEMA)
-        return conn
+        """Open an existing, current-schema database without mutating its layout."""
+        if not self._db_path.is_file():
+            raise IndexSchemaRepairRequired(
+                "consolidated index is absent; run an explicit build/schema preparation"
+            )
+        conn = sqlite3.connect(
+            self._existing_uri(mode="rw"),
+            uri=True,
+            timeout=self._busy_timeout_s,
+        )
+        try:
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA foreign_keys=ON")
+            if not _fts_layout_is_current(conn):
+                raise IndexSchemaRepairRequired(
+                    "consolidated-index FTS storage-schema v2 repair is required; "
+                    "ordinary reads and writes never run it implicitly"
+                )
+            return conn
+        except Exception:
+            conn.close()
+            raise
+
+    def prepare_schema(self, *, repair_existing: bool = True) -> None:
+        """Create or repair the index under the shared DB-wide writer gate.
+
+        This is the sole schema-changing entry point. It intentionally waits long
+        enough for the measured production repair and for an already-running legacy
+        builder to release the same advisory gate. Ordinary status/search/store
+        opens cannot invoke it accidentally. Scheduled builders pass
+        ``repair_existing=False``: they may initialize an absent database, but a
+        forward-only repair of an existing database remains an operator action.
+        """
+        # Fast, side-effect-free current-schema check. The gate is only needed for
+        # an absent/legacy database, not on every normal incremental build.
+        if self._db_path.is_file():
+            logically_absent = False
+            try:
+                probe = sqlite3.connect(
+                    self._existing_uri(mode="ro"),
+                    uri=True,
+                    timeout=self._busy_timeout_s,
+                )
+                try:
+                    probe.row_factory = sqlite3.Row
+                    probe.execute("PRAGMA query_only=ON")
+                    if _fts_layout_is_current(probe):
+                        return
+                    logically_absent = not _database_has_user_schema(probe)
+                finally:
+                    probe.close()
+            except UnsupportedIndexSchemaVersion:
+                raise
+            except sqlite3.Error:
+                pass
+            if not repair_existing and not logically_absent:
+                raise IndexSchemaRepairRequired(
+                    "existing consolidated index requires the explicit FTS "
+                    "storage-schema v2 repair; scheduled builds will not run it"
+                )
+
+        from work_buddy.index.locking import index_writer_gate
+
+        with index_writer_gate(
+            self._db_path,
+            timeout_s=_FTS_MIGRATION_GATE_TIMEOUT_S,
+            required=True,
+        ):
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+            existed_before_open = self._db_path.is_file()
+            conn = sqlite3.connect(
+                str(self._db_path),
+                timeout=_FTS_MIGRATION_BUSY_TIMEOUT_MS / 1000.0,
+            )
+            try:
+                conn.row_factory = sqlite3.Row
+                conn.execute(f"PRAGMA busy_timeout={_FTS_MIGRATION_BUSY_TIMEOUT_MS}")
+                # Reject a newer binary's schema before executing any DDL. If a
+                # peer initialized/repaired the DB while we waited for the gate,
+                # observe that committed state and return without touching it.
+                _fts_schema_version(conn)
+                if existed_before_open:
+                    try:
+                        if _fts_layout_is_current(conn):
+                            return
+                    except sqlite3.Error:
+                        pass
+                    if (
+                        not repair_existing
+                        and _database_has_user_schema(conn)
+                    ):
+                        raise IndexSchemaRepairRequired(
+                            "existing consolidated index requires the explicit FTS "
+                            "storage-schema v2 repair; scheduled builds will not run it"
+                        )
+                conn.execute("PRAGMA journal_mode=WAL")
+                conn.execute("PRAGMA foreign_keys=ON")
+                # Put the complete fresh bootstrap and an existing-database repair
+                # in one SQLite transaction. ``executescript`` otherwise commits
+                # each preceding transaction boundary before it runs; embedding
+                # BEGIN in the script leaves the transaction open for the FTS work.
+                conn.executescript("BEGIN IMMEDIATE;\n" + _SCHEMA)
+                _ensure_fts_schema(conn)
+            except Exception:
+                conn.rollback()
+                raise
+            finally:
+                conn.close()
+
+    def status_snapshot(self) -> dict[str, Any]:
+        """Inspect status through one read-only connection, never preparing schema."""
+        size_mb = None
+        try:
+            size_mb = round(self._db_path.stat().st_size / 1024 / 1024, 2)
+        except OSError:
+            return {"state": "absent", "partitions": [], "size_on_disk_mb": None}
+
+        try:
+            conn = sqlite3.connect(
+                self._existing_uri(mode="ro"),
+                uri=True,
+                timeout=self._busy_timeout_s,
+            )
+        except sqlite3.Error as exc:
+            return {
+                "state": "error",
+                "detail": f"{type(exc).__name__}: {exc}",
+                "partitions": [],
+                "size_on_disk_mb": size_mb,
+            }
+        try:
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA query_only=ON")
+            tables = {
+                str(row["name"])
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                ).fetchall()
+            }
+            try:
+                # Version rejection precedes every v2-specific table/column read.
+                # A future layout is free to rename those objects and must still
+                # be reported as unsupported, never absent or generically broken.
+                _fts_schema_version(conn)
+            except UnsupportedIndexSchemaVersion as exc:
+                return {
+                    "state": "unsupported",
+                    "detail": str(exc),
+                    "partitions": [],
+                    "size_on_disk_mb": size_mb,
+                }
+            if "documents" not in tables:
+                return {
+                    "state": "absent",
+                    "partitions": [],
+                    "size_on_disk_mb": size_mb,
+                }
+            current = _fts_layout_is_current(conn)
+            state = "current" if current else "repair_required"
+            detail = None if current else (
+                "consolidated-index FTS storage-schema v2 repair required; "
+                "status inspection did not run it"
+            )
+            vector_counts = {
+                str(row["partition"]): int(row["n"])
+                for row in conn.execute(
+                    "SELECT d.partition AS partition, COUNT(DISTINCT v.doc_id) AS n "
+                    "FROM documents d LEFT JOIN doc_vectors v ON v.doc_id = d.doc_id "
+                    "GROUP BY d.partition"
+                ).fetchall()
+            } if "doc_vectors" in tables else {}
+            last_builds = {
+                str(row["key"])[len("last_build:"):]: str(row["value"])
+                for row in conn.execute(
+                    "SELECT key, value FROM index_meta WHERE key LIKE 'last_build:%'"
+                ).fetchall()
+            } if "index_meta" in tables else {}
+            partitions = []
+            for row in conn.execute(
+                "SELECT partition, COUNT(*) AS n FROM documents "
+                "GROUP BY partition ORDER BY partition"
+            ).fetchall():
+                partition = str(row["partition"])
+                total = int(row["n"])
+                vectors = min(total, vector_counts.get(partition, 0))
+                partitions.append({
+                    "key": partition,
+                    "total_items": total,
+                    "dense_eligible": total,
+                    "vector_count": vectors,
+                    "pending": max(0, total - vectors),
+                    "last_build": last_builds.get(partition),
+                    "health": "ok" if state == "current" else "error",
+                    "detail": detail,
+                })
+            if not partitions and detail:
+                partitions.append({
+                    "key": "schema",
+                    "total_items": 0,
+                    "dense_eligible": 0,
+                    "vector_count": 0,
+                    "pending": 0,
+                    "last_build": None,
+                    "health": "error",
+                    "detail": detail,
+                })
+            return {
+                "state": state,
+                "detail": detail,
+                "partitions": partitions,
+                "size_on_disk_mb": size_mb,
+            }
+        except sqlite3.Error as exc:
+            return {
+                "state": "error",
+                "detail": f"{type(exc).__name__}: {exc}",
+                "partitions": [],
+                "size_on_disk_mb": size_mb,
+            }
+        finally:
+            conn.close()
 
     # -- writes -----------------------------------------------------------
     @_write_retry
     def upsert_documents(self, docs: list[Document], item_id: str = "") -> int:
-        """Insert/replace documents (tagged with ``item_id``) and refresh FTS rows.
+        """Insert/update documents (tagged with ``item_id``) and refresh FTS rows.
 
         ``item_id`` is the source item the docs came from (``parse(item_id)``), used
-        for per-item deletes. Returns the number of docs written.
+        for per-item deletes.  ``ON CONFLICT DO UPDATE`` preserves documents.rowid,
+        which is also the FTS row identity.  The document trigger refreshes FTS in
+        the same transaction.  Existing vectors are invalidated just as they were
+        under the former ``INSERT OR REPLACE`` implementation.
+
+        Returns the number of docs written.
         """
         if not docs:
             return 0
@@ -244,25 +730,29 @@ class IndexStore:
             now = _now_iso()
             for d in docs:
                 d.ensure_hash()
+                title, body, tags = _fts_columns(d.fields)
+                # REPLACE used to delete the documents row and FK-cascade vectors.
+                # Preserve that semantic explicitly while retaining the rowid.
+                conn.execute("DELETE FROM doc_vectors WHERE doc_id = ?", (d.doc_id,))
                 conn.execute(
-                    "INSERT OR REPLACE INTO documents "
+                    "INSERT INTO documents "
                     "(doc_id, partition, item_id, fields, projections, display_text, "
-                    " metadata, content_hash, timestamp, indexed_at) "
-                    "VALUES (?,?,?,?,?,?,?,?,?,?)",
+                    " metadata, content_hash, timestamp, indexed_at, title, body, tags) "
+                    "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?) "
+                    "ON CONFLICT(doc_id) DO UPDATE SET "
+                    "partition = excluded.partition, item_id = excluded.item_id, "
+                    "fields = excluded.fields, projections = excluded.projections, "
+                    "display_text = excluded.display_text, metadata = excluded.metadata, "
+                    "content_hash = excluded.content_hash, timestamp = excluded.timestamp, "
+                    "indexed_at = excluded.indexed_at, title = excluded.title, "
+                    "body = excluded.body, tags = excluded.tags",
                     (
                         d.doc_id, d.partition, item_id,
                         json.dumps(d.fields),
                         json.dumps({k: {"text": p.text} for k, p in d.projections.items()}),
                         d.display_text, json.dumps(d.metadata), d.content_hash,
-                        d.timestamp, now,
+                        d.timestamp, now, title, body, tags,
                     ),
-                )
-                # refresh FTS (standalone → manage explicitly)
-                conn.execute("DELETE FROM doc_fts WHERE doc_id = ?", (d.doc_id,))
-                title, body, tags = _fts_columns(d.fields)
-                conn.execute(
-                    "INSERT INTO doc_fts (doc_id, title, body, tags) VALUES (?,?,?,?)",
-                    (d.doc_id, title, body, tags),
                 )
             conn.commit()
             return len(docs)
@@ -313,14 +803,9 @@ class IndexStore:
         """Delete all docs for an item (FTS rows + cascaded vectors). Returns rows."""
         conn = self._connect()
         try:
-            sql = "SELECT doc_id FROM documents WHERE item_id = ?"
             args: list[Any] = [item_id]
             if partition is not None:
-                sql += " AND partition = ?"
                 args.append(partition)
-            doc_ids = [r["doc_id"] for r in conn.execute(sql, args).fetchall()]
-            for did in doc_ids:
-                conn.execute("DELETE FROM doc_fts WHERE doc_id = ?", (did,))
             cur = conn.execute(
                 "DELETE FROM documents WHERE item_id = ?"
                 + (" AND partition = ?" if partition is not None else ""),
@@ -343,13 +828,6 @@ class IndexStore:
         """Drop an entire partition (FTS + docs + cascaded vectors + ledger)."""
         conn = self._connect()
         try:
-            doc_ids = [
-                r["doc_id"] for r in conn.execute(
-                    "SELECT doc_id FROM documents WHERE partition = ?", (partition,)
-                ).fetchall()
-            ]
-            for did in doc_ids:
-                conn.execute("DELETE FROM doc_fts WHERE doc_id = ?", (did,))
             cur = conn.execute("DELETE FROM documents WHERE partition = ?", (partition,))
             conn.execute("DELETE FROM indexed_items WHERE partition = ?", (partition,))
             conn.commit()
@@ -390,8 +868,8 @@ class IndexStore:
     @_write_retry
     def prune_orphans_older_than(self, partition: str, cutoff_ts: float) -> int:
         """TTL sweep: delete orphaned docs whose ``timestamp`` is older than ``cutoff_ts``
-        (FTS rows cleared explicitly; vectors FK-cascade). Bounds orphan growth under the
-        ``ttl`` retention mode. Returns docs deleted."""
+        (FTS rows and vectors are trigger/FK-cascaded). Bounds orphan growth under
+        the ``ttl`` retention mode. Returns docs deleted."""
         conn = self._connect()
         try:
             where = (
@@ -399,18 +877,25 @@ class IndexStore:
                 "AND json_extract(metadata, '$.lifecycle_state') = 'orphaned' "
                 "AND COALESCE(timestamp, 0) < ?"
             )
-            doc_ids = [
-                r["doc_id"] for r in conn.execute(
-                    f"SELECT doc_id FROM documents WHERE {where}", (partition, cutoff_ts)
-                ).fetchall()
-            ]
-            for did in doc_ids:
-                conn.execute("DELETE FROM doc_fts WHERE doc_id = ?", (did,))
             cur = conn.execute(
                 f"DELETE FROM documents WHERE {where}", (partition, cutoff_ts)
             )
             conn.commit()
             return cur.rowcount
+        finally:
+            conn.close()
+
+    def has_orphans_older_than(self, partition: str, cutoff_ts: float) -> bool:
+        """Cheap read-only preflight used to publish a cache generation first."""
+        conn = self._connect()
+        try:
+            return conn.execute(
+                "SELECT 1 FROM documents "
+                "WHERE partition = ? "
+                "AND json_extract(metadata, '$.lifecycle_state') = 'orphaned' "
+                "AND COALESCE(timestamp, 0) < ? LIMIT 1",
+                (partition, cutoff_ts),
+            ).fetchone() is not None
         finally:
             conn.close()
 
@@ -496,6 +981,76 @@ class IndexStore:
         except (TypeError, ValueError):
             return 0
 
+    def partition_mutation_in_progress(self, partition: str) -> bool:
+        """Whether a prior/current writer has an unfinalized durable mutation."""
+        return self.get_meta(f"build_dirty:{partition}") is not None
+
+    @_write_retry
+    def begin_partition_mutation(self, partition: str) -> None:
+        """Fence resident readers before the first independently committed write."""
+        conn = self._connect()
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO index_meta (key, value) VALUES (?, ?)",
+                (f"build_dirty:{partition}", _now_iso()),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    @_write_retry
+    def finish_partition_mutation(self, partition: str) -> int:
+        """Atomically publish a new generation and remove its reader fence."""
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT value FROM index_meta WHERE key = ?",
+                (f"build_version:{partition}",),
+            ).fetchone()
+            try:
+                current = int(row["value"]) if row is not None else 0
+            except (TypeError, ValueError):
+                current = 0
+            nxt = current + 1
+            conn.execute(
+                "INSERT OR REPLACE INTO index_meta (key, value) VALUES (?, ?)",
+                (f"build_version:{partition}", str(nxt)),
+            )
+            conn.execute(
+                "DELETE FROM index_meta WHERE key = ?",
+                (f"build_dirty:{partition}",),
+            )
+            conn.commit()
+            return nxt
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def resident_version(self, partition: str) -> str:
+        """Stable generation for resident matrices; raises while writes are fenced.
+
+        Dirty state and version are read in one SQLite statement, so a reader cannot
+        observe the fence cleared without also observing the generation committed in
+        the same finalization transaction.
+        """
+        dirty_key = f"build_dirty:{partition}"
+        version_key = f"build_version:{partition}"
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT key, value FROM index_meta WHERE key IN (?, ?)",
+                (dirty_key, version_key),
+            ).fetchall()
+        finally:
+            conn.close()
+        values = {row["key"]: row["value"] for row in rows}
+        if dirty_key in values:
+            raise RuntimeError(f"partition {partition!r} is being mutated")
+        return str(values.get(version_key, "0"))
+
     def bump_version(self, partition: str) -> int:
         nxt = self.build_version(partition) + 1
         self.set_meta(f"build_version:{partition}", str(nxt))
@@ -522,11 +1077,10 @@ class IndexStore:
         meta_sql, meta_params = _metadata_where(filters)
         conn = self._connect()
         try:
-            # bm25() takes one weight per FTS column IN ORDER, including the leading
-            # UNINDEXED doc_id (col 0) — so a 0.0 placeholder precedes title/body/tags.
+            # FTS rowid is the documents rowid, so this is an indexed integer join.
             sql = (
-                f"SELECT f.doc_id AS doc_id, bm25(doc_fts, 0.0, {wt}, {wb}, {wg}) AS rank "
-                "FROM doc_fts f JOIN documents d ON d.doc_id = f.doc_id "
+                f"SELECT d.doc_id AS doc_id, bm25(doc_fts, {wt}, {wb}, {wg}) AS rank "
+                "FROM doc_fts f JOIN documents d ON d.rowid = f.rowid "
                 "WHERE doc_fts MATCH ?"
             )
             params: list[Any] = [match]
@@ -631,22 +1185,44 @@ class IndexStore:
         return matrix, doc_ids
 
     def docs_missing_vectors(
-        self, partition: str, projection: str
+        self,
+        partition: str,
+        projection: str,
+        *,
+        limit: int | None = None,
     ) -> list[tuple[str, Any]]:
         """``(doc_id, projection_text)`` for docs in the partition lacking a vector.
 
         The incremental/resumable encode work-list. ``projection_text`` is read from
-        the document's stored ``projections`` JSON (scalar or list).
+        the document's stored ``projections`` JSON (scalar or list). ``limit`` is
+        pushed into SQLite so a scheduled slice never materializes and JSON-decodes
+        the complete outstanding backlog merely to process its first few batches.
         """
+        if limit is not None and (
+            isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0
+        ):
+            raise ValueError("limit must be a positive integer")
+        projection_path = f"$.{projection}.text"
         conn = self._connect()
         try:
-            rows = conn.execute(
+            sql = (
                 "SELECT d.doc_id AS doc_id, d.projections AS projections "
                 "FROM documents d "
-                "LEFT JOIN doc_vectors v ON v.doc_id = d.doc_id AND v.projection = ? "
-                "WHERE d.partition = ? AND v.doc_id IS NULL ORDER BY d.doc_id",
-                (projection, partition),
-            ).fetchall()
+                "WHERE d.partition = ? "
+                "AND NOT EXISTS ("
+                "  SELECT 1 FROM doc_vectors v "
+                "  WHERE v.doc_id = d.doc_id AND v.projection = ?"
+                ") "
+                "AND EXISTS ("
+                "  SELECT 1 FROM json_each(d.projections, ?) p "
+                "  WHERE trim(COALESCE(CAST(p.value AS TEXT), '')) != ''"
+                ") ORDER BY d.doc_id"
+            )
+            params: list[Any] = [partition, projection, projection_path]
+            if limit is not None:
+                sql += " LIMIT ?"
+                params.append(limit)
+            rows = conn.execute(sql, params).fetchall()
         finally:
             conn.close()
         out: list[tuple[str, Any]] = []
@@ -656,9 +1232,43 @@ class IndexStore:
             if entry is None:
                 continue
             text = entry.get("text") if isinstance(entry, dict) else entry
-            if text:
+            # Match IndexBuilder's encode eligibility exactly. A pooled projection
+            # such as ``[""]`` is truthy as a container but has no encodable member;
+            # returning it would leave every bounded build permanently "partial".
+            if isinstance(text, list):
+                if any(text):
+                    out.append((r["doc_id"], text))
+            elif text:
                 out.append((r["doc_id"], text))
         return out
+
+    def missing_vector_count(self, partition: str, projection: str) -> int:
+        """Count encodable documents still missing ``projection`` vectors.
+
+        This is intentionally a database-side count: bounded builders load and
+        decode only their SQL-limited work slice while retaining exact progress and
+        completion reporting. ``json_each`` handles scalar and pooled-list text and
+        excludes empty projections that can never produce a vector.
+        """
+        projection_path = f"$.{projection}.text"
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT COUNT(*) AS n FROM documents d "
+                "WHERE d.partition = ? "
+                "AND NOT EXISTS ("
+                "  SELECT 1 FROM doc_vectors v "
+                "  WHERE v.doc_id = d.doc_id AND v.projection = ?"
+                ") "
+                "AND EXISTS ("
+                "  SELECT 1 FROM json_each(d.projections, ?) p "
+                "  WHERE trim(COALESCE(CAST(p.value AS TEXT), '')) != ''"
+                ")",
+                (partition, projection, projection_path),
+            ).fetchone()
+            return int(row["n"])
+        finally:
+            conn.close()
 
     # -- counts -----------------------------------------------------------
     def doc_count(self, partition: str | None = None) -> int:

--- a/work_buddy/ir/dense.py
+++ b/work_buddy/ir/dense.py
@@ -3,7 +3,7 @@
 Query encoding uses the lightweight ``leaf-ir-query`` model
 (MongoDB/mdbr-leaf-ir, 90 MB, eager-loaded at startup).  Document encoding
 uses the full asymmetric bundle ``leaf-ir`` (MongoDB/mdbr-leaf-ir-asym,
-526 MB, lazy-loaded only during indexing).  Both produce compatible 768-d
+526 MB, lazy-loaded only for document/passage embedding workloads).  Both produce compatible 768-d
 vectors per the model card's documented split-usage pattern.
 
 When running inside the embedding service process (``_IN_SERVICE = True``),
@@ -13,6 +13,7 @@ itself.  The flag is set by ``service.main()`` at startup.
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 import numpy as np
@@ -272,8 +273,8 @@ def _encode_bulk_direct(
     the LM Studio offload path's ``broker.slot`` row joins this provenance row,
     and writes one record per batch (best-effort). The description detail comes
     from the ambient ``inference_detail`` set by the caller (the IR source),
-    falling back to a count when none is set. ``provider`` is the *configured*
-    embedding provider (lmstudio vs sentence_transformer).
+    falling back to a count when none is set. ``provider`` records the backend
+    that actually produced the vectors (including local fallback).
     """
     import time as _time
     import uuid as _uuid
@@ -281,30 +282,43 @@ def _encode_bulk_direct(
     from work_buddy.inference.call_context import bind_call_id, current_detail
 
     model_key = "leaf-mt" if kind == "label" else "leaf-ir"
-    try:
-        from work_buddy.config import load_config
-        _mcfg = (
-            load_config().get("embedding", {}).get("models", {}).get(model_key, {})
-            or {}
-        )
-        provider = (_mcfg.get("provider") or "sentence_transformer").lower()
-    except Exception:
-        provider = "sentence_transformer"
+    routes: list[Any] = []
+    provider = "local"
 
     cid = _uuid.uuid4().hex[:12]
     status = "ok"
     t0 = _time.monotonic()
     try:
         with bind_call_id(cid):
-            return _encode_bulk_direct_impl(texts, batch_size=batch_size, kind=kind)
-    except Exception:
+            return _encode_bulk_direct_impl(
+                texts,
+                batch_size=batch_size,
+                kind=kind,
+                _routes=routes,
+                _call_id=cid,
+            )
+    except Exception as exc:
         status = "error"
+        route = getattr(exc, "route", None)
+        if route is not None:
+            routes.append(route)
         raise
     finally:
         try:
             from work_buddy.llm.provenance import record_inference_call
+            if routes:
+                actual = {route.provider for route in routes if route.provider}
+                if len(actual) == 1:
+                    provider = next(iter(actual))
+                elif actual:
+                    provider = "mixed"
+                else:
+                    provider = routes[-1].requested_provider
             n = len(texts)
             detail = current_detail() or f"{n} document{'s' if n != 1 else ''}"
+            reasons = sorted({route.reason for route in routes})
+            if reasons:
+                detail = f"{detail}; route={','.join(reasons)}"
             record_inference_call(
                 kind="embedding",
                 model=model_key,
@@ -325,14 +339,19 @@ def _encode_bulk_direct_impl(
     texts: list[str],
     batch_size: int = 32,
     kind: str = "passage",
+    *,
+    _routes: list[Any] | None = None,
+    _call_id: str | None = None,
 ) -> np.ndarray:
-    """Encode documents in-process (no HTTP to our own embedding service).
+    """Encode documents through the embedding component's routing authority.
 
-    Dispatches on the model's configured provider:
+    In the embedding service process, use its singleton
+    :class:`work_buddy.index.encode.ProviderRouter` directly. External callers
+    cross the service's ``/embed`` boundary, so a dashboard-activated policy,
+    breaker cooldown, and route telemetry cannot diverge across processes.
 
-    * ``provider: sentence_transformer`` (default) — in-process encode
-      via the ``SentenceTransformer`` loaded in the embedding service
-      registry (or a freshly-loaded one for CLI usage).
+    * ``provider: local`` / ``sentence_transformer`` (default): encode via the
+      ``SentenceTransformer`` loaded in the embedding service registry.
     * ``provider: lmstudio`` — POST to LM Studio's ``/v1/embeddings``
       endpoint. See ``docs/handbook/features_lmstudio-offload-setup.md``
       for the full setup procedure (GGUF audit, drift test, config).
@@ -341,8 +360,9 @@ def _encode_bulk_direct_impl(
           sentence_transformer path. The cosine drift between Q8 GGUF
           and fp32 sentence-transformers is ~0.0002 in practice, so
           mixed-provenance vectors cluster correctly for retrieval.
-        - ``on_error: fail`` — re-raises. Useful for research workflows
-          that need single-provenance vectors.
+        - ``on_error: fail`` raises ``ProviderRoutingError`` without
+          touching the local model. Useful for workflows that require
+          remote-only execution and single-provenance vectors.
 
     ``kind="passage"`` uses ``leaf-ir`` (asymmetric document encoder),
     ``kind="label"`` uses ``leaf-mt`` (symmetric).
@@ -353,99 +373,92 @@ def _encode_bulk_direct_impl(
     # leaf-mt encodes without a prompt; leaf-ir uses the "document" prompt.
     prompt = None if kind == "label" else "document"
 
-    # Load per-model config once so both provider dispatch and the
-    # local fallback path read from the same source of truth.
-    from work_buddy.config import load_config
-    cfg = load_config()
-    model_cfg = (
-        cfg.get("embedding", {}).get("models", {}).get(model_key, {}) or {}
+    # One router lives for the full batch so its remote failure cooldown
+    # prevents every subsequent chunk from retrying a known-bad endpoint.
+    from work_buddy.index.encode import (
+        ProviderRoutingError,
+        RouteInfo,
     )
-    provider = (model_cfg.get("provider") or "sentence_transformer").lower()
-
-    # Route to the LM Studio provider when opted in. Fallback logic is
-    # deliberately shallow: try once, on error either fail loudly or
-    # quietly drop to the local path. We do not silently retry LM
-    # Studio — a flaky link should surface as a provider error once,
-    # not hundreds of times across a 7k-row encode loop.
-    if provider == "lmstudio":
-        on_error = (model_cfg.get("on_error") or "fallback").lower()
-        lmstudio_model_id = model_cfg.get("lmstudio_model")
-        if not lmstudio_model_id:
-            msg = (
-                f"embedding.models.{model_key}.provider is 'lmstudio' "
-                "but lmstudio_model is not set. Refusing to proceed "
-                "with an unknown model id."
-            )
-            if on_error == "fail":
-                raise ValueError(msg)
-            logger.warning("%s — falling back to sentence_transformer", msg)
-        else:
-            try:
-                from work_buddy.embedding.providers.lmstudio import (
-                    encode as lmstudio_encode,
-                    resolve_base_url,
-                )
-                base_url = resolve_base_url(cfg)
-                logger.info(
-                    "Bulk-encoding %d texts via LM Studio "
-                    "(model_key=%s, lmstudio_model=%s, base_url=%s)",
-                    len(texts), model_key, lmstudio_model_id, base_url,
-                )
-                # LM Studio handles batching natively on the server;
-                # batch_size here bounds the HTTP payload size.
-                vecs = lmstudio_encode(
-                    texts,
-                    model_id=lmstudio_model_id,
-                    base_url=base_url,
-                    batch_size=batch_size,
-                )
-                print(
-                    f"  Encoded {len(texts)}/{len(texts)} documents "
-                    f"(via LM Studio).", file=sys.stderr,
-                )
-                return vecs
-            except Exception as exc:
-                if on_error == "fail":
-                    # Re-raise as-is to preserve the error_kind on
-                    # LocalInferenceError so callers can classify.
-                    raise
-                logger.warning(
-                    "LM Studio bulk encode failed (%s: %s) — falling "
-                    "back to local sentence_transformer for kind=%s",
-                    type(exc).__name__, exc, kind,
-                )
-                # fall through to the local path
-
-    # Local (sentence_transformers) path — the default, and the
-    # fallback when LM Studio is misconfigured or unreachable.
-    if _IN_SERVICE:
-        from work_buddy.embedding.service import _get_model
-        model = _get_model(model_key)  # may trigger lazy load on first call
-        logger.info("Using in-service %s model for bulk encoding (kind=%s)",
-                    model_key, kind)
-    else:
-        default_hf = "MongoDB/mdbr-leaf-mt" if kind == "label" else "MongoDB/mdbr-leaf-ir-asym"
-        model_name = model_cfg.get("name", default_hf)
-        from sentence_transformers import SentenceTransformer
-        logger.info("Loading %s for bulk encoding (kind=%s)...", model_name, kind)
-        model = SentenceTransformer(model_name)
-
     from work_buddy.inference import Priority
-    from work_buddy.inference.local_slot import local_embed_slot
 
-    all_vecs = []
+    if _IN_SERVICE:
+        # Share the service singleton: Settings activation, breaker cooldown,
+        # and health observability must all describe this exact policy object.
+        from work_buddy.embedding.service import _get_provider_router
+
+        router = _get_provider_router()
+    else:
+        # External callers must cross the same /embed policy boundary as every
+        # scheduled index client. Reading YAML and routing here would ignore a
+        # restart-gated dashboard override and hide the call from service health.
+        router = None
+
+    all_vecs: list[np.ndarray] = []
     total = len(texts)
     for i in range(0, total, batch_size):
         batch = texts[i : i + batch_size]
-        encode_kwargs = {"batch_size": batch_size, "show_progress_bar": False}
-        if prompt is not None:
-            encode_kwargs["prompt_name"] = prompt
-        # Per-batch BACKGROUND admission: the build holds the shared GPU slot only
-        # for one batch, so an INTERACTIVE query is admitted *between* batches
-        # rather than waiting out the whole rebuild.
-        with local_embed_slot(Priority.BACKGROUND):
-            vecs = model.encode(batch, **encode_kwargs)
-        all_vecs.append(vecs)
+        if router is not None:
+            routed = router.encode_with_route(
+                batch,
+                model_id=model_key,
+                prompt_name=prompt,
+                priority=Priority.BACKGROUND,
+                batch_size=batch_size,
+            )
+        else:
+            from work_buddy.embedding.client import embed_with_route
+
+            response = embed_with_route(
+                batch,
+                model=model_key,
+                prompt_name=prompt,
+                timeout_s=max(120, len(batch) * 2),
+                routing_role="document",
+                # _encode_bulk_direct writes one aggregate record spanning all
+                # chunks, with the actual route(s), after this loop completes.
+                record_provenance=False,
+                call_id=_call_id,
+            )
+            if response is None:
+                raise RuntimeError("Embedding service is unavailable")
+            route_payload = response.get("route")
+            route = (
+                RouteInfo.from_dict(route_payload, default_model=model_key)
+                if isinstance(route_payload, dict)
+                else RouteInfo(
+                    model=model_key,
+                    requested_provider="embedding-service",
+                    provider=None,
+                    provider_model=None,
+                    on_error="unknown",
+                    status="ok",
+                    fallback=False,
+                    reason="service_route_unreported",
+                    at=time.time(),
+                )
+            )
+            if response.get("vectors") is None:
+                if isinstance(route_payload, dict):
+                    raise ProviderRoutingError(
+                        str(response.get("error") or "Embedding provider unavailable"),
+                        code=str(
+                            response.get("code") or "embedding_provider_unavailable"
+                        ),
+                        route=route,
+                    )
+                raise RuntimeError(
+                    str(response.get("error") or "Embedding service returned no vectors")
+                )
+            from work_buddy.index.encode import RoutedEmbedding
+
+            routed = RoutedEmbedding(response["vectors"], route)
+        if _routes is not None:
+            _routes.append(routed.route)
+        if routed.vectors is None:
+            raise RuntimeError(
+                f"Embedding provider produced no vectors for model {model_key!r}"
+            )
+        all_vecs.append(np.asarray(routed.vectors, dtype=np.float32))
         done = min(i + batch_size, total)
         print(f"\r  Encoded {done}/{total} documents...", end="", file=sys.stderr)
 

--- a/work_buddy/mcp_server/ops/index_ops.py
+++ b/work_buddy/mcp_server/ops/index_ops.py
@@ -17,7 +17,12 @@ import json
 from work_buddy.mcp_server.op_registry import register_op
 
 
-def _index_rebuild_dispatch(partition: str | None = None, force: bool = False) -> str:
+def _index_rebuild_dispatch(
+    partition: str | None = None,
+    force: bool = False,
+    max_items: int | None = None,
+    max_vector_batches: int | None = None,
+) -> str:
     """Incrementally (re)build the consolidated index — flag-gated.
 
     Returns ``{"skipped": ...}`` while ``index.enabled`` is false, or
@@ -26,7 +31,28 @@ def _index_rebuild_dispatch(partition: str | None = None, force: bool = False) -
     (e.g. ``"knowledge"``) into the
     separate ``db/index-consolidated``, or all partitions when omitted. ``force=True`` rebuilds
     from scratch; the default is incremental (content-hash diff — cheap when nothing changed).
+    Scheduled heavy partitions may pass positive ``max_items`` and
+    ``max_vector_batches`` budgets. Each partial run commits durable lexical/vector
+    progress and reports its remaining backlog instead of monopolizing the serial
+    scheduler. Budgets require a named partition; ``max_items`` is incompatible with
+    ``force`` because a forced slice has no stable resume cursor.
     """
+    if partition is not None and not isinstance(partition, str):
+        raise ValueError("partition must be a string when provided")
+    partition = partition.strip() if isinstance(partition, str) else None
+    partition = partition or None
+    for label, value in (
+        ("max_items", max_items),
+        ("max_vector_batches", max_vector_batches),
+    ):
+        if value is not None and (
+            isinstance(value, bool) or not isinstance(value, int) or value <= 0
+        ):
+            raise ValueError(f"{label} must be a positive integer")
+    if partition is None and (max_items is not None or max_vector_batches is not None):
+        raise ValueError("build budgets require a named partition")
+    if force and (max_items is not None or max_vector_batches is not None):
+        raise ValueError("work budgets cannot be combined with force=True")
     from work_buddy.index.config import load_index_config
 
     cfg = load_index_config()
@@ -55,7 +81,16 @@ def _index_rebuild_dispatch(partition: str | None = None, force: bool = False) -
     from work_buddy.index.partitioned import UnifiedIndex
 
     ui = UnifiedIndex(config=cfg)
-    result = ui.build(partition, force=force) if partition else ui.build_all(force=force)
+    result = (
+        ui.build(
+            partition,
+            force=force,
+            max_items=max_items,
+            max_vector_batches=max_vector_batches,
+        )
+        if partition
+        else ui.build_all(force=force)
+    )
     return json.dumps({"result": result}, default=str)
 
 

--- a/work_buddy/settings/__init__.py
+++ b/work_buddy/settings/__init__.py
@@ -2,6 +2,7 @@
 
 from work_buddy.settings.broker import (
     SettingsError,
+    get_embedding_document_execution_mode,
     get_journal_day_binding,
     get_journal_day_boundary,
     get_journal_day_window,
@@ -16,6 +17,7 @@ from work_buddy.settings.broker import (
 
 __all__ = [
     "SettingsError",
+    "get_embedding_document_execution_mode",
     "get_journal_day_binding",
     "get_journal_day_boundary",
     "get_journal_day_window",

--- a/work_buddy/settings/broker.py
+++ b/work_buddy/settings/broker.py
@@ -114,6 +114,22 @@ def _configured_default(setting_id: str) -> Any:
     if setting_id == registry.JOURNAL_SMART_PROCESSING_ID:
         smart = (wb_config.load_config().get("journal") or {}).get("smart_processing") or {}
         return "enabled" if isinstance(smart, dict) and smart.get("enabled") is True else "disabled"
+    if setting_id == registry.EMBEDDING_DOCUMENT_EXECUTION_ID:
+        model = (
+            ((wb_config.load_config().get("embedding") or {}).get("models") or {})
+            .get("leaf-ir", {})
+        )
+        if not isinstance(model, dict):
+            return registry.EMBEDDING_EXECUTION_LOCAL
+        provider = str(model.get("provider") or "local").strip().lower()
+        if provider != "lmstudio":
+            return registry.EMBEDDING_EXECUTION_LOCAL
+        on_error = str(model.get("on_error") or "fallback").strip().lower()
+        return (
+            registry.EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO
+            if on_error == "fail"
+            else registry.EMBEDDING_EXECUTION_PREFER_LMSTUDIO
+        )
     if setting_id in {registry.DASHBOARD_ASSISTANCE_ID, registry.DASHBOARD_ASSISTANCE_TIER_ID}:
         assistance = (wb_config.load_config().get("dashboard") or {}).get("assistance") or {}
         if not isinstance(assistance, dict):
@@ -160,7 +176,11 @@ def _definition_value_version(setting_id: str) -> int:
 def _bootstrap_source(setting_id: str) -> str:
     return (
         "config-bootstrap"
-        if setting_id in {registry.JOURNAL_DAY_BOUNDARY_ID, registry.DASHBOARD_CHAT_EXECUTION_DEFAULT_ID}
+        if setting_id in {
+            registry.JOURNAL_DAY_BOUNDARY_ID,
+            registry.DASHBOARD_CHAT_EXECUTION_DEFAULT_ID,
+            registry.EMBEDDING_DOCUMENT_EXECUTION_ID,
+        }
         else "registry-default"
     )
 
@@ -559,6 +579,12 @@ def _record_from_row(row, observed_at: datetime) -> dict[str, Any]:
     configured_value = pending_value if has_pending else effective_value
     configured_source = row["pending_source"] if has_pending else effective_source
 
+    apply_behavior = _apply_behavior(row["setting_id"])
+    apply_status = (
+        "restart-required"
+        if has_pending and apply_behavior == "restart-component"
+        else "pending" if has_pending else "effective"
+    )
     record = {
         "setting_id": row["setting_id"],
         "value_version": int(row["value_version"]),
@@ -572,7 +598,7 @@ def _record_from_row(row, observed_at: datetime) -> dict[str, Any]:
         "is_modified": configured_source == "profile",
         "revision": f"value:{row['revision']}",
         "pending_value": pending_value if has_pending else None,
-        "apply_status": "pending" if has_pending else "effective",
+        "apply_status": apply_status,
     }
     if row["setting_id"] != registry.JOURNAL_DAY_BOUNDARY_ID:
         record.update(
@@ -1168,6 +1194,146 @@ def _write_immediate(
     return record, _change_event(record, reason)
 
 
+def _write_restart_pending(
+    *,
+    setting_id: str,
+    target_value: Any,
+    target_source: str,
+    expected_revision: str | None,
+    observed_at: datetime,
+    read_only: bool,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    """Persist a desired value without claiming the running component uses it."""
+    if read_only:
+        raise SettingsError(
+            "read_only",
+            "Dashboard settings are read-only.",
+            status_code=403,
+        )
+
+    conn = store.get_connection()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        row = _ensure_row(conn, setting_id, observed_at)
+        current = _record_from_row(row, observed_at)
+        _assert_revision(expected_revision, current)
+
+        # Selecting the running value cancels an outstanding restart request. A
+        # reset must still clear an active profile override, even when its value
+        # happens to equal the frozen default.
+        already_effective = target_value == current["effective_value"] and (
+            target_source == "profile" or current["source"] == "default"
+        )
+        if already_effective:
+            if current["pending_value"] is None:
+                conn.commit()
+                return current, None
+            conn.execute(
+                """
+                UPDATE setting_value_state
+                SET pending_value_json = NULL, pending_source = NULL,
+                    pending_timezone = NULL, effective_at = NULL,
+                    revision = revision + 1, updated_at = ?
+                WHERE setting_id = ? AND scope = 'profile' AND scope_id = ?
+                """,
+                (
+                    _now_iso(observed_at),
+                    setting_id,
+                    registry.PROFILE_SCOPE_ID,
+                ),
+            )
+            row = _ensure_row(conn, setting_id, observed_at)
+            record = _record_from_row(row, observed_at)
+            conn.commit()
+            return record, _change_event(record, "restart-value-cancelled")
+
+        pending_json = json.dumps(target_value) if target_source == "profile" else None
+        if (
+            current["pending_value"] == target_value
+            and current["configured_source"] == target_source
+        ):
+            conn.commit()
+            return current, None
+        conn.execute(
+            """
+            UPDATE setting_value_state
+            SET pending_value_json = ?, pending_source = ?,
+                pending_timezone = NULL, effective_at = NULL,
+                revision = revision + 1, updated_at = ?
+            WHERE setting_id = ? AND scope = 'profile' AND scope_id = ?
+            """,
+            (
+                pending_json,
+                target_source,
+                _now_iso(observed_at),
+                setting_id,
+                registry.PROFILE_SCOPE_ID,
+            ),
+        )
+        row = _ensure_row(conn, setting_id, observed_at)
+        record = _record_from_row(row, observed_at)
+        conn.commit()
+    finally:
+        conn.close()
+    return record, _change_event(record, "restart-value-saved")
+
+
+def activate_restart_component_value(
+    setting_id: str,
+    *,
+    observed_at: datetime | None = None,
+) -> tuple[Any, dict[str, Any], dict[str, Any] | None]:
+    """Apply one restart-gated value while the owning component is starting."""
+    if _apply_behavior(setting_id) != "restart-component":
+        raise SettingsError(
+            "invalid_apply_behavior",
+            f"Setting {setting_id} is not owned by a restarting component.",
+            status_code=400,
+        )
+    now = _observed_at(observed_at)
+    conn = store.get_connection()
+    event: dict[str, Any] | None = None
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        row = _ensure_row(conn, setting_id, now)
+        current = _record_from_row(row, now)
+        if row["pending_source"] is not None:
+            active_json = (
+                row["pending_value_json"]
+                if row["pending_source"] == "profile"
+                else None
+            )
+            conn.execute(
+                """
+                UPDATE setting_value_state
+                SET active_value_json = ?,
+                    pending_value_json = NULL, pending_source = NULL,
+                    pending_timezone = NULL, effective_at = NULL,
+                    applied_from_value_json = ?, applied_at = ?,
+                    revision = revision + 1, updated_at = ?
+                WHERE setting_id = ? AND scope = 'profile' AND scope_id = ?
+                """,
+                (
+                    active_json,
+                    json.dumps(current["effective_value"]),
+                    _now_iso(now),
+                    _now_iso(now),
+                    setting_id,
+                    registry.PROFILE_SCOPE_ID,
+                ),
+            )
+            row = _ensure_row(conn, setting_id, now)
+            record = _record_from_row(row, now)
+            event = _change_event(record, "restart-value-applied")
+        else:
+            record = current
+        conn.commit()
+    finally:
+        conn.close()
+    publish_change(event)
+    return record["effective_value"], record, event
+
+
 def update_value(
     setting_id: str,
     *,
@@ -1197,6 +1363,15 @@ def update_value(
         )
     if apply_behavior == "next-boundary":
         return _write_pending(
+            setting_id=setting_id,
+            target_value=value,
+            target_source="profile",
+            expected_revision=expected_revision,
+            observed_at=_observed_at(observed_at),
+            read_only=read_only,
+        )
+    if apply_behavior == "restart-component":
+        return _write_restart_pending(
             setting_id=setting_id,
             target_value=value,
             target_source="profile",
@@ -1278,6 +1453,30 @@ def preview_value(
                     else "immediate"
                 ),
                 "impact_preview": None,
+            },
+            "diagnostics": [],
+        }
+    if apply_behavior == "restart-component":
+        return {
+            "schema_version": registry.SCHEMA_VERSION,
+            "registry_revision": registry.REGISTRY_REVISION,
+            "timezone": _timezone_name(),
+            "configured_timezone": _timezone_name(),
+            "value_revision": record["revision"],
+            "preview": {
+                "setting_id": setting_id,
+                "scope": record["scope"],
+                "value": value,
+                "effective_at": None,
+                "apply_status": (
+                    "effective"
+                    if value == record["effective_value"]
+                    else "restart-required"
+                ),
+                "impact_preview": {
+                    "component": "embedding",
+                    "message": "The running embedding service keeps its current route until restart.",
+                },
             },
             "diagnostics": [],
         }
@@ -1376,6 +1575,15 @@ def reset_value(
             observed_at=now,
             read_only=read_only,
         )
+    if apply_behavior == "restart-component":
+        return _write_restart_pending(
+            setting_id=setting_id,
+            target_value=default,
+            target_source="default",
+            expected_revision=current["revision"],
+            observed_at=now,
+            read_only=read_only,
+        )
     if apply_behavior != "next-boundary":
         raise SettingsError(
             "unsupported_apply_behavior",
@@ -1409,6 +1617,26 @@ def reset_value(
         observed_at=now,
         read_only=read_only,
     )
+
+
+def get_embedding_document_execution_mode(
+    *,
+    activate_pending: bool = False,
+    observed_at: datetime | None = None,
+) -> tuple[str, dict[str, Any], dict[str, Any] | None]:
+    """Return the active document route, optionally applying a saved restart request."""
+    if activate_pending:
+        value, record, event = activate_restart_component_value(
+            registry.EMBEDDING_DOCUMENT_EXECUTION_ID,
+            observed_at=observed_at,
+        )
+    else:
+        record, event = _read_value(
+            registry.EMBEDDING_DOCUMENT_EXECUTION_ID,
+            _observed_at(observed_at),
+        )
+        value = record["effective_value"]
+    return str(value), record, event
 
 
 def get_journal_day_boundary(

--- a/work_buddy/settings/registry.py
+++ b/work_buddy/settings/registry.py
@@ -14,7 +14,7 @@ from work_buddy.journal_day import DEFAULT_DAY_BOUNDARY, parse_local_time
 
 
 SCHEMA_VERSION = 1
-REGISTRY_REVISION = "settings-registry:7"
+REGISTRY_REVISION = "settings-registry:8"
 JOURNAL_DAY_BOUNDARY_ID = "wb.journal.day-boundary"
 JOURNAL_SMART_PROCESSING_ID = "wb.journal.smart-processing"
 JOURNAL_SMART_EXECUTION_ID = "wb.journal.smart-execution"
@@ -25,6 +25,11 @@ DASHBOARD_ASSISTANCE_TIER_ID = "wb.dashboard.assistance-tier"
 DASHBOARD_CHAT_EXECUTION_DEFAULT_ID = "wb.dashboard.chat-execution-default"
 DASHBOARD_AI_CONTEXT_ID = "wb.settings.system.dashboard-ai"
 COWORK_REVIEW_NAV_BINDING_ID = "wb.cowork.review.nav-binding"
+EMBEDDING_DOCUMENT_EXECUTION_ID = "wb.embedding.document-execution"
+EMBEDDING_SETTINGS_CONTEXT_ID = "wb.settings.system.embeddings"
+EMBEDDING_EXECUTION_LOCAL = "local"
+EMBEDDING_EXECUTION_PREFER_LMSTUDIO = "prefer-lmstudio"
+EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO = "require-lmstudio"
 PROFILE_SCOPE_ID = "default"
 
 COWORK_REVIEW_SHORTCUT_DEFAULTS = {
@@ -110,6 +115,78 @@ _ADDITIONAL_DEFINITIONS: tuple[dict[str, Any], ...] = (
             "note": "Sets the initial provider/model for new, unbound dashboard chats only.",
         }],
         "presentation": {"control": "execution-profile", "apply_behavior": "immediate"},
+        "visibility": "frontend",
+        "sensitivity": "ordinary",
+    },
+    {
+        "setting_id": EMBEDDING_DOCUMENT_EXECUTION_ID,
+        "definition_version": 1,
+        "value_version": 1,
+        "owner": {"kind": "system", "id": "wb.embedding", "label": "Embeddings"},
+        "provenance": {
+            "complement_id": "wb.embedding",
+            "label": "Embedding service",
+            "trust_tier": "native",
+        },
+        "title": "Document embedding execution",
+        "short_description": (
+            "Choose where the large passage encoder runs for document similarity and indexing."
+        ),
+        "long_description": (
+            "Interactive query encoders remain local. Requiring LM Studio keeps the large "
+            "document encoder off this computer. When the remote model is unavailable, "
+            "document and passage embedding workloads either pause or continue through "
+            "their non-dense fallback. The saved choice takes effect when the embedding "
+            "service next starts."
+        ),
+        "keywords": [
+            "embedding", "document", "indexing", "LM Studio", "LM Link", "remote",
+            "local", "memory", "RAM", "leaf-ir",
+        ],
+        "tags": ["embedding", "inference", "memory"],
+        "value_schema": {
+            "type": "string",
+            "enum": [
+                EMBEDDING_EXECUTION_LOCAL,
+                EMBEDDING_EXECUTION_PREFER_LMSTUDIO,
+                EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO,
+            ],
+        },
+        "default_value": EMBEDDING_EXECUTION_LOCAL,
+        "allowed_scopes": ["profile"],
+        "default_scope": "profile",
+        "applies_to": [
+            {"kind": "system", "id": "wb.embedding", "label": "Embeddings"}
+        ],
+        "affects": [{
+            "ref": {"kind": "system", "id": "wb.embedding", "label": "Embedding service"},
+            "note": "Controls document and passage embedding; query-side models stay local.",
+        }],
+        "presentation": {
+            "control": "select",
+            "apply_behavior": "restart-component",
+            "options": [
+                {
+                    "value": EMBEDDING_EXECUTION_LOCAL,
+                    "label": "Local only",
+                    "description": "Always run document encoding in Work Buddy on this computer.",
+                },
+                {
+                    "value": EMBEDDING_EXECUTION_PREFER_LMSTUDIO,
+                    "label": "Prefer LM Studio",
+                    "description": (
+                        "Use LM Studio when available and deliberately fall back to the local model."
+                    ),
+                },
+                {
+                    "value": EMBEDDING_EXECUTION_REQUIRE_LMSTUDIO,
+                    "label": "Require LM Studio",
+                    "description": (
+                        "Never load the document encoder locally; document features pause or use their non-dense fallback when LM Studio is unavailable."
+                    ),
+                },
+            ],
+        },
         "visibility": "frontend",
         "sensitivity": "ordinary",
     },
@@ -338,6 +415,23 @@ _DEFINITIONS += _ADDITIONAL_DEFINITIONS
 
 _PAGES: tuple[dict[str, Any], ...] = (
     {
+        "page_id": EMBEDDING_SETTINGS_CONTEXT_ID,
+        "context_id": EMBEDDING_SETTINGS_CONTEXT_ID,
+        "context": {"kind": "system", "id": "wb.embedding", "label": "Embeddings"},
+        "owner": {"kind": "system", "id": "wb.embedding", "label": "Embeddings"},
+        "route": "/app/settings/system/embeddings",
+        "label": "Embeddings",
+        "description": "Control document-encoding placement and inspect the active route.",
+        "navigation_group": "system",
+        "order": 20,
+        "sections": [{
+            "section_id": "execution",
+            "label": "Execution",
+            "description": "Balance local memory use against document-feature availability.",
+            "order": 10,
+        }],
+    },
+    {
         "page_id": DASHBOARD_AI_CONTEXT_ID, "context_id": DASHBOARD_AI_CONTEXT_ID,
         "context": {"kind": "system", "id": "wb.dashboard", "label": "Dashboard AI"},
         "owner": {"kind": "system", "id": "wb.dashboard", "label": "Dashboard AI"},
@@ -390,6 +484,14 @@ _PAGES: tuple[dict[str, Any], ...] = (
 
 
 _PLACEMENTS: tuple[dict[str, Any], ...] = (
+    {
+        "placement_id": "wb.settings.placement.system.embeddings.document-execution",
+        "setting_id": EMBEDDING_DOCUMENT_EXECUTION_ID,
+        "page_id": EMBEDDING_SETTINGS_CONTEXT_ID,
+        "context_id": EMBEDDING_SETTINGS_CONTEXT_ID,
+        "section_id": "execution",
+        "order": 10,
+    },
     *tuple({
         "placement_id": f"wb.settings.placement.system.dashboard-ai.{suffix}",
         "setting_id": setting_id, "page_id": DASHBOARD_AI_CONTEXT_ID,
@@ -444,6 +546,7 @@ def _validate_native_registry() -> None:
         if definition["presentation"]["apply_behavior"] not in {
             "immediate",
             "next-boundary",
+            "restart-component",
         }:
             raise RuntimeError(
                 f"unsupported apply behavior for {definition['setting_id']}"

--- a/work_buddy/sidecar/daemon.py
+++ b/work_buddy/sidecar/daemon.py
@@ -332,9 +332,16 @@ def _print_startup_banner(
     if dashboard is None:
         return
 
+    # Windows login tasks launch the daemon through pythonw.exe, where the
+    # standard streams are None.  The banner is a convenience for interactive
+    # terminals; it must never make the windowless production entry point exit.
+    stream = sys.stdout
+    if stream is None:
+        return
+
     local_url = f"http://localhost:{dashboard.port}"
     remote_url = (cfg.get("dashboard", {}).get("external_url") or "").rstrip("/")
-    use_color = _supports_color(sys.stdout)
+    use_color = _supports_color(stream)
 
     if use_color:
         BOLD = "\x1b[1m"
@@ -351,15 +358,15 @@ def _print_startup_banner(
     # Two-column-aligned, with ``Local``/``Remote`` labels when both are
     # present — labels collapse to "Dashboard:" when only the local URL
     # exists, since the distinction would be redundant.
-    print()
-    print(f"    {BOLD}Work Buddy sidecar is running{RESET}")
+    print(file=stream)
+    print(f"    {BOLD}Work Buddy sidecar is running{RESET}", file=stream)
     if remote_url:
-        print(f"    {DIM}Local: {RESET}  {fmt_link(local_url)}")
-        print(f"    {DIM}Remote:{RESET}  {fmt_link(remote_url)}")
+        print(f"    {DIM}Local: {RESET}  {fmt_link(local_url)}", file=stream)
+        print(f"    {DIM}Remote:{RESET}  {fmt_link(remote_url)}", file=stream)
     else:
-        print(f"    {DIM}Dashboard:{RESET}  {fmt_link(local_url)}")
-    print()
-    sys.stdout.flush()
+        print(f"    {DIM}Dashboard:{RESET}  {fmt_link(local_url)}", file=stream)
+    print(file=stream)
+    stream.flush()
 
 
 # ---------------------------------------------------------------------------

--- a/work_buddy/sidecar/scheduler/engine.py
+++ b/work_buddy/sidecar/scheduler/engine.py
@@ -71,6 +71,30 @@ def _summarize_job_result(status: str, detail: Any) -> str:
             return f"{status} — {s[:80]}…"
         return f"{status} — {s}"
 
+    # Capability dispatch wraps the operation payload as {"result": ...}.
+    # Unwrap a single structured result so bounded index progress is not reduced
+    # to the uninformative fallback string "ok".
+    nested_result = detail.get("result")
+    if isinstance(nested_result, dict):
+        detail = nested_result
+
+    # --- Consolidated-index bounded build ---
+    remaining = detail.get("remaining")
+    if "complete" in detail and isinstance(remaining, dict):
+        remaining_items = int(remaining.get("items", 0) or 0)
+        vectors_by_projection = remaining.get("vectors", {})
+        remaining_vectors = (
+            sum(int(value or 0) for value in vectors_by_projection.values())
+            if isinstance(vectors_by_projection, dict)
+            else 0
+        )
+        partition = str(detail.get("partition") or "index")
+        completion = "complete" if detail.get("complete") else "partial"
+        return (
+            f"{status}: {partition} {completion}; "
+            f"{remaining_items} items, {remaining_vectors} vectors remaining"
+        )
+
     # --- Heartbeat / sidecar_status: summarize services ---
     services = detail.get("services")
     if isinstance(services, dict):

--- a/work_buddy/tasks/documents.py
+++ b/work_buddy/tasks/documents.py
@@ -20,7 +20,9 @@ from work_buddy.document_kernel.causality import (
     DomainDocumentBinding,
 )
 from work_buddy.document_kernel.client import DocumentKernelClient
+from work_buddy.document_kernel.projection import project_document
 from work_buddy.document_kernel.protocol import sha256_bytes, structured_head_sha256
+from work_buddy.document_kernel.runtime_service import shared_document_kernel
 from work_buddy.paths import resolve
 from work_buddy.truth import documents, ydoc_store
 from work_buddy.truth.contracts import Actor, InvariantViolation
@@ -49,28 +51,7 @@ def project_live_markdown(
 ) -> str:
     """Project the current Y.Doc snapshot plus every un-compacted update."""
 
-    document = documents.get_document(store, document_id)
-    if document.ydoc_snapshot_sha256 is None:
-        raise RuntimeError("task_document_snapshot_unavailable")
-    snapshot = ydoc_store.read_snapshot(
-        store,
-        snapshot_sha256=document.ydoc_snapshot_sha256,
-    )
-    updates, _cursor = ydoc_store.read_updates(store, document_id=document.id)
-    head = structured_head_sha256(snapshot, updates)
-    client = kernel or DocumentKernelClient()
-    projected = client.request(
-        {
-            "kind": "project_markdown",
-            "snapshotBase64": snapshot,
-            "updatesBase64": updates,
-            "expectedBaseStructuredHeadSha256": head,
-        },
-        request_id=f"task_read_{hashlib.sha256(f'{document.id}:{head}'.encode()).hexdigest()[:24]}",
-    )
-    if projected.projection is None:
-        raise RuntimeError("document_kernel_missing_projection")
-    return projected.projection.decode("utf-8")
+    return project_document(store, document_id, kernel=kernel).markdown
 
 
 @dataclass(frozen=True, slots=True)
@@ -241,7 +222,7 @@ class TaskDocumentService:
         kernel: DocumentKernelClient | None = None,
         stores: TaskDocumentStoreManager | None = None,
     ) -> None:
-        self.kernel = kernel or DocumentKernelClient()
+        self.kernel = kernel or shared_document_kernel()
         self.stores = stores or TaskDocumentStoreManager()
 
     @staticmethod

--- a/work_buddy/tools.py
+++ b/work_buddy/tools.py
@@ -705,8 +705,9 @@ def _probe_lmstudio() -> bool:
     import http.client
     import socket
     from urllib.parse import urlparse
-    from work_buddy.embedding.providers.lmstudio import resolve_base_url
+
     from work_buddy.config import load_config
+    from work_buddy.embedding.providers.lmstudio_config import resolve_base_url
 
     try:
         base_url = resolve_base_url(load_config())

--- a/work_buddy/vault_index/cutover.py
+++ b/work_buddy/vault_index/cutover.py
@@ -58,6 +58,11 @@ def refresh_vault_for_prospective_seal(
     partition = VaultChunkPartition(source=source)
     resident_registry = residents if residents is not None else get_registry()
 
+    # The targeted writer shares the build gate but does not use IndexBuilder, so
+    # it must cross the explicit schema-preparation boundary itself before taking
+    # its normal partition locks.
+    store.prepare_schema(repair_existing=False)
+
     # This is deliberately not an ordinary build.  A full discovery/diff would
     # parse and encode unrelated Vault edits, making a bounded authority operation
     # depend on arbitrary workspace churn.  Classify only already-represented item
@@ -66,13 +71,14 @@ def refresh_vault_for_prospective_seal(
     with index_writer_locks(store.db_path, partition.name):
         item_ids = store.partition_item_ids(partition.name)
         excluded_item_ids = source.authority_excluded_item_ids(item_ids)
+        # Fence cross-process resident readers before the first committed delete.
+        # Empty replays still publish a new generation, preserving the former
+        # bump_version behavior used by crash recovery.
+        store.begin_partition_mutation(partition.name)
         for item_id in excluded_item_ids:
             store.delete_item_docs(item_id, partition=partition.name)
 
-        # Always advance the version, even on an empty replay.  A previous process
-        # may have durably deleted every target and crashed before publishing the
-        # version/cache boundary.
-        store.bump_version(partition.name)
+        store.finish_partition_mutation(partition.name)
         for projection in get_projection_schema(partition):
             resident_registry.invalidate(f"{partition.name}:{projection}")
 


### PR DESCRIPTION
## Overview

This PR implements the RAM and index-reliability recommendations from task `t-0c23d85b235c`:

- Cap OpenBLAS at one worker per Work Buddy process while preserving an explicit operator override. This removes the measured machine-wide native worker reservation from each NumPy process without changing PyTorch OpenMP policy.
- Make the embedding service the authoritative document-provider route. Local only, Prefer LM Studio, and Require LM Studio now behave consistently across consolidated, knowledge, and legacy document-indexing callers.
- Add **System > Embeddings** to the React dashboard with restart-gated policy editing and runtime evidence for the running policy, last actual provider route, fallback, cooldown, endpoint reachability, model advertisement, and local `leaf-ir` residency.
- Change consolidated vector startup warming from all partitions to lazy by default. Cache loads are generation-fenced, single-flight, and able to remember a valid empty result.
- Make conversation catch-up durable and bounded at 25 source items and four vector batches per hourly slice, with honest partial-progress summaries.
- Replace the unindexed per-document FTS delete scan with rowid-aligned external-content FTS5 storage, canonical content columns, synchronization triggers, and a 200,000-row performance regression.
- Reuse one process-scoped document-kernel worker from task, direct-edit, and running-note services. The old production sidecar had accumulated 262 Node workers holding about 16.4 GB of private commit; a 60-instance regression and real canary now produce one worker.

## Cutover boundary

This is a storage and reliability prerequisite. It does **not** perform task `t-c3277a52bf9a` and must not be interpreted as the legacy-search consumer cutover.

- No `index.consumers` gate is enabled.
- Direct `work_buddy.ir.search` consumers remain in place.
- No orphan content is salvaged or deleted.
- The legacy IR package, database, and maintenance jobs remain in place.
- Dashboard status, search, ordinary store opens, and scheduled builders cannot repair an existing legacy-layout database. They report or raise `repair_required` instead.
- Only an explicit operator call to `IndexStore.prepare_schema()` may repair an existing database. It fails closed if the shared writer gate is unavailable and refuses a newer schema.

The original ordering remains in force: perform the safe storage repair, finish the historical dense backfill, prove ghost-adjusted parity, salvage or explicitly disposition legacy-only orphans, rerun ranking A/B, and only then route consumers one at a time and retire legacy last.

## Unmerged live deployment

The final PR commit is running against the production config and `.data` stores for live testing without a merge. The production consolidated database itself has **not** been repaired: it remains 1,526,636,544 bytes, has no compatibility marker or materialized lexical columns, and still declares the legacy `doc_id UNINDEXED` FTS table.

Verified live after a single-daemon restart:

- all five supervised service endpoints report `ok`;
- the dashboard displays **sidecar running / live** at `/app/settings/system/embeddings`;
- the effective and running policy are **Prefer LM Studio**;
- an explicit two-document batch returned two 768-dimensional vectors through `text-embedding-snowflake-arctic-embed-m-v1.5` with `fallback=false`;
- the local document model remains unloaded;
- the PID file, state file, and one running daemon agree;
- the sidecar has 16 threads and no leaked branch document-kernel workers;
- legacy `ir-index-rebuild` completed and the scheduler returned idle; consolidated refreshes against the deliberately unrepaired database fail quickly with `repair_required` instead of mutating it implicitly.

The global `wbuddy` shim and ignored local sidecar interpreter setting are temporarily pinned to the PR worktree so an ordinary CLI restart preserves the live test. The existing Windows `WB-Sidecar` Task Scheduler entry could not be rewritten unelevated, so its private main virtual environment also has a reversible import hook that resolves `work_buddy` and the production roots to this PR. These temporary pins must be removed after main is updated.

A power-loss/reboot test exposed a pre-existing Windows autostart bug: the task uses `pythonw.exe`, where `sys.stdout` is `None`, but the daemon printed an interactive startup banner after service initialization. The task loaded the correct branch and then exited with code 1 at the banner. Commit `c1c0daa31fa1093b0351852aabae48452cea8015` makes that banner a no-op in a windowless process and adds regression coverage. Re-running the actual `WB-Sidecar` task now stays running, advances supervisor ticks, reaches 5/5 healthy, and routes a real document batch through LM Studio without local fallback.

## Live RAM comparison

These are point-in-time measurements from one person's 16 GB Windows laptop and its production workload. They demonstrate the observed effect in this environment; they are not universal hardware benchmarks or guaranteed savings on another machine.

| Metric | Old production stack | Fresh PR autostart | After scheduled index work |
|---|---:|---:|---:|
| Work Buddy private commit | ~21,369 MB | 1,420.4 MB | 2,404.5 MB |
| Working set | Not captured comparably | 1,362.0 MB | 399.2 MB |
| Document-kernel workers | 262 | 0 | 0 |
| Worker private commit alone | ~16,408 MB | 0 MB | 0 MB |
| Sidecar threads | 282 | 16 | 17 |

“Private commit” is process-private committed capacity backed by RAM or the pagefile, not necessarily physical RAM resident at that moment. “Working set” is the portion physically resident when measured. The post-index increase reflects retained allocator/cache high-water capacity; Windows had trimmed most of those pages from physical memory by the final capture.
## Storage-repair rollout

The rowid-aligned FTS repair is forward-only for old binaries. Roll it out as a stop-the-world maintenance operation:

1. Keep every consolidated consumer gate off and keep the private `index-conversation-refresh` override disabled.
2. Stop every process that can open `index-consolidated.db`.
3. Checkpoint WAL and take a coherent backup. Keep at least 1.2 GB of temporary free-space headroom beyond normal database growth.
4. Deploy this commit to every participating process before reopening the database.
5. Run the explicit schema preparation exactly once. The shared advisory writer gate plus `BEGIN IMMEDIATE` elect one repairer; fresh initialization and legacy repair are atomic and crash-recoverable.
6. Verify the machine-readable compatibility marker, all three synchronization triggers, FTS integrity, exact document/FTS row parity, and representative lexical queries.
7. Start only new binaries and leave consolidated consumer gates off.
8. Re-enable the bounded conversation job deliberately. Observe multiple slices and confirm scheduler availability, declining pending counts, durable vector progress, and a fresh `last_build` only after convergence.
9. Complete parity, orphan-disposition, and ranking gates before claiming or starting `t-c3277a52bf9a`.

If rollback is required after repair, stop every new binary and restore the coherent pre-repair database backup before starting old code. Do not point an old binary at the rowid-aligned layout.

The final coherent-copy rehearsal repaired all 219,988 copied documents: it populated canonical lexical fields, rebuilt exactly one FTS row per document, passed `PRAGMA integrity_check`, and returned representative lexical results in 529.6 seconds. The closed copy grew from 1,526,636,544 to 1,718,980,608 bytes. This was lexical storage repair on a disposable copy, not dense-vector completion. The same copy still had 47,580 conversation documents without vectors, so task `t-c3277a52bf9a` is not ready.

## Verification

- Required GitHub Python suite with coverage: passed on the final amendment (18m3s)
- Dashboard unit tests, tagged browser tests, and production build: passed
- DCO: passed
- Linux packaging and archive verification: passed
- macOS packaging and archive verification: passed on rerun; the first attempt built and uploaded every byte but GitHub's artifact service returned a transient `403 Forbidden` while finalizing the upload
- Focused Python coverage across storage/build/search/residency/outbox/retention, provider routing, LM Studio, settings, dashboard APIs, OpenBLAS policy, scheduler, refresh slicing, and the shared document-kernel lifetime
- 89 focused Python tests passed locally after the windowless-startup amendment
- 200,000-row FTS component-scale regression plus a coherent 219,988-document production-copy repair rehearsal
- Live LM Studio routing in an isolated production-shaped canary and again through the running production service
- Live React settings verification in an isolated harness and again through the running production dashboard
- Knowledge-store validation: 523 units, 0 failures; 37 pre-existing advisory warnings

Primary task: `t-0c23d85b235c`

Explicitly not completed: `t-c3277a52bf9a`

Do not merge automatically. The user reviews and merges Work Buddy PRs.
